### PR TITLE
Módulo seguridad completo v1.0

### DIFF
--- a/seguridad/data/asignaciones.json
+++ b/seguridad/data/asignaciones.json
@@ -1,0 +1,3 @@
+{
+  "asignaciones": []
+}

--- a/seguridad/data/users.json
+++ b/seguridad/data/users.json
@@ -1,0 +1,46 @@
+{
+  "users": [
+    {
+      "user": "admin",
+      "pass": "FTS2024",
+      "expira": "2026-03-18",
+      "acceso": "ambos"
+    },
+    {
+      "user": "esteban",
+      "pass": "5",
+      "expira": "2026-03-18",
+      "acceso": "instructor"
+    },
+    {
+      "user": "tecnicos",
+      "pass": "FTS2026",
+      "expira": "2026-03-12",
+      "acceso": "empleado"
+    },
+    {
+      "user": "tecnicos2",
+      "pass": "FTS2026",
+      "expira": "2026-03-17",
+      "acceso": "ambos"
+    },
+    {
+      "user": "felipe",
+      "pass": "perezfts2026",
+      "expira": "2026-04-10",
+      "acceso": "ambos"
+    },
+    {
+      "user": "stephany",
+      "pass": "HSES",
+      "expira": "2026-04-23",
+      "acceso": "empleado"
+    },
+    {
+      "user": "german",
+      "pass": "HSEG",
+      "expira": "2026-04-22",
+      "acceso": "empleado"
+    }
+  ]
+}

--- a/seguridad/data/version.json
+++ b/seguridad/data/version.json
@@ -1,0 +1,5 @@
+{
+  "version": "1.0.0",
+  "modulo": "seguridad",
+  "updated": "2026-04-02"
+}

--- a/seguridad/data/videos.json
+++ b/seguridad/data/videos.json
@@ -1,0 +1,342 @@
+{
+  "cursos": [
+    {
+      "id": "v001",
+      "titulo": "Seguridad en Alturas",
+      "descripcion": "NOM-009-STPS-2011 · Prevención de caídas, uso de arnés y EPP en trabajos en altura.",
+      "url": "https://TUEMPRESA.sharepoint.com/sites/FTS/Videos/seguridad-alturas.mp4",
+      "duracion_min": 30,
+      "obligatorio": true,
+      "activo": true,
+      "orden_sugerido": 1,
+      "examen": [
+        {
+          "pregunta": "¿Cuál es el EPP obligatorio para trabajo en alturas mayores a 1.8 m?",
+          "opciones": ["Casco solamente", "Arnés de seguridad y línea de vida", "Guantes de trabajo", "Lentes de seguridad"],
+          "correcta": 1
+        },
+        {
+          "pregunta": "¿Con qué frecuencia debe inspeccionarse el arnés antes de usarlo?",
+          "opciones": ["Una vez al mes", "Cada 6 meses", "Antes de cada uso", "Solo cuando esté dañado"],
+          "correcta": 2
+        },
+        {
+          "pregunta": "¿Cuál es la altura mínima a partir de la cual se requiere protección contra caídas según NOM-009?",
+          "opciones": ["1.0 metro", "1.5 metros", "1.8 metros", "2.0 metros"],
+          "correcta": 2
+        },
+        {
+          "pregunta": "¿Qué se debe verificar antes de usar una escalera portátil?",
+          "opciones": ["Que esté pintada", "Que los peldaños y largueros no estén dañados", "Que sea de metal", "Que sea nueva"],
+          "correcta": 1
+        },
+        {
+          "pregunta": "El punto de anclaje para el arnés debe soportar al menos:",
+          "opciones": ["500 kg", "1,000 kg", "2,268 kg (5,000 lbs)", "500 lbs"],
+          "correcta": 2
+        }
+      ]
+    },
+    {
+      "id": "v002",
+      "titulo": "Riesgos Eléctricos",
+      "descripcion": "NOM-029-STPS-2011 · Mantenimiento de instalaciones eléctricas y protección contra choques eléctricos.",
+      "url": "https://TUEMPRESA.sharepoint.com/sites/FTS/Videos/riesgos-electricos.mp4",
+      "duracion_min": 25,
+      "obligatorio": true,
+      "activo": true,
+      "orden_sugerido": 2,
+      "examen": [
+        {
+          "pregunta": "¿Qué significa el acrónimo LOTO?",
+          "opciones": ["Bloqueo y Etiquetado de energías peligrosas", "Lista de Operaciones de Trabajo", "Límite de Operación Total", "Logística de Operación Técnica"],
+          "correcta": 0
+        },
+        {
+          "pregunta": "¿Cuál es el voltaje considerado de alto riesgo en instalaciones industriales?",
+          "opciones": ["Mayor a 24V", "Mayor a 50V", "Mayor a 110V", "Mayor a 220V"],
+          "correcta": 1
+        },
+        {
+          "pregunta": "Antes de realizar cualquier trabajo eléctrico se debe verificar:",
+          "opciones": ["Que haya luz suficiente", "Que el equipo esté apagado visualmente", "Ausencia de energía con multímetro o detector", "Que el supervisor esté presente"],
+          "correcta": 2
+        },
+        {
+          "pregunta": "¿Cuántos candados se colocan en un dispositivo de bloqueo cuando intervienen varios trabajadores?",
+          "opciones": ["Solo uno del supervisor", "Uno por cada trabajador involucrado", "Dos como máximo", "Solo cuando hay más de 5 personas"],
+          "correcta": 1
+        },
+        {
+          "pregunta": "¿Qué color identifica los conductores de tierra física en México?",
+          "opciones": ["Rojo", "Negro", "Verde o verde con franja amarilla", "Blanco"],
+          "correcta": 2
+        }
+      ]
+    },
+    {
+      "id": "v003",
+      "titulo": "Equipo de Protección Personal (EPP)",
+      "descripcion": "NOM-017-STPS-2008 · Selección, uso, mantenimiento y disposición del EPP en el área de trabajo.",
+      "url": "https://TUEMPRESA.sharepoint.com/sites/FTS/Videos/epp.mp4",
+      "duracion_min": 20,
+      "obligatorio": true,
+      "activo": true,
+      "orden_sugerido": 3,
+      "examen": [
+        {
+          "pregunta": "¿Quién es responsable de proporcionar el EPP al trabajador?",
+          "opciones": ["El propio trabajador", "El patrón / empresa", "El sindicato", "La STPS"],
+          "correcta": 1
+        },
+        {
+          "pregunta": "¿Cuándo debe reemplazarse un casco de seguridad?",
+          "opciones": ["Cada 10 años", "Solo si tiene grietas visibles", "Cada 5 años o después de cualquier impacto", "Nunca si está limpio"],
+          "correcta": 2
+        },
+        {
+          "pregunta": "¿Cuál es la función principal del calzado dieléctrico?",
+          "opciones": ["Proteger contra caídas de objetos", "Aislar al trabajador de corriente eléctrica", "Proteger contra aplastamiento", "Dar comodidad al caminar"],
+          "correcta": 1
+        },
+        {
+          "pregunta": "Los lentes de seguridad con protección lateral son obligatorios cuando:",
+          "opciones": ["Solo en trabajo nocturno", "Existe riesgo de proyección de partículas o salpicaduras", "Solo en trabajo con químicos", "Siempre que haya más de 5 personas"],
+          "correcta": 1
+        },
+        {
+          "pregunta": "¿Qué tipo de guante se usa para trabajo con químicos corrosivos?",
+          "opciones": ["Guante de algodón", "Guante de cuero", "Guante de nitrilo o neopreno resistente a químicos", "Guante de tela con puntos antideslizantes"],
+          "correcta": 2
+        }
+      ]
+    },
+    {
+      "id": "v004",
+      "titulo": "Manejo de Materiales Peligrosos",
+      "descripcion": "NOM-005-STPS-1998 · Identificación, manejo, transporte y almacenamiento de sustancias químicas peligrosas.",
+      "url": "https://TUEMPRESA.sharepoint.com/sites/FTS/Videos/materiales-peligrosos.mp4",
+      "duracion_min": 35,
+      "obligatorio": true,
+      "activo": true,
+      "orden_sugerido": 4,
+      "examen": [
+        {
+          "pregunta": "¿Qué documento describe los peligros, propiedades y medidas de seguridad de una sustancia química?",
+          "opciones": ["Hoja de trabajo", "Hoja de Datos de Seguridad (HDS / SDS)", "Etiqueta de transporte", "Permiso de uso"],
+          "correcta": 1
+        },
+        {
+          "pregunta": "El sistema GHS utiliza rombos de colores para identificar peligros. ¿Qué indica el rombo ROJO?",
+          "opciones": ["Peligro para la salud", "Inflamabilidad", "Reactividad", "Peligro específico"],
+          "correcta": 1
+        },
+        {
+          "pregunta": "En caso de derrame de un químico desconocido, lo primero es:",
+          "opciones": ["Limpiarlo con agua inmediatamente", "Evacuar el área y dar aviso al supervisor", "Cubrir con arena y continuar", "Inhalar para identificarlo"],
+          "correcta": 1
+        },
+        {
+          "pregunta": "¿Cuál es la temperatura de inflamación que clasifica un líquido como inflamable?",
+          "opciones": ["Mayor a 93°C", "Menor a 93°C (200°F)", "Exactamente 100°C", "Menor a 200°C"],
+          "correcta": 1
+        },
+        {
+          "pregunta": "Los recipientes de sustancias peligrosas deben estar etiquetados con:",
+          "opciones": ["Solo el nombre del producto", "Nombre, pictogramas de peligro, indicaciones de precaución e información del fabricante", "Solo el número de lote", "Solo la fecha de caducidad"],
+          "correcta": 1
+        }
+      ]
+    },
+    {
+      "id": "v005",
+      "titulo": "Prevención y Combate de Incendios",
+      "descripcion": "NOM-002-STPS-2010 · Condiciones de seguridad para la prevención y protección contra incendios en centros de trabajo.",
+      "url": "https://TUEMPRESA.sharepoint.com/sites/FTS/Videos/incendios.mp4",
+      "duracion_min": 25,
+      "obligatorio": true,
+      "activo": true,
+      "orden_sugerido": 5,
+      "examen": [
+        {
+          "pregunta": "¿Cuáles son los tres elementos del triángulo del fuego?",
+          "opciones": ["Agua, oxígeno y calor", "Combustible, oxígeno y calor (o fuente de ignición)", "Grasa, aire y chispa", "Madera, papel y plástico"],
+          "correcta": 1
+        },
+        {
+          "pregunta": "¿Qué tipo de extintor se usa para fuegos clase C (eléctricos)?",
+          "opciones": ["Agua", "Espuma AFFF", "CO₂ o polvo químico seco ABC", "Solo agua nebulizada"],
+          "correcta": 2
+        },
+        {
+          "pregunta": "La técnica correcta para usar un extintor se resume en el acrónimo:",
+          "opciones": ["STOP", "PASS (Jalar, Apuntar, Apretar, Barrer)", "RACE", "ABC"],
+          "correcta": 1
+        },
+        {
+          "pregunta": "¿Con qué frecuencia mínima deben revisarse los extintores portátiles?",
+          "opciones": ["Cada 5 años", "Solo cuando se usan", "Mensualmente (inspección visual) y anualmente (revisión técnica)", "Cada 2 años"],
+          "correcta": 2
+        },
+        {
+          "pregunta": "Al evacuar un edificio en llamas debes:",
+          "opciones": ["Usar el elevador para bajar más rápido", "Abrir puertas sin tocarlas primero", "Desplazarte agachado si hay humo y no usar el elevador", "Regresar por tus pertenencias"],
+          "correcta": 2
+        }
+      ]
+    },
+    {
+      "id": "v006",
+      "titulo": "Primeros Auxilios Básicos",
+      "descripcion": "Atención inicial de emergencias médicas: RCP, control de hemorragias, quemaduras y fracturas en el área de trabajo.",
+      "url": "https://TUEMPRESA.sharepoint.com/sites/FTS/Videos/primeros-auxilios.mp4",
+      "duracion_min": 40,
+      "obligatorio": true,
+      "activo": true,
+      "orden_sugerido": 6,
+      "examen": [
+        {
+          "pregunta": "Al encontrar a una persona inconsciente, lo primero es:",
+          "opciones": ["Darle agua", "Verificar respuesta, pedir ayuda y revisar respiración", "Moverla inmediatamente", "Aplicar RCP sin verificar"],
+          "correcta": 1
+        },
+        {
+          "pregunta": "¿Cuántas compresiones por minuto se realizan en RCP para adultos?",
+          "opciones": ["40-60 por minuto", "60-80 por minuto", "100-120 por minuto", "150 por minuto"],
+          "correcta": 2
+        },
+        {
+          "pregunta": "Para controlar una hemorragia externa severa se debe:",
+          "opciones": ["Lavar con agua y aplicar alcohol", "Aplicar presión directa con tela limpia sobre la herida", "Retirar el objeto incrustado", "Elevar la extremidad sin aplicar presión"],
+          "correcta": 1
+        },
+        {
+          "pregunta": "¿Cómo se debe tratar una quemadura de primer grado?",
+          "opciones": ["Aplicar mantequilla o aceite", "Reventar las ampollas", "Enfriar con agua limpia corriente por 10-20 minutos", "Cubrir con un trapo húmedo con alcohol"],
+          "correcta": 2
+        },
+        {
+          "pregunta": "Ante la sospecha de fractura en una extremidad se debe:",
+          "opciones": ["Intentar alinear el hueso manualmente", "Inmovilizar la extremidad tal como está y esperar ayuda médica", "Masajear la zona afectada", "Pedir al trabajador que camine para verificar"],
+          "correcta": 1
+        }
+      ]
+    },
+    {
+      "id": "v007",
+      "titulo": "Orden y Limpieza — Metodología 5S",
+      "descripcion": "Implementación de las 5S: Seiri, Seiton, Seiso, Seiketsu y Shitsuke para mantener un ambiente de trabajo seguro y eficiente.",
+      "url": "https://TUEMPRESA.sharepoint.com/sites/FTS/Videos/5s.mp4",
+      "duracion_min": 20,
+      "obligatorio": false,
+      "activo": true,
+      "orden_sugerido": 7,
+      "examen": [
+        {
+          "pregunta": "¿Qué significa la primera 'S' (Seiri) de la metodología 5S?",
+          "opciones": ["Limpiar el área de trabajo", "Clasificar y eliminar lo innecesario", "Organizar lo que queda", "Crear hábitos"],
+          "correcta": 1
+        },
+        {
+          "pregunta": "Un área de trabajo desordenada y sucia aumenta el riesgo de:",
+          "opciones": ["Mayor productividad", "Tropiezos, caídas y accidentes", "Mejor comunicación", "Menores costos"],
+          "correcta": 1
+        },
+        {
+          "pregunta": "¿Qué representa la quinta 'S' (Shitsuke)?",
+          "opciones": ["Limpiar", "Estandarizar procedimientos", "Disciplina y creación de hábitos", "Clasificar materiales"],
+          "correcta": 2
+        },
+        {
+          "pregunta": "Las señalizaciones en el piso (líneas amarillas, rojas) sirven para:",
+          "opciones": ["Decoración del área", "Delimitar zonas de trabajo, tránsito y peligro", "Indicar pasillos de emergencia únicamente", "Marcar áreas de descanso"],
+          "correcta": 1
+        }
+      ]
+    },
+    {
+      "id": "v008",
+      "titulo": "Trabajo en Espacios Confinados",
+      "descripcion": "NOM-033-STPS-2015 · Condiciones de seguridad para realizar trabajos en espacios confinados.",
+      "url": "https://TUEMPRESA.sharepoint.com/sites/FTS/Videos/espacios-confinados.mp4",
+      "duracion_min": 35,
+      "obligatorio": false,
+      "activo": true,
+      "orden_sugerido": 8,
+      "examen": [
+        {
+          "pregunta": "Un espacio confinado se caracteriza por:",
+          "opciones": ["Tener paredes de concreto", "Tener aberturas limitadas de entrada/salida y no estar diseñado para ocupación continua", "Ser un área pequeña de almacén", "Ser cualquier área cerrada con llave"],
+          "correcta": 1
+        },
+        {
+          "pregunta": "Antes de entrar a un espacio confinado con riesgo, es obligatorio contar con:",
+          "opciones": ["Solo el permiso del supervisor inmediato", "Permiso de trabajo escrito, monitoreo de atmósfera y vigía externo", "Casco y guantes únicamente", "Solo el detector de gas"],
+          "correcta": 1
+        },
+        {
+          "pregunta": "¿Cuál es el nivel mínimo de oxígeno seguro para trabajar en un espacio confinado?",
+          "opciones": ["15%", "16.5%", "19.5%", "25%"],
+          "correcta": 2
+        },
+        {
+          "pregunta": "La función del vigía (persona que permanece fuera del espacio confinado) es:",
+          "opciones": ["Ayudar a cargar materiales", "Monitorear al trabajador, mantener comunicación y coordinar rescate si es necesario", "Supervisar la calidad del trabajo", "Llevar el registro de horas trabajadas"],
+          "correcta": 1
+        }
+      ]
+    },
+    {
+      "id": "v009",
+      "titulo": "Inducción de Seguridad — Bienvenida FTS",
+      "descripcion": "Reglas generales de seguridad, política de cero accidentes, señalizaciones, rutas de evacuación y contactos de emergencia de SERVICIOS FTS SA DE CV.",
+      "url": "https://TUEMPRESA.sharepoint.com/sites/FTS/Videos/induccion-fts.mp4",
+      "duracion_min": 15,
+      "obligatorio": true,
+      "activo": true,
+      "orden_sugerido": 0,
+      "examen": [
+        {
+          "pregunta": "¿Cuál es la política de seguridad de FTS?",
+          "opciones": ["Producción primero, seguridad después", "Cero accidentes — ningún trabajo vale una lesión", "Reportar accidentes solo si son graves", "La seguridad es responsabilidad solo del área HSE"],
+          "correcta": 1
+        },
+        {
+          "pregunta": "Al identificar una condición insegura en tu área de trabajo, debes:",
+          "opciones": ["Ignorarla si no te afecta directamente", "Corregirla tú mismo sin avisar", "Reportarla de inmediato a tu supervisor o al área de seguridad", "Esperar a la reunión mensual para mencionarla"],
+          "correcta": 2
+        },
+        {
+          "pregunta": "¿Qué debes hacer si presencias un accidente de trabajo?",
+          "opciones": ["Tomar fotos y publicarlas en redes sociales", "Brindar primeros auxilios básicos, activar plan de emergencia y reportar", "Continuar trabajando para no perder tiempo", "Esperar a que llegue el médico sin hacer nada"],
+          "correcta": 1
+        },
+        {
+          "pregunta": "Las rutas de evacuación deben estar:",
+          "opciones": ["Bloqueadas con material de trabajo cuando no se usan", "Señalizadas, libres de obstáculos y conocidas por todos", "Solo visibles en el reglamento interno", "Abiertas solo durante simulacros"],
+          "correcta": 1
+        }
+      ]
+    }
+  ],
+  "paquetes": [
+    {
+      "id": "onboarding",
+      "nombre": "Onboarding General",
+      "descripcion": "Cursos obligatorios para todos los trabajadores nuevos de FTS",
+      "cursos": ["v009", "v001", "v002", "v003", "v005", "v006"]
+    },
+    {
+      "id": "campo",
+      "nombre": "Técnico de Campo",
+      "descripcion": "Cursos para técnicos que trabajan en instalaciones industriales y plantas",
+      "cursos": ["v001", "v002", "v003", "v004", "v005", "v006", "v008"]
+    },
+    {
+      "id": "basico",
+      "nombre": "Seguridad Básica",
+      "descripcion": "Cursos mínimos de seguridad para cualquier trabajador",
+      "cursos": ["v009", "v003", "v005", "v006"]
+    }
+  ]
+}

--- a/seguridad/index.html
+++ b/seguridad/index.html
@@ -2353,6 +2353,6 @@ function addCursoPersonalizado(){
   </div>
 </div>
 
-<!-- videos.js se conectará en instrucción #3 -->
+<script src="js/videos.js"></script>
 </body>
 </html>

--- a/seguridad/index.html
+++ b/seguridad/index.html
@@ -1,0 +1,2358 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no">
+<meta name="theme-color" content="#ffffff">
+<meta name="mobile-web-app-capable" content="yes">
+<meta name="apple-mobile-web-app-capable" content="yes">
+<meta name="apple-mobile-web-app-status-bar-style" content="black-translucent">
+<meta name="apple-mobile-web-app-title" content="FTS Seguridad">
+<link rel="manifest" id="pwa-manifest">
+<link rel="apple-touch-icon" id="pwa-icon">
+<title>FTS · Seguridad Industrial</title>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/jspdf/2.5.1/jspdf.umd.min.js"><\/script>
+<link rel="stylesheet" href="../shared/fts-styles.css">
+<style>
+/* ═══ CSS local — estilos específicos del módulo Seguridad ═══ */
+/* (No incluidos en shared/fts-styles.css) */
+
+/* ══════════════════ MODE SELECT ══════════════════ */
+#s-home{align-items:center;justify-content:flex-start;padding:0}
+.home-top{width:100%;flex:1;display:flex;flex-direction:column;align-items:center;justify-content:center;padding:48px 28px 24px;text-align:center;position:relative;overflow:hidden}
+.home-top::before{content:'';position:absolute;top:0;left:0;right:0;height:300px;background:radial-gradient(ellipse 80% 60% at 50% -5%,rgba(216,59,1,.06) 0%,transparent 70%);pointer-events:none}
+.logo-mark{width:160px;height:54px;background:var(--logo) center/contain no-repeat;display:block;margin-bottom:24px;position:relative;z-index:1}
+.home-top h1{font-size:26px;font-weight:700;line-height:1.2;margin-bottom:10px;position:relative;z-index:1;letter-spacing:-.3px}
+.home-top h1 span{color:var(--o);font-weight:800}
+.home-top p{font-size:12px;color:var(--muted2);position:relative;z-index:1;letter-spacing:.5px;text-transform:uppercase;font-weight:500}
+.home-cards{width:100%;background:var(--d2);border-top:1px solid var(--border);border-radius:24px 24px 0 0;padding:28px 20px 40px;display:flex;flex-direction:column;gap:14px;box-shadow:0 -4px 20px rgba(0,0,0,.06)}
+.home-cards h2{font-size:11px;font-weight:600;color:var(--muted2);letter-spacing:1px;text-transform:uppercase;margin-bottom:4px}
+.mode-card.emp:active{border-color:var(--green);box-shadow:0 0 0 2px rgba(16,124,16,.15)}
+.mode-icon{width:48px;height:48px;border-radius:12px;display:flex;align-items:center;justify-content:center;font-size:22px;flex-shrink:0}
+.mode-icon.inst{background:rgba(216,59,1,.08);border:1px solid rgba(216,59,1,.2)}
+.mode-icon.emp{background:rgba(16,124,16,.08);border:1px solid rgba(16,124,16,.2)}
+.mode-info strong{font-size:15px;font-weight:700;display:block;margin-bottom:2px}
+.mode-info span{font-size:12px;color:var(--muted2)}
+.mode-arrow{margin-left:auto;font-size:20px;color:var(--muted)}
+
+
+/* ══════════════════ INSTRUCTOR PIN ══════════════════ */
+#s-pin{align-items:center;justify-content:center;padding:32px 24px}
+.pin-error{font-size:13px;color:var(--red);margin-bottom:10px;min-height:18px}
+.lnk{background:none;border:none;color:var(--muted2);font-size:13px;cursor:pointer;font-family:inherit;padding:8px;text-decoration:underline}
+
+.content{flex:1;padding:16px;display:flex;flex-direction:column;gap:14px;overflow-y:auto}
+.field{display:flex;flex-direction:column;gap:6px;margin-bottom:12px}
+.field label{font-size:11px;font-weight:700;letter-spacing:.8px;text-transform:uppercase;color:var(--muted)}
+.field input,.field select{background:var(--d2);border:1px solid var(--border);color:var(--text);padding:13px 14px;font-size:14px;font-family:'Inter',sans-serif;outline:none;border-radius:8px;width:100%;-webkit-appearance:none;transition:border-color .2s;box-shadow:0 1px 2px rgba(0,0,0,.04)}
+.field input:focus,.field select:focus{border-color:var(--o);box-shadow:0 0 0 1px var(--o)}
+.field input::placeholder{color:#666}
+
+/* ══════════════════ INSTRUCTOR DASHBOARD ══════════════════ */
+
+/* Worker list */
+.worker-row{background:var(--d3);border:1px solid var(--border);border-radius:10px;padding:13px 14px;display:flex;align-items:center;gap:10px;cursor:pointer;transition:background .15s}
+.worker-row:active{background:var(--d4)}
+.worker-row.sel{border-color:var(--o);background:rgba(224,64,16,.05)}
+.wr-chk{width:22px;height:22px;border-radius:6px;border:2px solid var(--border);display:flex;align-items:center;justify-content:center;flex-shrink:0;font-size:13px;transition:all .2s}
+.worker-row.sel .wr-chk{background:var(--o);border-color:var(--o)}
+.wr-info strong{font-size:13px;font-weight:600;display:block}
+.wr-info span{font-size:11px;color:var(--muted2)}
+
+/* Course checkboxes */
+.course-chk{background:var(--d3);border:1px solid var(--border);border-radius:10px;padding:12px 14px;display:flex;align-items:center;gap:10px;cursor:pointer}
+.course-chk:active{background:var(--d4)}
+.course-chk.sel{border-color:var(--o);background:rgba(224,64,16,.05)}
+.cc-box{width:22px;height:22px;border-radius:6px;border:2px solid var(--border);display:flex;align-items:center;justify-content:center;flex-shrink:0;font-size:12px;transition:all .2s;flex-shrink:0}
+.course-chk.sel .cc-box{background:var(--o);border-color:var(--o)}
+.cc-info strong{font-size:13px;font-weight:500;display:block;line-height:1.3}
+.cc-info span{font-size:11px;color:var(--muted2)}
+
+/* Instructor selector */
+.inst-radio{background:var(--d3);border:1.5px solid var(--border);border-radius:10px;padding:13px 14px;display:flex;align-items:center;gap:10px;cursor:pointer;transition:all .15s}
+.inst-radio.sel{border-color:var(--o);background:rgba(224,64,16,.05)}
+.ir-dot{width:20px;height:20px;border-radius:50%;border:2px solid var(--border);display:flex;align-items:center;justify-content:center;flex-shrink:0;transition:all .2s}
+.inst-radio.sel .ir-dot{border-color:var(--o)}
+.ir-dot::after{content:'';width:8px;height:8px;border-radius:50%;background:transparent;transition:background .2s}
+.inst-radio.sel .ir-dot::after{background:var(--o)}
+
+/* Date input */
+.date-field{display:flex;gap:8px;align-items:flex-end}
+.date-field .field{flex:1;margin-bottom:0}
+
+/* ══════════════════ EMPLOYEE FLOW ══════════════════ */
+/* Access */
+.emp-hero{flex:1;display:flex;flex-direction:column;align-items:center;justify-content:center;padding:44px 28px 20px;text-align:center;position:relative;overflow:hidden}
+.emp-hero::before{content:'';position:absolute;top:0;left:0;right:0;height:200px;background:radial-gradient(ellipse 80% 60% at 50% 0%,rgba(16,124,16,.06) 0%,transparent 70%);pointer-events:none}
+.emp-hero .logo-mark{margin:0 auto 20px}
+.emp-hero h1{font-size:24px;font-weight:800;line-height:1.2;margin-bottom:8px;position:relative;z-index:1}
+.emp-hero h1 span{color:var(--green)}
+.emp-hero p{font-size:13px;color:var(--muted2);position:relative;z-index:1}
+.emp-form{background:var(--d2);border-top:1px solid var(--border);padding:24px 20px 40px;border-radius:20px 20px 0 0}
+
+/* Camera */
+#s-cam{background:#000}
+.cam-area{flex:1;position:relative;display:flex;align-items:center;justify-content:center;overflow:hidden;min-height:300px}
+#cam-vid{width:100%;height:100%;object-fit:cover}
+.cam-ov{position:absolute;inset:0;display:flex;flex-direction:column;align-items:center;justify-content:center;pointer-events:none}
+.cam-ring{width:190px;height:190px;border:2px solid var(--green);border-radius:50%;box-shadow:0 0 0 2000px rgba(0,0,0,.55)}
+.cam-top{position:absolute;top:16px;left:0;right:0;text-align:center}
+.cam-pill{display:inline-flex;align-items:center;gap:6px;background:rgba(0,0,0,.7);border:1px solid rgba(255,255,255,.1);padding:6px 14px;border-radius:20px;font-size:12px}
+.blink{width:6px;height:6px;border-radius:50%;background:var(--red);animation:blink 1s infinite}
+.blink.ok{background:var(--green);animation:none}
+@keyframes blink{0%,100%{opacity:1}50%{opacity:.2}}
+.cam-bot{position:absolute;bottom:0;left:0;right:0;background:linear-gradient(transparent,rgba(0,0,0,.9));padding:28px 24px 20px;text-align:center}
+.cam-bot p{font-size:14px;margin-bottom:3px}
+.cam-bot span{font-size:12px;color:#777}
+.cam-actions{background:#000;padding:16px 20px 36px;display:flex;flex-direction:column;gap:10px}
+.cam-preview{display:none;flex-direction:column;align-items:center;gap:14px;padding:20px;text-align:center}
+.cam-preview img{width:140px;height:140px;border-radius:50%;object-fit:cover;border:3px solid var(--green)}
+.cam-preview p{font-size:14px;font-weight:600}
+.cam-preview span{font-size:12px;color:var(--muted2)}
+
+/* Employee dashboard */
+.prog-bar-wrap{padding:12px 16px 4px}
+.prog-labels{display:flex;justify-content:space-between;font-size:11px;color:var(--muted2);margin-bottom:5px}
+.stat-row{display:flex;gap:8px}
+.stat{flex:1;background:var(--d3);border:1px solid var(--border);border-radius:10px;padding:11px;text-align:center}
+.stat strong{font-size:22px;font-weight:800;display:block}
+.stat span{font-size:10px;color:var(--muted2);letter-spacing:.5px;text-transform:uppercase}
+.stat.g strong{color:var(--green)}
+.stat.o strong{color:var(--o)}
+
+/* Course list */
+.ci{display:flex;align-items:center;gap:11px;padding:13px 15px;border-bottom:1px solid var(--border);cursor:pointer;transition:background .15s}
+.ci:last-child{border-bottom:none}
+.ci.locked{opacity:.4;pointer-events:none}
+.ci:not(.locked):not(.done):active{background:var(--d3)}
+.ci-num{width:36px;height:36px;border-radius:50%;border:1.5px solid var(--border);display:flex;align-items:center;justify-content:center;font-size:12px;font-weight:700;color:var(--muted2);flex-shrink:0;transition:all .2s}
+.ci.done .ci-num{background:var(--green);border-color:var(--green);color:#fff}
+.ci.active .ci-num{background:var(--green);border-color:var(--green);color:#fff;opacity:.7}
+.ci-txt strong{font-size:13px;font-weight:500;display:block;margin-bottom:1px;line-height:1.3}
+.ci-txt span{font-size:11px;color:var(--muted2)}
+.ci-badge{font-size:10px;font-weight:700;padding:3px 8px;border-radius:5px;flex-shrink:0;margin-left:auto}
+.ci-badge.done{background:rgba(34,197,94,.12);color:var(--green)}
+.ci-badge.next{background:rgba(34,197,94,.12);color:var(--green)}
+.ci-badge.lock{background:var(--d4);color:var(--muted)}
+
+/* Course screen */
+.vid-placeholder{background:#000;aspect-ratio:16/9;display:flex;flex-direction:column;align-items:center;justify-content:center;gap:10px;border-radius:10px;overflow:hidden;min-height:160px}
+.play-btn{width:60px;height:60px;background:rgba(34,197,94,.9);border-radius:50%;display:flex;align-items:center;justify-content:center;cursor:pointer;transition:transform .15s}
+.play-btn:active{transform:scale(.9)}
+.vid-bar{height:4px;background:var(--border);border-radius:2px;margin:10px 0 4px}
+.vid-fill{height:100%;background:var(--green);border-radius:2px;transition:width .5s linear;width:0%}
+.vid-time{display:flex;justify-content:space-between;font-size:11px;color:var(--muted2)}
+
+/* Quiz */
+.quiz-q{font-size:15px;font-weight:600;line-height:1.4;margin-bottom:16px}
+.quiz-opts{display:flex;flex-direction:column;gap:9px}
+.qopt{background:var(--d3);border:1.5px solid var(--border);border-radius:11px;padding:13px 14px;cursor:pointer;font-size:13px;display:flex;align-items:center;gap:10px;transition:all .15s}
+.qopt:active{transform:scale(.98)}
+.qopt.sel{border-color:var(--green);background:rgba(34,197,94,.06)}
+.qopt.right{border-color:var(--green);background:rgba(34,197,94,.08);color:var(--green)}
+.qopt.wrong{border-color:var(--red);background:rgba(239,68,68,.08);color:var(--red)}
+.ql{width:26px;height:26px;border-radius:50%;background:var(--d4);display:flex;align-items:center;justify-content:center;font-size:11px;font-weight:700;flex-shrink:0;transition:all .2s}
+.qopt.right .ql{background:var(--green);color:#fff}
+.qopt.wrong .ql{background:var(--red);color:#fff}
+.qfb{margin-top:12px;padding:11px 13px;border-radius:9px;font-size:13px;font-weight:500;display:none}
+.qfb.on{display:block}
+.qfb.ok{background:rgba(34,197,94,.08);border:1px solid rgba(34,197,94,.25);color:var(--green)}
+.qfb.fail{background:rgba(239,68,68,.08);border:1px solid rgba(239,68,68,.25);color:#f87171}
+.demo-pill{background:rgba(224,64,16,.08);border:1px solid rgba(224,64,16,.2);color:var(--o);padding:6px 10px;border-radius:7px;font-size:11px;font-weight:600;margin-bottom:12px;display:block}
+
+/* Complete */
+#s-emp-done{align-items:center;justify-content:center;text-align:center;padding:32px 20px}
+.done-icon{width:90px;height:90px;background:rgba(34,197,94,.1);border:2px solid rgba(34,197,94,.35);border-radius:50%;display:flex;align-items:center;justify-content:center;font-size:42px;margin:0 auto 20px;animation:pop .4s ease}
+@keyframes pop{0%{transform:scale(.4);opacity:0}80%{transform:scale(1.1)}100%{transform:scale(1);opacity:1}}
+#s-emp-done h1{font-size:24px;font-weight:800;margin-bottom:8px}
+#s-emp-done h1 span{color:var(--green)}
+.done-card{background:var(--d2);border:1px solid var(--border);border-radius:14px;padding:18px;width:100%;max-width:340px;margin:20px auto;text-align:left}
+.done-badge{display:inline-flex;align-items:center;gap:5px;background:rgba(34,197,94,.1);border:1px solid rgba(34,197,94,.3);color:var(--green);padding:5px 12px;border-radius:20px;font-size:11px;font-weight:700;margin-bottom:16px}
+.ir{display:flex;align-items:center;gap:8px;padding:10px 0;border-bottom:1px solid var(--border);font-size:13px}
+.ir:last-child{border-bottom:none}
+.ir .lbl{color:var(--muted2);flex:0 0 90px;font-size:12px}
+.ir .val{font-weight:500;flex:1}
+
+/* ── User Management Panel ── */
+.usr-row { display:flex; align-items:center; gap:10px; background:var(--d2); border:1px solid var(--border); border-radius:12px; padding:12px 14px; margin-bottom:8px; }
+.usr-dot  { width:9px; height:9px; border-radius:50%; flex-shrink:0; }
+.usr-dot.ok  { background:#22c55e; box-shadow:0 0 5px #22c55e66; }
+.usr-dot.warn{ background:#f59e0b; box-shadow:0 0 5px #f59e0b66; }
+.usr-dot.exp { background:#ef4444; box-shadow:0 0 5px #ef444466; }
+.usr-info { flex:1; min-width:0; }
+.usr-info strong { font-size:13px; font-weight:600; display:block; }
+.usr-info span   { font-size:11px; color:var(--muted2); }
+.usr-exp  { font-size:11px; color:var(--muted2); flex-shrink:0; text-align:right; }
+.usr-exp input[type=date] { font-size:11px; border:1px solid var(--border); border-radius:6px; padding:4px 6px; background:var(--d2); color:var(--text); font-family:'Inter',sans-serif; }
+.usr-del  { background:none; border:none; cursor:pointer; font-size:16px; padding:4px; color:#ccc; flex-shrink:0; }
+.usr-del:hover { color:var(--red); }
+.json-out { background:#1a1a1a; color:#7eff8a; font-family:monospace; font-size:11px; border-radius:10px; padding:14px; width:100%; box-sizing:border-box; resize:none; border:none; line-height:1.6; }
+
+.mt{margin-top:10px}
+.mt2{margin-top:6px}
+.row{display:flex;gap:8px}
+.row>.btn{flex:1}
+</style>
+
+</style>
+</head>
+<body>
+
+
+<!-- ════════════ HOME: APP LAUNCHER ════════════ -->
+<div id="s-home" class="scr on">
+  <div class="home-top">
+    <div class="logo-mark"></div>
+    <h1>Suite<br><span>Industrial</span></h1>
+    <p>SERVICIOS FTS SA DE CV · STPS</p>
+  </div>
+  <div class="home-cards">
+    <h2>Selecciona la aplicación</h2>
+    <div class="mode-card" onclick="goInstPin()">
+      <div class="mode-icon inst">🏗️</div>
+      <div class="mode-info">
+        <strong>Instructor DC-3</strong>
+        <span>Generar constancias de capacitación</span>
+      </div>
+      <span class="mode-arrow">›</span>
+    </div>
+    <div class="mode-card emp" onclick="goEmpAccess()">
+      <div class="mode-icon emp">👷</div>
+      <div class="mode-info">
+        <strong>Empleado DC-3</strong>
+        <span>Realizar cursos de capacitación</span>
+      </div>
+      <span class="mode-arrow">›</span>
+    </div>
+    <div class="mode-card" onclick="go('s-iperc-pin')" style="border-color:rgba(124,58,237,.25);background:rgba(124,58,237,.02)">
+      <div class="mode-icon" style="background:rgba(124,58,237,.08);border:1px solid rgba(124,58,237,.3);font-size:20px">⚠️</div>
+      <div class="mode-info">
+        <strong style="color:#7c3aed">Herramienta de Análisis de Riesgos</strong>
+        <span>IPERC · SAP · Método FINE · NOM-STPS</span>
+      </div>
+      <span class="mode-arrow">›</span>
+    </div>
+  </div>
+  <!-- Botón sincronización servidor — discreto, al fondo del home -->
+  <div style="padding:0 20px 28px;text-align:center">
+    <button id="btn-sync" onclick="syncServer()" style="background:none;border:1px solid var(--border);border-radius:8px;padding:10px 18px;font-size:12px;font-family:'Inter',sans-serif;color:var(--muted2);cursor:pointer;display:inline-flex;align-items:center;gap:7px;transition:all .2s">
+      <span style="font-size:14px">🔄</span>
+      <span id="sync-lbl">Sincronizar con servidor FTS</span>
+    </button>
+  </div>
+</div>
+
+<!-- ════════════ INSTRUCTOR LOGIN ════════════ -->
+<div id="s-pin" class="scr">
+  <div class="pin-box" style="text-align:center">
+    <div class="logo-mark" style="margin:0 auto 20px"></div>
+    <h2>Acceso Instructor</h2>
+    <p style="margin-bottom:20px">Ingresa tus credenciales autorizadas</p>
+    <div class="field" style="text-align:left"><label>Usuario</label>
+      <input id="auth-user" type="text" placeholder="Tu usuario" autocomplete="username">
+    </div>
+    <div class="field" style="text-align:left"><label>Contraseña</label>
+      <input id="auth-pass" type="password" placeholder="••••••••" autocomplete="current-password">
+    </div>
+    <div class="pin-error" id="pin-err"></div>
+    <button class="btn btn-p" onclick="authLogin()" style="margin-top:8px">Iniciar sesión →</button>
+    <button class="lnk" style="width:100%;text-align:center;margin-top:12px" onclick="go('s-home')">← Regresar</button>
+  </div>
+</div>
+
+<!-- ════════════ IPERC ACCESS LOGIN ════════════ -->
+<div id="s-iperc-pin" class="scr" style="justify-content:center;align-items:center;min-height:100vh;padding:24px 20px">
+  <div style="width:100%;max-width:360px;margin:auto;text-align:center">
+    <div style="margin:0 auto 20px;background:#7c3aed;border-radius:10px;width:80px;height:36px;display:flex;align-items:center;justify-content:center;color:#fff;font-size:14px;font-weight:800;letter-spacing:1px">FTS</div>
+    <h2 style="font-size:22px;font-weight:700;margin-bottom:6px">Acceso Segurista</h2>
+    <p style="margin-bottom:6px;color:var(--muted2);font-size:13px">Análisis de Riesgos · IPERC · Método FINE</p>
+    <p style="margin-bottom:24px;font-size:12px;background:rgba(124,58,237,.06);border:1px solid rgba(124,58,237,.2);color:#7c3aed;padding:8px 12px;border-radius:8px">Los mismos usuarios del sistema DC-3 con acceso <strong>segurista</strong> o <strong>ambos</strong></p>
+    <div class="field" style="text-align:left;margin-bottom:12px"><label style="font-size:10px;font-weight:700;text-transform:uppercase;letter-spacing:.8px;color:var(--muted)">Usuario</label>
+      <input id="iperc-login-user" type="text" placeholder="Tu usuario" autocomplete="username" onkeydown="if(event.key==='Enter')ipercAccessLogin()" style="width:100%;background:var(--d3);border:1px solid var(--border);color:var(--text);padding:12px 14px;border-radius:10px;font-size:14px;font-family:Inter,sans-serif;box-sizing:border-box;margin-top:4px">
+    </div>
+    <div class="field" style="text-align:left;margin-bottom:8px"><label style="font-size:10px;font-weight:700;text-transform:uppercase;letter-spacing:.8px;color:var(--muted)">Contraseña</label>
+      <input id="iperc-login-pass" type="password" placeholder="••••••••" autocomplete="current-password" onkeydown="if(event.key==='Enter')ipercAccessLogin()" style="width:100%;background:var(--d3);border:1px solid var(--border);color:var(--text);padding:12px 14px;border-radius:10px;font-size:14px;font-family:Inter,sans-serif;box-sizing:border-box;margin-top:4px">
+    </div>
+    <div class="pin-error" id="iperc-login-err" style="min-height:20px;font-size:12px;color:var(--red);margin-bottom:8px"></div>
+    <button onclick="ipercAccessLogin()" style="width:100%;background:#7c3aed;color:#fff;border:none;border-radius:10px;padding:14px;font-size:14px;font-weight:600;font-family:Inter,sans-serif;cursor:pointer;transition:background .15s" onmouseover="this.style.background='#6d28d9'" onmouseout="this.style.background='#7c3aed'">Ingresar →</button>
+    <button class="lnk" style="width:100%;text-align:center;margin-top:14px;font-size:12px" onclick="go('s-home')">← Volver al inicio</button>
+  </div>
+</div>
+
+<!-- ════════════ INSTRUCTOR DASHBOARD ════════════ -->
+<div id="s-inst" class="scr">
+  <div class="topbar">
+    <a class="tb-back" href="../index.html" style="text-decoration:none">‹</a>
+    <div class="tb-logo"></div>
+    <div class="tb-info"><strong>Panel del Instructor</strong><span>SERVICIOS FTS SA DE CV</span></div>
+    <button id="btn-settings" style="display:none;background:none;border:1px solid var(--border);border-radius:8px;padding:6px 10px;font-size:16px;cursor:pointer;color:var(--muted2)" onclick="toggleSettings()">⚙️</button>
+    <div class="tb-badge" style="color:var(--o);cursor:pointer" onclick="stopHeartbeat();_loggedUser=null;const b=document.getElementById('expiry-warning-banner');if(b)b.remove();go('s-home')">Salir</div>
+  </div>
+  <div class="tab-row">
+    <button class="tab on" onclick="instTab('workers')">👷 Trabajadores</button>
+    <button class="tab" onclick="instTab('courses')">📋 Cursos</button>
+    <button class="tab" onclick="instTab('generate')">📄 Generar DC-3</button>
+  </div>
+
+  <!-- Settings Panel (solo master) -->
+  <div id="settings-panel" style="display:none;padding:16px;background:var(--d3);border-bottom:2px solid var(--o)">
+    <div style="font-size:13px;font-weight:700;margin-bottom:12px;color:var(--o)">⚙️ Configuración Master</div>
+    <button class="btn btn-p" style="padding:11px" onclick="loadUserPanel();go('s-users')">👥 Gestionar Usuarios y Accesos</button>
+  </div>
+
+  <!-- Tab: Workers -->
+  <div class="tab-pane on" id="tp-workers">
+    <div class="field"><label>Apellido Paterno</label>
+      <input id="new-ap" type="text" placeholder="Ej: DE LA CRUZ" style="text-transform:uppercase">
+    </div>
+    <div class="field"><label>Apellido Materno</label>
+      <input id="new-am" type="text" placeholder="Ej: CALDERON" style="text-transform:uppercase">
+    </div>
+    <div class="field"><label>Nombre(s)</label>
+      <input id="new-nom" type="text" placeholder="Ej: JESUS ESTEBAN" style="text-transform:uppercase">
+    </div>
+    <div class="field" style="margin-bottom:0">
+      <input id="new-curp" type="text" placeholder="CURP (18 caracteres)" maxlength="18" style="text-transform:uppercase;letter-spacing:1px;font-size:13px">
+    </div>
+    <button class="btn btn-p mt" onclick="addWorker()">+ Agregar trabajador</button>
+    <div id="worker-list" style="display:flex;flex-direction:column;gap:8px"></div>
+  </div>
+
+  <!-- Tab: Courses -->
+  <div class="tab-pane" id="tp-courses">
+    <div class="card-hd" style="padding:12px 14px;border-radius:10px;margin-bottom:4px">
+      <div class="card-icon" style="font-size:16px">ℹ️</div>
+      <div><div class="card-title" style="font-size:13px">Instructor</div><div class="card-sub">Selecciona quién firmará los DC-3</div></div>
+    </div>
+    <div id="inst-selector" style="display:flex;flex-direction:column;gap:8px;margin-bottom:8px"></div>
+    <div style="height:1px;background:var(--border);margin:4px 0 8px"></div>
+    <div class="card-hd" style="padding:12px 14px;border-radius:10px;margin-bottom:4px">
+      <div class="card-icon" style="font-size:16px">📋</div>
+      <div><div class="card-title" style="font-size:13px">Cursos a certificar</div><div class="card-sub">Selecciona cuáles se impartieron</div></div>
+    </div>
+    <div style="display:flex;gap:8px;margin-bottom:8px;flex-wrap:wrap">
+      <button class="btn btn-s" style="padding:10px;font-size:12px" onclick="selectAllCourses(true)">✓ Todos</button>
+      <button class="btn btn-s" style="padding:10px;font-size:12px" onclick="selectAllCourses(false)">✗ Ninguno</button>
+      <button class="btn btn-s" style="padding:10px;font-size:12px;color:#7c3aed;border-color:#c4b5fd" onclick="toggleAddCursoForm()">＋ Curso personalizado</button>
+    </div>
+    <!-- FORM INLINE: Agregar curso temporal -->
+    <div id="add-curso-form" style="display:none;background:rgba(124,58,237,.06);border:1.5px solid rgba(124,58,237,.25);border-radius:12px;padding:14px;margin-bottom:10px">
+      <div style="font-size:12px;font-weight:700;color:#7c3aed;margin-bottom:10px;text-transform:uppercase;letter-spacing:.5px">Curso personalizado (temporal)</div>
+      <div style="display:flex;flex-direction:column;gap:8px">
+        <input id="nc-nombre" type="text" placeholder="Nombre del curso (MAYÚSCULAS)" maxlength="120"
+          style="background:var(--d2);border:1px solid var(--border);color:var(--text);padding:10px 12px;border-radius:8px;font-size:13px;font-family:Inter,sans-serif;outline:none"
+          oninput="this.value=this.value.toUpperCase()">
+        <div style="display:flex;gap:8px">
+          <input id="nc-hrs" type="number" placeholder="Hrs" min="1" max="999" value="8"
+            style="width:80px;background:var(--d2);border:1px solid var(--border);color:var(--text);padding:10px 12px;border-radius:8px;font-size:13px;font-family:Inter,sans-serif;outline:none">
+          <input id="nc-area-label" type="text" placeholder="Área (ej. Seguridad)" maxlength="60"
+            style="flex:1;background:var(--d2);border:1px solid var(--border);color:var(--text);padding:10px 12px;border-radius:8px;font-size:13px;font-family:Inter,sans-serif;outline:none"
+            oninput="this.value=this.value.toUpperCase()">
+          <input id="nc-area-code" type="text" placeholder="Cód." value="6000" maxlength="10"
+            style="width:70px;background:var(--d2);border:1px solid var(--border);color:var(--text);padding:10px 12px;border-radius:8px;font-size:13px;font-family:Inter,sans-serif;outline:none">
+        </div>
+        <div style="display:flex;gap:8px">
+          <button onclick="addCursoPersonalizado()" style="flex:1;padding:10px;background:#7c3aed;color:#fff;border:none;border-radius:8px;font-size:13px;font-weight:600;font-family:Inter,sans-serif;cursor:pointer">✓ Agregar y seleccionar</button>
+          <button onclick="toggleAddCursoForm()" style="padding:10px 16px;background:var(--d3);border:1px solid var(--border);color:var(--muted2);border-radius:8px;font-size:13px;font-family:Inter,sans-serif;cursor:pointer">Cancelar</button>
+        </div>
+      </div>
+    </div>
+    <div id="course-selector" style="display:flex;flex-direction:column;gap:8px"></div>
+  </div>
+
+  <!-- Tab: Generate -->
+  <div class="tab-pane" id="tp-generate">
+    <div class="card">
+      <div class="card-hd"><div class="card-icon" style="font-size:16px">📅</div><div><div class="card-title">Fecha de impartición</div><div class="card-sub">Se aplica a todos los cursos seleccionados</div></div></div>
+      <div class="card-body">
+        <div class="field" style="margin-bottom:0">
+          <label>Fecha del curso</label>
+          <input type="date" id="inst-fecha">
+        </div>
+      </div>
+    </div>
+    <div id="gen-summary" class="card">
+      <div class="card-hd"><div class="card-icon" style="font-size:16px">📊</div><div><div class="card-title">Resumen</div><div class="card-sub" id="gen-sub">Configura trabajadores y cursos primero</div></div></div>
+      <div class="card-body" id="gen-body">
+        <p style="font-size:13px;color:var(--muted2)">Selecciona trabajadores en la pestaña "Trabajadores" y cursos en "Cursos" antes de generar.</p>
+      </div>
+    </div>
+    <button class="btn btn-p" onclick="generateDC3()">🖨️ Generar DC-3 (PDF)</button>
+  </div>
+</div>
+
+<!-- ════════════ EMPLOYEE: LOGIN ════════════ -->
+<div id="s-emp" class="scr">
+  <div class="emp-hero">
+    <div class="logo-mark"></div>
+    <h1>Capacitación<br><span>Seguridad</span></h1>
+    <p>Completa tus cursos para obtener tus constancias</p>
+  </div>
+  <div class="emp-form">
+    <div class="field"><label>Usuario</label>
+      <input id="emp-user" type="text" placeholder="Tu usuario" autocomplete="username">
+    </div>
+    <div class="field"><label>Contraseña</label>
+      <input id="emp-pass" type="password" placeholder="••••••••" autocomplete="current-password">
+    </div>
+    <div class="pin-error" id="emp-auth-err"></div>
+    <button class="btn btn-g" onclick="empAuthStep()">Continuar →</button>
+    <button class="lnk" style="width:100%;text-align:center;margin-top:8px" onclick="go('s-home')">← Regresar</button>
+  </div>
+</div>
+
+<!-- ════════════ EMPLOYEE: INFO ════════════ -->
+<div id="s-emp-info" class="scr">
+  <div class="emp-hero" style="flex:0;padding:28px 28px 12px">
+    <h2 style="font-size:18px;font-weight:700;position:relative;z-index:1">Datos del Trabajador</h2>
+    <p>Ingresa tu información para generar tus constancias</p>
+  </div>
+  <div class="emp-form" style="flex:1">
+    <div class="field"><label>Apellido Paterno</label>
+      <input id="emp-ap" type="text" placeholder="Ej: DE LA CRUZ" style="text-transform:uppercase">
+    </div>
+    <div class="field"><label>Apellido Materno</label>
+      <input id="emp-am" type="text" placeholder="Ej: CALDERON" style="text-transform:uppercase">
+    </div>
+    <div class="field"><label>Nombre(s)</label>
+      <input id="emp-nom" type="text" placeholder="Ej: JESUS ESTEBAN" style="text-transform:uppercase">
+    </div>
+    <div class="field"><label>CURP</label>
+      <input id="emp-curp" type="text" placeholder="XXXX000000XXXXXXXX" maxlength="18" style="text-transform:uppercase;letter-spacing:1px;font-size:13px">
+    </div>
+    <button class="btn btn-g" onclick="empInfoStep()">Continuar a foto →</button>
+    <button class="lnk" style="width:100%;text-align:center;margin-top:8px" onclick="go('s-emp')">← Cambiar cuenta</button>
+  </div>
+</div>
+
+<!-- ════════════ EMPLOYEE: CAMERA ════════════ -->
+<div id="s-cam" class="scr">
+  <div class="cam-area">
+    <video id="cam-vid" autoplay playsinline muted></video>
+    <canvas id="cam-cvs" style="display:none"></canvas>
+    <div class="cam-ov"><div class="cam-ring"></div></div>
+    <div class="cam-top">
+      <div class="cam-pill"><div class="blink" id="cam-dot"></div><span id="cam-txt">Iniciando...</span></div>
+    </div>
+    <div class="cam-bot"><p>Coloca tu rostro dentro del círculo</p><span>Buena iluminación frontal</span></div>
+  </div>
+  <div class="cam-preview" id="cam-prev-wrap">
+    <img id="cam-prev-img" src="" alt="">
+    <p>¿Se ve bien tu foto?</p>
+    <span id="cam-ts"></span>
+  </div>
+  <div class="cam-actions" id="cam-act1">
+    <button class="btn btn-g" id="btn-cap" onclick="capturePhoto()" disabled>📷 Tomar foto de verificación</button>
+    <button class="btn btn-s" onclick="go('s-emp-info');stopCam()">Cancelar</button>
+  </div>
+  <div class="cam-actions" id="cam-act2" style="display:none">
+    <button class="btn btn-g" onclick="confirmPhoto()">✓ Confirmar y continuar</button>
+    <button class="btn btn-s" onclick="retakePhoto()">Tomar otra foto</button>
+  </div>
+</div>
+
+<!-- ════════════ EMPLOYEE: DASHBOARD ════════════ -->
+<div id="s-edash" class="scr">
+  <div class="topbar">
+    <div class="tb-logo"></div>
+    <div class="tb-info"><strong id="tb-nombre">—</strong><span id="tb-curp">—</span></div>
+    <div class="tb-badge" id="tb-prog" style="color:var(--green)">0/11</div>
+    <div class="tb-badge" style="color:var(--o);cursor:pointer" onclick="go('s-emp-info')">Salir</div>
+  </div>
+  <div class="prog-bar-wrap">
+    <div class="prog-labels"><span>Progreso</span><span id="pct-label">0%</span></div>
+    <div class="prog-bar"><div class="prog-fill" id="pct-fill" style="width:0%"></div></div>
+  </div>
+  <div class="content">
+    <div class="stat-row">
+      <div class="stat o"><strong id="stat-pend">11</strong><span>Pendientes</span></div>
+      <div class="stat g"><strong id="stat-done">0</strong><span>Completados</span></div>
+      <div class="stat"><strong id="stat-avg">—</strong><span>Promedio</span></div>
+    </div>
+    <div class="card" style="padding:10px 14px;display:flex;align-items:center;gap:8px;font-size:12px;color:var(--muted2)">
+      <span>📷</span><span>Identidad verificada · <strong style="color:var(--green)" id="foto-ts">—</strong></span>
+    </div>
+    <div class="card">
+      <div class="card-hd"><div class="card-icon g" style="font-size:17px">📋</div><div><div class="card-title">Cursos de Seguridad</div><div class="card-sub">SERVICIOS FTS SA DE CV · STPS</div></div></div>
+      <div id="emp-course-list"></div>
+    </div>
+  </div>
+</div>
+
+<!-- ════════════ EMPLOYEE: COURSE ════════════ -->
+<div id="s-course" class="scr">
+  <div class="topbar">
+    <button class="tb-back" onclick="go('s-edash')">‹</button>
+    <div class="tb-info"><strong id="course-tb-title">—</strong><span id="course-tb-sub">—</span></div>
+  </div>
+  <div class="content">
+    <!-- Video -->
+    <div class="card">
+      <div class="card-hd"><div class="card-icon g" style="font-size:17px">🎬</div><div><div class="card-title">Material del Curso</div><div class="card-sub" id="vid-label">—</div></div></div>
+      <div class="card-body" style="padding:12px">
+        <div class="vid-placeholder" id="vid-area">
+          <div style="font-size:40px">🎥</div>
+          <p style="font-size:12px;color:#555;text-align:center;padding:0 16px">Video del curso · Simulado en demo</p>
+          <div class="play-btn" id="play-btn" onclick="startVideo()">
+            <svg width="22" height="22" viewBox="0 0 24 24" fill="white"><path d="M8 5v14l11-7z"/></svg>
+          </div>
+        </div>
+        <div id="vid-progress" style="display:none">
+          <div class="vid-bar"><div class="vid-fill" id="vid-fill"></div></div>
+          <div class="vid-time"><span id="vid-cur">0:00</span><span id="vid-tot">—</span></div>
+        </div>
+        <p style="font-size:11px;color:var(--muted2);text-align:center;margin-top:8px" id="vid-dur">—</p>
+      </div>
+    </div>
+    <!-- Quiz -->
+    <div class="card" id="quiz-card" style="display:none">
+      <div class="card-hd"><div class="card-icon g" style="font-size:17px">✏️</div><div><div class="card-title">Examen</div><div class="card-sub" id="quiz-sub">—</div></div></div>
+      <div class="card-body" id="quiz-body"></div>
+    </div>
+    <!-- Result -->
+    <div class="card" id="result-card" style="display:none">
+      <div class="card-hd"><div class="card-icon g" style="font-size:17px">🏆</div><div><div class="card-title">Resultado</div><div class="card-sub" id="result-sub">—</div></div></div>
+      <div class="card-body">
+        <div class="stat-row" style="margin-bottom:12px">
+          <div class="stat g"><strong id="r-score">—</strong><span>Calificación</span></div>
+          <div class="stat"><strong id="r-correct">—</strong><span>Correctas</span></div>
+          <div class="stat"><strong id="r-time">—</strong><span>Tiempo</span></div>
+        </div>
+        <button class="btn btn-g" id="btn-complete" onclick="completeCourse()">✓ Registrar y continuar</button>
+      </div>
+    </div>
+  </div>
+</div>
+
+<!-- ════════════ EMPLOYEE: DONE ════════════ -->
+<div id="s-emp-done" class="scr">
+  <div class="done-icon">🎓</div>
+  <h1>¡Capacitación<br><span>Completa!</span></h1>
+  <p style="font-size:13px;color:var(--muted2);max-width:280px">Todos los cursos finalizados. Tu instructor validará y generará tus DC-3.</p>
+  <div class="done-card">
+    <div class="done-badge">✓ Sesión verificada</div>
+    <div class="ir"><span class="lbl">Trabajador</span><span class="val" id="dc-nombre">—</span></div>
+    <div class="ir"><span class="lbl">CURP</span><span class="val" id="dc-curp" style="font-size:11px;letter-spacing:.5px">—</span></div>
+    <div class="ir"><span class="lbl">Cursos</span><span class="val" id="dc-cursos">11/11</span></div>
+    <div class="ir"><span class="lbl">Promedio</span><span class="val" id="dc-avg" style="color:var(--green);font-weight:700">—</span></div>
+    <div class="ir"><span class="lbl">Fecha</span><span class="val" id="dc-fecha">—</span></div>
+    <div class="ir" style="border:none"><span class="lbl">Foto ID</span><span class="val" style="color:var(--green);font-size:12px">✓ Registrada</span></div>
+  </div>
+  <button class="btn btn-g" style="max-width:300px;margin-bottom:10px" onclick="generateEmpDC3()">📄 Descargar mis DC-3 (PDF)</button>
+  <button class="btn btn-s" style="max-width:300px" onclick="go('s-home')">Volver al inicio</button>
+</div>
+
+<script>
+// ══ PDF ASSETS ══
+const LOGO_B64  = 'data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wCEAAYGBgYHBgcICAcKCwoLCg8ODAwODxYQERAREBYiFRkVFRkVIh4kHhweJB42KiYmKjY+NDI0PkxERExfWl98fKcBBgYGBgcGBwgIBwoLCgsKDw4MDA4PFhAREBEQFiIVGRUVGRUiHiQeHB4kHjYqJiYqNj40MjQ+TERETF9aX3x8p//CABEIAc4GQAMBIgACEQEDEQH/xAAxAAEAAwEBAQAAAAAAAAAAAAAABAUGAwIBAQEAAwEBAAAAAAAAAAAAAAAAAgMEAQX/2gAMAwEAAhADEAAAAtUAAAAAAAAA410bLfnneML72PVI2zeUdyzr85udm3+d0VuILM4AFbV2VPR6HZxRt7OI7OI7OI7OI7OI7OI7OI7OI7d4UjsdINHmAAAUfBGz+lJRiUlGElGElGElGElGElGElGElGElGElGElGElGElGElGElGElGElGElGF3Y5O6nlshblARJcOM6hGU+jJRhJRhJ+xRKRRKRRKRRKRRK+xBLRBLRBLRBL+wxMQxMQxMQxMQxNQjk1CE1CE1CGm7RZV/nB2ICGoK9EhGV7JKMJKMJKMJKMJKMJKMJKMJKMJKMJKMJKMJKMJKMJXeuOX83J9p0aZEl2ZA7wAAAAAAAiU0Lrariq9YRuAAAAlaLO6K3CFmYACrp7ino9EI3AAAAAAAAJEeQjpBp8oAADORpMbN6gJgAAAAAAAAAAAAAAAAAAXdjk723FPFmVDmQY2UIo9MAAAAAAAAAAAAAAAAAAADRSosq/ywlBD9Z+vR8+FW4HQAAAAAAAAAAAAAAFzTO16xDmX+aHeAAAACHzsmlic6twQ0AAAAAAStFndFbhCzMABV09xT0eiEbgAAAAAAAEiPIR0g0+UAABnI0mNm9QEwAAAAAAAAAAAAAAAAAAANBMymhtwyoU2FKqgFHpgAAAAAAAAAAAAAAAAAAAaOTGk3+W4fc7yz54Kd4OgAAAAAAAAAAAAAAAAdNPlLueWxF2IAAAU0Z9acp9AOWAAAAAAAStFndFbhCzMABV09xT0eiEbgAAAAAAAEiPIR0g0+UAABnI0mNm9QEwBKRirdKuoW4qFuKha/SpWoqlp8drFn84rVl8K5YfHYCd8ISZ8diJXwjJPznY7v8OLqOTr8Obod5vY8evo0HKmn2ZKt6V6/L18Pj6Pj78dAAAAAAAAAAAAAAAAA0fuPS24fvIq2g6AWPaVVQtzlQtxULcVC3FQtxULcVC3FQtxULcVC3FQtxULcVC38lU9+I2g6Amwu3YaYaPLAAFPGfiuKfRDkwAAAAAAAJWizuitwhZmAAq6e4p6PRCNwAAAAAAACRHkI6QafKAAAzkaTGzeoCYC2qbaVNsL/OAAAAAAAAAAAAAAAAAAAAAAAAADgD5S3dNG+sFPoAATr6ivbcHx9TzvPo75eh4exz+dRz89jvJ1HL52EXO6LO1bAhpASos3sL8aPLAAAAAAAAAAAAArqS+oaPQCN4D349OaoafJAEbnY1L9+UekHLAAAAAAAAAJWizuitwhZmAAq6e4p6PRCNwAAAAAAACRHkI6QafKAAAzkaTGzeoCYC2qbaVNsL/OAAAAAAAAAAAAAAAAAAAAAAAAAAAU1zTQvrBT6AAE+9or27zwnQAAAAAABEz1/QU7whoATYU3sL8aPLAAAAAAAAAAAAAg0Oq416c20iNubaQZv3ofrncXYgPmam1lO4IaQAAAAAAAAAJWiz2htwBZnAAq6e3qKPRCNwAAAAAAACRHkI6QafKAAAzkaTGzeoCYC2qbaVNsL/OAAAAAAAAAAAAAAAAAAAAAAAAAAAU1zTQvrBT6AAE+9or27zwnQAAAAAABAoruko9AI3gJsKb2F+NHlgAAAAAAAAAAAAAAAAAI8jPxthij0gAAAAAAABMRh9buZZmqJ0lPOEqwAAPnPq52P5lOSh87A7VwNHTxuqxVtAAAAASI8hHSDT5QAAGcjSY2b1ATAW1TbSpthf5wAAAAAAAAAAAAAAAAAAAAAAAAAACmuaaF9YKfQAAn3tFe3eeE6AAAAAAAK2luKej0AjeAmwpvYX40eWAAAAAAAAAAAAAAAAABGzk6DR6ARvAAAAAAH1z5KsLKzLHkFmQO8AAAAAAAAVNtWQtphT6QAAAACRHkI6QafKAAAzkaTGzeoCYC2qbaVNsL/OAAAAAAAAAAAAAAAAAAAAAAAAAAAU1zTQvrBT6AAE+9or27zwnQAAAAAABV09vUUeiEbgE2FI7DSDR5YAAAAAAAAAAAAAAAADn0rYzpRR6gAAAAAA6OL/13uwBOgAAAAAAAAABXWMGNlCKPTAAAAASI8hHSDT5QAAGcjSY2b1ATAdeRyYhuxmIYmIYmIYmIYmIYmIYmIYmIYmIYmIYmIYmSKuX2GhF/nAAAAAAAAAAAAAAKa5poX1gp9AACfe0V7d54ToAAAAAAAraXRZ2neENAAHfrDdhMQxMQxMQxMQxMQxMQxMQxMQxMQxMQxMQxMQxNQjk7tVnNDLycmdGjR5FmUO8Z3Q5SvUFW0AAAAAD7oYdtbhCzMAAAAAAAAAAAiS/PJZVeqdtEvRRL0US9FEvRRL0UUi1995MF2EAADORpMbN6gJgAAAAAAAAAAAAAJcSX2GhGjywAAAAAAAAAAAAAFNc00L6wU+gABPvaK9u88J0AAAAAAAfMxqK+F9GKfQAAAAAAAAAAAAAAAAAAXdI7XrESXf5sPP21TTvCN4AAAADryuO12f00eYAAAAAAAAAAAAAAAAAAAAAAABnI0mNm9QEwAAAAAAAAAAAAAEuJL7DQjR5YAAAAAAAAAAAAACmuaaF9YKfQAAn3tFe3eeE6AAAAAAAAKCFq6CndDENIAAAAAAAAAAAAAAAAAHXTZS8nlhQJEeN4cmAAAAA1Gd01mMLcgAAAAAAAAAAAAAAAAAAAAAAAGcjSY2b1ATAEtGIt0q6hbioW4qFuKhbioW4qFuKhbioW4qFuKhbioW4qJczr2NgLsAAAAAAAAAAAAAACmuaaF9YKfQAAn3tFe3eeE6AAAAAAAAAK+o06F+TaKPDRSrdyVQtxULYVK2FSthUrYVK2FSthUrYVK3FQtxULcVC2FStvhVOnONoOgJsLt2Hzl688kDoAAAAE+9prm7zwnQAAAAAAAAAAAAAAAAAAAAAAABnI0mNm9QEwFtU20qbYX+cAAAAAAAAAAAAAAAAAAAAAAAAAAAprmmhfWCn0AAJ97RXt3nhOgAAAAAAAAAAAAAAAAAAAAAAAACupL6ho9AI3gOnP255+evIDoAAAAFtbU9xd5wTpAAAAAAAAAAAAETnZbKK9WrZQatlBq2UGrZQatlBq2Un9jeCzMAABnI0mNm9QEwFtU20qbYX+cAAAAAAAAAAAAAAAAAAAAAAAAAAAprmmhfWCn0AAJ97RXt3nhOgAAAAAAAAAAAAAAAAAAAAAAAACDQ31DRvCOgB78enPXORHcBIAAAACwvM7orcAWZwAAAAAAAAAAAFTbZ2F8UU+gAAAAAmQ5fYaEaPLAAAzkaTGzeoCYC2qbaVNsL/OAAAAAAAAAAAAAAAAAAAAAAAAAAAU1zTQvrBT6AAE+9or27zwnQAAAAAAAAAAAAAAAAAAAAAAAABBob6ho3hHQA9efTkuFaVfaw5aAAAAB91WUv55ZouxAAAAAAAAAAAAc8vc01O4IaQAAAAEyHYdrvBo8wAADORpMbN6gJgLaptpU2wv84AAAAAAAAAAAAAAAAAAAAAAAAAABTXNNC+sFPoAAT72ivbvPCdAAAAAAAEaL5qKtlypkbLlTC57UE3sb8XYQAAAAAAAAAAAAINDfUNG8I6AHrz7cuqLU5aecIaQAAAAEyGR1iPI0eWHeAAAAAAAAAACByVRxM/qA6AAAAAtaq9lRPF/ngAAZyNJjZvUBMBbVNtKm2F/nAAAAAAAAAAAAAAAAAAAAAAAAAAAKa5poX1gp9AACfe0V7d54ToAAAAAAAqam3qKPRCNwCbCkdhpBo8sAAAAAAAAAAAACDQ29RR6ARvAe/HRzUZnTU1uGsFW8AAAAACTo8nazy24uxAAAAAAAAAAfMzOrKdwQ0gAAAAANPntNZjC3IAABnI0mNm9QEwFtU20qbYX+cAAAAAAAAAAAAAAAAAAAAAAAAAAAprmmhfWCn0AAJ97RXt3nhOgAAAAAACupNHnKd4Q0AAd+sN2Ez7CE1COTUITUITUITUITUITUITUITUITUITUITPkQ6HJgAO3Gf2F7HkL/Mybvwz+qDoAAAAAF5YZO7txWIsygAAAAAAAIH2ir0/BVuAAAAAAAtLjh3v8wJVgAAZyNJjZvUBMBbVNtKm2F/nAAAAAAAAAAAAAAAAAAAAAAAAAAAKa5poX1gp9AACfe0V7d54ToAAAAAAAZfUV0L6QU+gAAAAAAAAAAAAAAAAAAAvqrR2ZAtx11Jq8xTt5iGoAAAAAACxusp1nm06vsLcYdiAAAAI3OyauDFr1hXrAAAAAAAS4milTKF/nAAAAZyNJjZvUBMBbVNtKm2F/nAAAAAAAAAAAAAAAAAAAAAAAAAAAKa5poX1gp9AACfe0V7d54ToAAAAAAAAz8PV56ndFENIAAAAAAAAAAAAAAAAD0v5Vdupd5wd4rbJyWTd+Gf1AdAAAAAAAdOZy2nZtKnV/cn1lTp2b+95o2Z5O6WHSo2SopC8EgAAAAAAB9cl6Dh3v84JVAAAAZyNc8qPQq1oSq1oKu28zO1TBdiAAAAAAAAAAAAAAAAAAAAAAAAAAAU1zwjZmmg8166FfChXwgXsaTZlCVQAAAAAAAAFZU6n5Xoyi/jw0VC1O1S1FUtfjtWtBVrQVa0FWtBVrQVa0FWtBVrQVa0FWtTlUtRVLbq5SWFv1nTy6k8odAARs5rKevVViraAAAAAAAAAAAAAAAAAAAAAAt4WisyhbiAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAzkbUZuj0OYjeAAAAAAAAAAAAAAAAAAAA6+NHKn30LvODoAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABw7udy3jSZ6n0PAjcAAAAAAAAAAAAAAAAAA9fdBKr5KLvODvAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHHs53L89RQU74wjeAAAAAAAAAAAAAAAA7d72efn2LcId4AAAAAAAR/nJSUb2djij2cO7ojkhz6OHjglKHYjlx1R5Dod4AI/OyEZyUlG7d57IrkpGclJc+nYB0QuUbLJDmdgIxJePbgiuynz64cCXcdieOPOyR3g58dFf95ZPfPvax86+osrnQ7wAh8o2WLh37AO8Hw+oPiNli5dewEUlOfRw5c0pI7EARudkq2VyUg5dh1RZTojEly6uHKHydihzOxEUlIzkpKNJ7E8cHZSM52S+fZQOXPkpI7E4+eSkDsT5A5KwV88+jsQAAAAKer1kavVnHfhVsB0AAAAAAAAAAAAT0YVzM624gszgAAAAAAAAZzl1n0ejAmW6zKp7inc431DfJM7os7xNtaq17CBTXNNDTqBdhVVrVQuh6HPaHkgszgKO8RnmOd5T1b+lxLWY2T1mTjb39XUkgzizN4zsyJVr8y7r7KrN3kh2LNaXNcnZ2VbZSrZPWZOF2kkR5FmalrbKFT6F3My2msyRqK9ooX6k+XYYNH9tad8LzpEqctoauPG3SC3Fk9NmdNVs7C7F8zsyBVt8yL712vKWVlmo3axEl24eeclcqtvPvfpVZW7ldHPtFe+ZV5/RZWfXpjSIWmd9i7CBCoraup3y42h9So+c+qdGUveFfVuus9KkuWPvrGsyZ6dA0teyiveyeVnNG6yyb7q2RdF9W4oef0FBXrkNGlTz6E81RVTeFPpaHrVT7cNFy+8qfQ1j59v8vOfY9xT6MKbZLMgTpAAAAAAV1i5LL89ZX1a6NIjw0g6AAAAAAAAerDsK2Zc955o0ksyh3gAAAAAAAAAGcjSZ1Ho1E+9ToU9xUdr4X2f0HJM7os27Ptaq17XAprmmhp1Auwqq1qoXQ9DntDyQWZwAIFPcU9O7Ti7CyesydWs0Urkq6xLcmdl8FW2+F2ABmtLmq9PH7a2cbcv51GX5PSSI8i7BS/fnqrXw8aLMO3NJ248nqY0nndgy+oy+iq1yhdiiZ65qad+o+luHJ6bM6arZ2F2LOy+Xinffi7AzWky1eq1ta+wlVmbOD2r1XdfYV1mTl9jRK9epF2CtpdPmKd13Y+fVmQJQA80GhRsyttIoK9erRZVuFmtLTQvg6WkvXQszUtdq+NeqquszZc7ai3JR+/Hundci7DDz+goKd/xrHYc+j5ZkzVnTaarbQ2FZ95ObX39N2F3IgzrMkGj1XzluevKflC3Ri7EAAAAAAAA4d3O1MHSI3ZNq40Ls6uuHLKxL4Rs5np3yld+xrlz37Xn+uj6SqpJ01OkJVAAAAAAAAAAAAAZyw8yatkwW40Gc5LKW/2qp3WVT1tTvLLsECk0VZXskeovty4qrWHOils46vVNnVdpZlCVQECnv6+rZcC3GyespK9X3vHRstO8WVbjj5zV8YXVkqvhxvsbSqupUfc1pak6WUSXKtk9ZSRus5HLrPPS+pHqvTOjyFmXKeruJTvuRf59LB1FdVr8+K73yzhcdpsqQnmydp4U+jIsKe4nm55zVce8qZcKHXokeJ1pKP30W4ome1kWvRB718eN/WZ0tO1Bbl55fV0tWu59FmUO8AhRbOkr1WFH6toWyZRdhU1zAjZBva2ydcuqVVJOhV9W3pY87jsPotyUfuR6q2Txbjh5/S1dWzv9juduefvnZlzWrqLiN1PA0MXkrCjvIMquFrXWLlFP51ENEzl9vD//xAAC/9oADAMBAAIAAwAAACEAAAAAAAAAYpPCOsAAAIMMMMMMMMNcAAAAMEEEEEEEEEEEEEEEEEEEMABMEEEEEEEGAAAAAAAADHHHEkAAcEEEEEEEEEEEEFHOUkAAAAAAAAbEAAAACoAAAAAAAAAAAABYAAAAMAAAAAAAAAAAAAAAAAAAAAAIAAAAAAAAAAAAAAAAAAAACoBqEAAAAAAAAAAAAAAABEkAAAAAfgAAAAAACoAAAAAAAAAAAABYAAAAMAAAAAAAAAAAAAAAAAAABAIIAAAAAAAAAAAAAAAAAAAACogEAAAAAAAAAAAAAAAAACMAAAALEAAAAAAACoAAAAAAAAAAAABYAAAAMAAcEEEkEQIMIEAUIY8cIAIckUEAAAAAAAAAAAAAAAAADEAAAAEEEEEEEEEEEEUkABEAAAIEAAAAAAAACoAAAAAAAAAAAABYAAAAMABUAAAAAAAAAAAAAAAAAAAAAAAAAAMNEAAArNKJPFABAkABAAAAAAAAAAAAAAAIAAQAAIMAAAAAAAAACoAAAAAAAAAAAABYAAAAMABUAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAACkAAAAAAACAAAAAAAAAAAAAAAAAAkIIMAAoAAAAAAAAAACsAAAgAAAAAAAABYAAAAMABUAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAACkAAAAAAAAoAAAAAAAAAAAAAAAAAAAAABSAAAAAAAAAZlAAAACMJKEAAAAABYAAAAMABUAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAACkAAAAAAAAsAAAAAAAAAAAAAAAAAAAAAAsAAAAAAAUEIAAAAAAAABcAAAAABYAAAAMABUAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAACkAAAAAAAAgAAUAAAAAAAAAAAAAAAAABKAAAAAAAFgAAAAAAAAAABAAAAAABYAAAAMABAAAAAAAAAAAAAEAAAAAAAAAAAAAAAAAACkAAAAAAAAkAACEAAAAAAAAAAAAGOMIB0AAAAAABkAAAAAAAAAAAAQ888889kAAAAMAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAACkAAAAAAADUAAAAAAAAAAAAAAAAAADcMoAAAAAAKAAAAAAAAAAAAAAAAAAAAAAAAAMAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAACkAAAAAAAAA4AAAAAAAAAAAAAAAAAADKgAAAAABoAAAAAAAAAAAAAAAAAAAAAAAAAMAAMwwwwwwwwwwwwwAAAAAAAAAAAAAAAAAACkAAAAAAAAABAEww000000kwww0kEAAEoAAAAAAgAAAAAAAAAAAAAAAAAAAAAAAAAMABUAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAACkAAAAAAAAAAAAAAAAAAAAAAAAACIAAAEAAAAAAoAAAAAAAAAAAAAEIIIIIIEAAAAMABUAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAACkAAAAAAAAAAAAAAAAAAAAAAAAAAMAACMAAAAAAIAAAAAAAAAAAAAEAAAAAAQAAAAMABUAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAACkAAAAAAAAAAAAAAAAAAAAAAAAAAMAAEsAAAAABMAAAAAAAAAAAADEAAAAABMAAAAMABUAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAACkAAAAAAABHPOEAAAAAAAAAAAAAAMAAAIAAAAABMIAAAAAAAAAAAAAAAAAABcAAAAMABUAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAACkAAAAAAACkAAEAAAAAAAAAAAAAAMAAAYAAAAAAAcAAAAAAAAAABIAAAAAAAsAAAAMABUAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAACkAAAAAAAAgAACEAEEEEEEEEEEECAABQIoAAAAAACgAAAAAAAAAkAAAAAAACoAAAAMABUAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAACkAAAAAAAAEAAAAAAAAAAAAAAAAAAABACsAAAAAAABEgAAAAAIGAAAAAAABAAAAAAMABUAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAACkAAAAAAAAA0AAAAAAAAAAAAAAAAAAgIAEoAAAAAAABEK8g3EMAAAAAAAAGgAAAAAoABcAAAAAAAAAAAAAAAAAAAAAAAAAAAAEQ02AAAAAAAAAABYYEEAAAAAAAAAAEEuiMAACAAAAAAAAAAAAAAAAAAAAAAAAgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAC4AAAAAAAAAAAAAAAAAAAAAiMAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAIkAAAAAAAAAAAAAAAAAAACIAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAK4AAAAAAAAAAAAAAAAAgIAAAAAAAAEEcoIMgAMoAAIIAMIsAwkYMcIgAkAMQoQkAAooAQgIMMgAAY8MsMMIkEIEwIgwAQAwkAAAAACAoAAAAAAAAAAAAAYsAAAAAAAAABTFehcP0AIMABOAIFKBLsJUAEESmoT0L0JcBiG0vYKMG/oACAPLTVMVNBHERCMA10OIMAAAAAABGIoAAAAAAAAAhqIAAAAAAAAAAAVBOpYP0AIMAACkAEMEUABXGEFeahBMAQJcCEB0CUWQCGIABGksNACDsCsAQAY6n6JQcAAAAAAAAALGoksUwYsEAAAAAAAAAAAAAAUAA88HR0A2gACQAS4EI0tIAQBtI8AY3EM56WsSBcFMCYIAABMMcsJFsCgB07bDsIv8v/xAAC/9oADAMBAAIAAwAAABDzzzzzzzzzjmGEFbzzwoIIIIIIIIIDzzzzvHHHHHHHHHHHHHHHHHHHPzz7HHGAAAACEEEFPLLLIMMMNXzznHHHHHHHHHHHHHHATfzzzzzzzyyEAAAABTzzysAAAAAAAAALzzzysAAAAAAAAAAAAAAAAAABB3zwAAAAAAAAAAAAAAAAAAAAB/zsEAAAAAAAAAAAAAAADffzzzzzxGAAAAAABTzzysAAAAAAAAALzzzysAAAAAAAAAAAAAAAAAAABBigAAAAAAAAAAAAAAAAAAAABbaIAAAAAAAAAAAAAAAAADLzzzzsMAAAAAAABTzzysAAAAAAAAALzzzysAAUIIIo0wcck8EgIsgEAMBUoYEAAAAAAAAAAAAAAAAAAYMAQgIIIIIIIIIIIIIoABTzzzuEAAAAAAAABTzzysAAAAAAAAALzzzysABbzzzzzzzzzzzzzzzzzzzzzzzzz27+wAADf862x9444oABLzzzzzzzzzzzzzyoABfzz2AAAAAAAAAABTzzysAAAAAAAAALzzzysABbzzzzzzzzzzzzzzzzzzzzzzzzzzzz4AABXzzzzzzzwkAALzzzzzzzzzzzzzyc01nzwEAAAAAAAAAAB3zzysAAAAAAAAALzzzysABbzzzzzzzzzzzzzzzzzzzzzzzzzzzz4AABXzzzzzzzwMAALzzzzzzzzzzzzzzzzzzykAAAAAAAAAcI/wA888s+csAAAAAAC8888rAAW8888888888888888888888888888+AAAV88888888BAAC8888888888888888888IAAAAAAABV98888888887AAAAAAC8888rAAW8888888888888888888888888888+AAAV88888888LAAA888888888888888888+gAAAAAACn88888888888vAAAAAAC8888rAATCCCCCCCCCCCCB888888888888888+AAAV88888888oAAAgCCCCCCCCCCCSzz198kAAAAAAAf888888888888qDDDDDDC8888rAAAAAAAAAAAAAAAB888888888888888+AAAV888888884AAAAAAAAAAAAAAAAAAAQ8iAAAAAAB9888888888888888888888888rAAAAAAAAAAAAAAAB888888888888888+AAAV888888888JAAAAAAAAAAAAAAAAAAAnKAAAAAAt8888888888888888888888888rAAFDDDDDDDDDDDDB888888888888888+AAAV8888888888NALDGOOOOOODDDOMKAABoAAAAAAf8888888888888888888888888rAAW8888888888888888888888888888+AAAV88888888888888888888888888KAAGqAAAAAAV8888888888888+NNNNNNa8888rAAW8888888888888888888888888888+AAAV88888888888888888888888888rAAHCAAAAAAX88888888888884AAAAAAS8888rAAW8888888888888888888888888888+AAAV88888888888888888888888888rAAWrAAAAAAC8888888888888iAAAAAAQ8888rAAW8888888888888888888888888888+AAAV888888885xxy88888888888888rAAXhAAAAAAG188888888888+jAAAAAAU8888rAAW8888888888888888888888888888+AAAV88888888iAAA88888888888888oAASrAAAAAAAm88888888888JAAAAAAAU8888rAAW8888888888888888888888888888+AAAV88888888pAAAASzzzzzzzzzzzhgAAX9AAAAAAAQ1888888888iAAAAAAAA88888rAAW8888888888888888888888888888+AAAV88888888NAAAAAAAAAAAAAAAAAAAAf8GAAAAAAAAj18888855AAAAAAAAT88888rAAW8888888888888888888888888888+AAAV888888888LAAAAAAAAAAAAAAAAAAJ888AAAAAAAAASC/78zhAAAAAAAAF888888lMMZ8888888888888888888888888888+JMMV888888888tOLNNEMMMMMMMMMNNBM/888ZAAAAAAAAAAAAAAAAAAAAAAAI888888888888888888888888888888888888888888888888888888888888888888888888888tqAAAAAAAAAAAAAAAAAAAAAP8AvPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPAQAAAAAAAAAAAAAAAAAACHfPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPPLLgAAAAAAAAAAAAAAAAHHvPPPPPPPOdO9Pf9vP9fPOfuvMtue+/d+P+vP8Az7ff3vzzTXz3fbD/AD0859/04/73zyy6y1y8681488888tZIAAAAAAAAAAAAAC+c8888888887do8p/+8+988to9DG2Hlt+9/wDcMaeRLY/AfMD9fGpWensPPErvGn+kRjOXUr3yPhOsPPPPPPPPLJyAAAAAAAAABfnfPPPPPPPPPPLWKN7P/vPvfPPAvAznLPPPl7fUVA/m/FYQfGPIPPKpfK3vPP1NGl7PPPFPAjmJMuV/KfPPPPPPPPLHBzSBRQhPHfPPPPPPPPPPPPKvP3GH6IOAFPPA/CMFepPvv/NQLYfPzV/wFqL1fWec/A/fPCI/P3KS7PE/EY3h6aztg//EADgRAAECAgQLCAICAwEBAAAAAAECAwAEERNTkRASFCAhMDEzUnGhMjRAQVFygbEighVhBUJiYEP/2gAIAQIBAT8A1Lkwy3tUKfQQuf4EXwqcfP8AsByEF507XFXxjq4jEiSWlUn/AGzJtahMLAUfL6isXxm+KxfGb4rF8ZvisXxm+KxfGb4rF8ZvisXxm+KxfGb4rF8Zvhta6xH5HtDNcccDi/zV2j5xWu2ir4rXbRV8Vrtoq+K120VfFa7aKvitdtFXxWu2ir4rXbRV8Vrtoq+K120VfFa7aKvitdtFXxWu2ir4rXbRV8Vrtoq+K120VfFa7aKvitdtFXxWu2ir4lZqmhDh0+RwvkhlwjhitdtFXxWu2ir4rXbRV8Vrtoq+K120VfFa7aKvitdtFXxWu2ir4rnbRV5iudtFXmK520VeYrnbRV5iuetF3mK561XeYrnrVd5iuetV3mK560XeYr3rRV8V71oq+K960VfFe9aKvhkktNk8IwzU1ifgjtfUVrtoq+K120VfFa7aKvitdtFXxWu2ir4rXbRV8Vrtoq+K120VfFa7aKvitdtFXxWu2ir4rXbRV8Vrtoq+K120VfAfeGxxUNTyhocFP9iELQtNKTSNS9NNt6O0fQQ7NOuedA9BnSG6V7syc7wv4+tU1vEe4Zru9c9x8LKTWNQhZ0+RwTG4c9vhmNy37RgmpmrGIntfXgmXlNLpHyIQtK0BSdhzlrShJUo0CH5xa6QnQnUSG6V7syc7wv4+tU1vEe4Zru9c9x8NKzOOAhZ/LyPrExuHPb4Znct+0RMzIaGKntHpBJJJPg5F2hZQdh2ZrzyGk0n4EOvLdVSo8hqZDdK92ZOd4X8fWqa3iPcM13eue44UIUtQSkUkxkkxwdRGSTHB1EZJMcHURkkxwdRGSzFnGSzFmYyV+zMZM/ZmMnfs1RUPWaroqXrNdxiqds1XRVOcCroq3OBV0Yi+E3RiL4TGKrhMYqvQwAoeRgTBWwtCwcbFvig+kUH08IuYqmGgO0UCCSSSTSThEq+QCERkkxwdRGSTHB1EZJMcHURkkxwdRGSTHB1EZJMcHURkkxwdRGSTHB1EZJMcHURkkxwdRGSTHB1EZJMcHURkkxwdRBBBIIwtKxXUH/oZjzqWkYx+BDjinFFSjqpDdK92ZOd4X8fWqa3iPcM13eue44ZTvCPnxVAigRQPSJ0CoOjzGZIgVP7GMUegjFT6CMRHCIxEcIuirb4E3RVt8Cboq2+BN0VbfAm6J+gOoA4MLO+b9w187vzyGFPaHPCtSUJKlHQIeeU6sqPwNXIbpXuzJzvC/j61TW8R7hmu71z3HDKd4R8+NndweYzJHcfsdTPb/wDUYWN837xr5iVcdcxklNFEZA9xIjIHuJECQeBBxkYZx/HViA6B96yQ3SvdmTneF/H1qmt4j3DNd3rnuOGU7wj58bO7g8xmSO4/Y6md355DCxvm/ePCTLtU0SNp0DVIQtZoSkmG5AnStVH9CESzKNiBzOnNKEHakGKlmzTdBl2LMRNS7SGipKKDSM9reI9wzXd657jhlO8I+fGzu4PMZkjuP2OpnO8L+MLG+b948JNu47pA2J0DUsSRNCnNA9IShKBQkADVTfd1/Ge1vEe4Zru9c9xwyneEfPjZ3cHmMyR3H7HUzneF/H1hZIDrZPEPBvLq2lK9BqACSABEtKhsBStKvrWTIpYc5Z7W8R7hmu71z3HCFFJpBIMVz1qu8xXPWq7zFc9arvMVz1qu8xXPWq7zFc9arvMVz1qu8xXPWq7zFc9arvMVz1qu8xXPWq7zFc9arvMNPOl1sFxVBUPPwE7uDzGZI7j9jqZ1ND9PqBmB10CgOKviuetV3mK561XeYrnrVd5iuetV3mK561XeYrnrVd5iuetV3mK561XeYrnrVd5iuetV3mK561XeYrnrVd5ivetFXwJl8f8A0MNT52OD5EJWlYpSaRgn1/ihHqadRJsYqaxQ0nZrXUlTa0jzBjIn/QXxkT/oL4yJ/wBBfGRP+gvjIn/QXxkT/oL4RJvBaSQNBHnmu71z3HwDO+b948BO7g8xmSO4/Y6mcax28YbU+EZeW0qkbPMQhaVpCk7DE6ql8j0AGew3WOpT5efind657j4BnfN+8eAndweYzJHcfsdVNSpQStA/H68JIu0LLZ2HZD5pecP/AEc+QR21/Hind657jhQhS1BKRSTGSTHB1EZJMcHURkkxwdRGSTHB1EZJMcHURkkxwdRGSTHB1EZJMcHURkkxwdRGSTHB1EZJMcHURkkxwdRDUq+lxBKNAUDtHgJ3cHmMyR3H7HVuyba9KfxMKkXxsoMZJMcHURkkxwdRGSTHB1EZJMcHURkkxwdRGSTHB1EZJMcHURkkxwdRGSTHB1EZJMcHURkkxwdRGSTHB1EZJMcHURkkxwdRBBBIIoOFo4rqD6KEKNKlc8+SFDA/snxTu9c9xwyneEfPjZ3cHmMyR3H7Hxc7vzyGFPaHODtOfJ93R865asRClegj+QFn1j+QFn1j+QFn1j+QFn1j+QFn1j+QFn1hueC1pTV0Un1zXd657jhlO8I+fGzu4PMZkjuP2Pi53fnkMKdohwULWP7OfImlkj0Vrp1eKzRxHPY3zfuGa7vXPccMp3hHz42d3B5jMkdx+x8XO788hhG0RMpxX3B/dN+fILoWpHqPrXTzmM6E8Iz5cUvN+4Zru9c9xwyneEfPjZ3cHmMyR3H7HUzEy8h5SUq0CMsmOPoIyyY4+ghqafU4gFWgqA2a+d355DCnaInk0OhXqM9CyhaVDyMIUFpChsI1jiw2hSj5CFEqUSdpOfJppfT/AECc13eue44ZTvCPnxs7uDzGZI7j9jqZvvC/j6wtEB1snYFDXzhBfNB2AYU9oc4nkYzQVwnUSb+KatR0HZrJx/HViJ2D71Egjtr+M13eue44ZTvCPnxs7uDzGZI7j9jqZ5ND1PqBmB10CgOKA5xXvWi74r3rRV8V71oq+K960VfFe9aKvivetFXxXvWir4r3rRV8V71oq+K960VfFe9aKvivetFXxXPWi7zmMpxnUD/oQtIWlST5iFJKVFJ2g6iVmgaELOnyOqmprFBQg6fM+mpl26tpKfPac13eue44ZTvCPnxs7uDzGZI7j9jqZ1rHbxhtT9eFkWtJcPIYJ5qhYWNh26licUihK9KeohDrbgpSoHOUtKBSogCH50mlLegeuplWqx0eg0nOd3rnuOGU7wj58bO7g8xmSO4/Y6qaliglaR+P14NiXU6r0T5mEpCUhIFAGB1sONqSYUkpUUnaNSCQaQSDCJ15O0hXOB/kB5t3GMvb4FQf8gnybMLnnjsATClrWaVKJ1UszVNgHadJznJZ8uLIQaCoxksxZmMlmLMxLS7yHkKUggDxsw2pxopTtpEZC/8A83xkL/8AzfGQv/8AN8SzSmm8VW2nVuyTa9KfxPSFST42AHkYySYs4ySYs4yWYszGSzFmYyWYszGSzFmYyWYszGSzFmYyWYszGSzFmYyWYszGSzFmYySYs4ySYs4EnMH/AFo+YakUjSs0/wBCAAAABQMydYpFYnaNviJJik1ihoGz/wAbNS9Uqkdk9PDS0uXVaeyNsAAAAbB/41SUqSUkUgxMS6mleqTsPhGJdTyvRI2mEIShISkUAf8Aj1JSpJChSDExKqa0p0p+vBS8opyhS9CfuEpCQABQBqS80DQXE3wHWiQA4knnClJSKVEAQlSVClJBH9QpaUilSgOcJUFCkEEQXG0mgrSD6U4CoJFJIAhK0qFKVA8sKlpSKVKA5xXs2iL4S42o0JWkn+jCloRRjKA5mK9m0RfAIUKQaRgMywDQXBCHEL7KgYUtCe0oDnAIUKQQRCloRRjKA5mAQRSIrWwrFx00+lOBTjaTQVpB9CcBIApJAEZSxTRWCAQRSMCXG1GhKweRwmYYBoLghKkqFKSCMJmWAaKwQlSVCkEEQpaE9pQHMwCFCkGkQp1tJoK0g+hOFS0oFKiAIS+yo0BYpgqCRSSAIStCuyoHkYUtCe0oDnCVJUKUkEQt5pBoUsAwhxCxSlQMKcQntKA5mK9m0RfCVoV2VA8jCnG0mhS0g/2Yr2bRF+AutpNBWkH0JwVrYVilaafSnAt1tHaUBCHW3OyoHPfkgaVN6D6QpKkmhQoOuQ2tw0JFMMSaUUFek9NWlsOTKkE0AqVCJNtC0qClUgxOd3VzESO4/YxP7pPuiT7uj5+4mu9D4wTnd1/H3EhuVe7C8yl5IBJFBh5lLbwQCaNENSqGl4wUY/yG1r5huSaUhCipWlIMNoCEBIOgRNOrcdqkbKaOZhEi0B+RJMMywacKknQU0UGJ/do90Svd24/yG1v5hndN+0Q+CZhwD1iUmKxOKo/kOsTneE8hBNAglyaeoBoT9CMgbo0KVTDS1y72Io6KdMK7J5RIb1XtwTTy1uVSPWjmYTIIxfyUaf6haHJVwFJ0GELC0JUPMRMOLeeqk7AaITIN0aVKJhmWcadJC/x+4mGQ62R5jZEq/VpWhflSREs2XnS4vYDT84Zo40ziqNCRRBkmTilJNH3BSCkpOwiEUy0xQeyfqHSqZmAkbBohQq2VBH+qTREq206pVYdPkIZlkNLUoE6Yel0PEFRIogMpymqpNGNRDMuhkqxSTTE9vx7RGQNcaoSKAB6CH6VvOn0P1ohl0KYSs+Q0/EEqKqz1VFNIhoJdfNadsIlG0OBYJ5ahxptwUKTTDsisaWzSPSFJUk0KBB1SGnHOykmGpAbXD8CEoSgUJAA1gbrZhSKaKVKhuSKFpVWU0H0ic7urmIkdyfcYn90n3RJ93R8/cTXeh8YJzu6/j7iQ3KvdmTfeh8YP8hta+YRIlSEqrNoB2Q0irbSimmiEfhOnG4z1wz+7R7oalFuNpUF0AxMMKaxaVU0wzum/aIHf/wBomGlMOBxGym6H3A64hQ9BDgJbWBtKTEgQHFA7SME4Qp8BPoBB7B5RIb1XtwD8J38uM9cE+oYqE+dNMSoIl26YZOJOflxERMV2IKrtUwp+bSsJUqg8hgnkBLoI8xSYZQENIA9ML0uh4adB9YIflVDTSDcYQsLQlQ8xE8hJaCvMGJBADaleZNGB6SBJU2aD6RKvuByqcwDv374J7fj2iP482nSAMVIHoIlE1jj1Pmk9YDhQy60duND7WJLM89PzDBxmWz/yIfk0uEqSaFQ066w6G17KaNUpKVChQBELkmVbKUwqQcHZWDCpV9O1PUQUKG0YEsuK2JhMk+doA5mEyHEu6ESrCP8AWnnr2WlibKiNFKsDiA4hST5xRMSyjQYofmVCkw2gIQlI8hE024X8ZI8hCXJ3GFJ+omklTCwNuiG8qbFCNA+IllOqQS5tpwzLS1TAIGjRgnm1rLeKPWErnEgAbAKBshkrLaSvtecTMrW/kntfcZRMt/iTfErXqWVuHRRQInUKWhISPOJZJSwgGJ5tay3ij1hoENIB4RAbXlmNRoxoUkLSUkaDCpZxDlAFIp24H5RQVWNH+6IymZP4Y2mJaUKVBbm3yEK7J5Q2mYbJKBQfiJZcwpZrNlH9RMytb+SdCvuK+Za/AmGpZx1WO6dH3gmZUuHHR2vMesZTMo/EmJeXWpda6f7GCdbWtaCkeUI0ITyGGYMw25WJP40RS/NKA0UCEJCEJSPIRNpUpkgDTSIk0qS1QR/tCgopOKaDRoivmWfwNHzpiVYWXK1eANryzGo0Y2CcacU9SkeQitnfX6hRVUn1xIkm1ICyobaIdlyqaBA/EkExNoK2aANIIiVCgyARQQTC3ZlhaqSDSYaadfdDi9lMf//EAEcRAAECBAAGDQkHBAMBAQEAAAECAwAEBREGEhUxVJIQExQgITA0NUFRcXOxIkBSYXKRorLBFiMyQlOBgmOh0eEzYGI2g9L/2gAIAQMBAT8A4mWpc9M2LbBxfSVwCGMFznfmP2QPqYaoFMbztFZ61KMIkJFA8mVaH8RAYZGZpGqIwlSlM61ipA+5Hid5RGGVUuXKmkE+XwkD0jG5pf8ARb1RG5pf9FvVEbml/wBFvVEbml/0W9URuaX/AEW9URuaX/Rb1RG5pf8ARb1RG5pf9FvVEbml/wBFvVETcuwJWYIZRfalflHVvZSUlDKS5Mu0SWkXJQOqNxyejNagjccnozWoI3HJ6M1qCNxyejNagjccnozWoI3HJ6M1qCNxyejNagjccnozWoI3HJ6M1qCNxyejNagjccnozWoI3HJ6M1qCNxyejNagjccnozWoI3HJ6M1qCNxyejNagjccnozWoI3HJ6M1qCNxyejNagis0TExpiWT5OdaB0esbNNSlU/KpUAQXBcGNxyejNagjccnozWoI3HJ6M1qCNxSeis6gjcMlorOoI3DJaKzqCNwyWis6gjcMlorOoI3BI6IzqCNwSOiM6gjcEjojOoI3BI6IzqCMnyGiMaiYyfIaGxqJjJ8hobGomMnyGhsaiYyfIaGxqJjJtP0RnUEZNp+iM6gjJtP0RnUEZNp+iM6gifQlE9NJSAEh1QAGYC+zRqMZkh98ENflT6f+o3FJ6M1qCNxyejNagjccnozWoI3HJ6M1qCNxyejNagjccnozWoI3HJ6M1qCNxyejNagjccnozWoI3HJ6M1qCNxyejNagjccnozWoI3HJ6M1qCNxSejM6ghymU9wWVKtfsm3hE5g02oFUq5in0FcIiYln5dwtvIKVDiZGiTc3ZRG1t+kr6CJOjSMrYhvHX6a+HfYT8uZ7keJ3lC5qlv5/MeKnOSTHdL8N7Jcjlu6R4ea1ujbXjTMunyM60Do9Y2KVzjKd4PNqjzhN98vx2KLRzNKD7wsyDwD0z/iAAAABYDzGekWZ1ktuDh/KrpSYmZdyWeWy4LKSd8xLvTDobaQVKMU2gsS2K49Zx34U8RhPy5nuR4neULmqW/n8x4qc5JMd0vw3slyOW7pHh5tWqOZcmYYT90T5SfQ/wBRSecpXvB5tUOXzffL8Yo9IVOLDroIZSdY9QhKUoSEpAAAsAPM8JJMLl0zKR5TZsr1pO9kZB+dexGxwD8SjmSIkZCXkmsRpPD+ZRzq4nCflzPcjxO8oXNUt/P5jxU5ySY7pfhvZLkct3SPDZffaYaU66rFQnOYy5S9J+FUZcpek/CqMuUvSfhVGXKXpI1VRlul6SPcYy1S9KT7jGWKZpSIyvTdKRAqtO0tr3xlKn6WzriN3yGlsa6Y3bJaUzriN1ymkNa4jdUt+u3rCN0S/wCsjWEbez+qjWEbc1+oj3iNsb9NPvgraIIKkkHOLwulIlqnLPsKBZLguL/g/wBRjo9Me+MdHpCLjrEXHmUvSjPVKcWs2aQ+sHrJvmhCENoShCQEgWAGyutUxCikzIuDY2BMZcpek/CqMuUvSfhVGXKXpPwqjLlL0n4VRlyl6T8Koy5S9J+FUZcpek/CqMuUvSfhVGXKXpPwqjLlL0n4VRlyl6T8Koy5S9J+FUZcpekjVVCFpWkKSoFJFwRszzYdk5lBGdtXhvJCRenXw2jNnUroAiUlGZRlLTSbAZz0k9Z4rCflzPcjxO8oXNUt/P5jxU5ySY7pfhvZLkct3SPDZrnNcz2J+YedYyusxjK9Ixti/TPvjB9azUkAqNsRW8wjUoVAWUR90mA44Pzq98ba7+or3xt7/wCqvWMbomP1nNYxuqZ/Xc1jG65rSHdYxuyb0l3XMbsm9Jd1zGDRJk3lEkkvm5PYNmoEiQmyDYhlfhx+DxJpqLnMtWy5ba139E7LDLj7qGm03Uo2AinyLUlLhtPCrOtXWeLwn5cz3I8TvKFzVLfz+Y8VOckmO6X4b2S5HLd0jw2a5zXM9ifmHnuD3OaPYVvMJOcR3SeJwbFqcfW6rZqPN833K/Dj6VWpWTlAy4h0qCibpAtw9pj7TyH6T+qn/MfaeQ/Sf1U/5heEsipCgGn+EEZk/wCdnB+nbQzulwfeODyfUnjMJiDPNdyPE7yg81S38/mPFTnJJjul+G9kuRy3dI8Nmuc1zPYn5h57g9zmj2FbzCTnEd0nicHhamN+tavHZqPN833K/DzSjyO7JxKVD7tHlL/xxT8yxLox3nEoHriawmbTdMs1jf8ApfAPdExVqhMXx31AeinyRvUTD7YAQ8tI6goiBUJ8Zpt7XMCrVIZppz3xRqpPPzyGnnsZBSrgsOgb+c5JMd0vw3slyOW7pHhs1zmuZ7E/MPPcHuc0ewreYSc4juk8TQOa2O1XzbNR5vm+5X4eaUKT3NIpUR5bvlH6DiCQASTYCKjhElBLcpZR6XDmHZDz7z6yt1xS1HpPFUI2qkv/AC+U7+c5JMd0vw3slyOW7pHhs1zmuZ7E/MPPcHuc0ewreYSc4juk8TQua5f+XzHZnkKXJTSUi5LSwB+3mdPlt1TjDPQVeV2DhMAAb9a0oSpSlAJAuSYq1Zcm1FpolLI96u3jKSrFqUr3gHv385ySY7pfhvZLkct3SPDZcbbcQULQlSTnBFxGT5DQ2NRMZPkNDY1Exk+Q0NjUTGT5DQ2NRMZPkNDY1Exk+Q0NjUTGT5DQ2NRMZPkNDY1Exk+Q0NjUTGT5DQ2NRMZPkNDY1Exk+Q0NjUTE7IySZKaUmVZBDKyCEC4IHmGD3OaPYVvMJOcR3SeJwddC6cE9KFqB8d4qSklqKlSrJJzkoBMZPkNDY1Exk+Q0NjUTGT5DQ2NRMZPkNDY1Exk+Q0NjUTGT5DQ2NRMZPkNDY1Exk+Q0NjUTGT5DQ2NRMZPkNDY1Exk+Q0NjUTGT5DQ2NRMZNp+iM6ghdIpq88qgdnk+ETmDIsVSrn8F/Qw8w8w4W3UFKh0HYwYYu6++R+FISP34jCCpFxwyrR8hB8s9Z6uNk3UszTDisyHEk9gMfaKm+kvVj7RU30l6sfaKm+kvVj7RU30l6sfaKm+kvVj7RU30l6sTFfpzjDyEqXdSFAeT1jeyXI5bukeHmE/yGb7hfy+YYPc5o9hW8wk5xHdJ4mgTwl5stLNkO2HYro80n5BidZKFiyh+FfSkxMMOS7y2nBZSTYxg80G6ahXS4tSvpv6nN7kknXR+K1k+0YJJJJNyfOZLkct3SPDzCf5DN9wv5fMMHuc0ewreYSc4juk8VRqyiYQlh9VnRwAn8/8AvzTCSSC2EzSR5SOBXrSYpzYbkJVP9JPvI3+FD/DLsA9az4DzqS5HLd0jw2X32pdpTrqrITnMZdpekfCqMu0vSPhVGXaXpHwqjLtL0j4VRl2l6R8Koy7S9I+FUZdpekfCqMu0vSPhVGXaXpHwqjLtL0j4VRl2l6R8Koy7S9I+FUTdaprkpMIQ/dSmlgDFOcjzDB7nNHsK3mEnOI7pPFyVfm5cBDn3qPWfKH7w1hHTljyytB9ab+EZdpekfCqMu0vSPhVGXKXpI1VRlyl6SNVUZcpekjVVGXKXpI1VRlyl6SNVUZcpekjVVGXKXpI1VRl2l6R8Koy7S9I+FUZdpekfCqMuUvSfhVGXKXpI1VQhaFpSpCgUkXBGzOthyTmEEZ21eEMjFabHUkDf4RLxqkoeihI+vnUlyOW7pHhs1zmuZ7E/MPPcHuc0ewreYSc4juk+d4PEmmoucy1bLv8AxOeyYSbpT2b+vg5Uf7EfKOOlmS++00DYrWE37Y+yx0v4P9x9ljpfwf7j7LHS/g/3H2WOl/B/uPssdL+D/cfZY6X8H+4msHCxLuvbpxsRJVbE3slyOW7pHhs1zmuZ7E/MPPcHuc0ewreYSc4juk+d4O82p7xWy5woX7JiWVjS7KuttJ943+ErZTPpV6TQ47B1jbKgF9DaCr9zwb+o8gm+5X4b2S5HLd0jw2a5zXM9ifmHnuD3OaPYVvMJOcR3SfO8HebU94rZX+BXYYpDm2U2VV1IxdXg3+E0uVyzTw/Iqx7Fcdg3LbVJqeI4XVfCnf1NWLT5s/0lD3jeyXI5bukeGzXOa5nsT8w89we5zR7Ct5hJziO6TxNKo8hMSDLrrRK1XucYjMSIyBS/0TrGMgUv9E6xicolOalJhxDJCktKIOMc4HH4O82p7xWy4bNr9kxg09jyTjZPChz+yt/MMImGHGV5lpIh9lbDzjSxZSFWPGSksuZmGmUZ1H3DpMNtpabQ2gWSlIA7Bv6+7iUx0empKf733slyOW7pHhs1zmuZ7E/MPPcHuc0ewreYSc4juk8TQuapb+XzHZnkKXJTKEi6lNLAHrI4/B9C0U1vGBF1KI7Nl3/ic9kxg3MbXOqaOZ1H908PEYQUwvI3U0m60Dyx1p4zB+nFhkzDg+8cHkjqTxGFD/J2AetZ8BvZLkct3SPDZrnNcz2J+Yee4Pc5o9hW8wk5xHdJ4nBx0Lp2J0ocUPfw7xclJrUVLlWVE5yUAmMnSGiMagjJ1P0RnUEZOp+iM6gjJ1P0RnUEZOp+iM6gjJ1P0RnUEZOp+iM6gjJ1P0RnUEZOp+iM6gjJ1P0RnUEZOp+iM6gjJ1P0RnUECnyGiMaid5PuhqSmVnobV7yIYeUy826nOhQI/aGnEutIcQbpUkEfvxFZohQVTEsm6M60Do9Y4qiUYvKTMvps2OFCT+b/AFxNUmt1TzzgN03xU9g3slyOW7pHhs1zmuZ7E/MPPcHuc0ewreYSc4juk8Tg/OiXmi0s2Q7YdiujzXCWeAQiUQeE2Uv6DYwbnNsYVLKPlN8KfZPE1KgMzJU4wQ24c4/KqJmTmZVeK80U9R6D2HfMsPPrCGm1LUegCKbg8lspdm7KV0N9A7eJrc5uWSXY+W55Kfqd9Jcjlu6R4bNc5rmexPzDz3B7nNHsK3mEnOI7pPFUasImUJYeVZ4CwJ/OP8+Z1KpsyLRuQp0jyUfUw66484txxV1KNydiSmlyky28n8p4R1jpENOodbQ4g3SoAg8StCHElK0hSTnBFxExg9T3blKVNn/yeD3GHMFl3+7mgfaTaPsxN/rtf3hGC7v55pI7Ekwxg3Itm7ilueomw/tDLDLCcVptKB1AW4kkAEkxV5/ds2pST92jyUf530rV6ciWYSqZSCG0gixzgRlmmaUn3GMs0zSk+4xVqnIP099tt8KWbWFj1+e0mbalJxLzl8UJI4PXAwkp39XVj7R07+pqx9o6d/U1YrE4zOTe2tXxcQDhFuKBINxElhDNMAIeG2oGsIawhpqwCpakHqUk/S8Zbpekj3GMt0vSR7jGWqXpSfcYyzTNKT7jGWaZpSfcYyzTNKT7jGWaZpSfcYyzTNKT7jGWaZpSfcYyzTNKT7jGWaZpSfcYy1S9KT7jGW6XpI9xjLdL0ke4wuvUtI4Hir1BJicwldWCmWbxB6auEwtxbiytaipRzkm53mD1SxFbkdPkqN2z1Hq84wgqe1oMo0rylD7w9Q6v+mAkEERRaoJxra3D98gcP/odfm1WqiJFmybF5Q8hP1MLWpa1LUSVKNyT/wBNZdcZcQ42opUk3Bil1Rqea6EupHlJ+o80qdUZkW+hTpHko+ph99191TrqipSjwn/p7LzjLiXG1lKkm4Iil1lqcAbcsh7q6FdnmVUrjUqFNMELd/smHXXHXFOOKKlKNyTxKZCeUAoSrxBFwQgwuRnUJKlyrqUgXJKCAIbacdWENoUtXUkXMOsusqxXW1IVa9lCxhpl55RS02tZAvZIJhxtxpZQ4hSVDOCLGG5SacRjoYcUn0gkkbDbbjqwhtClKOYAXMOsvMqCXW1IJF7KBB2WmHnlFLTS1kC5CQTGTp/RH9Qw7KTTScZyXcQnrUkgQ1LTD19qZWu2fFSTaMnT+iP6hhaFtrKFpKVDOCLEQASQAIRSaktOMJVdvXweMPy0wwbOsrR2iGmHniQ00tZAuQkEwttbayhaClQzgixENS0w9famVrtnxUk2hSVJUUqBBBsQYEnNlvbBLulFr4wSbW2G5WadQVtsOLT1pSSNhCFuKCUJKlHMALmDSakE425V2hSVJJSoEEZwYAJNhDsrMspCnWHEAmwKkkbKKVUVpxkyrlvWLeMOsvMqxXW1IV1KFtgAqIABJOYCE0mpKTjCVXb18EONONKKHEKSrqIsYalph6+1MrXbPipJtC0LbWULSUqGcEWIhuTm3UBbcu6pJzEJJGyyw88vEabUtXUBeHqZPsoK3JZYSM5z+ENtuOrCG0KUo5gBcw7Lvs221laL5sZJF4al33iQ00tds+KCYcacaWUOIUhXUoWMMU6dmE4zUutSevMIflpiXVivNKQfWIalph4EtMuLAz4qSYydP6I/qGHZaYZttrK0XzYySLw1KTTycZphxab2ulJIjJ0/oj+oYIIJBFiM4huTm3EBaJd1SfSCSRsCTm1N7YJd0otfGCTa2xLyU1M32llawOkDgiYkpuWttzKkA5ic2+BIIIMU3CFSLNzd1J6HBnHbDTrbyAttYUk5iOOmZqXlm8d5wJH9z2RUa+9MXbl7tt9f5jxbs0uUo7TyEgqS03YH12ETGEE2+w40plsBaSCReMH+dGvZV4RhJziO6TGDHLne5PiIr3Osz/D5RFE5mX2ubFB50l/5fKYwm5c13I8Ts0+oOyLq3G0JUVJxfKinzzk1IKmFpSFDG4Bm4Inq1MTrG0rbbAxgbi8YLfhnO1H1iZwhm2Zl9pLLRCHFJBIPQbRNTC5mYceWAFLNyBFGkmJSSM68BjFJVf0U+qH8JZxSztSUIR0Ai5ierDk9KIadbAWlwKunMRYiMF+VP919YrfOkz2j5RGC34ZvtR9Yn+XTXfL8Ypi0opcqpR4MUD3m0Vyl7ld25pP3KzqmMH+anPbX4QlJUoAC5JsIQ3K0WQ2xScZw2BPSpR6OyE4TzePcstFHUL3idlpaqyAmWU/eBN0np4M6TDX/ACt+0Iwn5Gz330OxRJFiXld2vgYxSVAn8qRD2E8wXDtLLYR0Y1yYln5WtSi0Ot2WnOPRJ6REwwuXfdZVnQoiKTKS8hI7seHllGNfqScwEOYTTZWS202E9ANyYqFYlp2SSlUv99fP0J9YMUufVJTSV/kVwLHqis0zdbss8xa6yEqPqOZUVibRISSJRg2UpOKPUnZoqA1SC6ygKdUFntUMwhOENQbLqXUJJsQARbFMIdcbdS6g2UFXBHXD4brFJx0AbYkXA6ljOIk0N0mlF5weWoYxHWTmTDKt1VBovm+2PJx/3MVqbnJNloyyAEZlKtfFtmET9XfnWGmloSMXhJHSYp9VfkEuJbQhWOQTjXhU+6KTuzFTj7WFW6IqFVenw2HEITiE2xb9MYOG1NV3io+007+g17jDiytxaznUon3xTAlinSSD+dIt2quqJ6TU3UnJdA/E4MTsVmhttpLW5RmS0B+xuPpBTZRSeg2ieW9JU1G4mwcWwzXsnriYrk1MSamHEoJJ4V26OIlZ2ZlF4zLhT1joPaIk8JGF2TMo2tXpDhTDTzTyAttxK09YN+KmZ6UlRd55KfV0+6JzCVRumVbt/wC1fQQ8+8+srdcUtR6TxipsSdJafKMbFab4L2z2ETeESZiWeZ3MRjpIvjRg/wA6NeyrwjCUEVBJ62h4mMGAd2vH+ifERXedZn+HyiKJzMvtc2KDzpL/AMvlMYTcua7keJ3lE5mX/wDpsYLfhnO1H1iYwkSy+81uUnEWpN8fPY2idmRNTTrwTi45va94eBfweAb0dHw2vs4L8qf7r6xO1yWlplxlUsVFJFzwRTKk1PB0tslGJa/rvE/y6a75fjC//mR3Q+aKVPNVGVXKTPCsJsb/AJk9faIp0oqTlJhlRvZxdj1ggRKrSial1qzJdST2AxhM2tUqysC6Ur8r99igJLNMK3OBJUpY9mGzd9B/9jxjCfkbPffQ7DgMxg8A1wnc6fhzjYwXbXtsw5+TFCf3itLSuqTJT1gfuAAYnkl+g/di/wByhVh1CxMUsSBmFbttteIbZ/xXHow1TqE8yp5tkKQL3OMsZtjBx9x2SUhZuG12T2RPvuPzj61m5xyOwDZp1VmJFRCLKQTdSDDaqbWmVAt2cSOH0k9hiYZUw+6yo3KFEXjBt9xE6WgfIWkkj1iMJn3DNNs38hKAoD1nYkMIlISG5tGOnNjjP+4is0yVVK7tlgBwAkDMoHp2F/8AzY7gbGDhtTVd6qPtSjRDrw4ouvLUB+NZIHaYrjplJWRCM6HUkfwELk25ifk5xPCkNE//AM+MU6c3RWJ+xunEAT2INoqLe1z80n+qq3YTeKdXnpVKWnU7Y2M3pAROyMlUZNU1LgBYSSCBa9s4I4pp51lWM24pB60m0S+EU+1YLxHR6xY+8QzhPLH/AJWFpPqsoQ1Wqc7+F436ikwh9pz8KrwSBnhyelWvxuW/Yw7hDTUZlLX2J/zaHsKM4Zlv3WfoImK3UX+AvYg6keTBJJJJueOn5yWXRA0ly69raFrHoI2JSZVKzLTyRcoN7dYi9MrDaCUkkdoUmC5TKO0oJSQT0C5Kj2xMvrmH3Xl51qvFEm5VunbW6uxKlXFjmMOSmD4bWUpN8U24VxRnUNVFhazZIxrn9jE1kWbcC3jjKCbA+WPCKs3JNzCBKCyMQXz57+vZpE5LNUpTa3LK8vgsdjByaYYTNbau1yi3AT1w5L4PuuLcWLqUoqJuvOYn0sIm3ksf8YPk5/rFHrIkxtLwJaJuCM6YyTSJu7yEkA8JxSUiKyac0w3LSqbKC8ZfAerpJjB6YZYmHi4qwLfUT0xV3EO1GYWg3SSLH9hGDk0wwma21drlFuAnridUlc5MqSbguqI98Lm5f7PhnH8vawLWPXDLzjDqHW1WUk3BhmsSj8rjqVirKSCmxNjsUytsqZErOC4tihVrgjqMZIo6Bt5b8nPnURFWraHWjLSoIRmUrNcdQhsgOIJ9IRNP0mbQlD68ZINwLKHhFXYpTbDZlBZZXw/izW9cUesmSu06Cpom/BnSYybR5y76UcB4SU3SDE5WJSRZMvJo8oeqwT/kwSVEkm5JuTFHrSZVG0P3LV/JUOHFg0mkTF30oNjwnFJAiqVWWaljJSabC1lG1gB1DYwem5diXeDi7EudRPRD5BedIzFZ2aSilTMoZZ1BDpVcnpPUQYSim0VpxQKypXXwk+qJh5T77rqhYrUT74obzbNQQtxVk4qorzzT08FtquNrAhktJdbLqSpAUMYDORGTaRULPt4wFhcJ8kcEVmoyyJXcMv1AHqSBsKnJfIO04/l7SBax2KDOSzMgUOOWJcVwWMbkwd9E+9yGQ1lBsXs2HxqgxhFNtPmWS0u4SFE8BGeJGrNtUdaSo7a2lSU/SKFMIYnwparJKFAmK0tldRccbN0qCT1dFoZk6PUmGtrSpBQm1hwH94npyTpskqUYBKykgDqvnJMf/8QAPRAAAAQBBQwJAwUBAQEAAAAAAAECAwQFERVToRASFCAhMTRAUVJxchMwMjNBUGGBkSJjgiNCQ2KxJHCS/9oACAEBAAE/AtVW+yjtLIKlFgsxGoHKivBsgqUIk8xkXAgcXEH/ACmOnerFfI6V2sV8iDccOJbI1nNx6iUlrR0V6oyzjCH6xXyMIfrFfIwh+sV8jCH6xXyMIfrFfIwh+sV8jCH6xXyMIfrFfIwh+sV8jCH6xXyMIfrFfIwh+sV8jCH6xXyMIfrFfIwh+sV8jCH6xXyMIfrFfIwh+sV8jCH6xXyMIfrFfIhnnTfbI1qz9TExL6X3Ek4ZERjDImtMYZE1pjDImtMYZE1pjDImtMYZE1pjDImtMYZE1pjDImtMYZE1pjDImtMYZE1pjDImtMYZE1pjDImtMYZE1pjDImtMYZE1pjDImtMYZE1pjDImtMYZE1pjDImtMYZE1pjDImtMYZE1pjDImtMYZE1pjDImtMYZE1pjDImtMYZE1pjDImtMYZE1pjDImtMYZE1pjDImtMYZE1pjDImtMQcdfTIcz+B7ceOWtti+ScxzjDImtMYZE1pjDImtMYZE1pjDImtMYZE1pjDImtMYbFVpjDYqtMYbFVpjDYqtMYbFVpjDYqtMYbFVpjDYqtMYbFVpjDYqsGHRVYMOiqwYdFVgw6KrBh0VWDDoqsGHRVYMOiqwYfF1lhDD4ussIYfF1lhDD4ussIYfF1lhDD4ussIYfF1lhDD4ussIYfF1lhCkIrfsFIRW/YKQit+wUhFb9gpCK37BSEVv2CkIrfsFIRW/YINxTjBKVnx4qLSyUxZVDDImtMYZE1pjDImtMYZE1pjDImtMYZE1pjDImtMYZE1pjDImtMYZE1pjDImtMYZE1pjDImtMYZE1pjDImtMYZE1pjDImtMYZE1pjDImtMYZE1pjDImtMYZE1pjDImtMYZE1pjDImtMYZE1pjDImtMYZE1pjDoqsCZTeLtERhmUGFZFfSM+ruRTDXaXl2ByUz/Yj5C4l9faWfUQWlNceolb+H8tVhNJa5upjNJd4+UwUbPM24eXwPGlLRvyLyuT9FTxPGi4omSmLtgzNRmZnl8gaiHWj+lXsIaObdmSeRWqPR7LfZ+ow7GPueMxbC6uC0prj1Erfw/lqsJpLXN1MZpLvHyqCjL6Ztw8vgeLKWjfkXlcn6KnieLFRRMpmLtGDM1GZmeXyOCjL6Ztw8vgeovxjTWTOrYHop13OeTYXWwWlNceolb+H8tVhNJa5upjNJd4+VwUZ0n0L7X+4kpaOXP5XJ+ip98SJiUsp/seYgpSlqNRnlPyWCielRMrtJ65xxDaZ1HMIiOWvIj6U29fBaU1x6iVv4fy1WE0lrm6mM0l3j5WRzCDi+lK9V2/8Absp6OXP5XJ+io97sREJZRP4+BBxxTijUo8vkzLptOEsglZLSSi8esiYtDOTOrYHHVuqnUeoQWlNceolb+H8tVhNJa5upjNJd4+WEZpMjLOISKJ5Mx9os9yU9HLn8rk/RUe9x99DKJz9iDrq3VmpR+USY5fIUg/25urio6adDWfaM+owWlNceolb+H8tVhNJa5upjNJd4+WpUaVEojykISLS8mbMrxISlo5c5eVyfoqPcPvoZTOfsQddW6u+V5TJ672JL1ydVFxt9OhvN4nt1OC0prj1Erfw/lqsJpLXN1MZpLvHHhYXCL76pphRR1tgoo62wUUdbYKKOtsFFHW2CijrbBRZ1lgopVaQotVYQopdYQotysIUW5vkKMd30ijHt5Iox/eSKMiNqBRsR/X5FHRPp8ijondL5FHxW5aMAi6u0hgMVVDAoqqMYHE1RjBImqUMFiapQwaIqlDBn6pQ6B6rV8DoHqtXwOheq1fA6F2rV8DonatXwOidq1fA6NzcP4HRubh/A6NzcP4HRubh/ASTyFEpKVEZB99T8KRGg78lF4C8XumL1W6YvVbpi9VsMTHsEx7BMezySGc6OAvtk4ddW6q+UeO1Jzik3yjvRRR1tgoo62wUUdbYKKOtsFFHW2CijrbBRR1tgoo62wUUdbYKKOtsFFHW2CijrbBRR1tgoo62wUUdbYKKOtsFFHW2CijrbBRR1tgoo62wUUdbYKKOtsFFHW2CijrbBRR1tgoo62wHJaqywONrbVeqLLjw5zPt8xdTGRl/9CD+nbt1SC0prj1Erfw/lqsJpLXN1MZpLvHHkrtO+3mcxbBMWwTFsF4jdIXiN0heI3SBtt7ifgSklKXUTERfTjyeRHEZdhi8Rul8C8RukOhaq0/A6FqrT8A2mqtPwOgZqkfANliqR8DBmKpPwMGYqk/AwWHqkjBoeqSMEhqpIOFh6pIwOGqiGBw1UQwOGqiGCQ1UQiUJRCOERTFNjwSSVEtkeuymguiQrxvpsdvvEcxdRGxc/6aDyeJ6rBaU1x6iVv4fy1WE0lrm6mM0l3jjyV2nfbzqVO+RyY8m6T+J6lHaK57f7jyfpSPf/ADXZU0dPPjo7aeOPHRV4XRoz+OrQWlNceolb+H8tVhNJa5upjNJd448ldp3286lTvkcmPJuk/iepSjox8Sx5P0pHv/muyp3CefHb7xHMWNFRHQt/2PMDMzOc9WgtKa49RK38P5arCaS1zdTGaS7xx5K7Tvt51KnfI5MeTdJ/E9SlPRy58eT9KR7/AOa68026m9WU+UYBCVdpjAISrtMYBCVdpjAISrtMYBCVdpjAISrtMFAwpHP0dp4q1EhJqPMQfeN5w1H7avBaU1x6iVv4fy1WE0lrm6mM0l3jjyV2nfbzqVO+RyY8m6T+J6lKnco5seT9KR7/AOeUyhETq6JOYs+sQRHhLZzdRKv8P5arCaS1zdTGaS7xx5K7Tvt51KnfI5MeTdJ/E9SlXu2+OPJ+lI9/88oiXuhaM/HwGfVW2HXOygw3Jh/vX8BEHDI/ZPxE3UKabX2kkfEYHDVRDAIXcFHQ26fyKNhv7fIOTGd5YOS01p/AiYfoFkm+nyddCaS1zdTGaS7xx5K7Tvt51KnfI5MeTdJ/E9SlXstcceT9KR7/AOeURr3SOzFmTk1RmBecyn9JeoagWEeF8frqcqd4jh10JpLXN1MZpLvHHkrtO+3nUqd8jkx5N0n8T1KVf4vfHk/Ske/+eTxb3RMmfieQtTYhHXvRO0MQjTOWadW09VlXO379dCaS1zdTGaS7xx5K7Tvt51KnfI5MeTdJ/E9SlX+L3x5P0pHv/nk8oO3716WZOopSajIiLKIaAJP1O5T2avKpZGvfroTSWubqYzSXeOPJXad9vOpU75HJjybpP4nqUq/xe+PCuE2+hR5vJnl9G2pewgZznPqDTS3VXqSEPDIZLarxPWJTL9JHN10JpLXN1MZpLvHHafdanvFTTjD4ussIYfF1lhDD4ussIYfF1lhDD4ussIYfF1lhDD4ussIYfF1lhDD4ussIYfF1lhDD4ussIYfF1lhDD4ussIYfF1lhDD4ussIYfF1lhDD4ussIYfF1lhDD4ussIYfF1lhDD4ussIYfF1lhDD4ussIYfF1lhDD4ussIQsXEOPoSpeQ/QvIJU75HJjybpP4nqUql9LZ+vUNxT7ZTJcOYYfF1lhDD4ussIYfF1lhDD4ussIYfF1lhDD4ussIYfF1lhDD4ussIYfF1lhDD4ussIYfF1lhDD4ussIYfF1lhDD4ussIYfF1lhDD4ussIYfF1lhDD4ussIYfF1lhDD4ussIYfF1lhDD4ussIYfF1lhDD4ussIYfF1lhCkIrfsFIRW/YClGJLxL4CZTX+5sg1HQ6/G9P1x5Td+lCNuXUGm1OrJKQwwhlMxe56zKJf8/wCRddCaS1zdTGaS7x8hgdKb9/IJU75HJjybpP4nqUoIv4c/TL5OzFPNZjnLYYh4xp7JmVsxY1y/iFemTryIzOYhCw5Mo/sefWo8v+ZXEuuhNJa5upjNJd4+QwOlN+/kEqd8jkx5N0n8T1IyIyMjDzZtuKRs8nzCDjb/AOhzteB7brirxtSthA8pz9fJ0P8Ayn+Otusk6g0H4ii2d5QotneUKLZ3lCi2d5QotneUKLZ3lCi2d5QotneUKLZ3lCi2d5QotneUKLZ3lCi2d5QRANNrSslKnLqYzSXePkMDpTfv5BKnfI5MeTdJ/E9TlFi/T0hZ05+HlMHE9MiZXaLPcj1XsMfqc3Xstm64lBeISkkkRF4eZRmku8fIYHSm/fyCVO+RyY8m6T+J6pGQxsrnLsnm8oYdNpwlkEqJSSMsxiUz7tPv18mtZFOexeZxmku8fIYHSm/fyCVO+RyY8m6T+J6otCVpNKiyCJg1snPnTt8okx2dBtn4ZhKKp4ibYnr2WybZQn08zjNJd4+QwOlN+/kEqd8jkx5N0n8T1Z+TkKyt/SezwDjDrR/WnyaAXexKfXIIs54lzj10Mi/fbL180jNJd448LC4RffVNMKK+7YKK+7YKK+7YKK+7YKK+7YKK+7YKK+7YKK+7YKK+7YKK+7YKK+7YKK+7YKK+7YKK+7YKK+7YKK+7YKK+7YKK+7YKK+7YKK+7YKK+7YKK+7YKK+7YKK+7YKK+7YGYDoXUrv55vIJU75HJjybpP4nq8xGHIGGV+2bgDktHg4Yor7tgor7tgor7tgor7tgos6ywUUdbYKKOtsFFHW2CijrbBRR1tgoo62wUUdbYKKOtsFFHW2CijrbBRR1tgoo62wUWdbYKK+7YKK+7YKK+7YKK+7YKK+7YKK+7YKLOtsFFHW2CijrbAclqrCDrS2lXqix4c5n2+Yg/lec5j66Ti/6OBH5pGaS7xx5K7Tvt51KnfI5MeTdJ/E/NpTSXRIV4302O13rfMQX21ceuksv1HD/r5pGaS7xx5K7Tvt51KnfI5MeTdJ/E/NpU0dPPjt94jmIHnPrpK7TvAvNIzSXeOPJXad9vOpU75HJjybpP4n5tKmjp58dvvEcSC+2rj10ln9bnDXY9V7DH65BOe0TntE57ROe0TntE57ROe0TntE57ROe0TntE57ROe0Scr/o9j6mM0l3jjyV2nfbzqVO+RyY8m6T+J+bSpo6efHR208Q9kdc5j66TT/X/AB12VFd2j366A0pHv1MZpLvHHkrtO+3nUqd8jkx5N0n8T82lTR08+Ojtp4iKKaId5uug1XsS3xm12MXfxC/TJ10DpTfv1MZpLvHHkrtO+3nUqd8jkx5N0n8T82lTR08+Ojtp4iUEzRJ+pEfXEcxkYSq+Qk9pa28vo2lr2F18BpSPfqYzSXeOPJXad9vOpU75HJjybpP4nqUTFYPe/TPOKVKrFKlVilSqxSpVYpUqsUqVWGI8nXCReTa7Kmjp58dHbTxEqJ+ps/Tr5OcvmJt3W5ScmShvblPr5NL/AKPx6mM0l3jjyV2nfbzqVO+RyY8m6T+J6lKudr3x5P0pHv8A5rsqaOnnx2+8RzEJSROwR7D6+Be6N8p8ysmtTh9zpXVK+OvksvqcV6TdTGaS7xx5K7Tvt51KnfI5MeTdJ/E9SlXtNe+PJ+lI9/8ANdlTR08+O33iOYhEov2HE+moQb/StFPnLIesyg9eN3hZ1f5qEmlMwZ7T6mM0l3jjyV2nfbzqVO+RyY8m6T+J6lKv8XvjwrhNPoUeYFl1yUnUzJb8Z5zx2u9b5iuPovHlp9evhX+hdI/DxBGRlOWrqUSUmo8xB503XDUeoMIvGW0+nUxmku8ceSu077edSp3yOTHk3SfxPUpUL9Ns/XqG4l9spkryDD4ussIYfF1lhCkIrfsFIRW/YKQit+wUhFb9gpCK37BSEVv2CkIrfsFIRW/YKQit+wUhFb9gpCK37BSEVv2CkIrfsFIRW/YKQit+wUhFb9gpCK37BSEVv2CkIrfsFIRW/YKQit+wUhFb9gpCK37Bh8XWWEDjoo/5LCBmZ48MU77fNclJuZaF7S1CT4qb9JR8NXj4m+Pok5iz6hDt9I8hPr1UZpLvHHkrtO+3nUqd8jkx5N0n8T1KPRfQyvTL5XJzd9ET7pXI1q/h1emXUYGMv5m1n9Xh66rGxXRleJ7R2ajJreVTnsXVRmku8ceSu077edSp3yOTHk3SfxPUjIjIyMOtm24pB+B+VSe1eM33iq7EtdE8pPxqMHHEqZDmfwPU4uLJor1Pb/wGZmc56jDNdEylPj49VGaS7xx5K7Tvt51KnfI5MeTdJ/E9TlGHvi6Us5Z/KYVjpnSLwLPiSmzOgnC8M+pQ0epv6V5U/wCBCkrKdJzlqEVHkX0tf/Qz6jBNdI8WxOU+rjNJd448ldp3286lTvkcmPJuk/ieqRkN0K8nZPN5OlJqUSSzmIaHJhubx8cRSSUkyPMYdbNtxSD8NSaecaOdBhiUW1ZF/SdgIyMpyPrHotlrxnPYQfi3XsmZOzU4JromfVWU+rjNJd448ldp3286lTvkcmPJuk/ieqOoStBpUWQRMKtg9qdvkqEKWq9SU5iFhSZKc8qtuNKLE6ekLwz6o28632FGQblQy7aJ+ARHQyv3zcQSkmWQyPGOKh0Z3CC5TQXYQZh2Mfc/dMWwtUgmOldy9lOfrIzSXeOPJXad9vOpU75HJjybpP4nqpkRlMYfk4jnNo/YLbW2cykzeQ5wzJ7i8q/pK0NMttFMkscyIymMRLJsumn41YjMswJ94v5FfIwuJrVDC4mtMHEvn/KoGpSs5merERmZEWcQ7JMtEnx8esek9xx1a78soot2sSKLdrEii3axIot2sSKLdrEii3axIhIVUOa51Ec/nT0M08qdU4OTob+3yKNh/wC3yKNh9qhRsPtUKNh9qhRsPtUGoNpld8mefV1JSopjKcOSfDqzTp4A5L2O2Cil1hCil1hCil1hCil1hCi11hCi3KxIot2sSKLdrEii3axIot2sSKLdrEii3axIot2sSKLdrEii3axIot2sSKLdrEii3axIot2sSKLdrEii3axIot2sSKLdrEii3KxIopdYQopdYQopdYQotdYQKSlVtgTJjRdpZmG2Gm+ygi6qNY6ZvJ2izeYyfD/yq/H/AMYlCGmPpU5jz+XwkP0y/wCpZwRTf+MGRGRkYioc2F/1PMflrLSnVklIaaS0gkl/408yh1BpUHWlNLNKvK0IUtRJSWUxDQ6WETePif8A45Ew6XkTePgYWhTajSospeUpSpaiSksohYUmU/28T/8AHomFS8j+xZjC0KQo0qKY/J0IU4okpLKIaFSyn+3if/kERDIfTMecsxh1pbSr1ReSssLeVMn5DEOhlMxZ/E//ACJ1lDqb1Re4iIVxg8uVO3yOGglu5VZEhttDab1JTFqaoyHQo0qVlL0FIQu/YKQhd+wNRTDir1CsvC47ENNGRLVNOGophxd6lU53VRcO2s0qVlL0DcQ09PeHmuOvIaTOo5iCY2GMyK/z+mI4+0zNfnNOERbDiiSlWXhjqjIdtRpUrKXoKQhd+wUhC79gpCF37A26hxN8g5yuFHwu/YKQhd+wUhC79gaebdIzQc8101ERTmcxBcoQ6c06uApRurUER8OrxMuIIyMpyO4qMh0KNJqyl6Bt9p4jvDnmu4fC79gbWlxJKTmuORLLSplqmyBMZDrUSSXlO644htN8o5iBR0Lmv7MRx5pvtqmBykyWZKjCZSYPOSiDa0LKdKiO6ZzEZikIXfsDakrSSk5jxJyILj4dHjPwFKNbig1FsOZCVl2HiqWlJTmcxBUosJzTqFJtbigzEsudlWXZcPIQw+F37A0+27OaDnuOvttTX5zTikIXfsxnYthrOqc9hClG6tQYi2XTmI8uw7jj7TU1+c04KPhd+y7h0KkzI12BqJadyIOf2uOvtNdpQpNrwQoNR7C8mVJ+txRkRGZjD4XfsFIQu/YKQhd+wUhC79gLKHHENJvlnkGHwu/YKQhd+wUhC79gSolJIyzHcdfbamvzmnGHwp/vsuuRLLRzLUERkOtRJSvKfpdUtKCnUcxBUpMlmJRhEpsz5UqIIUlZXyTnLrDIjKYyyCJk80zqayls8gShSzmSU5iHk9Kfqcyns1WM0l3iG2XXJ7xM4wOJqjECw82/OtBkU1yVe8b5RJ2klwO7G6U6JK/m9rkqdynmDPfN8xYkq52vcQOlN48TDPrfcUTZzGYcYebKdaDIERmcxDA4mqMQKFtszKKY74K7J8LiIZ9aSUlszIYHE1RiT23GkLJaZstx1xLaDUoPxC3lZc2wNQ7zvYT7ijH5u0gOwrzXaTk2iB0Vv3uRWkO8xiSuy7xK4rsnwuQGiouSppCeS5BRPTIvT7RXJS0b8iDfeI4ldjIvovpT2v8AAZmo5zOcwmDiVZmw5CvtlOpBzBtxbar5JzCFiEvInzGWe473TnKdyD0VrhdWtKEmo8xCIilvHsTsDbTjnYSZjAIrcCkqScyimMQcaaTJDh5Nuy688llBqMPPLdVOo/YNw7zvZQDgIndtBktCpjIyMhAxK3SNKizeNyPh+jcvi7KhBv8AQvEfgee5FPdK6Z+HgICHv1359lP+4sc8bTZEWdQSlS1ERZTMUY9N2kzhMM903RzTGQSRkkiM5/URDBOtGn4CkmkzI85CAfv2r086RGP9Ezk7SshDOIVjoWiLx8REOdEypYUpS1GZnOYRJzykzmZEHIV5tZJvZ580whm1ttJSpU4eKdpZFsGBxNUYW2ts5lFMYbbW4cyEzjA4mqMJyISXoJS0f3uYHE1RjA4mqMMTpYbSeck3JUV9bafS5DO37CD9LkW50j6z9iDKr11s9iiuxT5uuHulmDEI49lLIW0PQLrSb7IovQSey6gjWZzEfh10RCNPZcytoehnWT+osm3XWIBxeVf0laGmW2imSWrRmku8RJWZ32E5XZV7xvlEnaSXA7sbpTokr+b2uSp3KeYM983zFiSrna9xA6U31Ep9ynmDPfN8xXVdk+FyAmwVv3/0TldlJ2dwm9ghmemdJPh4hKSSUxFkupSSSmIslyK0h3mMSV2XeJXFdk+FyA0VFyVNITyBDd+hwy/blDbim1kpOcgw6l5slF7iUtG/Ig33iOJXFrvEKPYQWs1qNR5zEBDFN0qi4XY+GJpRKT2TEK70TyT8Mx3He6c5TuQeitcLspu/UlsuJhhrpXST8hCEoSSUlMVyKhkvN/28DGYQDt+wU+dOS5KDpqevfBIhGOmdy5izgiIimK4/DNvEV98hDaEJmSUxXHmkuNmgwtCkKNJ5yBxZ4ESZ/q7PsG21OLJJeIabJtBJLwxZUSf6avDMId3onkrMIcQtM6TnxJRh/wCVP5CGd6J5KvkRjvSPHsLIQk9ic+lPwzXJQIzhlAjmMgw+28WQ/bFlLSPxISX3y+S7KWj+4T2i4jIJyuygqeJV6ZAaP0Er/sZCS3O2j3EQvo2Vq9MgYR0jqE+ozGEHOhJ+gMKI0qMj8DEBEo6MmzyH4aiZEecPyak8reQ9ngHGXGjmWmbWWYF5zP8ASXqGYRlnMU57T1iM0l3jdk3SfxO5KveN8ok7SS4HdjdKdElfze1yVO5TzBnvm+YsSVc7XuIHSm+olTuU8wZ75vmK6rsnwxJL7tzmuRukuCS+05wxorSHeYwSlFmMxfr3jF+veO5AaKi5KmkJ5BJfeOcojIboVzl2TELEGw5/U84jzI4SctpBvvEcSuRmjO8LjGRlvlK7KBf8yuJXE9lPAO905yncg9Fa4XY3SXBJRfW4fpiRRTRDvMJKPvfa5E6Q7zGJKLI77XH442XVI6Oeb1FKnVWilTqrbsow86elTnLPcgGL1HSHnVm4YzjaXEGlWYREG6z6p2hK1oOdKjIQ0oz/AEu//V1REojI8wiGTZdNPwGWjdcSgghJISSSzFdiYBSDvm8pbBlI9hhiUFpmJz6i2+ISpKkkaTnI7sp6R+JCS++XyXZS0f3xIbR2uUrkQd8+4f8AYJavpNm/IQjnRxCD9ZhKbkxIb9zEmtzqWvZkDpTOLL+xiDVfQzfCb4uRkF0v1o7X+haFoOZRTGGYx5rxnLYYYfQ8mcvctRNJGUxlOHpNbPsHeh2FfazpybS1RKFrOZKTMNSa4fbO9DUKy1mTl2nrUZpLvESWkjJ2ctgvEbpC9SXgVyVe8b4CAVexKPW7FnfRLh+okv8Al9rkqdynmDPfN8xYkq52vcQOlN9RKncp5gz3zfMV1XZPhcgUpOFbyF4/6LxG6QIiLNclBF7ET7SEnukh+Y/3ZMaK0h3mMSa22tLl8gjy+JDB2KlHwFQ7F6f6SM2y5AaKi5KmkJ5BJXeOcocaS4g0qzB5lTLhpME9/wAy2j2zkG+8RxK4+i/aWnaVyBeJbBF4pyXZSdK9Jss55TDSDW4lJeJ3He6c5TuQeitcLspN3r99vEIF7o3ynzHkurWSEmo8xBar5albTEmIvWlK3j/y5GovYlfrlEmukh00n+65EQCnnlLJZFOIiCNhF8ayzhpF+4hO07sSX/O7ynch+4Z5C6iIgWnJzT9KgZGRmR+Ak9Zrhyn8Ml2VO+RyCTtJLgeK/CsullLLtD7JsuGgxJjh/Wjwz3ZT0j8SEl98vkuylo/uE9ouIvEbpC8RulcUcyTPYVyHKZhsv6h9HRurTsMPum6u+9CEG30cOn1ymIwpolziJMV+gZbFXXGm1pmWmcRkJ0Myk9kxCOGiIR6nNqjsKw5nRl2kHJLP9i/kOQkQ3nbP265DLq+ygwiTXj7RkkIk9hOedQJKUlMREWuRmku8RJWZ72xJSaNTRKL9oIzI5yDUplN9aTn9A7KX0zNpm9TuSe0aGJzzqy3JU7lPMEKvVpVsOcUqVTaESmSlJT0Wc9tyVc7XuGHeidSuaeYUqVTaGZQJ1wkdHNP640qdynmDPfN8xXVdk+FyHlAmWko6Oeb1FKlU2iGienSZ3s0x3IuH6ZvJnLMDI0nMeQwxKKklM4U/qKSZ2KD0orVkbK99fEQmjN8LkVpDvMYkrsu8SuK7J8LkBoqLkqaQnkEld45y3IqGJ5v+xZgZGkzIw33iOJXY+FNKjcSWQ8/oGnVtKvkmESomb6kZfQOSnk/TR7mFKNRmZ5xAQxo/UVn8LjvdOcp3GZRJppKOjnm9RSpVNoac6RpKpppxEw5PNzePgYUlSVGRllDEoLbK9UV8QpNvcUIiKcfz5E7Awwp5cxZvEwlJJSSSzFcjobpkTp7RDKRhmUlJKZwp/UUm14IUIiJW+eXN4EJPYOfpT9rsVozvLch9HZ5Cxo2J6FN6XaMQsoXib1yfiFyiwRfTOZhR3xmZ+IgUGiHKfxy3ZU75HIJO0kuB3Yh7oWjVMIePWhar/KRikYebOfwH3jecNQkxBkS1+xXZT0j8SEl98vkuylo/uCzilCqrRSpVNobXftoVtKcRR3sO6f8AW4WQiISm3MtC9uQMN9I6hO07kpF/08SISUrK4kGcwXHudMSk9kvAJlGHMss5CMiyemSkshCDbNb6PTKerqbbUX1JIwqAhj/bNwCpKR+1w/cKkxwv5CCoJxPikG2ZXCQZhMI4rxSEya4f70hMlF+534IFJ0MW0wlhlHZbT5A/ArceWolFlMQbCmL+cyOebFfk1Ods5vQONKbPLMG2VOHkmDEnpSd8s7708LsYybzZJI/EUa5vpFGub6Q3J7iVpO/LIdyNhlPmiYyKYUa5vpFGub6RDwS2nkrNRZMaMZN5BJI/ENye4laTvyyHdPMYo1zfSKNc30ijXN9Ig2FMIURnPOd1+Eaez5D2h6BW3lviMgRZZg1J6lZVLKb0DaCQgklmK49ALW6tV8WUxBsKYJZGZHPcPMYo1zfSIdBtMpRcjIVT7pKJRF9Mwg4ZTC1GZkc5XYuDJ0yUk5leITJzhKI79OfEfk1B5UHe+gdZU2cxzBmGW7mMgxAttzGf1KurKdCi2kKNc30ijXN9Io1zfSIdBtsoSfhcehm3i+ovcPQK28t8RkCSZnMGZNnyrXk9AhtDab1JTFiREE07lzK2h2DW1+4ghBrOYgxJxZ3FT+hCaa6+m/aWnaQo1zfSGk3rSE7EkWM9DoeTMr2D8Etr9xGQQg1nMQh5PIjvnDn9MSNhVPOJMlFmELBrZdvjUWa6tCVpNKiyB+TzROaV5PUXuWYMSca5jWrJ6BKSSRERTEV2LhFvO3xKLMIOFUwtSjMjyTXYto3m70j8RRrm+kUa5vpFGub6Q0k0NITsIRTRuNXhHnCJPWS0mayz3Ipnpmr0QkGbLl+oyPJkuRsKp5aTIyLIISEWy5fGos1yIk9KjvkHN6BbZoOYwzBrd/cRBiHQymYvkf/EACwQAAECAggHAQEBAQEAAAAAAAEAESFhEDFAQVGRofAgMFBxgbHR8cHhcGD/2gAIAQEAAT8hstTs4PFetphqv78VtFO6rJJP9yJq80jiLjAk1XIrOkbHtZSEIQhCEIQhCEIQhCEP5Axh+TD5AHSFVVVVVVVVVVVVVVVVVVVVVVVVVY17iPG5GxDjkKqqqrsAtgFsAtgFsAtgFsAtgFsAp3IKbyCm8gpvIKbyCm8gpvIKbyCm8gt35Ld+S3fkt35Ld+S3fkt35Ld+S3fkpTIpTIpTIpTIpTIpTIpTIpTIjbuRPvjrENQw72xVVVVVVVVVVVVVVVVVXeBAF/IJq9Oq1DnVmgQAILg2eAAkRKqIhNdJQgNORrHrkbXiy6F1Je1Rjd+o1umPFB+SqGEyj1iVZ6AJGFiqXgB3HtZHAeHVmobljl6x65G14suhdTW7h83UK3THhrsVQwmU/WIxPQql9QORsL46U/qgbfjc3WPXI2vFl0LqauyAALCIHavgh7T10vW+3BjP9BPgiRPRAWLhROxpjHnFQ4J3f1HP1j1yNrxZdC6opCBBYi9DfmAZKdK9Hpeo9qX8iXkTlYujXEpjMIxsAccwIyXg7qPOdB2sGseuRteLLoXVVOUwFwU/sCqYzo0r0el6j2ov15icDE6dIdFWfsPLE8TYeyJJEkuTYdY9cja8WXQurKfECOCnCYP6Bb5gel6j2T74+Qo6L2FwEuks24T/AFySQA5RnpqtjWseuRteLLoVgUhCKvc9akkkkkkkkkkkkODT8REfyX46IvjS+EX+6/ZK/SPyjpRoUiWyLZ+imswtgKd78tEVeQvxKOfrF+yTP1L90v2S/RL9Ev0S/RKrAAWKFMuQdGBiER15ZX5i/MTXyU4pxTHRGJrsJvKIXx9cYeC65nKkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkYFhQ7ZBxvHkBIAcohmebKrJrHrkbXiy6FYF0HU0tkpbJS2SeryF+eF+eFUNAhFLIa/jGwAIV+eR/zwvwC/EL/AAJfmUF8KF5kqFfgI/5C/AX+E4FVSNImVQHnjHxCJyD22EcGoOM2Jh7OQ/PvKVl1j1yNrxZdCsC6DrTeTPHUWINtipx6O2mh+jxi45ffG4Gjr4Czax65G14suhWBdB1pvJnjqLEH5+O0dtNH9Hj3zHiA9IH+oyI5Jcmzax65G14suhWBdB1pvJnjqLEH5g9Hj0dtABiDmciPhbv2W79lu/Zbv2W79lu/ZBARAuP04SysByvBEwFn1j1yNrxZdCsC6DrTeTPHUWI3MuPR9JI0f02iPBgS58cje8WXQrAug603kzx1FiCzPrj0fSAd7od6JJEkxNlJxk7s05cQlEo4HsY0AFQbkDBD6mOiT8USf7KJUDKpdxeR8VxBmRq4XOzc7QrAug603kzx1FiCgTcej6QP5Lp/TZIETfhMJMx8JmsQx+d0KwLoOtN5M8dRYipxmj6ONMbHEUAnf4gwCywCPLnNCsC6DrTeTPHUWkGj6ORYufN9hJWJVAJm9RHdAAQFmiU+c0KwLoOtN5M8dRYitxl/+Y+YIEEOOihLSO6IQjElzYAF0fSh+JaGNbw52hWBSJYxAH2t35Ld+S3fkt35Ld+S3fkt35Ld+S3fkt35Ld+S3fkt35Ld+S3fkt35Ld+S3fkt35Ld+S3fkt35Ld+S3fkt35J++84Yul0DeTPHUWI8mDkMXMED7W78lu/JbvyW78lu/JbvyW78lu/JbvyW78lu/JbvyW78lu/JbvyW78lu/JbvyW78lu/JbvyW78lu/JbvyW58lIZFIZFez3Qas9iyMgGU47Qt53YWAMTk6Kvecy05XnWhdKXV+nQN5M8dRYiazZ0c76WQgBVV/wCcMiwfHPEgOSWAUVtef5ahdv2c7QulLq/ToG8meOosQJCBDFFdeh26OCSBBYhQ5qQHjcURIVZPPuOX1ayUkCsy24W3C24W3C24W3C24W3C24W3C24W3C24R+Arh+lLq/ToG8meOosZDfpAAkFxWoye1Ohs3i/rn35CJwCAUwBh/wCTXV+nQN5M8dRYwgFNg9aXSLnysYhEncDgrXueaPrP+n/lF1fp0DeTPHUWQFQJXI2AYODv0gp5XfsK7Rh/eeId0fc1/wDlF1fp0DeTPHUWUIeBRskQNAond0Y4lwkk8e3LnODU1+wj1tXA3e5605DkOQ5DkOQ5DkOQ5DkOQ5DkOQ5DkOQ5DkOQ5DkOQ5B73kGk3QN5M8dRZwgEEAg3Jxr52VeD7hOQ5DkORLpJJJJJJJJJJJJJJJJJJJJJJJIR3EchyHIchyHIIriSSSSAiGUiFkffG4UE53PznhOK62ug603kzx1HViG0GsOM2JsdG55+d2EzM9bXQdabyZ46jqxofo8e+YrXc4mtyOMU4xTjFOMU4xTjFOMU4xTjFOMU4xTjFOMU4sC6DrTeTPHUdWND9Hjg2UVACbnQGU5G21liYSeU8p5TynlPKeU8p5TynlPKeRmgmuwS6DrTeTPHUdWND9Hj0BAy3PzmDGJW2K5iXO2UrAug603kzx1HVjQ/R49ATWm5z9N+pbX5dA8c7cSsC6DrTeTPHUdWND9Hj0BOXcNzjDKwXQwNwc7X4QO6JJJJrPOHwfxYF0HWm8meOosQAnnFvwU3mpvNTeam81N5qbzQXG54vhG26H6PHoC7nMZc+OTE28Gq1tof4Bz3n4FYF0HWm8meOosRpeNo7aaH6PHuGK2ng8+JTRlqIAEksBWsNycg5/jTNYF0HWm8meOosRpeNo7aaH6PHvmKZQRe3cWAJxbx7T+GdgTZ9LAug603kzx1FiBifGqThY+YIgAILg1Ww4cuHZQ4xcG56JdG3bnnvnAZIAI4IgbOfFgOVfPVDAWAWGC/c12BdB1pvJnjqLEecRyHUxggfa2fktn5KSyKWyKWyKWyKWyKWyKWyKWyKWyKWyKWyKWyKWyKWyKWyKWyKWyKWyKWyKWyKWyKWyKSyLc+SAEE8hECSXJv42HJQ0Auj4sDsQRr/wAs8ZIkeJwsGExi7CwroOtN5M8dRYiZYHjpcqkPmqhqgRh+LCAYErbV2V3PCjJ9sMfXWEXQdabyZ46ixFWwQx6XKESYvi6kzNB37DYASC4MU6Ns73sZcUEkOiEk1k2GQx+42FdB1pvJnjqLGNIbnt6SaYXagGgKby0PZYmiTG9B8fEHPJADlOBnN/wiSRJLk32F9EPYoXQdabyZ46ixhAIIIgiPhG8JdHHi5IBCl/E58AV4DFX+DSxOEjEXFMI5yBQBBvHMAl154IyP9sbY+4hYl0HWm8meOosg7kJZNProocWRVvGvBIcTVXw9lkIvJLkKAHNAhIrMIE+hmIL8JIAcq+LKPpQ+cGATkD4BZG0hefFjXQdabyZ46iyh0AEGsFFWSepPxFPoIBIABysqa8oZeJvPGYAcEMQijqrKVmIORBkqmpkfWWYtcwvZhtORYBCFMeJ5g0BBuxdbgrcFbgrcFbgrcFQogKutDo3AMGLIMVIhVqI/qiP6oj+qI/qnFwiInGzsDhgURcC5NV/uJ+Ovx1+Ovx1+et4VuCtwVuCtwVuCtwVuCtwVuCtwVuCtwVuCtwVuCtwVuCsbIK/HK/HX46/PV4BCA7FUszi/lOrL34RDQ6gzA2v/AOMQKiQ4HHp5Y87/ABAAABgKh/xgbDghiEza/wALpoeq6zgEKuA1/wCNAKrqOBQooi/EdLcYIvSPzf8AHHcgGcm6hOkvgCqCe5if4D/j2FtgU3yOjvwiWNi2D/kFXAXZRWyNxuPborUoX3Am+6g/8iLnGF4dlCJyr76GwvY957IABBYy8RXBymsymsyiosesKHsQHECVVJFTEUtg6wOUc5geDV96AZ0FnZ0BpOTCK/gPS5AlHrkrncZDIrA5TWZTWZTWZV2I1TIlgSg72ZTWZTWZNxRNU1JsACslQUjSfUP9AJvBNkQkAQaiKC+3GMSOBQrQaglg6A7+ZGqcqjQLPhczEwUfUQcEU17Szs6OIAnMK3AysyXo95apG27zEJmwlSIxUA5RLfzIpD1B4CASSABeoYDORD8NNzMpHCbh4hRutSENUKsjHhE2DMgaCcOAQDfzoVAXigGWGQf0nL2ZAuH4SBDROKZwPCDGfaGiO64gSnI/tSYgALVkaJJCJiFAeGDheiKtZBFnaBRUsAOUA38ymsymsymsyIACKiFDgczs6A72ZTWZTWZF3gODQ58Mg/pAwAHE4qQdkSHAYlPPCQDqT0UF5Rtp7UEQAnNaDQSYcw+AJVgr+8COyIIgbeKmkuCaW7u6LMsRLa2o2KqMTRtJ8HtYPSr7b6NvJbvjwaBNYfXGekgCgoBJZygIDklhQp+e4LLUqCIBUaNIQIwvQRaATuNrl0KvUjIq5Ewc/ECfskQoN6vhcjUqPZ90aH7KBILhRRhxnOisRsWNLG/hD0ol5Q1yeYe0xixVhDxZLsovyjesKNzOk7rAiUTxwPtF2ZK0QB/cIjNBcU7wulS8dIxKLu0uBCHMRjcgw7T2BZaDEI4IkdzOiBf8CnCwvtOGe5MfVh2qFcSE+EfloQkEAslQVdIsEUfiUTgMU8YAAHEirrrLAoFbEYhC/wBvFyeHbB0ASAAcmpBvDE5qCVVXdHDEvQk/6ga0ebldECnSQaSRARyTAo149h2KLiDAdhQryFYF166ActSuiJGABoewhnOjG+A9xRg6D4ApmjWmP0Rh/qHwsUjxwNZuIwIOGOfOdmSv9Xi2Gq2t/wDTKAfibzZ1IB03/wBqYE4xo2k+D2sHpV9t9G3kt3x4NAmsPrkC2/Utwxp1Kgq+P2UwUkBVC57lPtN2hAgwCoCggEMQgdsFQ4XI1Kj2fdGh+yj1sAeF6NsxEUXswKrEbFjQK4SE+ES+I5TW6JyzoZALa5wKO7xHwGjesKNzOmM0APIUcXUa2ATeAoJAwABRBIg1hFeYlCMsDUoTFSf4QwAAC6gVBEVBWhIUF1AvKxXgUJ9iMUTeZAj4kqj8OFsIQOghRwK/KFhwTB3puKX0ivUHbsKLH/zFD2GrjQy9xBTgwKDTHaN8JuCrVvJin11oSfEFMFPY4Iyyr0gQGOZVj6Mwp1L4uy0Cp/CcwgcEIZzEgKdmyfJ0wIsAAgAQbinU84j0E1xtLCQm1slFNjQtqxtJ8HtYPSr7b6NvJbvjwaBNYfXI28luGNOpcBNuVUasekAfk43VCuxX75X79Hs+6ND9lA4NoqGMeEjghgxuP9TwHBMCtixoeDSe6AAYq/lSHtUEZDgW9YUbmdLvMPSBjgOvAAIYkRxu/wB0Ftr0JydBsqBGYOpdZOmBo/johzC8OIO5y3BFCWlP6nwCSIQvqvqkJTkGKOuqssQrzgxOAQbWAwoIBBBECjwOuCBfAkHhH/TT6hhAIGmpVvJin1+A2o7vk0VTIgEM1EOETsUwl/8Akn1uM7lSOBqnXh/BQ6LYvi5Cs8GKJwVH/sR3RYWsgwKcy+wMQooc9wLI+ASCYyMMBEq97uDa1a0Ma/lfhoEOBeKAiz+0J1iGlIwW4goX710beS3fHg0Caw+uRt5LcMadSoPRMZJl+GqkAdqDEuCKuEBm43HBrBmCvzaet8u0ez7o0P2VtJoUUQXijOIRiQqD+q2LGgrNEtDloThSFXx4FWLACAYALesKNzOmQAZiCE8QXUm8YDko5i8OagL8KBvFPKKMzYdxRCsCDYBk7aqMyIFuRS1R294cgQAGKxUe6r2iY+E6BydLeT4tVC7gQKiStUcQjHzBBKmpVvJin11oS/JX4aAAgFMsKJJJJXZbqvCp2ThG6yCYN+oTN7s4pzFFJEACAZDmaNxRtBg482SprwELF6SXBMYgiCCxDc0tF+IL6nFN8ZOpNhmADW1dZ/fAFZ3x7FARGILgoIRPEfIoihya0ymJko28lCp2WdlOb9k4wGA8/ijQJ4pFSmt+yfdxIuLbyW4Y06lQ4dEjBWXU5v2WDaVvQNnF/KLQEBiEHGiKgrUP+SAFi8kL2zwuRqVHs+6ND9lbSdDCgIh/xDKYgsQtixpvOnMQayPtMD4RGBgoJWSRiVBNjEOAo3rCh4VlnSc37Js4F2wRmNSM5NpgrCFWTVimxB7wmQQFQ/1CwvQCFqwGFBgCwZjBTAIQ/wBrVohiQUAmEKhQ1gIfdOt0bnhxEBU8DgEAD5qq+aM8qZFrURJ8ptzE9VO8meDQiLrgJooPNc4jsiF4KcEMcNcBJFnUf9KalW8mKfXRMBwKA7+/ZTm/ZMwGAmd14EZwQBJAQMlwZNyKjvCwNidkAwZMuS8CBQAJNwRkKqcYmnCR8GdAzQM7m8pghA8iztjv4V/e4jKl2P8AFUpc0Kc5x+J/cihpYhVfnFVmLNXgRWI7x+KpQcWj0AcWHENHDKXAQCGKMPm1SbB+CFgYd0LOl1IOUCHxW0K2hRHwU30QIwXea2hW0KPBi4OIfoEPiiPgpvpFwSW0K2hW0KAMiIUjXDBFAzoxFOMm0B5CqnQYUAyMHN6fZkVUC4MQtoUcBBIeIoDKAEXcqHPCFI2GUKqlAG+kgEMQ4Ti/ZE4kuyqV90/uYahTOtGa2hW0K2hRQgWs9FXIioK0EIZYU27OjGApEEAwcGgp/VGiUIBIPKBIG2ooAAADAUlClicBbQohoxygcTD+4VhOJWOmDzQMDhCrgDmM2PdCJkOEKXqBXJvY4aydPRgLLWQ+wEBS29DRFOUyq70tmAsMVtCtoVtCjDNWCjcIEg7yTeCAJruofXAFwQUSVEMoZbjC6NyIJhhQYDmayqT3B4UZASa7E1lWV//EACwQAQABAQQJBAMBAQAAAAAAAAEAESExUWEQIEBBcZGh8PEwUIGxYMHR4XD/2gAIAQEAAT8Q2VmhrCeQlntZdRFLQvGfqksMbAP6n0RQ+peEiwkcZINlZi89DN16K0nz6efTz6efTz6efTz6efTz6efTz6efTz6efTz6efTz6efTz6efQ/7RGj6NDHUbj2gzMzMzMzMzMzMzMzMzMzMzMzMzMGKXfrZtcVwCwjrmZmZkvwMeBjwMeBjwMeBjwMeBjwMBgHf5Ts/9Ts/9Ts/9Ts/9Ts/9Ts/9Ts/9QJ7vl6QQQQQQQQQR6C+++++++4+R6gFyNdjTHk54WVobWZmZmZmZmZmZmZmZmZgAdGGxqcX+yUkMZLioC+NsHWBURqJs7KiS2xvgilGbrZ5ERasd50vQdox/h44OxxdT05ta69xO1CC5BYOAWqNVfYHwBats4OExrzWxqAqgSqahufXCKu6qt76faMf4eODLIVOAUTpc9W69wO7EBuGg4BpRqr7EKhFEuY7w+rsMDCiue7ij+QrD5Y+r2jH+IDgxIRRGok5ZRbUBzovN7WE1P7pmf7Mo4qsJ7IgIiNRIN2IH0nrDHPNyDey3cLFiq+t2jH+Ijg0rIEFiJB5rabgN57isAZUao36/kTw21/R7MmjWyYl5K80+QPqLqaFg2Rau3RcGA2DtGP8AEhwbwygXiQcJq7nK9vWAMXqrDvcRhcjcMD2hqrPpkqitw7skvWRVVqq7D2jH+Jjgw1IBeMsMnxIEPbMgFtUrBvY8VbuQvaTbzd9PRQIAFVYsnaAvyGWx9ox+2jgwoUFbaa6UpSlL/Xp53Dv355fLqU4oiVeSzvWf2qEBe84aLyag8z+RO7hoCXvAaT7klHt84lfzVET+U8RPMZc7+c8jnnUSv0JU37RVSJV1SkkkkUBVQrEYHhZAoQEqLjLzuedxFVI4p4RnhWJlXkeyODXlC+3uwGBrAqEoK1UagbVKUpSlKUpSlKUpSlKUpSlKQ2a5oI//AJRMR11Pbi5tPQQIAFVYxgLQt/ZHaMf5AODljctPHo/56KKr4l03XMKk4wMkpUIVr17oKJB0WBJxvdDHDaEIEK9/lLAK/fum8lh4ZD/Dw5+noINoamMzKmf1AHM64AkNNxYbaWgUYcmf1r5vjkPQayjYe/gy2XtGP8nHBy6FtNjicPPXO+4vZJ+cQ89dZgnY77dxdm7Rj/JxwcuhbTYoBgOuv33F7Jn7hg1nxo1U9rCKfWRers3aMf5OODl0LabFAeymv33FttDVhsACVtGuk00001Q1iTfnHVDRfSWVo2YLcbP2jH+Tjg5dC2mwrHH6LX77i9ppYV6o34doeN2hGha9BD+PnBy6FtNigeOvO+4vaACl1Z49ZRVd67KaCXh50SBpedXNhgAN5JYEDcFD0A23VhorhWX38J+kwrwluJ4KKueAJ9vFij58fokUVhn/AFv4xg5dC2mx80dfvuL2i2wr5rsYCtCCgfmnhA9L77crlAAAAFwbFRxTOT+MYOXQtpsWCz13fcXs6Uq5u79jYMaXLwb5R+V1sjlhstHH/jFg5dC2mw7Tru+4vZwtQHzewkQLQFVYOUvy/wDuQAAAKAbNwuX4xg5dC2mwWrlr2YoEuAWqAEEQRLkfZRUrWRjuEralJiuwJcW93DFgOkBafRgbRTw1PN7dg6+uAvynA7U0000000000000000000000001VIw7gNvB7B0LabHBfoYcBXME4UO0hNNNNNNNNNNNNNNNNNNNNNNNBN14xB3aH3pFeHf1Hyg532rE1plHOCOtW3f7Am9hp3DesAhVtUte01A70dE94wfdMfsHQtpsVSFm+Kx9nFDby0+GEV6haT7b9VFjbnB9epwYF6sKARD+lkbU5i/3gMH3TH7B0LabFco4MRlRG1E77w+zvWRURojERoCl2ZHPSpLuK0LostUK4r69g44Pva1KyVV6xrPJR5KPJR5KPJR5KPJR5KPJR5KPJR5KPJQYsIIp7UfdMfsHQtqsKIkqHe+0ASIGol4wLp4DBu0B3R/7evY+fCFqwrAoYB+Jn3TH7B0LarACII3jFb61Vjx+0Jq2qYzeSmlPKMc+ePXIjafGWr8UPumP2DoW12CKrRUcM7YX5PaFs4kdnrvm2v7+sCoEvRC6jq/FD7pj9g6FtlgAgIlEYAfe3l/I2tnQvrg+zbpyXEqdSZNdAHrCeqm5172bCigsSMtGWjLRloy0ZaMtGWjLRloy0ZaMtGWjLRloy0ZaMtGWjLRloy0ZaMtCANVXd69gdC26wRcKKKjEFWm+ChckGxwkZaMtGWiu2SedTzqedTzqedTzqedTzqedTzqedTzqDVYjDRloy0ZaMtGWi7oPOp51HVQ7qyv87sBia6BYXNpM1PWQu94fmpy6F77YOgUQcnf1r5APyEZK9Xr6wOBPzUHLoX4JYn9wwTrfrB2G121QmW5zLc5lucy3OZbnMtzmW5zLc5lucy3OZbnMtzmW5wS5H8KOXQvwSxPYhuJDYVKHT59Yh+/bcPdQb7nk2eTZ5Nnk2eTZ5Nnk2eTZ5Nnk2eTZ5Nnk2DZob8KOXQvwSxP7PjMt/WWT35I7aAbc+kes6Zh9n4Ucuhfglif2fGcUTnb6xKKFd0m20XbY4fra7N3/AG/hRy6F+CWJ/Z8Zg8Jy/j1lGoMOY1jAlDeArtYMb9GO5HaqirivrVlwL8KHLoW02D00IoCkePzx+ePzx+ePzx+L0CqsB9kT+z4yhS/sXr1KuqXM2tfhP6j1+Lr+FHLoW02FZa733F7JP7ZgjGlpryfXIy8xtztRfgKm4CPUFpclkevQo7hfJfwo5dC2mx2PE1++4vZJ/cMEtYE3OHriiJCiUgcy75bTTG3DsBXwtUcLH4UcuhbTY+GHXv4wuAVMGsAUWiO2AWB4JB964Kbx5jRZfQ+YWnrpCrRM83xDEAIWiNzs5KUUwCV5gVMJuNgEZRdzn4UOXQtpsGjLucPQw78gThQwlTtFV55555555555555555555597gTIipcTh9AiF0VU1V11Px+TXRZKiNnsGwma33Ozyfc8XD9DYKk3F55/Czl0LabFjStH5ntdAf21Y0Wi5ZtdgiiI0SUAB2rYNlEYtsY37R2Ctu78zav4WcuhbTYIKrgyZeEMDibn2paTR/jplXR89bGwAkAaiWJBQ7lbsubYzCJxMzEvuqKquwAqBC3067fws5dC2qw1mZQ3u6+0pAum+nFgAAAKAXGmjBr/N2IivChf/ANiOF1zeugQAKqwU+53RL1kKpqq7Dc9jCqXH4YcuhbVYPAoRG0Ri1FUv7fZ01kAQrUeIdQFRSTgwnWrg47jsVXV4nEIGF8lMuoDJUfUOD4g/LuimAX7W/Y6vNKWQN34YOXQtrsDyDdhmRKord/WB9lutAB9ss8DyhrBHt0449kv0WqGq4jMbMPVyZTANeLOUsEOmqoQAvWHLkikMtceVVN8nsjFqhWuXd+Gjl0LbLAS2oCokrwvaGYfeoseD7C9ZGgBVZQGzVsKPdZi8R1xcLIuRsSWvD457MACN6oz9/TAQDnTzMvG/OJVUzvtszYygXqwciriX1KdfIKieJjxMeJjxMeJjxMM9DhS2U96Zcq6ipfEECNTy38gi9D/IIvQ/yCL0P8gi9D/JXp3JIGzn6LeNSOMHFXkhb4Hks8/nn88/iQrz88ZHiY8THiY8THiY8THiY8THiY8THiY8THiY8THiY8THiYoim4JoO8/nn8SFefn6FcRMTAGXxHy5n0hpCmrvcYRKERonuDgt6IX/AIxRh2Qvg9vBUoo4mSBWAAWAH/GCzrIuRjEihf2Mz2210WtxvllEUdrvW9f+NEcaK70rkmCwBduE9reYygQoKULiP4f8cZ0qtw/4jmqYn7PaXANoEsMl/wCPRbihv88kfKuiP2ezvVZcbs2V00P/AI5P+QdxIAynYGwucV7KPsa+uYAqEFW9/wCRF3G4sXFS1BcIs4YH2NjvM0TckiN7i7Gy4KVmnI0331iK9DYDNNC6KIFk+CGHqkuY4mlligqNKldxKZpu90aBp9BhWviL7FK/eI1K4dBpKynCXUl0P2a70yoC0dS+++u9U11UJxhIXBVgnd8tN97IqgVUPyGkGwVRQJnRBY80TJEMjBUjmVIMJqoqOgY541aJFFAFStPHQSK4FYTDYHu4lacdCvBDaiU3EfugAIvFNLpwCgrTwirjgx3UIVXuvLgEUnCJBXM4OhM29KtNK10emAFWAU7fhKL1VoJU4OoRcKqaATgS/wC5oQqCR8o+RdrQ6oJ9e1CLA4ylzIiUxAKpXTo/wXQadaItBWhgEv2r27pSv2DYoXJ0UJpJbJplFyO/yhABBBtKOrv2iGAwD5ENla46mhuhqqwjTgSiBcuCJoQjXKigkO9NWiDimgQsiobXwCO0KxWBlEXWRfJoRKjkwCX9qHffep1QJwZVMpqCtPCHd3y033uWS0yVHQWiElCqpwMAcQLT0stpgsnwRjlAQavFNN9xxKRPkmHUgYTgJLkxiqnqG+SgKjEBt43/ANwiCCI0R2+6fAEJ30byzxgAAFDZT3arkVnbEOUi9B1eO04ae94Yg4Wi6J9p37Dq87bj16svISgVIoXxzgwYrO+Ih1VzBCd0w0Va10aUaNGdsQXL0cGij0P5XcGbGjRbJhaoFoqwvFgoRK6IydResEGyXNujv2M71g6O+YRvdQ0cAiI1EvEgEJszDrcSDUxtzeF/cfINqVWHyRxkmJheaBxSCzL8OSRESxGDnkdHdcejrX202/FJFShbL7xMU7wgWHFlfq8hmP4+0kSIPdpfl/IOjhdHfhEXlStlc4BFBu0bvMxeMuhitTXNUSwLeJYmC0LnbVy35KgWucJu+ESbSgquUdw3Nk/sWv8A4H/DVrl2oXjeynlEN6sKHuytgEJRuOdjY0wKLC+UcLOQYj1hV4krOqNIhLQqYpjD3kAC1VjZPDnxL2CQOKsIgY6qlMgq1TFUsKSGm3nhcCUMDzFSdsSzvTIMq3CNwXTviEEoDkQ0GgAqrQnYE7Yioya7kNHnSWipbWnyV0NVv1Ri1GlU4Gkm11ORPsxKp1MVMAhLJVrK8Qz+yAO+saQK7e8G+Uwqmloe2ArQiNfe2nIITGeJxHZzWwIPJQVsDo6vHacNPe8MQcLRdE+079h1edtx+gXBvtqWd0w0CqkkXkoI3I6H0ss9rJEWwkFhaAoBoVARKI2jDlVlC4q10d+xnesHR3zCN7qGjgEtP8aRalwMEwZYdmzeYGpiRo/SSsrelpxgii2luBoIREESiSvlKO5Oo8B0N3XHo619tKPOn7iJsiVDc3sEmOgH24uivoJzMHJhnUREwSHlVDd6F2igVjAfMsN9feEBhKgCgGhooo2AGEunCD7dFiust7cMU2mEvwLTvpB+rIi5pDI3sCe6V3rvXVGgrM4LRI8F6EvpYUjvfen0wBUFUoukUF2U/VJVopYLJfK1TyiqvroW539CiVa/wGNRRQaOUPcEVkGiFFCpdqd4xZ1LUj7hjPNTyWmntx3wVj7/AHOQhNwUg9GUaaMOSJQQobwrWI5n0QQ8a4DMxBI8oQO5GkKVeqWgVFAQRLR2A2rUQqMpd31ZVKxM3XuA7QCtAlsb7q0ZRQMV2ibWO40XV47Thp73hiDhaLon2nfsOrztuP0OjfbUs7phqfG+g1N3fUhN9B1u/YwhKzfUNF3muqaeLwImGd8ivVTAP0zIOOFG8dMiCYXMmi5S/LUOlqt6DnBRGNvQu8p3XHo619tLVTcPIRe6GcFqDvQr87YLcgtBmph/AgmI9HQbLf1ouI8u/kP91/IaK6NCgN+PQffAOetQpm/eOPBAO9yVoZITM29pKCIoAskRNAAEgd4yvQ31vZfA8IL2U4xhoNsgiNyMeQtrf/uSuxF4qGVArmBX+ADT2jFnUteMe3WaKLNRM4KkIBXxkEyrVD6FjJ7z9EBcua+FYg0b0RxU6DQb1WQQrloIQH3zKfDumPlLYVcm3gJDn43XNkYoApbmYjvawyhPe7XRpFPoUDHiMrhGIDQmEZNzcc/SuZbHIRWeG0Oifad+w6vO24/Q6N9tSzumGhx4tqG6XiMCQV3ANFGbTbmFEhp6W5heNbv2MX3nVBEzna/6ggGlCn843uoaf0WKv2izHEhA3W7pLmP2TK9tBpkA9QRk3kRFEokMYouGudKvCDJFxOi4w3sIi4AJ3XHo619tKmS2vhqJZdV3gtzpOmyiXjzvyrEStUTQGyUGcKSpgBOiBKC2TShFpfglCrAQt+LXSat/6NHacPoWqQgLTIQnKNLBVGDbI15F2noH3grqtVp7tkUoFQhclzAlkTpnT2jFnUtSPsGM8FniMAAALghoXIfBWIhVVVgPBepwVlj1BfktIAU0H8I9ZXO7eNNn1KnlkCpuHMHTQSW5CpwbyMzoQvSYEAHcmyE1FxF4pfFEYw/2S1kYL6o+UjclH1RxX94zmY2IHK5SuiPHTkIWAbhDp7CeFfMRMnODAvEivwvco/DN5bTFnAIoVKrVWWatjO7c0dE+0BTIpWqs8YgWMJ3FWlwFmGtLaqJAgDkIIaKuGOBrdG+2pZ3TDQhW3chrYJ4xAFM2G1bNF2u2vtSkLEhREhsEoqnzxlNU4NEq5e9P+BFqqq1Jeq6O/YzvWDo75hG91DT+i6CWkRT9smNDWReJqSIiWohav6Yjc7E3DBIUhhaoR5xFo29/RKnFSXqwyvoS3pvdHdcehzs3Lr0nhEGyC9K3qQlgeAiZtElPQKKtDF+swKI9RNr9zEx7QEd1IwIZZGirUNevhKJFuCJGCkAGp84HkI0IFBX7kf1jm4NzVv1Rex4dYeWqsLMaCWNztUwESrHsKj8rFsrxqVWFLKMcLmnoWpSTJaMc7qy4beXv6TK7NDKBW0wYlmFRzqW6XaMWdS1I7O60HlLs5aPGIqK2ya0ourKg4hxgbL1Ah3UMcApLkh1zm8OhHgbWAAKAUCVrGpTfvH9MuCkXgSs+hGua9ghRm+/pHGFd7Ct6lbA2d8bFsqL8hJyCx+sW1xIETJmUCQsJWxdAytDvl2Tj/CfvCS/syA6qw2va+CFhhOXmYG3pNuBrHoCQ12WtRAAiURuYzPVfb/CImkaWl+wjhRxp9DB1jRAoOOOm3045SePjx8IUiYYHQ472hHj48fDCEa1K2msR3TeBIlyNhgdKGb0Tx8ePjx8MjjDw6WVKlLC/OMoATipR1LVMpX7dFAofISo9R1GroL/BG0DEoChymjM0OZPBRbTxXFroeJMKrxIOGMleOm6LSu4iXY+IOlUBCiJUSUVt6ir/AJH6TOv2Easnep/REaJWgUbI0uIglrkSePjx8ePhioqFzbot6AbsYL84jCsQZroO1fb9+WbmEBvcV1K41Uy3g3y+F7EqMOIVCBSN5UB4mFWAABQA0gKQTcKTx8GsUyXKRrVbBLb0yrAHEYVASGCO8iiJ51gU0j0zZXiYX9UVW/SS4tFRAjWlQEHtj6Qg++1lfLKF4gXBpABVDVeLD4zgrvQ6b67i5ZPHx4+PHwRZVxcoRbeSuUVYvyeFpFop2C2uEjOcYBsXRYx7qojVjU0KiJb5cSl0dOo7ynUJSt5K1WVcnMjP/9k=';
+// ── Firma JPEG → PNG transparente con color de tinta y estilo de pluma ──
+// inkColor: {r,g,b}, opts: { pressure: 0.6-1.0, bleed: 0-0.3 }
+function makeSignatureTransparent(jpegDataUrl, inkColor, opts) {
+  const ink = inkColor || {r:20, g:20, b:30};
+  const pressure = (opts && opts.pressure) || 0.85;
+  const bleed = (opts && opts.bleed) || 0.1;
+  return new Promise((resolve) => {
+    const img = new Image();
+    img.onload = function() {
+      const canvas = document.createElement('canvas');
+      canvas.width = img.width;
+      canvas.height = img.height;
+      const ctx = canvas.getContext('2d');
+      ctx.drawImage(img, 0, 0);
+      const imageData = ctx.getImageData(0, 0, canvas.width, canvas.height);
+      const data = imageData.data;
+      for (let i = 0; i < data.length; i += 4) {
+        const r = data[i], g = data[i+1], b = data[i+2];
+        const lum = 0.299*r + 0.587*g + 0.114*b;
+        if (lum > 215) {
+          data[i+3] = 0; // fondo → transparente
+        } else if (lum > 155) {
+          // Borde del trazo — transición suave
+          const t = (lum - 155) / 60;
+          const alpha = Math.round(255 * (1 - t) * pressure * (0.5 + bleed));
+          data[i]   = Math.round(ink.r + (r - ink.r) * t * 0.3);
+          data[i+1] = Math.round(ink.g + (g - ink.g) * t * 0.3);
+          data[i+2] = Math.round(ink.b + (b - ink.b) * t * 0.3);
+          data[i+3] = Math.min(255, alpha);
+        } else {
+          // Trazo sólido — simula variación de presión
+          const depth = 1 - (lum / 155);
+          data[i]   = Math.round(ink.r * (1 - depth * 0.15));
+          data[i+1] = Math.round(ink.g * (1 - depth * 0.15));
+          data[i+2] = Math.round(ink.b * (1 - depth * 0.15));
+          data[i+3] = Math.round(Math.min(255, 200 + 55 * pressure * (0.7 + 0.3 * depth)));
+        }
+      }
+      ctx.putImageData(imageData, 0, 0);
+      resolve(canvas.toDataURL('image/png'));
+    };
+    img.onerror = () => resolve(jpegDataUrl);
+    img.src = jpegDataUrl;
+  });
+}
+
+// Cache de firmas transparentes (se llenan al cargar)
+let SIG_INSTR_PNG = null;
+let SIG_EMP_PNG = null;
+let SIG_ESTEBAN_PNG = null;
+
+const SIG_INSTR = 'data:image/jpeg;base64,/9j/4QEfRXhpZgAATU0AKgAAAAgABQEAAAMAAAABAxUAAAEBAAMAAAABAZQAAAExAAIAAAApAAAASodpAAQAAAABAAAAcwESAAQAAAABAAAAAAAAAABBbmRyb2lkIEJQMkEuMjUwNjA1LjAzMS5BMy5TOTM4QlhYUzdCWUxSAAAEkAMAAgAAABQAAACpkpEAAgAAAAQyODIAkBEAAgAAAAcAAAC9kggABAAAAAEAAAAAAAAAADIwMjY6MDM6MDggMTQ6MjU6MDcALTA2OjAwAAADAQAAAwAAAAEDFQAAATEAAgAAACkAAADuAQEAAwAAAAEBlAAAAAAAAEFuZHJvaWQgQlAyQS4yNTA2MDUuMDMxLkEzLlM5MzhCWFhTN0JZTFIA/+AAEEpGSUYAAQEAAAEAAQAA/+ICGElDQ19QUk9GSUxFAAEBAAACCAAAAAAEMAAAbW50clJHQiBYWVogB+AAAQABAAAAAAAAYWNzcAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAEAAPbWAAEAAAAA0y0AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAJZGVzYwAAAPAAAABkclhZWgAAAVQAAAAUZ1hZWgAAAWgAAAAUYlhZWgAAAXwAAAAUd3RwdAAAAZAAAAAUclRSQwAAAaQAAAAoZ1RSQwAAAaQAAAAoYlRSQwAAAaQAAAAoY3BydAAAAcwAAAA8bWx1YwAAAAAAAAABAAAADGVuVVMAAABGAAAAHABEAGkAcwBwAGwAYQB5ACAAUAAzACAARwBhAG0AdQB0ACAAdwBpAHQAaAAgAHMAUgBHAEIAIABUAHIAYQBuAHMAZgBlAHIAAFhZWiAAAAAAAACD3QAAPb7///+7WFlaIAAAAAAAAEq/AACxNwAACrlYWVogAAAAAAAAKDsAABELAADIy1hZWiAAAAAAAAD21gABAAAAANMtcGFyYQAAAAAABAAAAAJmZgAA8qcAAA1ZAAAT0AAAClsAAAAAAAAAAG1sdWMAAAAAAAAAAQAAAAxlblVTAAAAIAAAABwARwBvAG8AZwBsAGUAIABJAG4AYwAuACAAMgAwADEANv/bAEMAAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAf/bAEMBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAf/AABEIAZQDFQMBIgACEQEDEQH/xAAfAAEAAgICAwEBAAAAAAAAAAAACQoHCAUGAQMLBAL/xABDEAAABgICAAMGAggFBAIBBAMBAgMEBQYABwgJERITChQVITHwFkEiUWFxgZGhwRcksdHhGCMy8RkzJSc0QlIpQ0T/xAAUAQEAAAAAAAAAAAAAAAAAAAAA/8QAFBEBAAAAAAAAAAAAAAAAAAAAAP/aAAwDAQACEQMRAD8AvwYxjAYxjAYxjAYxjAYxjAYxjAYxjAYxjAYxjAYxjAYxjAYxjAYxjAYxjAYxjAYxjAYxjAYxjAYxjAYxjAYxjAYxjAYxjAYxjAYxjAYxjAYxjAYxjAYxjAYxjAYxjAYxjAYxjAYxjAYxjAYxjAYxjAYxjAYxjAYxjAYxjAYxjAYxjAYxjAYxjAYxjAYxjAYxjAYxjAYxjAYxjAYxjAYxjAYxjAYxjAYxjAYxjAYxjAYxjAYxjAYxjAYxjAYxjAYxjAYxjAYxjAYxjAYxjAYzA/J7kXrjiToHanI/bTp82oGpaq6s84nFItnEzKqFWQj4euwLd67j2TmwWeeexlcgW71+wZLzEoySdPmjc6jlPl+Pm5obkTo3U2+K7XLZUq/t+gVjYkHXL1GIRFtiYi1xTaYjm85HtHsi0RdCzdIrFOzfvGblBRF00crN10lBDMOMYwGMYwGMYwGMYwGMYwGMYwGMYwGMYwGMYwGMYwGMYwGMYwGMYwGMYwGMYwGMYwGMYwGMYwGMYwGMYwGMYwGMYwGMYwGMYwGMYwGMYwGMYwGMYwGMYwGMYwGMYwGMYwGMYwGMYwGMYwGMYwGMYwGMYwGMYwGMYwGMYwGMYwGMYwGMYwGMYwGMYwGMYwGMYwGP/X8/l/7/AK4/fmuHLnk/rfhpx02ryS2q8KhUtY1h1MfDiOkmshaZ9YxWNYpkIdYpyDOW6wuY6Ai/MRRJBy/K6dARm2cqphB/2vvJXsC55cQ+o2mqu3GsImWi+VvOCRilRKnG6zqp11KlRJN6gX1ox3YWovCIoKe8k+PXrWE4doKMadUlkRgwYxTFlFxjJpGxkc0bsY+OYNkWbFgxZokbs2TNo3Img1aNW6aaDZugmRFFFMiaRCEKUoQWdG/G3YjHXe3uw/kg0VJyf7D7aO2phm9brouKJpkrp+tqulsW7ohTx7N/FPC2NJFuCQHqq1CiX6JHlb8iU72AxjGAxjGAxjGAxjGAxjGAxjGAxjGAxjGAxjGAxjGAxjGAxj+X8fHw/j4fPPWusi2QVcOVU26CCaiy66xypooIpEE6qqyhxKmmkmQpjHUMYpSFAxjmKUBMAezGcZDzcNYY5vMQEtGTkS8BQWkpDv2snHOgSUOiqLd6zVWbLeksmoip6ap/IqmchvAxTAHJ4DGMYDGMYDGMYDGMYDGdQv1/pGq6XZtjbJtcBRqHTYh3P2q3WiTaQ0BAQzBP1HUhJyT1RJs2QTDwKAnOBlVTpoJFUWUTTPWevXMjmp3TXqxaA61lrFxr4Jxyz2r7s55WyuyMVar2kAlRmKvpWNWcx0s0F20OcqbSKcxdvXbLtXFtsOso56EPOBZ+ipmHnWgvoOVjZlkV09YmeRT5rItCvY50sxkGZnDRVZEHTB83cM3rcT+s1doqt1yJqpHKXks1D4O8KNNcAuPtc476RSnlq3FPntin7DaJVeXsdzusygxRsFtmFB9OPYu5X4czKEXBMYyFYINkUWbEh/XXX28wGMYwGMYwGMYwGMYwGMYwGMYwGMYwGMYwGMYwGMYwGMYwGMYwGMYwGMYwGMYwGMYwGMYwGMYwGMYwGMYwGMYwGMYwGMYwGMYwGMYwGMYwGMYwGMYwGMY+/wDj+OA/t8/5ff7f3ZVz2a/ed5vYihoitu/f+svr4vEVZd4SqZjuqtyf5AslH6EfSIx40KDOXq8UmSTg1/RdqIEq5LhOEdApeKKsjtD3J8xNqnc6+6wuFg/G+ZfMxo7gJiTin7lsvobRb9Jw2t+xpqRYCC1edy0M3nU46TBQr2DrcTaLIzIlMIVQJGTXg9w51bwP416843anbAeHp8eDmyWVdqi1mL/epJFua13ufKiY5Rk598gUyLcVV04iIbRcCzVMwimhShtg2bN2bdBozQRatGqKTZs1bJJoN27ZAhUkEEEUilTRQRTKRNJJMpCJkKUhCgUPDPdjGAxjGAxjGAxjGAxjGAxjGAxjGAxjGAxjGAxjGAxjGA+/v6Z6HTpqybOXr1y3Zs2aCrl27dLJt2zVs3SMs4cOHCxiJIoIokMqsqocqaSZTHOYpSiIYe5BchtM8WNVWfdW+79Ba41xU2/qyc9OuQS95dqlUFhCQjAgHfz1il1EzN4eAiWzuVk3P/aaNVRA4lriIk5ud/Vh94WW2Lwi6ijqLIg3art4XfHL+MbOhKKhjGReNWVLkwS8BBQklQo0fMiRLaMy1OvXQ2v5Ad5EJM7Ol+NXWVoK39hnIWLVXYT0vQjrsOP+vHQK+7JSFn2eVA0VNRRHJFkjyjGTg6O5VTBolsVJ8YzcmIWXVNz97BXKNr7c+YUzW9bu1kZFnwn4jyRahraPIQyyqEfebQZKRY2Bdkv4FMLlHYs2m2dO0IfZkeAp+nOhxo4s6E4f6shNN8d9bV/W1GhEUwM1iG/qS8/IEJ5Vp+3WF0K03a7E8ERF3NTz58+OTyNklUmaDdsjsF+3+39g/tgU4tUyujOk/ubt3H2kbnm9acDb7xaS27uGqbMt0nZKlrO8HPLsqu+iVHCLuYczj6WhK5Ew6olk7FJo7FWgVFpQiUMkyt/VS1Vy9VatXenTUdZKjcYCGtVWsUQ5TexM/XLDHNpeEmot4kIpO46VjHjV8ycpiKa7ZdJUgiUwDnzIew1a2dofdltnXujHidpX2Xu+C0DrqSYqJP4FKs6uhoqhTNxRcs1zIvaaxRqFl2Q8lEXKiS8EDuUQOCRkiE+l/qrXNd07q/W2o6ikohVNW0Gn65rCKogZVGvUivR1ZhU1DFACickdFtiHEA8omAfD8sDv2MYwGMYwGMY/fgM185Qco9H8OdNWne/IG7sKPr6qpFIo5cf5mYsEy5TWNFVSpQqRvfbHaZtRE6cbDx5DqmTScv3ijOJYSMg0xXzy576D68tGyu6t5Tvgor7zG6913EOGp7ztO3ERKo3rNRjV1CCp6ZlW607OOALEVqOVB/KLlFRm2dwucR+BXILs72/XexPtkh3UZRY9f41xO4FvSuk6NRKy4Mi5hrVs6vyCaSsg6kUk279WCnGKE5cHSbSQuybGrt4ugJh0PX2nOV/tAVph928qyWzjN1YwNjTsGluM0U8cQ+weSaUasYIq7bAmmZmrpKvvUvFdKeTOdi2RVUjtYNPUcPdnObQeu9dUPUdHq+tNY1GAodApUQ1gapUKvGt4iBgolmUQQZx7BoRNFInmOosup5TLOnSqzt0qs6WWWP25u2bsm6DRogi1atUU27Zs2STQbtm6JASRQQRSAqSSKSRSkTSTKVNMgAQoAUoBntwH5+P5/r/P+eMYwGMYwGMYwGMYwGMYwGMYwGMYwGMYwGMYwGMYwGMYwGMYwGMYwGMYwGMYwGMYwGMYwGM9ayyLZFZw4VTQboJKLLrrKESRQRSKJ1VVVTiUiaSZCmOoc5ilIUBMYwFAcgR3j3VTF73DYeLvVhxymue28KsuRpd9hRsy0gOM+t1FnBWZHMvsgHaEfZUUnpV2bh0nN1KrOFEzfA7pNum7xggE+WMrkDr/ANp22CRaxjvLrp0UL1NVdvQEIS0T6sSoYRMkxXfuNT7UREqYeCZnKdwmh8Q83/d8fEMVx/b52Addt7htd9x/GBi51RPPixlb5j8Z41eYp6y5yJekexQTdyvDSKp3Cipnce2Lri5so1qo6jNc2cRTUWC0XjMX6b3VqbkLryA2xpHYVW2frmzt/eIS21GUQlIxyJfKDhouKQgvGyrBQwN5SGk0WctFOwOzkmTV0koiXKGAxjGAxjGAxjHiHj4fLx+v1+fgHy+n6vmHiP5D8vzwGMff39/z8fkwGMYwGMYwGMYwGMYwGMYwH/P3/wAfn9AzSHsG506p69+N1s3xstyR/KkKpXdWUBssAT20NnSLN0pWqbDoE8y4IrrIHf2GUTRVJB11lJygouFkG7J3m7kdyO05xO05c98b4uUfR9b0ePF5KyrwRVdvnavinG16vxhB97nbNOuxTj4SDYEVeSD1UiZClSKqsnX34R6Y232/cmq/2ic06TI07jHqiRXHr14xWBMnuDpmm+SdobzuzFQvhNLOnjCNl4yQXTBvbLCwjnscP+H1Sq6VkDajp04N7OobTYPYPzRS+Oc7+ZAjaLQrJICk403qqYOyk6zqmEj1DKDWlVWLODdWKDSOBoBnFVekqETWqr1V9OhjGAxjGAxjGAxjGAxjGAxjGAxjGAxjGAxjGAxjGAxjGAzQTn52Qcb+u7W6dv3LPqSt7szd6hqfSdVEshsva08h6aCEdARCYKnjocj5w0bS9slSIwkT7wkgCj6ZdRkLI487OezbXPXfraFSRhVts8mdtuQrPHjj1XRcPbNfbS9cJxbKUlWMYRxLM6cwlnLRq5cM2ysnYJRdvWq2itJuV3EdqT1w9WWwWG03HYp2Vz7feHPG/Fay9Yr0qRvI0Ti9CHAzqHq1IifFeHQt8Ek5O2JIRSYQ9LEziPqRnEirNW6whg3j118cm+z7ZNc5n9w0eeD1tAu1ZrjP17sHD5jSqRFPV0nLKybjjQXBxJTUgxRaBJQEwY1gsfgRC6kgK+1T1unZajmEfER7KIiWLOLi4xm2j4yMj2yDKPj2DJFNszZMWTYiTdmzaN0k27Vs3STRQRTIkkQqZSlD9mMAHh4/q/5/P+45Az7Qxz5f8KeDMtVKBNnh93cnXkjqahvmigEka5UhZJL7UubQxVElW7iNrL1CsRL9soV5FWS4wcw3Axo44ZPNnzAu/jmetzO7CdnlrEoEpqXjeipo7XwtlQGOcjVZhVvf7SgHlSTdnsGxX0s2ZyTcFwkKzFVk5FlmjZE5QnB9k34Y1v8ACW6+d9qj2761r2h5oHUnvbcwrV2Hi4aAs2yrOxFZAyQrWdzYK7VWMg0WTdsm1bt0asX3WZUKe559/TIlejDSC+heq7iNWZBoLWbuVDebkmhUSBFwupuWwy+xoMzpPylMVdpUrDXIsQUAFSpR6RFfA5TAEtWAxjGAxjH38/8Aj+n7fr8sBkdXY12V6K649Uo2zYjk1u2tcyPIzSuiq84BW87Ts5ATboINWrdB64iKuzfuWSM9a3DJZmwFy3YMEJWffxULIdU7Oe0DVHXNrSOM6Yn2hyQ2Z/8AhtBceq6ou6td9sT10WKj5OTaRiLuTiqY1llkWriQSaKSE7IAFdrDZ/MqnI00o61Or/a85tpXsw7QnyW0ebl69ymtb67l00nNQ4t1woLOK/EQ0CCi8OwukM3dmJGMGRV2OvljuXTV3JXp/L2Qgdb4Odau8+UO8Ynsx7b2yNj3oY7OS47cVnSQ/wCHHGyrtlgkawpL1Nwq8bFuEauoEpG1x+u+cwUyc1ou7mX2QoP4Wsd+I/rxjAYxjAYxjAYxjAYxjAYxjAYxjAYxjAYxjAYxjAYxjAYxjAYxjAYxjAYxjAYxjAYxjAYxjAZ4ExSgJjCBSlATGMYQApQAPERMI/IAAA8REfl4ePjnnK7faFyY3fy03sw6e+Bc+MXsW7QzeW5r71j/AHhWM486LkyNfjFZVkGazcze12uGk2BZNkg4TdPI2ehaaycNpC2yL+thhTkVvPfndryFunBbhXcZnVnAHUUweucz+WkKkUjna8imuqjI6c1O9UKZKUinySKzYFGx/cZ9MV7DYTKUVKCidh2DeMnFnRPDzUte0nx517C6+oddRJ/l45EFJewygpkI8stvnVwNKWizyZiAd/NS7hy7UIVFqiKEe0ZtG/o4pcW9QcNND0Lj1o+uNq9R6LEoNBXBJuEza59RBEJ67Wx6gkkMta7Q+TPIzMgoQqfqKJsWCLOKZR7BrsTgM6VsbW9B2/R7LrTaNOrl/oFxjF4a0VC2RLObgJuNX8BO2fxz5JVBUCKFTcN1QKVdo6RQdtVUXSCKxO64wKa/J7hXy96H9lTXNDrLk7RsrhZLyTeX5C8VrI9lrUxp8W3HyuH8g3IdxKy1RZNVF0oTZ7BM981sj6aVud2SplmpF7Yw6+exvjp2PadabO0lPlZWSLbsUNm6lnHTQt91fYHJFANHzjJEwBIQjxZBwet22PSGHsLNIxie4yraVhozfNdBFyis2copOG7hJRBw3XTIqiuiqQU1UVklAMmqkqQxiKJnKYhyGEpgEBEMpfdoPXJuzqp3YHav1cne1Wmwki5kt8aVhmC8jV6bDSrgjixPjVdosiWa0NYliE/F1WL6Z9avvdLNXXcTCMWb6ihdGxkcXWb2VaV7LtDs9na6WRrmw62nHRW5dRvXpHE9rm2OGxjiCZjFSVmKdOHQeOahaUkEkJZmi4aO0WE9GTMRHyOeP5eHz/P+3+g/t/YGB5x9/f0xnC2SxwVPrs/bbRKsoGs1aFlLHYpySWK2joaChGK8nLysg5P4Ebso6PauHjtc4gRJBFRQwgUo4EYPb12FqdfvGUkzr9k3s/Jrdk8jqrjNQzMFJhabv0qo0bPLGtDI+ZaTi6W0kG74zICHRl7I/qtZXBMlh9ZGvo84abs4Q82+m3au0uSW59yc/eV3ISVNyFUs94czdSruqitqgbaWvK41IQ78IeFgrw/iHizmSWrc04ilV6/B1+JjG7JLZ7r3g57uN7Lth9pOzY2QS4p8TJ4+qeFNIm275u1lbXDGPJNL4vHLnFqSVgkZNO/T6glFyhdLRS4lu8cttegijs9tFQvID2kXjjUo4gP4bg7wwvuz7WChyrNY64bXCdp7Vuoh5BI2eliNja9mGnqKe9LCQHSSJEmJVzhYn+/7f6/L5f2HGPv/AF/3H+Y4wGMYwGMYwGMYwGMYwGYA5Pcn9J8PNMWzfW/7qxpGvai3L67pfwcS07LuSKjE1WqQ5DA8sNqnFkVEIqGYlMqr6bh45O1jGT981165/dlfGjrr1+nZdy2I8xsKyM3H+FujqidCR2hs+WBUGbVvCwwGMaLgfiJ02snbZcreGYD52zY0nNKMYV9Etxk4Bcn+zXbVb50dvUYtA67rz9xN8YevhVF41p1FjHSpDsLFt6BfAms8k3LVuzWewE83NY7UuRAbsnAVxi110IY80Jx2353rbsqnNbnNWZjWXXfr2XWnOI3EB86Vbq7eKVQUmWz9oIIGTGRg5ZsQFHL9cCBaWipoGpptdfrSEvdbUrFixi2TOMjGbWOjo5q3Yx8exbpNGLFk0RI3as2bRuRNBq1aoJpot26KaaKKRCJJFKUpSh7WzZsybN2bNug0ZtEEWzVq2SIg2bNkEypIN26CRSJIoIJEIkkimUqaZClIQoFAAz3YDGMYDGMYDGMYDGMYDGMYDGMYDGMYDGMYDGMYDGMfuwH388j37JewzV/XPx+kNq3BFO2bGsqy1X0dp5i79KybV2EuRMjKLZt0E3D9CuxKrpo9ts63ZuQio9VBq2ReTstBRclAd2pe0OX/AFFyJt/GfhgtRoyG0nLniN4b9sUU1u7x1cGRnEfMav1RTZBdnDyljiZo3wBR2/JLi9ssdMLLNoKi1Sx25XcDrm4M765Ub6ju2fs3jj/4zSrVNxxT4yyLJdGq8a6CZRVxWJpxXZQ66sfb/dnJ5SBi5BMsxCyL91dbUZTYEgglVA711bdcG2Q2bN9m/Y6uW886tzNQkahS5Zp/+C4tUWQRH4TUa3BulXSMFcUIVckSsgiZRejw53VcSeOJ+TuctLz/AOMYDGM/JIP2MUweyko9aRsZGtHL+RkZBwi0YMGLNE7h29eu3J027Vo1bpqLuXC6iaKCKZ1VTlIUxgCJ7uh7CYrrz4WXW6xEmRHd+1EZHV2g4xIxxeJ3WZjHHv8AdlCorJOG8XrmEM5sij7wFspYCVmBXMkpYG5woIyfCGzw0P13cfbEm9Yb87EtgVfb020fIrqS9U0/sC7NdQcdnjpN2Ch2jucUd7o2VPvzB7u/r83TU5IiDmsOzqy/Lzzr2hbuwh4NZSQd8JOMacq/YMiIHKwl9P0Swswkn7oBAiaMpyIvakQzcKq+7TDGhOo9qAKOqiBh2f2KRnvL2sTUVLYoNj1fjhUK3GIos0Uyx8O2oPGqy7Vj2bVuimVu2Qjr1dGUWVFIqaTR4JikAqiQFELkldr8PUq/BVWusEIuv1mGjK/BxjYPBvHQ8KxQjYxggHiIgi0ZNkG6QeI+CaRQ8R8M5nGMBjGPv7+/3YDIuu0XtB1V1vamaP3bNPZPIrZIKQuhNCRCyy9hu9icrBHtZqYZxxV5WOo8XIrIpSEgg3F7MvzI1qvlWmHnnZ9T7Se2jVPXZUI6pwkWXc/LXZREIzS/HmuqryE1JSky4GMhbJc2UMVzNRtTNKmI1jY9i3/EV6lC/h6rpkN8UnIHVLrD6stojtVx2WdmsqO1+c2wzIz9Kpc56LytcaIddNcYiMiYtFZxCN7nFRzojKLYRaXwXWrf1WcEd3YVHs8UP19XHV7s1rsuQ7K+yeQNtHnftUqc9VavPppuoLjRXX7USxcDCQ4+pGxl4j4lcsUk2jiBHa6iwPXYAx5RSbmX9hPGMBjGMBjGMBjGMBjGMBjGMBjGMBjGMBjGMBjGMBjGMBjGMBjGMBjGMBjGMBjGMBjGMBjGMBj7+/rjH7g8f3YEdXaNzug+vvidcdupoJTu2LMoXXPH+iETF6/ue4bO0dI1hAkSkB3clE18yatmsLdsmCjqMizxLZVKSlY4qmLOobgTLcNNAyV33M7Xt3Mjk/KI7h5S7Fm1RfWV3b5/3mYY0JxJn8RVZUQ01JIPAbj7o8tklZ5NqY0e7j0W0f8Ao0qvbv2zXLkpONwnODvWVOyWtOOjNYTuKxtHkuss1Vs2yW5BMVCQQrbuMaz7Fyn6iIsonUL4gHB/Mtxs0YD7+/8Af936gxjGAxjGAz8z1kykmTyNkmbWQjpBq4Yv2D5uk7ZPmTpI6Dpm8arkUQctXKCh0XDdYh0VkjmTVIchhKP6cYFHDsR4P766O+UUT2W9dSTwvG2ZnAbbZ1MmV89rGv0p2SQPK69uUW0OVR7o66uRTTqMv5yvteWUjGNSfRsg1pcpIWq+v3sA0T2MaGit26VlBavG4tonZWtpZ02PcdWXMzYFnNcsKCHkByxceVZ1WbK1RJGWeJKDxqVq+bysTF7h26pVe/VaxUm71+ItdPtsNJV6z1meYN5OFnoOYaqspOKlI50mq2eMXzRdVBy3WTMRVM5iiHzyiXzP4a8qfZ+OVDbnVwTdy1j4g2eYbRtrqck4kZmHq8ZLyBDudN7maEWFzKUeTdGAmttkGUCVhpQzFg7kWVuaRUpbQvq5WV9ok5YXOVq2nOrPjU5GZ5Hc27XW4S2xUW4EXVe1I7nkY2PjZtRugu7hWexbUkQH8qTzIMqDS76E0iSLk0lj716j7sOGW2+B+xOc7G0FgIvTtWTd7Y09MyLImxqfsB4QjKu68K3KBSTA3uyLNISgWtm2LC2Ir1Nw4LEvo6wxEJGl0N8bdpcoty7k7p+XJFJLZe85qzV7jjBySTsyNKohF1oCbsdeTdkIDeBaQ7NvqfXIplK5Tq8Hanzsz0LKzfnCejj/AKd0n1v8LqprdpJx1a1Hxr1PIzV2usg3bx/xAtciXdo2RsmwEblImEnYpQs7aZUEymArh6do1D0UkESxUdD1StW8XPMftO2fALQtu53bofk1gwkCKC9geP8Aqxy7rdSYIHVVV8qa0girXHBk1V0H7XXsLIt1hbOEiE/jvA2Xcd/XLi/1BaTlXLHYfNe3Rdl3lNRahwfa/wCMVFmzTFgl3QpGEyCVhd1eefJAqmqzlY7Xs9WniRyWBIik8Oq9ZUzS+taHqPXUK3rtD1rUYCkVGFbEIVOPgK1GNoqNQMJE0wVce7NSHdujFBV26Os6XMZZZQwh33GMYDGMYDGMYDGYd3fyE0dxrpTvYm/dr0TUdLaecoz17scdAN3i5PJ/kYlF4sR5NyigqJEbxMO2fSbpRVNJs0VUUIUa++xO+Ta/KS4S2jenTiTfeT90TWGKkeQOxYGSqGkaQq5UM3QnV2D5xDLjHemsg7ZvtjWPWoFXIKYV6eRMVFYLE+09t6w0fR5rZW4r/UdZUGutzuZm3Xaejq7BsiESUVKiZ9JLoJLPXBUjkYxzcVn8guBWzFs4cKJpGru7I7n+RnN25z3HrpV4/wA1taUYuVIm28y9tQp6vpDXXgoQxpWDirG3SbyCq0ec72KPe/hs06WQMlFapuKKqJj/AL9VdFuz+S16heQncdyetXK2/tFiS0Lx6pkvI1rQVBUXXTfKQYDHpwhn8emJjNXsTSYCgxbhVM4SMla2qpll7D2uNZ6709TYTXeqaPVNcUSttSMoGn0mBjK3XIpsQA/QZxMQ2as0jKCHqLqgl6rhUx1nB1VjnOIQ88B+mKl8e9i/9WfL7ZMvzP52TLw0y/3FsFd/MVXXkicwKNm+rK/PCso2dQof5OItcmi3eRbJJFvTYGhx4rRis33/AL/t/pjGAxjGAxjGAxjGAxjGAxjGAxjGAxjGAxjGAxjGAxjH3+vAZoV2Vc2aLwI4hba3nZ7JERFwRqs9X9LQL9ZMz67bjlYV+nRq/GRwkXcSCSMsVGYsKiLZwlE1mOlpd6UGjNTxzDy05aaR4T6Ot2/9+WtvWKVVm5k2bUhklrDcbKug4VhaVTYk6qSs3aZ5VsolHsUjpot0EncrKuo6FjZKSZ/PXl79ym9or7LaFryxSDula4SdzD6MqcOoMlAcctBxT5kvcZ1RNYjZtNXqTbFhmEhNvU0jWO9S1bglCw0MiwiocJVvZ1en+u7LYVvsy5UIjeHctZp2c49a/sKLp41WnYWwv4+T3beglEvGelfxKxkT0Bgr71HoOGo3h2q+kla6aHuzZ0HVesqXpbWtC1HriFb12ha0qMBR6hCNgAE46v1qMbRMYgY5SlFw4Bs1TO7dqgK7x0dZ2uc66ypzd+wGMYwGVhPaZuw1xx443RHDnVs4s23TypYOELcWIVU+MVrQqbtWLng8iSRlE1tqS6DiisSkETPIBle0Cem4I0VGwryH31rfi9pDZvIHbkx8D13qmqv7XZHpClVdrpNvTbx8NFNjHTB7O2GXcR8BX48DkNIzcpHsSHKdwUQ+X3t60b+7POSNw5P2mN95vHKHfdc42aBpx1EpGFZWOyJRUU0qkK0l4uTScVPTWtZeutrJLRwxMzC3XYVAvhVfe5CXVwLb/srnEsNScMb3ycsUUZrbeUV5MjXnDtodJyTU+qV5SuwKjY6/iqkjM3V/e3yxkE0EZNi0r7sxniTdkolp50huP+p7vP7K+WSgJvq9XkdyM6q5AfXBqS97niK9QVSuhAxDGJraizbAwp+n64LGOkCaBDIjavrev6xw84dM9da7SFGs8cePbiFrJxKCTl2hrehr+jKPAFRYTSUs4izykkudVZRxIu3ThZVVVRRQ1YL2QusoE1pzgvqhQVkp/YGmqys6VIB3BkK5AX+Z8ouTCKpgVXt6iipBHwMoQqhhMYQ8oXHMYzp1/wBh0TVNNsOw9m3Gs6/olUj1pay3C4TTCvVyCjkPDzu5SXlF2zJokJjETIKypTKrKJoJFOqoQhg7jkEnaJ3IwXF2aa8SeIEGnyO7Btjv2lRp2sKw0Us8XrCXnEQFlLX9GOU8ruxpoKkkIegEcIuhal+PXBxA1tNuaa0R5J9yXJ/sK2VLcMek2h2OZdGWcRWzuYlhiFYCtVKuOxMwVnKY8l25yUOHMBnPu18tseldJFVuq111ShnCxE0tKV1gdPmkeuuHeXyTkVN38s7y3eOdoch7a3M6mlH06oD2wQdDLJKPZGv198+OdWXknb11aLk8A8lY5EURYwsSGDerTp6d8erhI82+cVn/AOoLsJ2e4d2WwW6efpWSE086nWpUnMPUFxSLHvre3jjBByNqjUEYaBikvwdrlvH1VsvIWKfHGMBjGMBjGMBjGMBjGMBjGMBjGMBjGMBjGMBjGMBjGMBjGMBjGMBjGMBjGMBjONlpmHgWZpGclY2GjyKoIHfyz5rHMyru1iNmqBnLxVFAqrhwomg3TE4HWWUTSTAxzAUeS/t8vz+/5fqwGMYwGMYwGMYwGQrd2XLzYelNFUbi5xtE77l7zut5NA6YYMTAaQrcDPKsYnYmwlPT87iNQhoibawbKfBMC12TsSNrE4t6w9KE1P39+OVxuN7VLm931ct+Q8r4zGsutrXFf4vagKqCZmLPcFxLYW+xpluQxTIGl4R8XcNYkjtwUekZvqqo+dNgbsWOBL1wN4g0jgpxS1Fxno4pPEqHXyHtljKkCa902HNqHl73b3AnIRwJJmxunykU2cmVViYBKIg01jtYtuBdv8YwGMYwGMYwGMYwGddt1Qqt/q9gpF4rsLbafa4l9A2asWKNay8FPQsm3O1kIuWjHyS7R8xeN1Dort3CSiahDCAl+mdi+/v65Xw75+0NPiRpg3FfQUs6m+aXJiNQqFMr9VSWlLNr2k292rXH1zBpHgd63tllOo6qurWKBCyjqxOXFjYkVJWRbvQpcc9uKNBJzX5ba360qxtzc2g9KILWLYyNXiZS6QNFShZVo2uzFlMV5WQe2PWNKtjksVDWOaIWQKSOknIOpeLhPxfI2yOvX2jvr0kuP9V1xuCENw9tOnNbs4GK17GQk5ZtWzUJRK6k2jYjVVijG0g7ZuHUfGEbRVYvZYp8Dw7aJbWO0PFPiDiRfpe63Yzrh4iwdRsbCOU5B7VMwvu/55moR2JLGq3XCAoLJ8UBBWE1xEPDwqYIKKsX1kc2mwMzAhOETThF7P8AgbxS52dommOE3FDTNK1ztWNZudx889/auZqwzaha4ciwK1rclUYtZDXy+yp1B6zlTTUhXlpx1O26jlfyDlq7s6aISA9KOvbbyr2byJ7k98M2yeweUM3Ka347VIXKD9PU3HGjv2sIzYIICK5omasLmvMGLwyQtVZJrBPLYVP0thOwPYw/d8g/aP5+P7A8PzEfn/fKTdi9m77CuJNpfXfrc57LME11gcLQ8pZr5oG4O2yXiCEVIPKQtbqXewIPkBUbGlVotykZTzR5RTKivybSV9re0OINXMK03bX443iku7JxJv3vxSeUDEFeKka7s1yUxSlN4vgIsbziKRwP6gFC6jjKazLs/wDaXqWZFnZ+s6s3PwMAKuU+Om5H7tUoeIG8jug7jJEomHw+RjR6hfmPgmICXw7C17cvaIphMGsV1HxbSQVU9FJzM6B5IsGJFDgIEMqSU2dDEBMoh4mVUkUUgDwATlEwDgXCP3eI/f5fw/P/AGzqd0vtG1tAurVsW51OhVhiAi9sd1scPVoFoAEOoYXUxOPGEe3AE01DiKrkn6BDmHwKUwhUxLS/aoOZwps7LdNVcFKLJlEzgY+QotOkTNjj4mXZuKQjundsRIIp+sizYup6rlXW8hnqiKYoyCWRqH7L/BbEsbLYHP7nXyF5TXDymcPm0e/exJBWW8DOI93etjze0rhNMFFSkUWdMkag9ceBC+VsZP1Dhu7ye9ot6zOOxHsVV9oy3Ji8oACTWqcfIY1ril3Sqvu7YVdjyziD1wqzUWAwrngLNYpNBuX1UohyZZmi60db80O/PsiUBlxA4s1vgBo2cUUSb7w3skZa6KwT1QrdKUilbzXgdSKTpgKztu6oelpkWa/6LO4JqptHqs4PFvq84FcNDsJHQHGjXdYtkekmRDYs6xcXvZhFAEqiq7a/XdzYLPFC6WIVZw1g5GLjRUImVJkkk3bpI78YFbfR/s5mqJq4tN09j3IncnPvdBlE3TpvdLXZ4TWjQxVjOkYwWys7KXuejo5YEkmbRS3V+ruGiQs3FKIwUBklYR1zrPXWoKfD6+1TRalrejV9sm1hajSK9F1iuxiCaaaQEZxMO1aMkjGImT1VQRBVYxfOqc5/Ew93xgMeP1/b9/YYxgMYxgMYxgMYxgMYxgMYxgMYxgMYxgMYxgMYxgMYxgMwhyO5F6i4n6Yve/d5WxpTtb69iFZSZkVzJnev3BhKjGV6vsDKJKzNnsUgq2iK/CNTC5k5N23bJ+UpjqEzfkHvd31jb/7ONc6FoOldzUjWsTrLYFht12rOxC2L8M29SVjYmJgJ4gV6Fn1HE5SWSdpRi4yQYJR8klbZBJeSYeQFDhTK58c2+SHbByTqLoaxYp2Rs04Wt8NOHFbTVnk6VXbAKYsdj7AYtlCMpK93FogymW7eSQMSdjUQtVjGvaVgaND7Ous9MXVFCdaWkJZ7dn8dc+UW5yxk1um7NikeM4MjYqrmN1lUJRdIr5zXYB08dupmYVMRa4WVVeYcJIxzOvR0T2PrH6b+OXW7FL2+OXc7m5NWdg4b3zkNcmBEplYJJUXEpD0GFWeSpaPXXyw+eTEknK2WxreKtiscg0Tj4yMl7wGMYwGMZBd3w9oCPXpxeVq2t5kiPJ/kAym6nqYGTpr8S17CJtitrVuB02UBUyY1tN4jG08FkRTfXN+wcgk+joCeQTCC7vb5j7E7IeZerepnhy8JaoGubIZwV9eQ8i5TiLrvREXreWjpx2gB2xqHoaGQlX9ifnKu0bWJG1v3TdQKbCvDbcdbXEfW052qH1vrVAZnjj0y6gDT0HYHcS1IXYvMba6kyG39izR0jCktZiz6l8ZOU1FHitbDXtAYMUmTSOjFgxb1D8U2nWL168i+3/kdBqrbzt2mLDZdPV+2oJnkK3SpsUQoSzlw8UM7bWbkDeJCrC7cnVB61prmARIom5sFhjzzP9DHGma4/wDXpr64X4rxxuPlTOTnKfbEvLJeE3Iy+1havaqEiqqUrsqpaCzrEg9YrFSKzsMrPqA2RXdujKBKzt6qvb3qbaFHjvJ8QuWu7rVWPqHImT32w1qTiGvnUUEqZCeu8J5jnMBCB4mMIFARymN7Lvy30BxxqPMXR/I3cOs9B2smwKTcIdtuW71rWic0DOHsVWuEawfXGTh2a8tUnkHGGmYn1wftkZRNyRuqg3fqtLvuQecsfZ7Oufl3tyy7vtta2ZrS/wB3lXE/eXem7tH1mJuFjfrncylhloCxVi4RDWZmHBzOZl7AtYY0q+OvKPiryrt6+chhHmt7SVw20P6uv+LKT3mfvOUWLDV6K1uL0mrWk++OdlGIyF9TYuVbeuq+VZnZw2tYuzlmiqDHDYYN4oRYmjus+rfsu7d7jDb27dduW3RuhEHzefpHEikCaszQIeqUAZqUdVV9E6tbrMSggrYbse57gdJCswkmsGAM5NOfnht1O8DuCLkk7x/0XCstgego3X2vdnj6/bMMRYgJOCRtlsqzz8KN3aJE0n0fSWdZjHwJlUeMl1zKKnka8fv+f+4/x+f1wMEccuMeheJOsYfT/HbWVa1dQIUpTJxMA1UF5KvhIUi0zZp1+o7n7XYXRSlB5P2SSk5dyUiaSrwySSKZM74xgMYxgMYxgMYxgMYxgMYxgMYxgMYxgMYxgMYxgMYxgMYxgMYxgMYxgMYxgMxDvzeuseMundgb33LZG9T1vrSuvrJZphYhl1vdmhQK3jopkmILys7MPVG0VBQ7QDvJaWeM49qQy7ghcy0ssi2RVcOFk27dBJRZddZQqSKKKRBOqqqqcSkTSTIUx1FDmKQhAExhAAEcqRchtx17t45H7EtlztIVzpc6yZqTu28bKq5O0jeVe4qTFOZJWtxQIPGys5XkEvNHQiDJczh1WZkrlkKFi2lUCw4Qy9oXIXfnP2v6237u4lsgGvJC3nqHWtwWhnrpEWVCUmE6o95I7LaNTM1JqeuUo+Tqutl/BsterPIO5SNfk1PRUKtdb8XDDUl50NxK45aZ2Zan122FrPTlAp91ssg+Uk139lhq6xay6SUiss4XfR8a9KrFRbtZZVZeMYslVlDKHMOVael3UVt7POfm3u2/e9WRhNXabmUdbcTdcIsUmVVqz2EhvhFRhK9GoIFiTQ2ktevGInUYItmT7Z1rC1sSN5SHeIpXL8BjGMBjGMBjGMDp2xLpG631/etiTIeaIoVOs10lSioVHxjatCvpx8HrHASpeLViqHqGASk/8jB4AOQeezh0STa9ez3kDaUyKXvmByF3hv61yJ0zldu3C9vca/SIc65lHPuB3dGlJmPTWUOAhOOHqZj+/GWV3/7TZxzXetnndJszqJOf+k/esakqiYSKpDOa7n4QyyZyh5kzpEkTKFUIJTpiUDkOQxQOXpnTtCNYDq74MMGf/wBS/HmjTZvEgE/zVmZqWR94AHiA+L2Wc/p/U/zOb9Iw4ElGMZhPkTyJ07xT09c97b3ukXRNbUWNO/mJmQU8zh25MBiR8DBRyYi9nbNOO/TjYGBjEl5GVkFkmzZExjGEoZs+n5+P9v2fT5/1/wBmVhurfm5zb7Yucdv5SNX9g0J158eo61Uiq6gj1WLpvuG92uI9yiGexJJRub8Q2Ktxj1vsGYcwx0I6jyCNRrMOL5Gfn5mXs8/f3+7/AN+OAxjGAxjPWqqkgkouuqmiiimdVZZU5U0kkkyidRRRQ4lImmQhRMc5jAUhQExh8AHA007AOamuev8A4tbG5JbGMV4FcZfBqHVCH8j2/wCzJtu7TplMZiUfUSTknzdR5NP0yqGhaxGzs8KK6cWdE8BfRTwV2RyG2Rau5fncVO77q3hKPZ7jzET7EPQqkEcRig2ixh1zKN4dH4S1SqOm4oiYI1ujMTz7D3g03XJGO1V5B2+T9oX7V6Rxn1jIyDvr34cvXlh2Rc4hw7j468IpSLSPudlYSKBlEFZHYkgwQ1zqRbyneM6qjZdgR6RGrudZo3WYKDhqxCQ9brsYxhK/XoqPgoKFjGyTONiYeJaIsIyMjmaBSINGEexboNGjZIhUkEEU0kilIQAANJeyPm9VOvviPsjkPPItJazMkEalqSmujuCjfNuWZF4nTKuBWhDOTtCqNH1gnhQ8rhGrwM45bGFygiQ+svTVwatXFbQU3uPkCo9sPNHl9ME3ZyWt1iSKa1R8tYjOZmC1s9XAxit/walMPlZtm1BJoS3y0+g1A8WwiCN9IHAm7bO5MzBUhbBwf6oXhzuSGTB5U9rcupNyVMUHBTgvFTjSky0KqQEzkce4p6/clHxjNjiZSzP/AC/n9+H0H64DH/v6f2+mMYD7+fzxjGAxjGAxjGAxjGAxjGAxjGAxj+mY723tSjaN1hftxbMnGtcoOtKnOXS2TTtVFJNnCwDBZ+69EHCqJHD5wVEGkaxKqVeRkV2rBsB3DlIhgyJjNWeF3LWhc5OOGv8Ak5rGsbBqFI2N+IfgkLs2Dj4C1JFrVllqs9cLNYiZsMO5j3chDOnEXIxU1ItHjE6RzKIOgcNG+02AxjGAxjGAxjGAxjGAxjGAxjGAxjGAxjGAxjGAxjGBiXfG8Nb8bNO7F3xt6fSrOttW1eQtlrlzkFdZNixKUqLGOZlEqklNTD9VpDQMSgPvUtNSEfGNCncu0yjRA4S6i2P7QL2tXzlnyDrzkeLWo5eLmJyrySKy1eSo0E+djpvjeycoGI2du5ooL2DYqzUySciyJd5U4RshaoZNXMvfhza2J2E8v9b9UnEFcbbAVvZcRW7oeCkXBI7YnIBwutHLQcu8b+ZoWi6TaKPVZ984A8cysqdql5RIUKXDSJbX/CXibpXrB4ZQOp4eSj4usayq0xsbdezJEgtS2e3IQpJfZWyZtUExWRj0m0SZGMaqAsrCU+EhIYFFwjCKqBFt3Su1eVXIvr96i6QoCDHeOyo7e/IdnFEK3CB466kGUXbtFyNzpIs2M+WAvbmITVFqiNjpNcZt1xWeooHsZx8exiWDGKi2baOjIxm2j45gyRTbM2TFkiRu0ZtGyJSpN2zVummgggkQiaSSZCEKBSgGV2+matz3MXkJy37j9mQz6NDf9lkdFcToSWKBj1jjlrV+zhXsqzTO1Kik4sUzWouEfumCjY42Wr7AWVQMjPmUWsX4DPPiP39P5fTPGMBjGMBjGMBjGMBjGMBjGMBjGMBjGMBjGMBjGMBjGMBjGMBjGMBjGMBjGce7loqPdRjJ/Jx7J7NOFWkOzePW7Z1Ku0GyzxdrGt1lU1nzlFm3cO1UGpFVU2yCq5ygkmcxQ5DGP4/w/l+z+/6/2YwGPv7+/wCWP35pB2J826L188T9k8kboVtIyEE0LX9bVBwsqge/bUnm7wtNqKZ0QFdNq5cNXMrPukAMtG1aHnpVMip2JUjhGV3B8mdt7p2Tr7p74YSzphyF5ORSEnyA2Qw94UjdC8a3aiyVneTjuPEF2b62xCTz4m1TXbSH4QUQiGhRktiVpwWIXuWXgdYVnh37PzwDh003U9M69e7fasvOm+tNttEkxNQWuw5Jq1XFR5YJxw53ZsiScFFtEMG1KkUSs4CP9ybSt8BdXD1u8MOTHapzzVUlOV2/4OX37ux/JiDeegK/NuG7zVugIH1U3PwCSsE7IV6NXhE00mcTZJqvVFwj8Po8csSPH2c3j7euXvKjk129cjG3xeySd3tlZ1U5dtzgzNsS6thd7Gnq+i5RKZpDUCjykNrWomZrLsEo+xWCGIVFxWyAQLVfDzi/QuGXGjUPGnW6JPw5qypMoVeVFsi0d2iyLipJW65SibchE/itusz2VsD8CgJEl35m6PlboJELstjGAxjGAxjGAxjGBqhzv1nK7m4S8udUQDc7uxbD42brqdaakL5zuLLM66sTOuogQPmf1JpRiUSFEDHARKUxTCBg056ItrQ+2+qXiHJRb0rp3SqNJapnWwnIZxFy+tLPNVNNk6IQxvSMvCx8PLMyCbzHipSPWMUgq+UsuuVxNl9NvMPQOyNq3/qV52uOK9S3hbpO837j9sSttbRq2ItcwRMJGbobt1W7yjB+8+KiCDb8EhLx8e1i4tG0rRUVEsIwJk+YPM3j9wX03Nbu5EXZpVa1HEVbQcKgZB5b75YfRMqzqdFr5l27mfsD0SgPpJGSYxjT1pacfRkM0eSCFL+Np/PT2mnkpH3O2ozXHrr01ZanjaKOgKrqt1xuh5QfRtY97TaNdrb7nItdFlM2hVmWuUVk9OY7WKj12VZs0llF9m12DvbaLHcnaRzo2RymmWShRCj1N5YmMao1Kp66kKW/25+6lIaquVSpEXrtHpdJVSSIcY6Zj11E1W9oTWus9f6boVU1dquoQNB15R4dtA1OoViPSjIODimniKbVm0QKBfOoqoq6eOljKvJB8u5fvnDl45cOFA6bx449aj4raco2htG1FjSta6+iE4qCh2YAo4cKCYy8jNzb8xQczVknn6jiWsE4+Mo+lpV25euVDHV8AzVjGAxjGAH7+/v94ZWQ9ob7BL3Q6rRetvimMzOcpuXx4qvTremukhsVc1pa5YayyqTISKkVZWbckqZeut1TqoFj6Y0s7p0oxGYhJEliLdO3KToLUeyt27HkgiKJqmkWS+2t94pCsSGrEU5lXaDFJZVEruUekbAxiY8igLyMm4aMGwHcOUiGqY9B+lLxz35h8le5bkxHmfyjm9z1L0PDyIKPoyCsTyJZtJZ5X1H7dNVSG1JrZ3XdXUt+j50VTyViFf05uA9VMJ9eqrrypnW5xPqul4szCa2ZPmSuu8b23aokWtmx5NmgV6zaOgTK5PVKe3ISs09sqJC/Dma0ys3Rl52ZUcdS7gub8jwp4kTLjWwryfJffku00Pxhq0YQ7mbk9oXnyRRLDHtklCrCNIjHa86yXMRRk4tYVSAd+QtgRNkprhw3Zt13btdFq0aoquHLpyqRFBs3QTFVddddUxU0kUkyGUVVUOVNMhTHOYpQEQrNcFIZ522diOxuzvYaLx1xY4iWiY0XwDqD5L3WOnLPFJFWum65COOU6MisZSTbzURIiZQxZyTgIv3gj/UqBRCV3q44Rx/AXhxrXSTsyEntCTSc7G3zbAOR07tm57qVCRt7pzJlVWGXbV0pWNJg5Q5gUkK/WIt+5ID506OpIdjGAxjGAxjGAxjGAxjGAxjGAxjGAxjGAymt2+8pdqdlvPnXPSxxgnl4/Vje+wLXlHcoIp3BpOcrK5LTc2Mo4IidH8I6Ng45SUdxaqpG87tZolDPkwfVqCMtMd3Z9nkF1ycW5Q1RmItfk5uNlJ1PRtZVVBZ5DHVTK0sW2JFmUpwJDUBq7TcxhXhfdpq3uIGHMkvHnmVWOjns1fXjJ6Q0ZP8AOjdsa8eb95Ys/iFSfWYq7uz17SkhIBPN5VzIPFlnaspueZIzvcq5cGUXe1+PpLkyybpzKImCx9qfV9K0nrKg6g1xDoV+h6zqFfo9Rh0CkArGBrcY2io5JQ6aaRXDs7dqRV87OQFnrxRw8cCZwuoc2QMYwGMYwGMZGN2ndnGpusrQLjYdqK0te3bmnJwujtSkdCk+u1qbNiGUlZgUTlcxdBqxnLN7bpwPIYqS7KEjDqTs1Ft1AzLzZ7BOLXX5rtPYfJHYbev/ABFUreq0SDTQndl3l0KnkUSqVOTdtnj5s0ADKSM29Vjq7FlAhJOYaLOGia+zmsth1fb2tte7Yo7xWQpW0KPU9iVB+u3O0XfVe6wLCyQDxdqqIqNlXMTJtFlG5/8AuInOKZ/ESjnzqNb8O999knYJoSrcrrPaL9yE346iuRPLRg8ReMEuM/FJidtP1DXDhqmqmWh2jZVXdMT1+rsEWKmuoW3asZel8Ssd1jmH0e4KDhqxBw9arsYyha/XouPg4OGjW6bSOiYaJZosIyMYNUQIi2YsGTdBq0bpEKmigimmQAKQoYHKYxjAYxjAYxjAYxjAYxjAYxjAZB/3r9nDbry4qPYfX8ykjya320mqXp1Bo6QCTpLAWYIWrb6yBgVEiVNbvGzetCqkdN5dJOFEyDuNjZsqEsG/976x4x6a2JvvcdhSq2ttYVx5ZrPLHTFw493biRFnGxbIpiqyc5OSS7OFgIlAwuZaZfsY9v4rOU8oP8UNT7i9oi7SbbyF3vHzUZxe1hIRspaY1ERNCVfWEJKPHOreOkI/AyaZ5y6G9/eXKTZAkuq2VvltRBhIvYVmqEt/sy/Wa71drt72G7zh1HG1t5RThvotCbMLySrmpZkSuJbYrgzkFHCFi2w6E3w94c5nhaI2Reou1W15ftk90e9fdNyvFY0P1caEfHDfnYReY2oTyzI5jOaNx6gJNGS2Tb5NIoEEsVINo142kEhXTGQpkFsNFEqqrUEzTuvXlV17UXcg8UhqjSaRXHDx0oCbWJr9XqtajDrLqFSRIizjIaFiGRjAmkRNsyZNvKmRNJIClrtdQUHM88OW/KvuO2VGuyVy2Tcrxt4UQsygcFKvo6jOzMbBaWCSgEK3dWN2VOLcqERTcM7MvtVmKijSTL4hPhonTFH466Y1fonW0eEZRtTUiu0StNhKT3hSOr0a3YFfyChClBzLSyyS0pMvzgK0hKvHj1wY67hQ5ssY/wCf6j4j9/l8/D6jjAYxjAYxjAYxjAYxjAYxjAYxjAYxjAYxjAYxjAYxjAYxjAYxjAYxjAYxke3Zb2H6q62uN05u2/Fb2G3Saq1b0/q9GSSYzGyL4s1Ms2YJmEirhjW4VLyylxsJGq6MLFFIkmR1NSkHFyQfi7F+znjZ1ratC67mmhm77Ymb8dXaWrjtt+OtiyLMokE6CahViV2qM3R0Up26yyAxcWU/oNEJebWYQb6oRp2tc4O2HuF48yPK2RstEfa6NUOVU9pyKNIQld4z6ErUlB3LWtYRhnqrp9CbC2o6dVBy7UmY9tZVIK5Vm0yck6UeqQNK3h4M8QJ+4RW0e+/uRdK26Wh6e/3PpXUVmYkSga7Tq9HmmKNaPwc7Fds1TW8zGK0NrpRNZJJxIR91l05m1TkO+ZSYdCWmLtO6u3r2P7xZGT3r2K7Ok9qFQdJ+daqaZh5aaba2rcWssUF0YZ8DySlowESNUH1PToYLNzGjG5iBP5jGMBlYBAqncX2/OHC6Sdh4CdV025ZoJKeV7Ut0cq13BE1VFkDmdQ1kh65NQqiiCxSvWYV2mNjF8sdtNUDyDd1vNKe4f8NJuL1Su7X5K8lZxlx746Q0R5j2FS6XwSRkrZYdIhFTEe1KAdOncM6UJ7qW5PaiwcCASRAN2DiPpPWvTv1ilbXZZqA6V1da95b/ALA0VILu57Tcwn4juos3RjrfEnjh80jtfUzygo4kIyIrDMqars/lUCA/2lrlLduRG+ePXUvx7Bedtc7cqJadnxUaqoHxTZF7MWK05QZQ6CZl2zKEg51XYdiIum5jDNrLTZo/pL1wx0rWHDfjBSOGfGLTXGjX6aZoHVVNYQjqUK3RbL2azuTKylyuD9NFNMgSNttb6ZsLwoEAElZAUEwBFJMpahPs6embfzi57co+0nfLP4w/qdlnjVFy6STWjB3RtwH7mUCE9VI5UmerNaKhAxzEqbUIxpc6sqwMUI30k7x+AxjGAxjGAxjGAxjGAx/f+f8AP64xgMYxgMYxgMB9Q8fp+eM69brXX6HVLPeLZJt4Wq02uzdrs0y7EwNYmv16Ncy8zJuRIU5wbsI5m5drCQhjAmkYSlMPgAhVT9pE5XbF2PP6I6jeNrJae2tyenqTPbKbx7lUiowL+3fD9Y0V4sh6iDJhO2qIc3i5PH4oFgK3UYKRdgMLNPFk7E/CXi1U+FnFbSfGSnGRdR2q6WxiJaYRRBD8TXGQVXm7zazpeRI5DWa4Sc3NkROAnaovUmnmErco5VY6TK1c+zHtZ5S9tGzYldpRdcS0zW9PxciKbj4XZbVXfwbR623H3hy2OrrPRiZkrEo2SRScWe2w06yMkqs5IF036fT+H39/q+nywIXu9jk7ZdF8JZDUWqhWc7/5p2+G4oacjGLlRCVM82gYYi4SzIyJPWRUbVdy6gGD9BZstG2S1V12mqY6ZUz79cJOLtX4X8U9H8ZakLddlqqjx8PLyjYgJp2K5SCi07fLSJfQbnAbNcpScnCkVRIqik+TbmD/ALIZDDKOD9h/fbWmMUKkxx36kNfyj+eflKZzASnKrZnmafCE1vS9NKTr6zSLU9AxSLs7BpGeAXSiLtBE1kXx8fH8h8fp4eH7h/cP5YDGMYDGMYDGMYDGMYDGMYDGMYDGMYDML8id/ay4taS2TyC3FNhX9c6trTuy2N8RMF3jgqR0msbCxDQTp+/z1hl3LCBgI4FEhfzEiyaAon63qFzRlDv2nbsBld4bvp3XFpNy+nYDV9igZvbTSug4eOrpvOfZ+7U7XjNKNWWCaSpURPIHcxpEVTq3uwqxjlqnMU9AShqxxA17t32hTtfntzcgEniWjNeqxt22BAslDKwNL09X5dyXWGgYNY/oplVur8rhjNv0SNpCVbDse8JEJLgdMfowMGDKKYsoyMZtI6NjmjZhHx7BskzYsWTNEjdqzZtW5E27Vo1bppoN2yJCJIIkImmQpClAIuenjr5i+uvhlSNYSrBh/jVeSIbF37ONhbuVHewZpml5auhJJJlM6g9fRPutUigIoZm4dtJeeapIKz7sDSo/+sBjGMBjGfndu2rBq5fPnLdkyZN1nbx47WTbNWjVumZZw5cuFjERQboJEOqssqciaSZTHOYpSiIBgXlLyb1Lw80RsLkNuywo1+ha9hlZF0JRIeUn5Zb/AC8BUa2yMcoyVmtEqo1h4ZiUSpmduSrvFmke3ePG9B0u8LvycuGyO7Xm/ANrnBVi7hpzr14mu01pSE2fu5u5VWoVVhK4ummtZNPaHcSBLrsx8zZAfZF/ItDuDqyb6VgnOzXNnft97/ew+tcPdDWxSucB+OcvI26/bbQ9FpWUq1WUzM9kch7G9lTNY4WxWaryn6ZYyipWxkZIJ118OaWixjESCdZeiqn2E8v4jl1F01Os9dXXSVfj91w6weRSrFnZbdXCxZrFvN8ks3SCbfryjZO5Ppt36j93dH1VbvXS07rydUdhKN0/cBLVxF07adwchph3eebHLOWbba5K3mc9JzORUpLlVlYnWCb0oeQG1OPKPjTgMATjXVqeSicd54CLrqTWYDGMBjGMBjGMBjGMBjGMBjGMBjGVh/aN+1tHinph3w50nYCE5Eb9q7hC7TcPInRlNPaelvUZSD0FmagLR9x2KgR9A10vnTeRVdGdspBYPDVZ26CITuP5u7X7eeamv+tfhIL206rqOwl60K8Y9OSu7Z2vEneN7NsibftEViJap1PEoTXwqUODpiqyaWa7k+INntcTYXHuv/g9qvr44y0fjtq5uV2aJQCb2Dc10E0ZbY+yZRq0LabnK+UPMmV6u2RYQUadRYsFWY6GgiOHBY/3leIr2d7qnJwz0WXk3uusN2/JzkDAMnccyk2ghL6i09IptJOGpwlXL6sbabgoRpZrymAIuGhEq5WHSLd5AS3vlhzYF9p+rKLcNl7CsEfVaLQKzN3C42aWVFGNgq3XY5zLTUq9UApjggyYNV11CpkUVU8npopqKGImIQYd7W/L3PUnSvWRx4fh/wBRnYfb22unx2xvUUpWgW7wgbNtcymUpzIQ0wyTdQ0iKgo+90mO2Ou1VK6iADJmOPGi6Jxl0bqvQGs2AR9G1LSYSlwCYh4OHaMU1Im7mJA3icV5aekTPZyZdGOY7qVkHjk5jHVERgv6eqJcuaXIfkJ3Ob3rshEutwvJHTXCynT6fg71zxwqkg6YPJtBMECslH1pdIpQpJhiKZ15FlseRS9WLujccsa4DGMYDGMYDGMYDGMYDGMYDGMYDGMYDGMYDGMYDGMYDGMYDGMYDGMYDGMfv+/5f+v1/LAx/tfaNE0lrW9bd2dYWFT19rirzFwt9hkVQTbRkHCM1XrxUAEQUculSJA3YMG4KPJF+s2YMkl3jlBJSllw21revaF+yK5c2ORVdk2PBrjRMs69rvU0u9FaIlHTISTFN1as3J68dIOZMBa7F3u7amVLIFkIeoFVCBmoJSJyL7QDy/2PzU5Oao6beIjkthlJi+VpLeCse4J8Nm9kLHby9apMpKNjLFbVXUsQm6v+yFVCLtmUugx97I1kKC8TUsl6l1rx96leAPwFBwSO1Lxi1RPXK9WczJo1nr1ORce4nbbaHiCPkB/br5YBURiYwqrhUXb6Gq8YYzVrHNihFf3B2iY5rcpeKXTBqeQcMoTY8xAb55kykGAJo1PQFAfjNQdWdKIARuzdSy8ItPs2R1Wq7ewt9ViX/K2BIFLF9Wq9fpFYrlLqUSzgKrUIGIrFago9P0WENX4CPbxUNEsUhE3ps46OaNmjZPzCJEUUy+I+AjkBnRFpq8bFhN+9qfIKLBHffP67SM7V264qqHpXHmuvk42jVmKMt6aycXKKwzQGBlUCmf0ypa9fFObzmE1hHAYD5f1/qHhjIcu7Tm/OcQ+JZ6PqNR4/5T8spkeP/HGuwgnGymsdtFnCWG4QqREz+L2pMJ1g2hVBMUAu1jpyJynQcLeUNFdHlHtY7qr5yTXEk5xD6uUHGqNJKCYrmv3jkfJKLjYLgxIf0yLnhZhvITicmwO6be6UnT8kAELKmE2PPasuX59Z8XdYcQ6xKAhZOR1q/Ft9bIKqgulqfV71hItGTsqZ0wSSs2xF664ZqKGVTcIUqbamQN5/USm96xuEkB1+cM9Tcdo8Gbq2x7BW37asLMgFLaNtWwjZ7cJMFCqqg4ZxZ0mNSgV/Epz1mtwgLF9YqhjU99nLn7ffaPoelkUVsWjNI7Fa1EwAPvMSlp7i2d9YLsmoqfzkNB7L2o2skewdNkSgdPYcWBDeIC+wLY/TjxFLws68uPuppJgVjfLBXC7a2r5kxTdjsTZxELJJxsiHpIgZ5UIhaDoXnBMPO2qjYRUXMJnCsn2PD9nyD+mMBjGMBjGMBjGMBjGMBjGMBjGMBjGMAH39/PK+PtKHL1vxu677HqyGkiNticspkun4NsmocrxKgtit5vbMyQhTpAoxGvEYUl8BjG8il+ZG9JQgHMSwcH39/wCuUcbN/wD5w+/ppVFExsnDvhGd82kkymO4rs/VdT2APjShjJlbtnZd0bmcsoP1CLkev9YtEXjc7gtf8uBYz6TuKC/D3re49a8m408ZfLvAqbq2W3XSBu9b3LahW9hJEyKJSh5JKq1Q1Xpj4pjKiDiuH8FBKJfLnHso5kQnA3hhuvke/UaKWKtVxSC1jEOwBQlh2vahNC0OLMh5FBcMkJpylNTpCEMZGtxEy7EPK2OOb1B8v9P3ff8A6+fzCtByRMftH7ktTcS4/wAZjih1m/DN+cjTl/7sFb+QsiCS1DoT7/8A53wQ4hHRazYwqEUYk3HCPEiKt0xwN8+lnh5P8SeFFVd7RRcOORnIqXkuRPIeclUifiN1e9kKfGWMDOuPFRUz+p15xGxUs39dRqW1ntEgzKiWUUJktmPv7D8v9vAQ+Q4wGMYwGMYwGMYwGMYwGMYwGMYwGP6Yx9Pv9fy+/wC+BoV2Y81a/wAAeGm3eRkmZm4s8PEfhjVMC9N+haNs2pNePpUSKXlEXDJk7KvZZ9IngoWr1+dXT8ToAA1HfZt+Alp5T8lbn2WchiO7LXdbXywStFkbEgqZ1svknYnB5+f2AqoKSbV811+MwvMHcFJ6Z7/OQrlioRxV5JuXje33cmye4/tN1f11cZ5YJDWGmrW+oJ59qRWTqxL6BwPvHcU4pFrnTfVfWkLHmrMb5zAootXbAWCcqLXVu3Wu8cauPWteKOidZcedQw5ISgasrDOuQqA+UzuQWIZR3M2GXWKAe9z1nnHUjYZ56IF97l5N64AhCqFIUM44xjAYxjAZVV9pS7K5vT2uYTr84+ycg63nyPi0U9onqpjP5+uaksDhWEZUJm0jgXkSWncj4ysQDFBMXw0tvJt/dDFuEM7LYl5X8lde8PuOu2uSe0nYN6dqipPbE6aFcJtndhlznSjavUIlVYiiZZu42d9EVaF9QhkglJZqZcSIFVOSkt0/Ulbk9yc5bd6XO50H+FXG+Qtm02b563OePlNwR8KE1FR1RRcuG6Ek00dRW8HEU2umODtWzzWr2kSqs9jV0RDKrziRaOKGhOOXSxx+cM23O3sjWgdkc9dmxnpSP+FHH+NSk3T+iuX7QxnLOCg4trPMzJIn9CwNoW/JJlEuz4VNK5lx20Jrji7o/WXH3UsR8E17qipx9UrrQ4gd24I1A68jMyq4FTB5O2KXcyFgn3/kIZ/Nyb96YhTLmAsH3RxqK8b4sXIfuA5EQ3um4ualnlYfTEO887gNccZ6q/axNeiYUXZPfWTefeVyPjEhOYxZOs0Ws2JusctmdirYo+/v+eAxjGAxjGAxjGAxjGAxjGAxjOvW62VmhVWyXi5zkbWahT4KWs9osUy5TZRUFX4JivJzEvJO1RBNsxjmDZd26WOPlTRSOb5+GBpj2Oc8Na9dvFy78gL6swkZ5BBSu6ooS7wWz3ZOz5Jo5UrtWa+kBnKcemLdeZs8ikmYYisRkq/IVZ0Ro0c1FujjgXsXs25bbA7QeaZVrnRa3sxxaIhrYovxidy7uQOi7ZN2sc5RPHqax1A2SikgiG5TRBpFrV6a1TcxMHZoxvgjeOx94e0fdoNY1Fq9zZK5xP1lISaNXeqxxyNdZ6TaSEcjedzWaOXUK2/xB2U4axrWDinhiKldOKZTljg2iJWYNf40XpPXHHDT+utF6igEazrfV1XjalU4dM4rKox0emIKPJB2YpVJKalnijmXnZVwAupeafP5R4c7p2qcQyuAfu+Q/L6fq/f+/wCfy/3rjdv2xbdzX5D6N6XNAWSRh5HbTqN25zXvFfE5nGr+OtZXZTDODdKGOVgeQtavoTJ4l8YhXD0muIl0C0ZeFyZL1zv5ja74G8XNn8ldjnK5Z0uJBpVK0RUib+87BmjGY0ymRhROVUVJiYOkaScolVGHr7aZn10zMol0JdA+lTh9sHV+sNg82OUKBpDmjzynTbi2m9fNypuqPRZtytM0DWkW0VA69datYt62mpeuEUTLCqLwlPcoeWjR4lCYbW+vKbqPX9J1bryCZ1iia7q0FTKhXo8nps4euVyNbxMRHogPiY4N2TVIh1lDHWXUAy65zrKHObuuMYDGMYDGMYDGMYDGMYDGMYDGMYDGMYDGMYDGMYDGMYDGMYDGMYDGMYDIwe3HsJg+uTh5c9vN1413t62GU19oWsvRbuRltkTLFydvOvIxRUqjytUZgk5tNh8SC1cAyj6+q4bvLDH+pJXNzUPWoWYsdhk2MJAV+LkJucmZR0ixjIiHimiz+TlJF64Om3ZsI9k3XdvHS6hEW7dFRVQ5SEMYPn+XCZvftHXb3E1GFWnY3hXokz0Gjsjd0wCv6IgZdl+JrEssQvkY7E39YW7RjC+sASUTGOoJFdu8ZUCRcCEofszPAGwQdVvXZhv9u+mtvciV7Gz1K/sgndziNFl51V/fNnvheoA4Tn9qWluqlHynmK6UqUa5ft3K0XeVyG2L7nbRY+aHJniL02atlHbdrumxxW+OXs1ELlBap8f6BKLS0bFO1wUM1SeS7ivz1kaxz8zVx+IoTWCaPqo2dDzT32qyau4x6PnbRLBGULTehdZPJNygzRTbRdU19ritGUTYRjUTpkBCLgolNjFsSHAyopNmaPiocgDBj0Ra9vG95HlJ217zi3LTaHODYcrEaojZA7hdSkcb6DJhEV6CiFXflcJRkhLQzSBRSOCyLyC1nU5xm5MSYcecLBNVq9epFXrdLqUSzgKrUIGHq9Zgo8gpsIWvQEc2iYaJYpmExk2cdHNGzNsQTGEqKKZRERL4jz3/AD/T/f8ALHj9/f3/ACDGBxM/Ow1Wgpqz2SUYwderkTIz09NSjlNlGxELEM1pCUlJB2sYqLVjHsW67t25VMVJFuioqoYpCiIVg+vWNk+3Hsi2Z2p7Bh5ZPi9xfdvdI8D6vPM3kc2mZqOUdqy+1HUK+Kq3Uk2LaZdzrtwUoLNLZZ67EFfqPNVFSS7d3Mcj9ictt1a36U+HVhQJtDeDltK8uLy0SdOo7T+lmjVnZFYCedMfH3Y81CiFltTAyzRw7hfwlTUVXC2yPdUp/eO2hddcXtHaw4+6nivg2vtUVKMqdeanMRR25TZkOrITUquQqYO52xSzh/Pz74EyC/mpJ+9OQh1xLga+9l3Khtwv4Mcj+QwPEmliqGvpCM18U7hNFVzsy5KI07XxEEzFOo6Bpa5yLlHyCCaixImPkXQ+mg2WXRrdeyV8Xl0K1yb5sWlmsvKW+Xj9Ba+mHoiZ6rFxBo+/bXe+sv53L1rOTrzXDUjwpyJDI1aYQUO6cJqAy4b2tPlQ4Ua8aOEFUeqOXsu9dcgNjRTBQ6jtYqRpSg6li1EGoGWclfvXGxZBaMW8fO6j669I2VVIzWRsy9bHFxvwz4N8b+PBmaDOwUvXUW9vwoIJoi52XbjrW/YaypygKjkErdOSzJmuuc6wRrNkh4kTRTSTDeLGMYDGMYDGMYDGMYDGMYDGMYDGMYDAffh88YwIr+5rmqXgrwA3JtKGkxjNm3RiGm9MKIqlSepbK2FHSbRnNsDCskYHdKrjKyX1HwBUplawmidFQiokHRX2ZrhWTjhwSS31Z4gWWzOXcm02Aoo5STK9YajgAfxmqY4Dgl5wbTbZ3PbAQORwqk5jrlEFVIk4ZmIWM/vlu0t2K9n/AA86sdRSyrxhR7ExDaL6KUK4Qh7pslKOnbfIvU0QdpuP8ItJwRrOqr6QrMl7BZ4pw1Fw0OQbplVrEBSKvXKZVIttB1aowMRWK3CsSGIziICAj28VDxbQhhMYjaPjmjdqgUTGMVJIpRER8RENNOyTmdXOA/DfcXI2YUZrWGvQKsBq6CeAYxLTtmzJLx1EgzIkKZRZkSUH4zPAmHnb1mHm3of/ALUfNrl0scL7LxD4eR0zt33t9ya5NWSS5E8jZyYAp7ApeL8IyUfWpZfxOb3urwrhBKZbFOLYtzkbc+bFISRMA6K7WSS7a+4SqaUYqlnuFvVW/Z7A3CdP1Vq5sflg9kFU4Gjuze7+6ySNTkIM0TIRz0qzUWlQ2pEmWM3s7UFbMAfL9X0/Z+wfH9/6/wCOAxjGAxjGAxjGAxjGAxjGAxjGAxjGAyC7vf7QmnXrxfcVPXM2VLlFv+NmqrqZNg7bfE9ewgIe6WjcTxubzqNwriTokdTRWSEkjdXbJdNJ7HV+wJISr8nuSGruI2htl8idyTacHQdZV1xNyR/OmD+YfnOmygKtBoKGKD2xWuecx9egWXmIRxKSLUiyqCHqrp0mesfjjszvT7Fdmdh3LmMK84+6nuUYs3pRnajmtyVhhSoyurtBwiDgv+YpNGh1o+y7BOdBEtiO7QSlWqrrYMs7bBMN7OB1nL8VuPbnlpuOBMhyI5PQzaRh0Zhq7TsGvNJPHDaXgoJ6R74KNZ3Yb5uzvdlASAuEaWmxb0reTipVE1lr7/nj5/n/AK+P7P8A1+z8s6nfaone6NdKOtKycElcqnY6orOQqqaMzDJ2KHeRB5WJWWTWRSk44rwXjBRVJVJN0ikZRM5AEohiNDlvxjd6Qs3JVhvfV8roOmmm07PtqGt0VM0mGXrsp8El2ruai13bf31rLGRjyMUvUdvHLpimxRci+Zivm2s2Wv3Ot1+4VOYj7DVrXCRNlrVgiHST2Kna/OsG8pDTEW9RMZF5HScc7bPWTpExk3DZdNUhjEMA5Vw1p7NdsKr1upaB2B2VbQ2Fwmidixuzbbxij9TqUyGuMvFTBpQkUaVHbtmYRDOUMYqsy9SgHgLv0Qkm0S2liRspEWl4WFiK3DRNegI1lDQUDGMIWFh41skzjoqJi2qTGNjY9ogUiLVkxZIItWrZEhEkEEyJJkKUhQAOTx+/5/s/X+z+OM1F528tqfwc4obl5MXIzNyTXdVcq1WAdOCojcdgy5ixFDp6BSrIuVAnLO8jm8koz9RzGwgSkwKRm8Y4OUKnntK/Li6cl+SGj+qnjqLq0SrG30+X2TCwK51D2fdN8BGM1hr90ZqsJRbVCAnvxNNIOk1mKcjbIl05Bu9qhjJbA8v9AsoWB65vZ0eN8l5EbmjWtwc3LzW000XBNcViVWttvsMqsUSIlkbna4e43qOh58Gzts6gdSwKC5mU9HlHSboT1UlYdgcuO73mvKupCo6Rb7Ms0Rbp9ArpzYtrTcW8sm0LlCN5D00ZB/WazKBUqlHMnIEd2W8IxMR6MlAt0STU9EGp7/uh5yS7beQkYdvuHnJdZJrq6MeHWc/gHjpUZQI+Ag4NZ0VN4hEy0hEMINgk5TP73VNb0yabODhNuhUCwTTqhWtf1GrUOmQ7SvU+k1yEqVUgI8hiMIOt1yNaw8HEMyHOc5WkbGM2rNuBznOCSJAMcxvEw9jxjAYxjAYxkZGyO5jq+1Nfn2srxzL1QyuMVJqwssyhPxRc4uHl2y5mryMl7RSq7YarFPY52RRpKN5GbaqRTpFdvIlaroLJkCTfGcBVrVWbxW4K40ywQ1rqVnimU7XLNXpJpMQU7DSaBHUdKREowVXZSDB62VTXbOmqyiSqRynIYwD45z+AxjGAxjGAyk97Rr2VW7cmxobqj4lqzVkmpO21uE30pTFgeP75fJh6xLS+P0OVmBlHScbLOo2WvCKS/g5swwtXcGamr9mZPZw+7bs+iOuDi68Up0jGuuTG50Jao6QryyhFXED/AJUELJtqSZiRQh4igIPWqkYg6IKEzb38BGKIOIv42qyh89mp6vZMpXPZxyVjF526Xs0wpxwZXAHklPN28w5eJ2/fUs4lDquHU7cjrvoemyTsVHZ4ZxYrSJ3QWSAkGwTe9PnWbU+tTi9FUx42jZXf+yUo228gbszOR2R9aStlPh9JgX/pJqGplAbO14qHKHgSVlV56zmSbqTws2ksn3/P5/6/3/Xjx/j9/s+f3+7ILu6fl/sepVLXfXrxOOpKc1edyy2v6ggxcKtFta6ilVHcRfNnysq2N69bSUj0JmIh54CeeJZR9xtjRUjqmFIqGqqR1u7Ls7KskqWa62esq7t1khKBSQfIXlg18ypFCmEFW1jqNYdMgA5BM6jlKjHFASgx3CIpWfP5fT+fz/qP9g8c1M4P8QNa8FOM2s+Ner0CqxNHiSnsNkVaoNpS93eS8jq23ebBEP05CflRUVRRUUXCKiUYuCaq+4RbQhNssBjGMBjGMBjGMBjGMBjGMBjGMBjGMBjGMBjGMBjGMBjGMBjGMBjGMBjH3+rNfuVPJLXHELj3tXkdteRTYUrVdUfWB4h6xUXk9KCKbCtVKHMcihDTtwsjyKrMGQ5BSGUlWormSblVVTCtX7Tp2NSeu9e13rs0lIru9nb8j4+X3X8BId/MRWrnkn7vWNdsk2BzvUZ/aU6zE8lHkS99Vpcb8MWauI29oGGVbpR65WXXVw5rtWs8e0Dfu3hjtkb6lUgMZZpYXbI4VzXiSx/ERj9bQrw0IcqR1Gjm0O7bNshBvMkSTrQ9FvHC9doHY3uPs35OMiWGs6r2EF9Zov23rwU5viUTI41vWIoqxyD8D0dWGsRPRyBQUPFOIrWzZwRZq6XA17W73Wqa3ptr2Fe56Pq9Jo1dmbZbbJLKihGQNcr0e4lpqXfLAU5iNY+PauHSwkIdQSJmBMhziUghX/759l3DcqvFbqf0pLuGe0udu0IRTZb6NOsdxTOO1ImE5KyT8u3biVcsQ/ko53PLnSOum9rusrpELtFwfJkPPZq3WlO01rahal17EIQNF1rUK9R6jDtypETj6/WIttDxbcwIpIpqLFaNEhcL+mQzlwZRwoHqKGEa9XTZUbZzb5R8pO5jcdfkItptSXktF8Mq5OJFKtUtC0958Nlp9mkn/kzuJc8fG1g8o1SQWPYmG1FgFVlZSmPZRwGRmdrHYnU+uTjJJ7HMzJadz7AdOaDx71uj4rvrdsZ+08EJFyxSIs6Wq1NIu3mrGdFAxnZjRVaQWQlbLFGNuTyK5C6n4q6Yv2/d3WhtUdba4hVpmek1vBZ05OJ020ZBwjEDpqy9jsEms1hq/Dtje8Sks9aM0vKKvnLW064tD7P7ZuY0p2/cx6hKQujKLK/B+v8A0VY1/eYqMj65KuBj9hu48yKbaRbV2RQUlUJr0Skt20l5Cdae61+k1tg5Df8A6WOvO4cUdU27kdyadStp5zcvH3+I2+7JavdnNjqLWXeuJuL1sLtEyhEXqK7wZ68kZ+7NVLS4Sg00VoynQS+TbCP7vl+sfAP2/qAPkHzH5ftH88ff3/zkZXcbyUPxT62+VW0I5/8AD7XJa6eavoa6agpvkrltxwhruJk4wQEoGkKylYXlvSA3mIVOvrKqJLEIZBQKfWilzdwXtFLrZCojZNL0Pa0jstkY5SrxoaL4zGZResvUapeo3CNvtmi6OWYaGVMgq7vUodRd0ZYwL/Q6/p/AP4f8fv8Ap9PCnv7JLxoJAaf5KctplgJZPYtzhtKUh24IBVkaxQGKNpuTtiYAAx2NgsdqgGDhQ5jFF7RhTTKmZJYVbhGAxjGAxjGAxjGAxjGAxjGAxjGAxjGAzCPJTeNY4z8ftzcgbkYo1zT2t7bf5BsZT0jyZ65Dun7GDan8phF9PSKTSFjiAUTKP37dMAETAGZu/d/v/TKqPtUvKuRpXGnT/DOjOXLi68nr0hO2yFiiunMm81xriRjnUVDCzaeCih7Zsx9VVItISri9NTpVom2UOPqJBgv2YXj9Zt17H5ZdpG7xVsexdg3my64pc/JJqHMrYrS8Z7B3XamCbtZYyYOVpao1eFftw/yLItvgW7syKr5sSeftu51f9BnEG13qplGW31sx6jqHjfUWjUsrLTu2bi3cNYqTbwSZ/fJRjT2oOLG8RQQWTevmsPXz+DqwMSK5i66+LMbwm4TcfeOpUWLWX1/r5g52A8QI3SSf7IsZlrVseTUcJnMC6BrbLzCLFwusuZOIbMGoKii2SAkOfGMi3bp2oXDmxKnNN8Iuu2ZktScRG6yKw1/ZO/FisHly23GmOmgDtGFO3i7E1UWTA4Ijp9wiBXMVMpGCTTqZ4Lp8B+HlK1pYhCT3de1ldscirW4dll5KwbguLZq6n2bieMT3mYY1JEjWqxr1dVQZAsW5nDeDyZeqKyY4xgMYxgMYxgMYxgMYxgMYxgMYxgMfw8fr9f8Aj7/YP0xlT32int7PpWrSnX/xhsTtxv3ZsY2jd02uquDqyWsqNZUiEQ19DqsfUcp7G2OwdJovCNhJIVunPiKtyFmLTDPooIde+fsstnYryhrXCri48lrhpDXF/Y0yvRVXU9dPfe/3sgesBPsipGKnKQME9frVHX4mVMyeKOJ21IuVWU7GGYXaeuLhpXOBPDrTnG6FKzcTlXgCTGyp9kU/p2vatkKlKXyfKoqY6yjNSZVUjIIqxhO0rUXCx/yI0IUKnPsuvW0Nzvkz2H7ShU3FP1y7l6Px1aSDdMyM9sRRqeOu+xUmbpI5jx1IjXitarL8xQIvZ5WYeIAzlqan5b1P39/y/h/HAYxjAYH5/P8AjjGAyij7SLytuXMLmDo7q847qL2oaPca4nb4eHcKKtbTyL2MCMNV689Fqo6bHbazqU1/mn4ppjEyt2t7OVSIevgdO2X2OczqzwG4e7e5JTpWb2arEIMLreuPFDkJbtp2X1IyjV8QSKdc7I8qoWVnjoEMqzrMVNyBSiDM2UjOoMILQFS5Yd6fL47y6ONaS1spuhGs8BTzW6OWW2EXTuyzTQVG6IrLt0rGMa8m4/1m0a1s16nRRItRViECU3mFpYsmnwH9nD4pzS7SKaw9W2jzl2DXSJNl4zX8M6LcbHJS5VEiM1ZO5WJ3O7SGFfnRMaeU1FCJKHZTwohbhpFKqutqZU9e0aEZVql0atwlQqVdjUzJR8FWq3GtoeEiGRDGMcG0fGs27VHznOcSJAJznOJjDB10XcONgUDWuxOfXJ8XEtzB58SYbSuD2VQXbyFJ1fNOzWCmUpswdkBWANLldIWSUhETJpRcWnSqqq1bK0wiYT24DGM1t5UcuuPXC3VUruPkbseF17T48jhKOTeq+82K2zCSBl0a1Sq2288taLE8AoAjHxbZUG6QmfySzCLQdPkA2S/X4f1+X3/DxyALnn3+aC4031rx44u0mW5vcp5CfbVoNb6pfO3VWg5o7kyDuAkbZXoa0u7Dc0RSWQLT6VCzzto9IqzsD+AdNztzxNy/MjtW78b7a9VcH4yX4c8HI158Du+25Vy8hZqZi1imQkI627DgwVkJywSca4OsrqHVLlJg1Zu27K9WR/EOm08baDfOqOKvs2nAyYuuk4yL2bzj3Mq71rr3dWw4GPWuMlZJFiKtjsMPGog/QpGt9eQZlJolTjHa6E9YFKpC3Gbn1ZIki3DhezrtG5PcodoUnqm68afLVjkdtqsQTLkzaEZxA8npR3Ya83lr7qFvb4pMzKvra7jHLxvuHZDIpnEQRFxWaq3JZzOiN5KeJfQ1wH0JxiiNKbU0TqbfuypisPGm0N2XahwsxcZWzzrVVOXe0GYnWkjLa7ioQ7gWlOTrjqOkI9sxZSj5y7nln0g41Z9nG675fj9oia5tbwQeyfI/mFHksjN9Yyu17RVdPTEkFkjSST58qo6XntsypWex7I5VMdVxGBSm7r0JRhKpnssfxwK4Xs9V2ues4vm/1tbCmHc5KcBuRk1XKHLP3ALqvNW32euIRCLPyKGRKx/EFPnrWRFNJsLRO9tmh2zcUgQTse5Wf6YVvxl2h98exSKpOWbPklTdfMXaXj6a41y67+hXiSQgBSKFap1mNIZYAMVb1E1UTqJnE5rMGAxjGAzFe8d066456h2JvLbc+jWNc6vq0lbrZMql9RRCOjUvMVowbAYp5CXlXR20VCRSAi7lph6xjWhDuXaJDZU+/wDn+H5f1yin7QxztvvNPk9Q+qfieD23xtb2NX4HYjWuKrifYvIN88NGxdEVXRP7upV9Vg9FafWciEc2uSks6lyoBQ2MgAaxcY9V7h9or7TLfvTdjSwRPFvWj5jJWtk2VMEbSNRxcjIrat0BBP0zkQJZr6sk+XtMmxMi5ORTYN0bFbvCxbBT6G0JCw9bh4mu1+LYQkBAxjCFhIaKaIMIuJiItqkxjYuNYtipNmTBgzQQaM2jciSDdukmiiQiZClDRbrT4F0Lrp4o0Tj9VAjJW1ppBZ9wX1g0O3V2JtKXbNwsM+YXAA7CIYEQa1yqNHBU1WNWholFymaRF+4cb0zc3D1qGl7HYpSPg6/X4t/NTk3LvEI+Kh4eKaqvpOUk37tRJqxjo9kgu7evHKqbdq2RVWWORMhjAGv3LvlVqjhXx82LyM3JLpx1QoMOq6Qjk3DdKYt9kcgZCuUmsoLnD32xWeTFGPYIFAxGxDuJN+LeLj37tvEv078XNrbBt2y+2nmVHLJ8n+XrLx1bQ5RssLfj3x0OuVSn1iuISQqPIpzbYRtDuvKJUHzeptooz8U560XNFfWjV0TNd9vM5ryAvcTKRXV1wl2G+ZaEpki2dtmvK7dUK5TB5sGyNHByIPqZF+7tlzs1m50UYBywoyrYJGybLTaWkgACgAAHlKAeUAAPAAAPoAAHyAADw8A/IPDA8/XGMYDGMYDGY02jujTukIIlo3PtbW2o60oZUiVg2beaxQ4VU6BCHWTSk7RKRbJVRIiiZjpprGOUFCeIfpl8eN0vv/R/I6qu7zoPbevNyU+PnHtaf2XW9shbhDMbBHItXT2GeP4R28QayKDN/HvhaLnIsdhIMH6RTs3rVZUMu4xjAYxjAYxjAYxjAYxjAYxjAYxjAYxjAYxjAYxjAYxjAZRb9pE5nXPllyh1R1ZcbAfWwapeKsnsGJr6iig3bkFcioxtNooqtl1G7qO19CzqbiVFUAbM7ZYZNvKJN3tLIslbC7HeY0HwO4bbr5JyYtHE5Ua2eK1xCPBESWTaNoOEHQoYyRAMqsy+PPG8nO+imZRtW4yZf+UE2hzBVO9mF4ZT29N6bp7Nd6kd2l/XbPZ63rObsKCa7m0brvhVZ3bOyzHXbEBV/Aw1gTh2kg1EzZxLXqfEvoSFfL5Ati9ffDWlcCeJmpuNFNFq9Xp8KD+92dumchrvsyeEsjebcoZchHQtpKaVWQg2zsTKxNZZQkGUwoRiPhD33A7Xv3N3khqHpS41WFxFSeyzRm0ObewIg6/rat0XBnjZ9lWHggKbU7iwtXDCxv45woQJB051pXTqKMLpJIlmi5w8taFwc4ubc5MbCURWjdeVxVeAgBcooPLld5Q5YulU2OA6qah3NgsLpi0cqoFUPGxfxGZWT9yjHaicZ/RRxNu1E0vfOdHI1uu/5cc/rI73TfZOWbqpSFW1zPSDqboFNj2rwh3cEwkGr8bY4hU1yosI+QqtaVbIhT2hEgmd1Lquj6N1fr/TutIVCuUDWNQgKTUYZuUgFZQVcjkIxiVZUCEM6eLJNwcyD9UvvMg/VcvnZ1XLhVQ3I7D2HR9S0W2bN2XaYelUCiwchZrda7A7TYQ8DBRaB3L5++cH8fAiSRBKmkkVVw5XMk2aoruVkkT9jlZWKgYuSnJySj4aFho95KzExKvG8dFxUXHNlHchJSUg8URaMWDFois6evHSqTZs3RVWWVTSIYwU5t57M3N7RVy5Hi5x0m7HQur7jtbo2R3rt9oRzHE3NLsHxlmZ2CLhJE0i7lgYukdUVZ8RRrCtTr7VuUcd83rtfjw5qMZbe9pE5VNLHLM7fqzqG4zXRQkVFuBdQE9yPvUYBfXFyKKnnGZlWbhMsiugoqhqyjPgiY5ZG+Wp/JqW8qxWa9S63X6dUoWNrdVqkLF1utV6GZox8RBQEGxQjIeHi2LYhG7OPjY9q3Zs2yJCpoN0k0iFApAAOmaX01rTj1qykaW09U4yka111BNa9VKzFJiRsxYICoqqssqoJ138lIvFnMnMyz1VeRmJZ69lJFw5fO3C6mT8BlM72uTkgVjTeK/EqJfKFcWKdse/rwyTWFL042uNHVB1166ZDidy2kpCc2KsZNYpEE3VfarEK4XIUzO5iP0Hxz52fI9X/wCVr2jeM1i2Etg1fV961/UiiSaZ3sebUHGQjuZ2yVNY4nbCwtEhWNju4x75fcFFrOwFJN4CyZXYXP8Aqh44jxS68OKWmXjBKPscZqyIt13QIl6ayd82Us52JcGrxQxE1nLiKnLO8hCLLF84NIxsgQCIIopkkNzz9/l/b9X5/qH5eHyHPGAxjGAxjGAxjGAxjGAxjGAxjGAxjGAykHPEJ2Y+0/sYVyYs7qPhTJJJqIgcsmyaMOL3jKPW7lDx9yUZyPJ+xBFSKJwFE8fIC3ckcqEFBW4zyI2/FcfdB7q3pOA3NFae1Vf9lPEHRxTSeEpdWlLASP8AEp01DqyKzBNg3RROC67hwkgh4rKJgNP32awarqbTXYt2n8jZ73GIbybqszd3ekT97OhAtT7g26ZkiYUzyktbp2165ZxMY0ORWTnmiEQ0I5eu0kkgmY7tuVN+rOt9b8AeMbtV1y/5/TpNS05tHOFW7yh6lk1Tx+zNkSL5qoVaCaBFGdwLOWU9EWUYpb7OzcprUxfwkr4X8U9f8JuMupeNGtkiKQWtay3YSM2Zqi1fW+2vjnkrfdJYiBQKMlZ7E6kJVVMTKFYoOG8Y3ODNk2TJDr076fvvLHdG5O5/k1X1o298gzvqLxEpEkPnS1LxlhVRiI+RYs1CCm2lreiyLHoyzYrc8owStFqQ9RnsxwGWLMBjGaNdifOrWfXfxeu3IjYhkpF+y8lZ1lR/efdn+xtnzDR6rWaiyUKUx0GxysH03YZApFDRFXh5qTIk5cNUGbgHNTse4f8AX9XI+b5L7YjqtMTzVR5VNewrVxZ9lW5si5K0WeQdPigVfhFIuBOivPyxoquorpKNlZYjsCoH1a4j96XAXmNuCI0LR7LsbXO17OmuNOqm66IejHuTpsgq5PF1+VbS09CKzCzZBdaPiZCSjn8sKCjeJQfPCg3HUvqE69LjseUX7U+xVmG0uYvIQEbjrOt3mJOtFcetbOwVUqKFcqcuRZpWrNJQ6yDiEappGWoVQViYdgaPsL+3nc/q79GMTN7I6iarARrP/Gux9jepFKFPt26P4kjK1DSsOna02L0CC8bQyU/O0KYmBKoVigtEx7135PdyKFCxp+X8/H7+/p4/TGP7B/T6f2/p+zGAxjPIfw/qHj+X8P1/Xw8Pz8flgeMZhi3cj+PFAk3cNe986YpUwxMcj2Ktu0aPW5JmZMfA5XTGZnWTpuYg/I4LJEEo/IwAOR7b171OrHj/ACrOBs/LKkXWYdnUKdrpZrNbqaR5UVfRXNKz+tY+xViOVRVHyGj3U0SVP4HMkwVKmocoS4YzVLirzh4o826s+t/F/ddR2rHRKiaU7GxoyULbq4osQhkQsdGtDCDuUCi4E4ps3srBtmEgokuVg6dC3X9Pa37/AD+/v9/gDGM1M508rKvwl4m7v5M2kGLgus6U/f1mFfrigja79JiSGoFS8SLIuBJYre/h414o0MZyzjV30iUgkZHEoRh913dDVut6kNdXak/Dt55ebBi1HVercicr+E1NV3SS6KOxr4wbqkVcvHTkoJ0mpLqNgnl0XktJKlhYz3OapYaJ4b715R7x09Q7JMWCe5Yc+5ZzsaTsM64eScnqvjbZ3UxI7D31sZVFUHqNm2rFNZx3V4qVVbJrauTfPFomUHc2t5OH0mi9wSW0uUkJyW5Qnf7YYWbciWztxJzTxoK+x42ty0ZcLvR2KkwuMe3NN10qVRrsQqJYti3koeGZNQZot2ZfoB9EXFPYCVY2x2V8m4FJjyY5yyKVgr8WtFlih1nx3bCz/wAPKlAxiYEShIWxRkbAyETGJpJlba/r2tWXkbuGb5AQm00BovXfGbS2tNB6mh/gevNU1OLqFZYnOCzs7SOSH3iTlHQETF9Nzb9R3NTskchVZKZfvn6oeq4PmYMYwGa28quXPH3hVqaW3TyP2JFa+pUab3RiDkFX1gtU4omdRnWabXGJFpezWF8CZzJMI1soVo1TcykqvHw7J/Itesc5OZ+pOA3G688kdxLuVoKrkbRldrEWdIs/frzM+slWKPXirAKfxGZcoqrOXihDtoSEYy9gfk+HRLsxaAcUy5g9/HY3q6q7unZmDgp9sN+eVSugqancZOL4nazR3cVDOvKmjO3mMd15KBsEyBZe4yNhpE7KqPYCbhU4kPojcbeQutuV2jNb8h9QvZN/rnakCNgrC81GKw8uRuk/exL5lKRiqiotJCNlY59HO0013LYV2qh2rp02Mk4Uzf8AvzpGtNcUnT+vaVqvW9eYVOg68rMLT6fW4xIEmMNXoBgjHRjFEBHzqCk1QIKrhYyjl24Mq6dKquFlVTYm5gci69xI4v715JWcqC8bp/W9jt7WOcnFNKesTZoZrUawVT1EBKtarY7ha41N6yIA5lEvFVL5nKFLD2jPlDcubPO3TvW3ohcJyO1RbIGuSjBu5EkVYeRWzAYsDDKOSIqJIxmsqtJtIl5KnMdKvvJfYJZAqSbFUyeeOLWgKV2Oco+OfDXTTIbB1VdTTFqveropGqM65ym5KKqqvLTOnUbei1l0Ng3kZeUbIgKqCOuk7dKJqMCbEhWZq0/EqA5E8w+W7+napWeznJrlTabXCyOwFkHYjUInajiZk9+bQdyrKQbOIg5ae8scfYXajKXSWo1mvDVg2Ss61bdJfUO4ScOdS8DuONC43adZqBX6k0M8nrG9QQSnr/dpJNA1nvlkMgAkPMTztBMSolUUQiIptFwEeJIqJYIphtgAAUAAPkAB4AAAAB4B4AAB4B4fIPyDwAA8P1hnnGcVPTsPV4Oas1ikmkNX67EyU7Oy8gqVuwioaIZrSEnJPVz/AKCLRiybrunCpv0U0UjnH5FwNQOfXOvTPXlx1s/ILcjxRykyOEDQqNHOUELJs7YD5q7cQdLr/rFUIid0Rm5kJmXURXbV+vMJSacN3XuabJzUp4TcEeSnf7vCU5/9h9rsNf4tRsu+gtW62q7x9AtbYyipACuKFq1qsq4Up+rIJwiZlc74gZS03OxpPmbGTcWJOestcwlMTu8PaV+zlrVI5/MVDhBx/fupJugYqzFOm6XGcatJCdXbmOJFd071Vi2zNgQxVjwDRJumKL2Docm4d359e6/peqKNUdaa4rUVTqFQ69E1SoVaDbg1iYCvwjNJhGRrJEBMYEWzVFMgqKnUXXOBl3Cqq6iipw/JrHV+u9L0Kr6u1PTK7r7XtMi0Yar1CqxreJhIaOb+JgSbNGxCFMsuoZR09eLis9kHqzl8/cOXjhdwpSK7wpt1z37u+JXAaMXM9putJDVWubQzQWOPuEvuCYhtjbgnElkj+BPctSFpYOEUSg4RdVt0Q6wqiRFtew+/v6fw8RygvpuZY0j2sKzOtuqFZqyPI3c8NW3Mp4FRSfXzRlviNQJiVb/yGWZT9Vi4PylMYHsjFKo+XylOUL7zFkzjGTSOjmjZhHsGzdkwYskEmrNkzapFQbNGjVAiaDZs3QTTSQQRIRJFIhU0yFIUoBjnd21q7orTW19121QqVY1Jri67InhFQqRlIqlVyRsT1BIxvq4coRx2zVMoGUWcKpJJEOochDZQ/f8As/h9/u+g/LK4ntJfI2xVvi1rHhHqcBld3c8tq1jV0NX2LoqcurSIqx19zKJt00gUcJntV2f0SlJEVIk3k4qZsqBFjizWQOHv9mY1fPsOD+yOTd5I4WvvMPkVsnakpLLpGR+KwkFIDU2y6aagGWMkrdWexJAi51lQVJJFBP8ARIKq1iKZkghoeVlxYyUmEVGvpEY2GaGfy8gDFqq59ximJTEM9knfpe7sGhTlM5dKJIgYBP45hTivoSvcW+N+kOO9XOmvD6c1nUqIV+QpkxmpGDiWzecsKxDeAldWSc+IzzwoFIQHUit5E0ieVMufcCO/re7I9P8AZZqO2bN1hXLXQZjX18kqBfdcXsI0trrEkiglIwz5yEY6ct1YyfilwUauP+0ZCWj56FORRWGVcryIfuyqDwiiU+I/tIXO7jfQwTYan5J6pLutettye6MWNzeMKftVNy0aIqe6ptoWYu+14uJaJIkRZRM+Vu1TbItxSNaSvt7p2r6Tbdj7CsUZUaLRK5M2232iace6xUBXIFgtJS8s/X8DCRuxZNllzgmU6p/L5Ek1FDEIIRM93HZOw66OIsxKVOSZf9RW6UpjX+h4hRX/ADUXInZJJWnaCiBSKeeP1pGybSRagsQ7V7bpGpxLtMzGReKIw/8AsxXWy9iIWZ7Ld7Rj1/e9ijPwfHcljF6tLsq3ILP47YO4Hh5DzOXErfnR3tbrcosf3pStpWWWKo+j7mwdEi1rzLaHtHfbo5lphKervF3XnounrQF3qKWvONNRnATYwTZwQFWcfs3cck5UUXMQx1m05PS8g2K8r1JBBt9ECsVmApdbr1OqcSwgKtU4OJrVagYtArWMhICCYIRcNERzYngRuwjY5q2Zs0CABEW6KaZQ8Ch4Bzn9vv7/AG5Wv7LdpbF7JeVkP018YLJI1vX0ShD7B7Ct6VtYHCFJ160dNXzTTMe6Q9VoazTJ1I1WUinZjJSE5IQNfkE/g8LsJojv52wdgzjg9pKFrup4wb3zD5Fy6mruKurI5iSbl5u9Spmkaa4uoIwiD2vUpzLxaqzdcgt5ewSNfgFgK0knjtnynVD19tOAvHQ0ZcHxrdya3dKJ7W5T7LdyJ5p/a9qTIOn7uHQmlgBeQr9PWlpKOjHKnh8XlHlitaiSDyzO0SBvzqDUmvNDawo2m9T1iOpuutc12Pq9SrkUiVFrHxcel5SicQADu371cy0hLSTkyj6VlHT2TkF3D124XUyPjGAxjP4UUTRTUVWUKkkkQyiiqhikTSTIUTHOc5hApSEKAmMYwgBQAREQAMDwqqkgkquuomigimdVZZU5U0kUkyidRVVQ4gRNMhQExzmEClKAmMIAAiFSntS9pQq2o1bjovgEaEvWxIxSQhpvkzNoNJjUtVl4v0Sy0Rq2IVQettrWpos6aMyzbpI1BjF3TWSBC4wSjp2xxP3G9tOz+YOwl+rbq2ay+25q9LPKlubZesFCSStzKIGLN6019Y27hKKYUJg1IuO09lLSLaCex4OoNtMM6o3sL+e3R6wPZxOOfFmKqG2uWsbC8ieR6KLOZNXJQhZPSOsZkqqbxu1r9bctkU77NxJwBJazXFB1EHdlK6gqvFuGqEmuEKPATpW5Z9r13Jy85/bP3RVNLzrlm9YSmxJJ5I713SxFP1Vz0VrZGqrDW2tl3AnWhJd3DPI1CKcM4qkwc5GkGztLu/FLh7x14SauT09xo1vGa4pJ5M09KoNXcnLS1lsisbGxDqyWaem3khLzU08YxDBBZy7dikkk2Sbsm7RqmmgXZcoAUAKUAKUoAUpQAAKBQ+QAAB8gAPyAA8A/LPOAxjMP7i5B6L48xMBO722/rjUEParEwqVakdjXCCqLSeskkcCtYaJVm3zMr995PM5cJNvVBkwScSL0zdg2cOEwzBjH68YDGMYDGMYDGMYDGMYDGMYDGMYDGMYDGMYDH39/f7sZx8tKx0FFSc5MPG8dEQ0e8lZSQdqAk1Yx0c2UdvnjlUfkm3atkVV1lB+REyGMP0wKL/tRvKSzb15P6C66tTEd2Jehua5arVWodUqjqybz2+VCE1tVFWxlwRNJQNMlWryJE5UBMO0nCaxzgkkZO39wY4r1jhVxM0dxpq5GiiesqRHR9jlmiJEy2W+SYqTV+tJvKiioYLBcJGak25VymWbMnDVkZQxGxByjl03wj7sg72b3ysubRaSgaZZ9vcsVm0gmJ28eYJ5GraZrxVTgb01qdJW+pP4NsKguvdqOJjHWTaujDZi7puft109V6XwS4jKurJzy5kKtKNr+GgQBeT1pr6zPHMHP7JknCZ/GvvHrVCYjKnLLgmnCAwst7WctmtJODoNO9zPXPdt2lQPHCv8AmmuuzrjtbS6b5mETpPqhvHkA1Ues2FNbvmpioyEWkujKUtNJNwYBrUXtSXaOxSsdaVG06iii3SSQQTTQQRTIkiimQqaSKSZQIkkkmQCkTTTIBSEIQpSkKAFKUAAAzRDrd4H6+67eK9H4+0wGErYkSms+2r62anbOtj7RmGzUljsy4KmFwSPbptWcBWWa4+pHViGiGqwqvCPHLmC/uF7LNxcjdzIdQXWj71bd07Ker07fu0avJAgyqUWoguNq1vE2RmdRODbRMOR093Nc/VKlWIRN3TmYuJ1zPIRAY17EeXW9e4vlGt1Rdd04ZnoatSpjcuORkcqqvU5WIhZRu1m2hZaOXTI+1pWn5DsWseyeFW3DeCsYuNcI1CPNMTFnbiJxM01wl0JSePGjK8nB0yoNBUdvlionnrhZnhUjTt1tsgkkmeVs0+6SKs8dqACTVqmyh41JnDRkcwa4C6yOufVXWvxvhdO0crOwX6cKwsG69pe4g1k9j3srUySzkAUFRyxqdf8AXcxlKr51lE4mLUWcrmXnJackZCRTAY+/9sY+/n9P44GqXObkWz4kcP8AkZyNdLIJO9U6qtM/XCOSJHQe3hdkaH1/ErEWAUTJzN4kq9EHBQpyiD7/AOpX/wCo9Qn2TTjs8ue7eUPMi1pLyJ6XWIzUdWl5ITuVJG5bLky3C+yyTk/mMaXiYStQbR44UP6yjS9rh+n66pi7ze1h8my0Pifpfi9DyQpTfIDZa1ytDRFQxvV13p5Bq99zfJkEASSk7/ZadJR5l/EHC1UfFQIYzZY6Ek3QVxmPxj6wOP8AGybA0fbtztZLkPck1EBbKqPdqe5vKkLhA4esk7a6ujqBGPCOB9YHTBUBIgUCt0QmXxjGAxjGAxjGAxjGAxjGAxjGAxjGAx9/fjjGBXG9p95Mu9JddQ6ogHx2lj5QbIgdbufRMQjhPX9ZSVvl3cJKCYDlRduoSr1l8RMhhWjrO7ROYhDiBohOKugZnlpS+F/TJriSctNDarqtb5odpd0hnHuTmVu2yJRlfKvx/QnGRTERslWi5iuUl4yRMdVKxRys2qkq81LICviX2pXkS83Jzx01xaqLdxakOPdFik31WYC8eLye2N4vIifdV9OOijkervHtJjtYosyNVSSii0u5btARUORRa2P1I8DP+hHi1Gw93VUnuSm65IdxcoLy+e/FZaf2pZyqSDuEVmDlFZ9HUtN+tDN1hWURkpo9isyYEWsbooBJlAwUNV4OGrNci2MJXq7Ex0FBQsY3SZxsPDRDNGPi4uOaIFIi2ZR7Jug0atkiFTQbpETIUCkAA5XGMB9/y+/llQjfch/8xnelQOMLTzz/AA663hl7bt5AFfWrtx2RW5eNTtkc9Im5K0kPi2wUajqQ8at4P0a/V9ky8WJmrt4QbMXMff7DixxU5CciH4tzDqHU11ucU1c+X0ZOzRsM5CowhvOJSCeftCsPDJAcQIKr8gHECj45A57LToV5WuGu1uVVtKtI3/lfumwyClmkEwUkJmmazdv642cKvj+ZZyq52TIbScPlAMVNVwYnmIZVExhCzx9P3+I/q/p4B/XxH9+VtlHY8+faCoc8Of4xozqc1DMJTLz01Vod5yU2ug+i3MWk4AvgSRihdMTikPo+hPaSkwMq5ROmkpI32w88WvX9xCuO0IEiEvu67OEtX8daaDVOWfWTblrRWawj0lfAwupuKqCQL2mYYopHLIpxzaAA6T2dYAp17qA4JyPBTiTFwGw3Sk5yL3XYH+8OSdqduTyD+S2fc0kHC0CpIrkBw4b0+MK0h1x9RRq+s34nsbYpDWFYMCU/H9P3/T+OM9Lly3Zt3Dx4ug1aNUFXLp05VIg3bN0EzKrOHC6piJoooplMoqqoYqaZCmOcwFARwNauWvMLj5wg1BL7t5G3xlSabHH9xjGwJnkLNcbCogs4Y1Sl15sYX1gsUgVBUUmrcpGrJqm4lZl5FwzJ/JNafvI/nLys7CqDZ+SnIjfFu6xuqJOTf13XVbpLdd3yM5ZPmvqqt6zR49k6gpTYcjLpNDln5EZqM0xSgMZJ0hbxg5+dTwLy8506M7COwi4ckOS805lOs/gMs+h9Y6vbHF6ryY2Cu5Xb16p1SPRVbJPJXe9nrityn38iJIuC0RQk2FjcRjpQizySDXWlrxeKlfO77tzpUdCa94+a0eWvhJwN90RjaJq2ps0WiWsGstV3rNBihZLbOnqcJUIqdjkHLywPoq0WxhFtY+p1ishVpv3Fib3byF0fxm4tcVrNqy5bcSaP9dVHaWx5m5b+tVNm2fxKC2XvF0ZCsa015DzFaYSV8aRMHQag/h6ki6tMgE1TZijWKfv/AHWt0ucVuBGn4qHsFB1/u3fs7HFV2hui6UyIsDt2+ekQO+q1Cb2Jk+VqlAjzopNmrFqDZ/Yjtk5mymWdmasoyMn2crj7fd73fkp3BcjVE5vanJO4XGm6ucLtzA3jq8nYEldk2CDQWBZFnFGm4iI1fTiM1EnFfgaNZoIBGOlQTNbFwKqXYroTU3ATs/6rOSXEGox2lr7yc5KE0Du6g61aoVej7RodrtOuIOwv3lNhyNYRtJC2ujteZVbRoMZSdTrFofN07BBJyjq1b/D+v7A/L5B9f3/v+vjWJ2VMJc9PaKNG6/rBSzmper3VNnvWyZIoGWjU9z2xuHu8WyeiPuZJOMsszqgirNMij73/AF9c24mKMUorH2dh/YA/s+Qj+fh+QB+eA+/v7/nlCDtt5ebV7mud+t+tfhW9fTemKLe3ELKzTJVRSpXnYcMq7a3fcVgcsgEimr9SwYSjStuzGWTkxJYZ2K+JLWasNUJdPaNe1VPiXpBbiNpSyEQ5G8ga46b2uWh5JZvM6g01JAqwk5pNdmYi0dbNgAm9rlWEFknsdDFsdkSOyetq24dwScftTbK4c6Z19wn4xQh5rtj7PKhCjs+xRr9UjriBxFtzJvZ4apu5Jmn73TbpdKmH+I+ypT9CQplXZpKKtU5iFpso6DqdS438L+SPdVw94Ead94vHGHQVcLpe52kE45qTets0fA7f3rt61vXsWZwnJxWw72nL1x/JoKFK5r6XuVZdoV5tXHKX0a2rVqxbN2TJsgzZs0EmzRo1RTbtmrZumVJBu3QSKVJFBFIhU0UUikTSTKUiZSkKBQoI8COLlW4Re0q6p4pVSceWaJ1BQHkKexSaRCup21WTgI62FfZlBIAEY9nKXe02l9Ex4qLniIVw0hBduytBcK39f1/t/ZgMff3/AGD8/pjOnbD2DTNT0S37N2JYYyp0WhV2Wtdtsky7QYxkNAwbJZ/Iv3blwdNJNNFuibylMcDKqCRJMDqHIQwfPv8AaIObKXIPsGlNIPH7eV0LwfiV2P4PGR9CN2FuWQYwzy1oP48lirsjLJfiqRrWsLESCeJWisU6u3+z10oiV6oraS6NOvseF/FJnsPZ0KmblXyhUR27vWwSLJulYogtiMpNVfWix0f0GaFWZyS0lPMG5EkzXebsfn9Vo1ik2lW/om4SMOzjn1vDmdvJwk7oOl9tNN8WKnOCleqbE3JtS6W+8VGHlQcEUbr1KDkYKXsVsI4BU8yqhB19Rq4jZyXXZfQ//P8Ab+r/AG/n+X7hwGVHvayOVh6Vx60ZxCr0iKUvu64utn39u3UMVQuvtXCghXIuRIJikMyst9mWs0yMUipwea5VEx0CgUrmznyM5Fai4oaavO+t521jTNb6/iVZOYlHRiHdPXBh9GMr8Cw9Qi83Z7A/OhFV+EZgZ1KSblu2SAAOY5Pml7q5LXzuo7XdKPrvDlr1S2luDVGjKBRiKe8BQdGONhip7hIvW6ZTycuSMsVmtdolk0yldS8jI/DUWsWhGsWoWuPZwOrhfiXohblpuWBRb7+5I1qJc1SIkmCiMzqrSroSysVDrlckIsxsmxlfhtps7UUwXj4llUoZcGck1n2h7NWepu2bs26DRo3RatGiKTZq2bpEQbtmyKYJoN26CQESQQRTKUiSSZCppkKUhClKABnt/pgMqs+0mdqsJoLTdg4F6ikmsnu3fFSWjtwyDRyRUNWacsLcqbyGeERV8ydu2lFrLRzNg4Kf4fRnMrLu0UVZusOlt1+4PuTpXX5WU9M6bbx+2ebex2raN1/rKOSUnkdfjYQTbQlx2BFRgqvVnLxV03PSqEiBJu6vTtjgm1gTKP1aNnZjxA3txbbaKu3La1y9k5b8t2N/5B7lj5x01lJSoxb+WhoqkV+ckRae8lup3f42kbm2jX5a6yF1X6sxjSnpvxKQC5X7MHxoS0v1yobdk44ra2codj2XYSrpVMqb78C1Bwpr2jxq3lADCyB1BWu1RvqeYx0LiZcpvRXTKSxvms/C7XEfp/iDxc1bGNytmtB4+6gqwkAgJnVdxFCgWsi8XAPHzO38gR0+eqCImVduV1TCJjiI7MYDKiPtGXVNtfZNohOyHiVHS7/aGsoKDJuiqU0HpL06Y6+XB7TdzUkGBjSD+xUdgg1ibCyjBCTQr0DXJqHbHNBzKilu7GBVK6vvaW9BbYoMLrLn3Z2Okd211gyiybbcRMkrq3bKbdEEgmpJeEYPi67t6pEhXnmcugzpj1yJ30JMRxnyVYjsWcQrlHduvezdOY/vTRxxd4MVxSi8fkZZ6RNG9WlgediaxYYCOVMiWSM9npy37gVeMiGkK8xR1bGWBHxfR/m03759EcJ9t80dV8TeB2jYGT7A9tX1kz3HJ62lnkJr6AVmk1XreLtVXjHH4MbbBdg4c3TYNoSjWB6rUI95LXEZKRlUncBnqc9kFIaKgnVT51LRNjRiIsZ9hOaICaij2QjJuaWcQU7G7Srz9pEBKlcGi0HsA5fpsjN/eXZnCJxVC6v+X3+39v5fl8vn4/LxzSbk/wBjPCbh1DSslv8A5GazqEvFs3LolAaWNhY9oSx26Rjkaw+uK+tI294quqUjUjk8ShGN3C6ASEgyROKxau8V7JZttUpUJrsbTj2wnL6icVo6zS5QIPyOYqLveEGmY4F+QEMYAN9BOUM324x+yycDdPyUdYt6W7Z3KOcYLIrhCWB0hrTWayyBiqpKOKnTXKtoeACxQMqzktiP4l0iUGryMcIHcFXDXnp8X2f2OdsfKDt0ktczesuPramO9P6eQmilFewyaMPUKRFsUnZTHaSb+GpNXkJ/YKkSs+ioa32qPg46QeIIHUTxJ7TT2OzNqnq31ecdn8hN2Cel6pKchS1JVV5IzU1MOWrjWuhkGjNNRd69fPXMLdLJHt/Mqu7Uo8Qmcynx+OGwR2IcwNNdS3BWauVMqlLqi9fiE9acatN1yOi63X397k2zktfjYuuxiTNq3q9WTB5cLYVkih5oWKfoJrBLyjArmtb7N9wGuXJve947V+USkhc/hF6tbjU8paFAcv8AYm9phw4cX3bEk3VQKi8j6WaWcsK+5TT9yNe37x1H+5P6ARMQsZ9OHXHCdb/ESuUGVZslt77KCPv/ACDsLZwm9KvdnDIU4+mxr4hfIpW9dxjga/GggczN9KmsVlblRPY10ib9ch+QWqeLGmL/AL93XZ29S1rreDWnLBKqF9dyt/3E2sdDQzEDFWlbDPybhnCwEQ3MLiTlnzNmkJTLCYuX3jxpHM3chIOmzBgwbLvXz54uk1ZsmbVI67l27crmIi3bN0SHVXXWORJFMplFDlIUxgq4yruY79ebJK/Du3C3UbwmvrB3ZHhSumcXzB33EtlVCRrNUhkTSdEiknKqAKoqj7rSHq0mJmkts2FNXAzD1ZaI2pzd5Az/AHM8x4RVlJ3RhI1jgVpmZ8zhppHRAuX7SPvKLRQCppWO2RzuSTiZMzdE8q3m7PeEkQaW6sBEWNs/KxYsYxkzjI1m1j46Oat2EfHsW6LRkxYtESN2jNm1QKmg2atkE00G7dFNNJFJMiaZCkKUA/VgMYx+77/X+v6YHqXXRaorOXKyTdu3SUXXcLqESQQRSIKiqyyqglTTSSIUx1FDmKQhCiYwgUBHKV/PvsW5MdwPJZ31idXUg4jtOe8ysdure7KScw8Xfq9DrkZWuXf2diiq6r2h4hU4sCjGAvM7ceuGcawbP4iXjYOd2f8AaHez6fq8dHdZPEeTkrDyR32tD1Pbn4LE7qeq9PvXu0fB6milWoiYl526Em2ayTJJQHkXRXYpLpJmucY8aSn9QHWLROtbjTDVtWLi5DkVseLhp/kLsBA5Hy8hZioKuG9GgZESFEtHoRnzqKhU25UkZd/8TtLhJN1Mig2DuHWb1X8eOs3Vn4a1xHpW7btoj2hNsbynY5BK23Z4mZNweJjCCdwNTobF4mVSHp8c5OgBkG8jOO5udBaWUk3zz8x8P5Zj3bW0qNo7WN+3Ds2da1mga0qU5dbdOOzFBOPgq/HrSL1RJMTFM7eLJoC3j2CHmdyL9VswZpqu3KKRw0t5+9mvHvrsS0u33DH3u32ne18RpdHoeroeNsl0ctEHEc3nrWaFfTEOo5hoNeYhmAtmCjuYlpiZjYyJjnR1HazORT5fq/L+vh9fv6/s+gUqes8b33b9sV87Gt1Vx5H8cOIwxLLQuvJZUj6KgbaR06eanrXlBQjV/OV0nxncV6lWAuCoXxSpthSLASMU3a3G9nbP19pfX9t2rtW3QdC13RIV1YbbbrG8TYQ8JEsgD1HDlY3mMoqsoZJqxZNk138k/cNo6Paun7ps3VDhd3bs1hxz1Td92bktkbSNba8g3M/Z7FKKeVFs1Q8qaDRogXxcSMvKPFW8ZCxDJNaQl5V2zjWCC7t0ikb5+UHsrcntEXb3rFrMREnB8btbThbM3oqxjOY7WXGul2CHkLSrMqoeuzLfNtOkoSAl5YPekC2myQcYgLmuV2PRR6j3Cdol87FXC1lH8Ra84QU61S8Jxo1Wc3wmyciNgQwHjpbbt+KKxVkq1U2jtQ7grVN8nXVJSJ1nXPRtVpvuxqhaa9n0635Hg7xNPsza8GdhyS5PBE3m/oyYJrTFMpCKbl1r2guFVEwds5QjCUcWq5MlTlco2aeUg5EqytYaqgE+vz/qIf6/T5CHgAiH6v35Cb3Ldv8AQetHUxq3UTw905Y7Hh3Qat18usk5ZVFg4ByzLtPYbRNUrhGrRTtFYkJDeKLu6zbU0U0VaRbOemYjOPaF2iad61NRJTlhTJfd8X5B3H6M0ZGLqGnrxPlOmyTlpgrMi7qEo0Q+ctvjEwKBnL9YQg683fzTlNFL55mpZZhzx5k3jlF2M7qbwmoIKwp7D5HXZeRAZWzxzQzkavoTSkFFLOnUnYrk1hVKjRa3VCrIVajxE5aAVRiKs6dGC677OZrTk434mbA5P8odp7Gvdl5g7E/xSqELfrDJTfwqnsEX7JC7s20g7WThnezpN/ISQs2DVkxXqcLSXrVMWzhBJDaTmx3dcAuDku/o932W82ruJisoyX0zoxizv91jZMnkIEZaHoSUZT6bIgus2IeFstmj7KdFcHLKBfJlHISWnJrs77vVyak4A1GS6/uuyAIekSu8ZIDw1ksNchGaMOeqR8vW1UHThdCMKVgTWuo3iEPFF8Ia97JCLcthyc7gP018KOv9lGztDoaey93JpFWl9/7WbsbLsBeTUBNV24qqayAw2vWZnRVDN0aozay52pyt5yfsCyYvFA0d097Spxhs+z6jrTkLx65IcSw2G/ZMaPdtpVdu6pz4JF41ZMXs2s1MwnomMXWfMyqTEbA2CEjyL+8y0nHsSHeZKH2Idi2jOtjTsFt3dLG12YbddIyjUyhUBCEfXa0yrtJZ/JuYtjOzUEyNG1+IbLPZV6q9Ikk4Wio3xB5MMinr6e1abXq9xieF3C+vycOrtq7bbNtFyg5etmn4RrizB9q+pv5544WSJFxdtn7TYDtXKg+7glRZdy8UapNW5nGHdXvp/vm7jqzsJBKck+AfXupGuK3KSjI/wW8yVdmWTuIWdfJApJvfV3gG1qexrkp3KWpaYhFSaLeTbk94C6vEyJJeKjJdJs+ZpSkeykUmkm1UYyLVN62SckbSDJYAWZvUCqgk7aqgCjdcqiKgAYg5yGPvx/t9+P8ADw+bAff+35D/ABzUx1zn4otuVVf4TBuWtvOTlkgZ2wsdXRTeYl37VnXoZxY5FnOzMZGu63XJ38OspGfbV+dmI+adQ8c4fIsTJKMzOq+/e53uO+Mbux8MuGs+0dchHTM8TtvbcYcj/wDwSLIooiFSpvkKs0d7Yds1zFkpEwLp68Ismigie6n89U6B1H8P9c9THHHYXav2T2Y1R3Hs+CW/DcTcwcyuwqdXrauvNGhW0fIqnmp/fe63iJHslFpgrNwVeaqNZh/FkfbDIwC3wYxCEOoocqZEyic5ziBSFIUBExjGEQApSh4mEwiAAACIiAZ/f34/P6fT7H/TPmldiPYFzl7Z9z6o03DR1n1hqjetwrsfxt4tRbp82La6/MzysFWdq7eeNBTNY3cvKEWdRMg6YuqvCxMTPSsEzjY5gSx3CxVujtnuGpoHUvWp1hM4jmDyl1Dp6oa92tyNsj5u+0VqKL1ZS4ur3DYtzuDiTj69KScWaJXmrXZbBOx+v6pJLoM5V9ap5Z1UUgtFff3/ADxlOP2dXcPOLk9zQ5bbe3Byp2zyB0PSdeoUeSlLFMTqWqrRtywWeCe19/rSjSvucFWomHga1eHscevVioy6desUC5sVbrC9qWgCTIdl/c/x167XDPWCcTL765UWhozNTuPuv3SRpNs6mhbp1xXYc0ghKK05pPndIDBxjSGsFvniLNV4qsrRjskqmExn5ft/v/L5gH8PHA/L6/L8/wBnh9/fyyqhTuFPdB2hf/qdzh5Z3Dr+0bPOFnla4saEQkq7sEYBRU4t4+6ki5qFViirt1k3KSmyrHsSxpO250ZGh1cStE2+MuYXTH1C8E9Ul3JzA5ec1hK7M4iIVN3t+oTF+2PYfT9dWFpNTjNUhJSrtMiqPvSqi5IOCaKoPbRNMGRzvzBb8+/v7/hkXvY3238Ues+FrpdySc5ctl29VuvWtNa3TiZS/Oq/7yZB/bpVGVlImIrlaaCksg0fTUk0XnZFM8fBNJH3SXcRVKbQW9731iXCxc19X1Ta2oqfujXlw15w74t732PJ3vaO7jzzqPj47ee1KvCw1FZt9QVJZEZ+BejXGP40vLeDpuvn1kiUbbsGvdn2b1xbluXJLglQ+Y9tnL/zy7ItzMdubrg7C6crzGh+NEE+Is+hpRoU5kELRZ4VG4Sr2LYMmTLXcdqdnryANEsfxKEiH0XK9NsrNAwdjjfW+HWCHjZth65SEX9ylWSD9r6xUlFkyLeg4T9QqaqpAP5gIocoAYY7O4zaT/TvV/zZu0U4UZyKmjrDRmbxEwpuGi+1ncdqsjpqqUQOg7bDc/WaOEzFUbuSJLJmKoQpgkmQRRbIpNmySTdu3STQQboJlSRQRSKBEkkkkwKRNJMhSkTTIUpCFKBSgAAABDD7QRb9XQPVNycrOyb9DUd3sOJqUBrtrIiuvI3TYMDe6zfoGnwMayRcvnr2WGorFduU0PcYSLI9m5lyxiWDt4iFY3ow5WaW62ODXNzm1sVNrP7KvmxaboLROuU3JS2LY9zpdOe3VWuRCKRVHzOug92NXJO/WAqCzWHi46KKQq008g4qWsL9PPAvccTZ7z2b89XS9m5w8pY33yLgppiVIOP+qZQqB4inQ0a4Fc1an5WEbRTF1EtjkXplPZxtJEUJFe5EkKRPV5yN4h8SOR7HanN3UG4twx+pny0/qTXlRLWXMFUdtg6aISVwt1Ku03WmsjMw5YGCCJQLItQaTMSzkJdk/cwMKRnNfyO7juwPuOvg8POs/UN51Fr6yJnZXSwR8wiTZEzVJApGL+R2VsGO8ld05rwiay6MmxhJZzJzZSjF/iaZLKBV1gkY7ee7maCyuOvLrNVfbb5UbLlz6ztWytcmGZJr2SklTxj+laxfMFDNpXZ5v8w3mrWg5+B6xbJPVwemtTVd3Tt/+mTqSrHW3qN5aL8pFXXlvttii73BsBE4yLetsXCyUknq+myTkgOFYGMfETeWSbECOLpZkhlHQFi4+vMIz19SXSvpXrOrh7tMPWG3eU1qiSMbdtt1GglF1Fi5QT+IUvUrB4l75CV5VUpiS1heenZrcBCHkSxUT7nW42bPxH7+/wCf68Dx/wCv9f8AccYxgMffy+v8PHGYb5D7mrvHXQ+498WxRIte1BrW6bEkk1VPS99SqkA/mEotExQE53cu5aoRbBFIp13Lx4g3RTOsoQhgoR9s0rK9nHfRT+KNaeu3VPpd61rxWaKNlzFJFRsDIKWffNiIgj6hEXdclpi/pu3BQVdumNQjwV8voN2jX6F8NDxddh4qAg2LeMhYSNYw8RGsyek0jouMbJMo9i2TAf8Att2jVBJuin8wImmUA8fAByg57L/p2x8iuwbkDzR2AU0w71VUrNNuZ1ZBTxX3PyLmpdqvJouFDHKCqtPabRTeokMdcgTTQx1CJqeC9/T8vD8g+/7YDGMYDGMYDGMYDGMYDGMYDGMYDGMYDPxyMjHxEe+lpZ8zjIuMZuZGSkpFyiyj4+PZIncvHz545Ok3aM2jdJRw5cuFE0UEUzqqnImQxg/ZlUj2kDsUnKvry09f3HybVbbBsWunOy+VlrZpOjstc6EMRNrEUR9Kx6LxWHse4rJJVevnKqmikWFsEDCSazZhslq/aBHd0ka7hOyDuV5Y88dhsV52samt9o3VRWDxNRRmwumxLrLQ2jkHwL/pGRo9DhJ55AIKFBwhN1eBkPOBoxQit8j+339jlXH2UHTCVL4JbY3I5binL7t33LNGzgUgIDmoawrkPBQwAr4iZUEbVM34n0AhBESlATCoI2jsBjGPr+oP34FW/wBqc5KPKjxN1LxApqiz++8rdoxa0jAR5zryD+gawkIqYTjxYoB6orzuzpLXhYcVjAk8Ug5VFui4VbqKM5z+JGnapwb4QaW1JYpOLrtf496Nhy7Esb52gjDMZOBr6ll2lbHr4PBshHK2I9msLpx5hSRbLKH85yEE41ZbCJuyn2n1hWZIRmtQ8EvMf4Yob3lo3/6cwRkpEV2RhFkczvk/bWcZJ+qQwu4RBq0d+r7uk3JI33ZbO2Jye3Pxi6bNAWJ3AWjlTJI7A5NW2IMqdxRuOdXePH6zN4o0VMCSNgCt2WdkY5+DIssFXrVZUWXj7wsiqGNOHEJZO6Hn4bsi2hByDPgtxDnJelcFdd2dmu1G/bIjZJotK7slIpQ3perFycaxnHIKFN6FkY0WtJuHamurGV7aLzF2ktN69486j13o/VEEjW9dauqcPTanEJCVRRGLhmxW5HL9yVNM7+XklgWk5uVXKLuXmHj6UeHUdu1lDZR+/wCeAyEj2gzla44t9aO4E69NJw+wN9OIzQVNOk/K1kytLyDhTYL1iiQ5Hpxb61jLazK8aCmMbIScY5OuQ4opLbl8/ew/jv106bfbU3fYSrzb9F001tqmDctVdgbSsiaYejD1uMUP5m0agqoiewWp+RODrzM5Tull5BzGRcj8/LuHc87t2T3HfldzeTUoMrykDYivHzjkorIsW+idNVN7SUYUslCvm6akZL3t3cEJF8vIII2t+lBEl7Mg2CThoCthNn0EdJj6VreruanNOF+JVhh4bA4q8fJ9JNeDbubOlEyCO+77BGL7g7lp5jGV5WlRkmg4fuoiHq05PKKNYGlR8Zsd7WdvKUpfEHQGiItwo0R3juWTsdiMmJwGQrmnYBs7+DrB5gIdqraLzU5k4HKY/vcCzEhiARQD2jqNUYugUmnUSDSKhCUurV+pQ6BCgQiMVXIhpDsEikD5FKRo0RIBQEQKUoAAfQcri+0+cK9pcmuI+ttxakrjy4zXFe03G13GtRSKjmcPqy5wUYhcLJEsUSqryhqq/qVblJZi2TMslXBmpkBFGHWIoE5vDPSETxr4ncdNDwzdNBtq3TtBqjwUxKPv08xrrE1omFjJgCZ3c5ZFZWZeKJlKmo7fLHTIRMSkLi7sm5ixPA/hhu3kk7Kzc2Gp1sIjXEM9ETIz+0LYuSv0WNVQKQyjhihNvkJibSSADlr0VLuPOmVEyhdHenfuP0X2Aanp+t7RYofX3LKk1mGhLtrOek0GSuwF4iObsVr7rBZ8uU9li5g7cz+WgGx3VhqLxZVrJoOYs0XPy0cPNO+O+7Ls71N16ackQn+FXDq3IbZ5aX6FdLOKtdrVBOCxsrWWsigktHujx6K8jqqnOEjHM6sFn2LYEE5Ov1pu+AJIehLhnO8a+H594baUdTHJXm1NJcjdx2OYKmefBhayO5qg1ySclKRVZwhFz0ldJlJ0kk7Z26+2aOWKZNi2Am/3PnmjrjgJxb2TyU2ScHaFWYhF0uqpKem+vuyJtNw3plLjxD9NP4rJJi4l3yZFvglaYTk+ogs3iliG3CatGrFq2YsmzdkyZt0WjRm1RTbtWrVumVFu2bN0QIkg3RSIRNFFMhE0kylIQhSlKGfNR9oM7J0ucHLtXV2v5tzJcbOMUpMUmqEjXpm7C+30jsjHY+w0zh72ydoKvI/8K0iVM2ety1uKGdjyETtUi3WCKmy8h9rcjuWshyT2rH/4z7kv2yWFzTp54uRkY+8XQ0kwa0XXzKrxreRev6a2epQNdRo8euxdyVKjFKfBzcZKuo6QS+iV06dYk3xJrVp5S8o5R1snn5yZIvZ9yXqwuCS0pQoyxuW84rrOKkRMdE0gZ6m1fX2UjSosX000Y1+KKrXatEO3scvs6PU9S67Q6Z2Tb1gW8rtbZDB5Icd6LIMV1YHTuvUlXVeg7ow+LvpaRk7PZoFil+DZSRdLuK9RnDN2V3ITk84fx1tsfn4j+Y/q8P6B9MCjvzdtMfwY9qD01yf2kr+HdWbaQ1tMntT8pkoKMrl00S/4n2GaePRAySbSqzUW7np4PMK0fHFTfqJAi4aireDQXQdIIumyyThs4SIu3cIKEVQXRVIVRJZFVMxiKpKpmKdNQhhIchgMQRKICMaPZz1a6G7PtUwtL2c9kaLsOhun8hqrcVbYNJGw0tzLlakmop9FPFmjaz1CfBjHnma64fxqyjmOj3sZLxT1sLhSvTUuljvz0PHF0zoDsqrMPoxAAYQChN3bwqw1uEKIIlbw1VDXtpcUZRNEvqoxNHsh44ixwOWQSWUWWKFlDnp2T8VuuvXS9z37empLXIRrl5QtO1xwyktp7HconFAiVcrZ3KBmsQV34ISNtnFYyrxQlMk5lBfqNGDqtZJal7TO/wCrczt7b6zjiZ1+x8dO2zUOg4c8qFk3rKV9irKUr3pmsnFP7oymJVBmj/iVaAiqrHKHCS1nSpBz70+Q334U+zhaZ1RsdlyH5w7bsfODfSck2sHu13TkVtYNp5sYTIv7GytEnYrRtd8zOm3O1cXKTZ15XyGI/pboxG6yNlFFFJuik3bpJooIJkRQQRIVNJFFIoETSSTIBSJppkKBSEIAFIUAKUAAADAo2+yq8sOOulWnKPSG4drUbVWxdiW/W1hoMdf5lrUyXNtBw1vjJ2LipuaFnDrTEI5WZKBX3EkjMO05RReLYPU2smdpZf5qdvHBbg7SpKf2Nump3W8AwXXrOm9WWCEu2y7Q9KmUzNsaJiX67WqRro5wH8SXF3BwgJJuQaOnr1EjBbTnm17OPwL5fXCV2dWUbdxn2VPvncpZpPT3wUKXa5eQdOXsjMzuvZ2OeRbaWeOXJlnLupP6om8W87qSbvnayrg2P+JvsxfATjzcGF+2nI3vlRPRDgjmKrm006/G6sQcJAPpOJHX8CwKNmOUTeKkfbLBOVtyUiQL185iCcwRs6y0Jzm9ox3XT+QPLaOnuN3WtRJU01rLVkI+fNDbFIkuqyXTpyr5Bk8tU3Kt03MZZ94SsU1iIlmtIQWuIpJdeXZxsfvCWnU2A9puR18jCx1RomueXvKSl0OuIpg1i6/X9UUrckFqSAikHBvBJkxa1aoxkAgUxjekRgk3FQwpeb6LUfHsIlgyiopk0jIuNaNo+OjY9siyYR7BkiRszZMmbYibdq0aN000GzZBNNFBFMiSRCJlKUKsXaR7Ni15jb9u3KHjZvCG1RsDZb5Cd2BrzYkHKydHlbcVm2ZvrZXbZXlHM/V1Jj3JJ/MwrqtWZBzNPH8lHyMQ1OlEFCzLs3bmq9K1Z1dtw7JouragxIqd3Z9g2yCp8EgCCQrKlNJ2B8wZmV9MviVEiplj/IpEzGMUBqz9gftFZbxNJ8R+pauWLeW/NjPyUyJ3VGVZ68h4mSkAcNl2uoafLsE5K6WlsUijhO22CLZ0SCbIGmm6FtjvO7j9Y9R+ya7htc+1k+XHNGEPDsgKmMXqOEs94n37UqhPFm1t2zArTWvF9P1DFXGo2JMqgEJ7kJRFQtnjhD1icNOvmCVY8dNUtI62yLIjCybZt7j8WbWtKJDmOdKRtj1BIIpgsYxDLwFRYVqsqqoouTwouyCuIRl9RfSAlxZs3/WRzVnR3jzlt67qyGdz0wa5Q2n5edA6sq9azz87w902q7K4Wbzd9VcOWMUJ142nHOgLuxzkVntdek7cW8cSeRbSLeO6K4qNy0xNzKCRzsYK0x81+Na0wkVf/BBxZ4uWs68SX5+8Fqsv5hIKKYK3hsw9vrQOn+T2qbZpLe9EhdjayurIrOerU2mqCRzIqFcMZKNftFW0lCzkU7TSfQ07DvGMvEv0Unce8buEynANFeq/sg4587eOWrxoOwK+luap69qcJtnTkjJNWV8qlohINrGTbxvBuTIPpuoP3zFy+gbVEN3MU7j1UkXqkfMtpKJYymfL9w/6/wC33+f1pF8jPZLLyyub2x8NOUtZZV5V8q/garvZhZIOfqY+uoq1aI7G13FWMZ0rUopEQkT0eBeJgQPVB0qAuVMWQ/Qb3x1ASQ1V5w1SFikxFJJSt8veSsNDpJj+h5iMkNeR7sqYk/8A4FjgN5fAok+QFwLyOwdla71LVZK9bTvdP1vSodMVJS23qyQ9TrkcUE1FfF5NTrxjHoGMmiqdMijgp1ATN5Cm8o5VO58+0B2/d9uJwr6eapZN0bn2Io6qim9oWAe+lEKLmO2kB0/DSyDMXLpi3Bdw/wBrW9KMptWYJLTUYlJN/d7PEYI157LZyg3BaGFg5688/wATMmIgK7HXshsHb1pfomMmCrNhedyIVhCuCcnmN78anWQvnTImaNMBxWSs78JeuLiJ19VNzXONmrWNemZhkgytuyp9b8R7Ru6Tdf3kidluLtIjo0eVz4Oka9CoQ1XaOSlcMoNssJ1DBop059Olb6+K3J7p3PKNtq82NsMV3OyNiPHS861oradcBLTNLpkvJAaQknklInBzery7MElb5NAhEQaxCBU3s6OMYAPl9Pl+7PS5dNmTZw8eOEGjNogs5du3Kqbds2bIJmVXcOF1TESRQRSIZRVZU5U00ymOcwEKOe79/wB/t+ofT9/h+vK1ntKvYirxX4pNeMutp40fuzlc0lIKScx7ldvKU/RTMRaXybTWbj4tXl3cqN9fRRHHpg8hpC7vGSyb6BTHAgA5l7b2d7QR2x0bjnoyUfI8dtfTMxTaFLAr6sHA6wr8gg43HyIeIGIVD325IR7dWsNXXoLSTFtrioqi3l3i51foA6S03r3jzqTXekNUQSFb13q+qxNPqcOiJDHQi4puVIHL1cqaYv5aScetJzUmqT3mVl3r2SdmO5dqnNAf7Nx11E4ncTP+o/Y0EZlvXlfHRNmKm/RWSkabpNDxe69rPu7hIijF9ahcq36wCiJBeNZOoxj9Irushm4Hblz/ALbxR19QdCcbIf8AHfOPlzOG1lx3pUeKLx7VzSaicbL7bnWHmMKERVjPE04RaQIlGOZ8wyL4Vq7WLWZoGn3ZFv7bHYJyWU6bOGs4vBwK0ezluwXkVDphIMNU6uWWauH+poh2g4I3UtNhbqN46yRXvKS8k9kmdDXVQjS7I+ETq8c+O+peKWl6FoPSFXbVLXGuoVCGhY9ISKvXyxfFWSn55+VNJSYstgkDuJafmXBAcSUo7cuTgmU5Eian9YfXvUuvHjs11+WUC87rv7/8e8i9wPTOXU1svZ8mZy7frqycgZSUdV6uKSDyKrBH6gOV25ns/IoknrDNquJHf4j9PD6/lgMYx9/f388BkAHdd3XU3rqp7vS+nVou58yLvXRdwMWoRrJ13S0HKkOkyv1/bHOdJ3OOEvUeUejrJKBKnRSnrKmhWfcWloy92kdqheJjuucWeL1UPv7sH3iRGE1Lp6voFmk6KacRUJH37YrZE5U2zNqiVaYh66+cMQlWbFzNzr2EpzN7NZSB4rcMdi9kXZ8PHy17SmtsiN2nNi8uN6JuDv2801p79uXbE9AyiZCu3EI/sTxDU+qp10JmjxzNwtwbwlUirA9qsME83s3vXXcNl3Sxdr/K00xcLjbpm0joZa9ArKzVisUu7cNb3v2TdSfquHDtRwaUqdJdKCPmUWtM2mkUqNYkMuc51ilUyq64p1V19RYGOq1Ko9eh6pU63EIA2i4GuQEe3ioaIj24CIItI+PaN2qBRExvTSDznMYRNnZ8BlB3vb7ZrHzv2nD9bnChRe5atdbFrlRt09Vji5c8g9wFsreMrNIrCxTEbu9eV20DHLMn5FTtLla0Gcy3UTgoCHfy8hXtH/bubSVWd8B+Od0WYbev0WmHIq411UBkda60nWBFEKBGPUl0fdLrsKMdg5mfTcIO4SjqpJAdF1cGT6L0Z9nI4C1PXUba+2fl25h9b6e1TETaOhprYS7CGrSzwU30Ddtyu15UUyEjK4B16XRFygoaXtUlOuI0gSlehFHYWeuKGn9C9NvXHWq9s+4QFTqenqgve96bGXKoVG0bPsQN3VtkY9sQqsjMvJOcVZ1CiwrZF1MvouPrEC0QcPCpkPXks1z3p322q8b63rOWfin0o8WntgvMszVXTh7LuMdeR7uSl3Tl2iZw3nrURgi4TkpRJSRqmsW7s9eqqU7eXMpIu/6s962r7Shzki9WUpC4UHqr4t2dOcu1gTB3XpPaEkALJNH70q5PMW8X5Bu6jqLBuW6rjWVBczlrlW7eySi0LISs9+lbacfulja+rtC09rR9cQqmkdcfAKdHmZRNQ1qXZtVKs3KVsAmax8i/ZxcDKPHKh1ZM88uSQcOXEmudcILeofjbHdqvZFYeYs9qqOoPCbh0at17RemwbM1KtABVveD6H1Cm0FNVtNmrLY0jt/ackVV2abv78j+wC9LsFyoraf7Ne07j91l6oLadiuiW/bdsZPQ1JpCFfoo2i7P2/mRGVlFhI5/C1EjXflTm7Y+aqpFMVSOhGUzNGSjD1LeDHeDTeDvX1qHhvww46XbdHMu1yN2mrXMysEoai/4m3u0SbmIcwlYqrh/ftszkNUG9WrIQSEfUGqnwNoLawSzZuduvLV1rdNG69m7w/wDkg7d5k+2+RVhVjbNrrSdqMzlovXTlEQdQUzfopmUKu2ka2gZFOkapg2YVSgGL79JoL2VJtHVkOgcB+sDf3YNfNtdmfZso9rOzN5a7s1T4w6uUilUj6TrdprUjA1PaDWqS66ilfUpEfKmkNRViTW+Kpyy73ZNjU/FEjEyuerht7KXpvWdzb3LmHup5yBjK/Nlf13VdFhntBokymgZodJa/ybyRkrLKtnhkjEfVyvL1xISN2pXdglWSjmOG3Hjx+/v+v6/zwOuVCn1PX1Yg6TRKzA02m1eNaw9cqtXiWEDXoGJZpgk0jYeGi27ZhHsm5C+VJs0QSSIH0KAmzVvnXzi0j1+8fbRv/dsuUjGNTUjKVTGDhAlp2bd3LZdaFpNUaqgYyr6QOgdeRkjpHYV6FQfz0qZNhHrCOymxthU7Uuv7ttHYU4zrNE13VZ+63CwyBhKzhq1WoxzMTMiv5QMc5GjBouqCSRTrLGKVJBM6pyEN8rfsj57bq7T+V85sFRlOno8EayRmiNUN/M5Za+1dBpO5yQl5NuQxo5KZdwUMvc9p214YjFogwdKPX7OoViNSjA/AWT5b9tPYGkdN1JyG/eVNsUjmqjV6snA631RJRr9rKsARJ6knC64pOsUnIu0SrNXUpRWUgDhtYFLeYz76YnBLhDprr8461HjzphgY0fEFGXuVxft0UrJsm+v2zVGw3mzKIicBfSZmqDZhHkWWaQEEziq/HnFjGICNV/2SPi+xkHnJ7mhYWiT6SjXMXx61+9cEK4VZO3jWK2DtJ4VRbznRfOGbrWrRu7R8jgGbubanWMg/WSPdm+x+n+vz+x+mA+/+foP98qcd13tAkdoQt04ncGp+Nse9WqUlB7X3hHqIyNd0n6Q+4SVfpixiqRk7s9JysDF3LnVcwtHkPCMTbytxVFrW+29mva1tfkftwOrbqYdOL7yCvL59Vdx74qb0EqzqyAbl9C3xVYujf1Wca5hGyhyX3ZbUyrSnI+rXamvIbBdpBX6lHIbgFvus80rPwJ0Rp+/7mumqZKvRs2pCVKfGQ2lZ3cBGylj2lY3qijYsFr+RkZGTbUd2+loeuVigJtHa0mpaJe62+yhlLrxleO/FewMuxDnHHSG5rM3mHtg4q8aCvQkr9vjayc6ui93fen0whJN6/rCj2RCQLGWyyJyD65bMaPVa1FWR1Q51gvKJywtXIrfUBH9nXchSy68470JRWO4Q9dJHspWJDd+yJxuEpAIW6CemPY4ihe6tEZ/bt7syDG3WaAiUoSBgIatva/EO92+NfXlxp6XdSveyDtFuMBtbkuzYRLPWOuWCEZNwlDtbaESa1LXWo4Rf0Iu17IioqLbQ0VPNGkVQtU1uI8lTbxFdrgWteGiWk+dftKvN2BBKALRNK67WJFgowScvNY8bNYTEgm6l5CQlXJWR7ns+3pRqRhIUG0vcpaPjmrVnW6VAAauBgHghxp5mdvPNG42qFkpOmxt0enb7/wCQdcrJIqs6a1nIxpYhxQaB7oLNhXFpOjsEdaUjXtZfR7t3RSOKg+cN9aL3UjiU3nJsvjxpOoq9HnTRrp1etp7st8XROT+54VdK1267vGzgAl9cSGwmqRFJRVs4aittKTZEida64qrW0VhnHNPidxCA3z7buT9F6juHuoOrnr5jFa5vLcVfbxIvqmKquya5Tpx6nX5fYbt1FpEfSe4t5WVu/r8DLJFF8yQbWN3BoQ60TTCN5FOlvqKo/W7phtdL8yibLy32fBNH21buqRu6ToUc7Im/LqikvjgcWsLCKCkFrmmypVblYWqkg4V+CMK7HRYYK3vtDW3s7fUlQtY0NSAsHIabjnFZo5xaKuGOxeRFlj0pXZe2pli6OjIr0imHOZ80bPfE5YpjQKA4XbfEm7tv+To26upDWFYL2E8ykXmzObvJIp9jtJvYIKTVh1RVbgiSSZHEJQpzsdnW1g5TkbPJAk2kKvEO2dDjkokrSyJy0CW9+a3HXsI7cpzktyo2Cxg+vLhCodrQYFZutML7aSp0k6Wp9TqdbiVlXVpsW/tjx8jd3JBaooF1JXjxFnexrCvlfJSjs9+dsHerMvWPF4Z7rm68xfBFye6pf4ijuPacWYjhCRGtycQ4iJKyg4SN6biu0CZrNJjDGew1n2hZXSSTEwSw9iPc1xv4MnPqqqEd8keXdhH4TRON2qFDWKfCzO1gZRjTYchBoSxqaRZ4cgJV8rKSvkuBkvg9WXaLHlGcJuwtXTPHioT3cn3eyMHtPk89bCy4a8FJFymahUG0rFUkaNV3NZK4lGIu4E5i2KbjCkk46kMUJC129/atoPWTaJne4Q9T3B/rRr8psepQAWTaMXAy0vfeTO43jOcvicenHHeWt/HyKzdvD0CvqIIvnUghXGbF25jzmRsczPmQ96NWB1LBT/tE3ajsPdG3pORguAHEpIZJlCPl3kVCl1mymHIU2nOXDo6CFes+61IGTvmzpZdRB3G1aFnYRrJNfgtTO1DY7rC4vONpLbC7/wDttuackxjUZPZmnYG2sxQgYeHrCwMoDZCNbX8UkYmLdotqzx7oTBI/vr8sdZ2SMjIvqk9c7tdPdF2Jzy5i8g+6feFXlqtWrq3lNI8KaPYm5DOK7qSGXJDylvZLJqgiZVNkxeVNSQZEVj5a0z+2XKAlbe4HPrJsifnO/rmHDcSeP7mWo/Udw6k4JfbF1pjEKtBbosdeImxg6rUit0GzZtFqMm7qE1jFNmosK7Vm0tsuQYi8dUqEa2ZN07q40denGde+bBka9qDQ+nKzFVqtwUOzSRAW8axBhVKBQ643MReZn5FJmmwhIVmAqKgku+erto5nJSLUO08nuTmmeHuk7pv/AHzbW9Q15SGAru1zAmvLzsouBk4eqVWLMsirOWqwuwKxholBQnqqmO5drs41q+fNaz3Djjbuvu+5Nx3ZLztrL+s8Ltdyz0nDLi1MKKKwtsaMZRMza1WVioVJCarQOI5Bzappw0L/AIo2VulFNiNdc1ttCyWOtDaY5H+0P8joflhy1g7DqfrL1DZH6miNB/EHjD/Fx7HulWap13LYWxpkztRsLfZOxkQTSKQjnXWvFWnlnZaHuIwsLD1uGia7XoqNga/ARjCFg4OGZNoyIhoeLapMYyKio1kmizj46OZIINGTJoik2aNkUkEEk0kyEANRty9dvBTkLZT3PdHEvQ2wbisCZXdumtc14tokSIh4IpythYM2cvLJIF8SoIybx2miUxypFIU5wHOGm9BaP471gaXofUWt9O1Q6wOV4HW1NgKbHPHYef8AzsghBMGQST83qKCo/fi5eKGUOZRcxjmEcuYwGMYwGMYwH0ysp7UzymDT3A+scfIWT90tnKnYzGHftUlvRcqau1arHXW4uEjkH1wBW2n1rCuUQAiLuNmZNuuqKYmbObNefPH7vLlYuxvus17w416/dPIXXs/rXi7CnZgmszj7VZ5ltYNvW4EhFTyKVpxYFoewrLgQibXXAH9AUkPVXCyD7Nvxb/6d+tOi3WYjwaXTk7ZJneUyoqmIPCVeQK3rWtWQqiQonj3FNgGVtYpl8U0lbg9MUxjKnEZ986xSafX9d0ypa/qTBOKqtGrMDT6zGIiHpR1erMU0hYZgn4AACRnHMmzcggAB5UgHwDx8A7PgMYxgMYxgMYxgMYxgMYxgMYxgMYzrdyuFW17U7Le7xPxdWptOg5Sy2myTTpNjEQUBCs1pCVlZF2sJU27NiybrOF1DfQhB8AEwgUQ0m7JueVJ69eMdo3ROoNLJsKVP+DNG6yMdyeR2ftmZbrFrdebso/zSasOzVIaXtDpkBVmsGzcotVBlnkW2dVYedfD6+cQelfe+9+S0o/s3OLsK3doyycjZ+wptzTNUaLWxTaVf0zHqkOuDFnVFasg9sTBgqSO+Pt04hoVaCqFYFCSrhXVLX3Fc4lezrckG8Z8KuMk9ZaL176xsLUzU9vtUVKoNbDvewwyoqpHWQk41N4QTioVO3MYCARcqjqt6rLcv7Veiur1n1E6JDmTb8rNWrOjF8fKmgND283Kc/h//AAFyu3SDx+XqKE8fmADgbo9A9OQpXUfw9YpoeivNVq/3F4oYPBRyvcdu3+xIrqD8gN4MJBkgiPgHg1RQL+l5fMMxORgdLbhq56ruD6jMSiiXSEM3OJTAcPemknLNXwCIAAAYHqLgDF+pDAJDCJijkn+AxjGBQB6kOYupOJfKXuH5y75eLCSultKcXBszoBZb1b9o7+s04yo1aB0oUFZuxTdcYFOdURaxzBrIT8oZGLh3rhGdzpb417y2Vs3fHbpzHgBre9uYjVpH6aoDgVzjqzjkPwh5ANm7WRT9+iyWNhCVRlANlxTkDVCtsp2SMd9dJJBvT75Vw+qONHaRyHlYOFfcteG+q+X8BtTadWpLySYU18/Um7PYGGsLjclKtKwbV7U5uwX3Xhjgm4jLa1ibDHMZNJd07dxVmyJ9rZ4RgwRJJ8bOUcU5SSSSKxiWGo5JggUpQL6STlxsqEU9NIAAiQBHpgJQAPImAAUAtdfn9/T7/wCPDI7+w3s34z9b2tyWzcs8eb2BYmLw2r9J1Zw1cbE2PJIAdFEWjFQ5ggqqlICk2mbnKplio0onQZozE2dlBvoPJLvd5387jp636o+AGwU5CcWBivyB3O1bSdRpqC7kjc79dJsVrqyAdtCeoum8tew7A3VMVVBGpyqqAEW3P6/Ok5TV+11OafYftIeZXNqaMwlWUrZhdzuutQySCYigFSbziSH4mnIbzFRgJt1A1+Bp6aKCNKqUO7ZITi4Yd6zOv/bHLHd072y9n9KF3ui9STSR4v8AHy2NXg17Qeu49Y7qpzDmnTBTnjphmmqU1IhJtIz+HAzy/WFuve7Gk7gsZe1ZcTLhtjjJpTlFR413Kn4v2q1x2wGsci4WesdfbYLVG/4uUI3TUH3CrWunQDR6qAkFi2s7iTWMVkydLIWs/rnGTULDWSHlq7YomMnq/PRj+FnIOaYNZWHmYaVaKsJSJlox8kuykYySYrrs37B4gs1eNVlW7hJRFQ5DBGD1Sdmum+xLjjRZ+LuEAz5A1mrxERvHU7qWZI2+Dt0YzIwlbOxhVVSv5CkWx21Wnq7Os0nTJNs8NCyDlGdipRm2ksuN1p2u61L3O/2ut0en19qd9O2q4TsZW63Csif+TuVm5l0yjI9uURABXdukk/MIB4+IgA1buTvssOkbZfnm0+GHIi8cU55WRczTOmP4hze6hByDpRYTNqLYI2y069UqMTTWMCKT+VvCrcAUatDNmKqCDPGNR9mH3btOwQpucXZHtLb+v4BykohTaya5T0w5bpmABSi7bte12WLqRxQ9RIFG9FnhAFh8gpAQRUCIbnTpHib2O8/Y7W/TDpW/Sl+mrKvL7n2nAPj1HjJGvDyPpSV7rtZcVsZWj1yNegErJXhCbrlemnxTxtD15PScvFy8pIJqL2fzuh4jOLJE8QefWlNcVa1SDV9YDQexd0a7XsLqORVbRr2wV6K07b49ysxbLrptAUl5AWYOXJW5ig4WOe2rxL4XcauD2tU9V8aNXwmuq4sdo6sEg2BaRtd0l2jYWxJ27WyRUczdllRIZb0Dv3ZmUYk4VZQrKMjvTZk2fcOG7RBd06XRbNWyKrhy5cKkRQboIkMosuusoJU0kUkymUVUUMUhCFMYxilARAPnk9oFd7j+AOq6ePK7tOkbTJbelpOApur9Gbk22rZZ2MhkWrq0z9lkZCl6kVj6bEovWEW8XTcTrh9MzUNDkiFY13LycPqnxm63W+y3PBXi1JV06fI7nNbG2/8AZM+ZAzqb0BwRrqTz4Iog0UduI2Hsm52MbbNkBKOmkbOGr0PqursZVlGX21xUzsrs64su8Dufsths864acI+OkfYLHaLEq4dpwFX4icfFXMxcrQq5be9kjVdxTpnayEgRL3pkW8RRVyqIV4oJz79D1BmOSuzuXPbjsithByHJK7yOn+M9ddM0m5df8b9aOmUQ2iYFJAp2DWLMev1WhiWKURbBIauml0kE0JX/ALgWQKzWoGmVuv0+qxTOCrFUg4mtVyEj0/SYw8DBsG8ZDxbJPxMKTSPj2rdo2T8w+RFIpRER+Y83jGAxjGA+/v8AnjGMBj7/ANf9xxjAY/8Afy+WMYDGMYDGMYDGMYDGMYDGMYHVL3eajrGk27Y9/no+q0ahVqbuFwssqqKMbA1muRzmXm5d8oUpzlbR8c0culvTTUUMRISpJqKCUhvnh8eanc/aBO52d2rf4mSJx2qUy2vNthpAxTtqrx111JEY651OdRNIWQzGxJI7GNsKDRVBw5VsOwrZH+YYxcAl39qc7Bz661ZT+AeuJoULbuVmw2HvFywciRxE6qipdT8I09ZVs5Kogve7VDuJSUaKkKoNdqyLVyktG2ovnkz6L+BsV15cDomc2U1YVXcW649nuvfUvOqoxY1KMTiXDyoUucevFytY5jrWpO3LiaM4UTbx9nmrkudcGpkzECT/AJJ8h9ScPNBbB33tyXa1bWuqq0aSdlbpopLPViejG1ypVtiUU03M5Y5deOrdcjEvSTWkXzRExm7YFFkoZOojjds/kHtjYncbzIrq8bvLkSgtF8XtdygKnbaH4zmbGY1s0QydkIdhLXSDWFJs89Bu5d1hxIWVURe7MnkE9eoILz7QFyuRsc1GzFf6fuKGwveKxEviOoo/M3ctZUBAZGUZqFTXd0GNKu9RWTMKQRFZffCUxSttwsBadaXatmzJsgyZt0GjNoik2atGyJG7Zs2bplSbt26CRSpIoIpFKmkkkUqaZCgQpSlKAAHvxjPIeHj8/v7/AIfvD64HjIP+zTtFuGmrxXeDPBGpob37CdwpfDYStxxG0vAaFiJJkC/+IOxynMaNbSLGNXCfioafWawkbEoGt92VSraTGLs2Wu3nscS6/wDj+wQ100bW/ljvmVHW3GPWibM0zIS9yklmUa4t7qBRKdeShaetLxhiR/pmCfs8pWqz4AlLunLThOpDrVW4R64su2N5SwbL5yckHKt45H7alnBJqYayc88CwL63hJxQ6x1oaGklhc2OTZrFRuNqSUmD+aIj6vHxARScgtEVPo167uQHJu539/u7sw5alW1XIcj7C4WlLChsnarKTd2Amv3cyoeVia9R66wstsPOuEVJS32SCgRnkGMUvC1+ByX7LRwsPpfiRceWVtixa3flLOptagLtsKbyP01rt9JxUOugKpvXbFuNxWssysBUkUZSEiadJkUctzNFCx/e1s7SmLTu3hfxhgjruF42k2/aK8I2MIjLS+zbaz19UDqJfMFF2h9d2ZpHmDy+X4u/KIm9UoFue6K1bE6O0nqHTFfRaoQup9ZUXXMaRmkCDYWdLrMZXkVU0wIQfBcI/wBc5zlKoodQyqoCoY2BlX8/7/7/AK/rkRHcF2jU7rb4/Lu4JaKs/J7abZ7X9BazP5ZByrLLEM0V2FZIdFQrs1LqThRI50QAilnn1I2rsDpg7kpKJ7z2e9p2hesvUClpvjptcty2qPeBp/RsVJIoWa7SJPUbpzMwcpXClX19FOyCM/bXjZRMPRVioNtM2BVrFqwxdTHXRvPmjv4O4Ts3RXnLpanzO08aNMT7Bw1i6/FsjirS7y6qsgdYldpdWamItpyouAVdvnRg2dNqOJBzES04EVnIzoa51TXBmtcq5uqW7d/ODdG55DbfImgCVnL7RrlEtsQ8NV2yLZ0KErKXBtYZJ9M7QrdfFR2gvZIONNCHba0dyRNntHdQ/a12Soaqr3YPe5fibww1FAV+tUDj9WjQsHMx1aqkKyg6/FUnUcSaVhoN+gxYFZL37dTyYvLDznWQh7G1dGTTvIYwMC8aOMmkeIWnqvonj7RYyg66qqJxbRzIDOJCXlXBUgk7LZ5lwZSSsVomVEU1JSblF13bgE0GxDIsWjJo3y5aKtWLvXpio3SuQVuqlhYrxc/WbPER8/XpyMcl8jmOmIWVbu42SYuCfortHrZZuqX5KJmD5Zz2MDWbS/C7iLxym5GzaF4zaL0/ZZUqqT+x681fT6rPrtlgMCjAJqJiW0kjGCB1ALFoOko5P1FPTal9Q/m2Zx9B8BAf9A/L6/q/p8vHHy+X3+r9/wBRHwD/AN+AMY/1/L7/ANv/AH+B9KxcYX1JKSYRyfy/TfPG7Unz8RAPOuomX8v1+P7MDWfm1xZgebHFjcfFyy26wUOH27XmEOtb6uRFaXg3UPYoa0xborNwoghJxx5WCZNpyHUctCzUGvIxXvrMXgOkYqOOvQLxx4k8UOUmsdcyj7ZvI/kVx125pV3v3YEfHRryFJsKgzlYbxdIgWPv7eh1VeUkGcjNoEkp6bmPd00Zifko5nHsGk3sjtvVUP6nxbZuvov0QAyvxG51xl6Rfl+kp7zJJeQB+gCfwDxEPqIhmI7Zza4aUNJZa7cteM9RI3SFdYLJvXV8KciXl8wHBKQtCCh/OAh6ZSEMdQRKVMpjGKAhSL6iu46l9PWs95cNOX3H3eZbfFb4st2M1p0VU/xFWLC+qVNp87UbRB3O1U4G6TdekM5OPlWD2QK6RlXKqaazQGSiu4Ny589ofexOL6J4A6us3EfiS7emh9scgJ2WdNJSSrz0h2ctHT2wo9szRapHQB0mrrDUxpe1Swn91sdlNVnkgm1m7252k9I0tKt5DbHIXihsaYZFKm0lHVNQ3A6apoGEUitpWFpduFEhDCYyQIuSlDxEyf8A5AYeBH2gvprq0c2jovldGN49gQjNjE13Q3Ib3RogkXwTRaNmGnk2TdomUPKkVMU0AASlT8fEAENkut7q+449aGrVqbqKOUs2wrOgzPtDddlZMyXi/vmoeok08UBWTrVOjnBlFIKmxjlViwE5nki7mp1d7NvZIf3fYj/z/PIIHntJ3UY2FQEd+3KQKmPgUzPRm40wVD5/pE+IUxiYA8A8f+6VM3zAAKI/LOOH2lvqVAfD/GfYQh6fn84aQ2d5fN5RN6fzrxTecR8C+Pl9PzD4+p5f0gCGzlV1w9oPb/2d7Ki+RdctPH3iJpS+ztSolxnUQUpEbp9rLqow8lpaMVXSQ2Vf9pxUY0sNhsTYDRsHIPEo+2P4VvB16nnt98XOK2i+Gemqzorj5R4+j0KsoecxESkcTlmmlk0iydtuU6dMj2yWqYOkRSRl35xEqSbaOYIsIZhHRzOJtH2ljqUVFIFN135uBx8DHW0ftMSpfPwEVQb1pwcQ8PAQ9Eqo+ACHh4+ID2iO9o16fZMBSd8opOJBQfTEkroTkKchynDyiBzRmrZNIEx+hxUMUoAIiYfJ4iUK0HX5yR4zcm+4Tkf2Q86t7a115Q9Tzsvc9GQezbayj3khMqy7uq6RjanWXTo81Y2mqteQbmacfh6Je/DbknVJZ2i1eyjb3qTbsv8AaYOKD3R25tE8O0NibX2DsmhXHXMft9OIca7oFJC2QzuuOrXCq2lqldZ+ZiG79y9hmgU6GjlniDVwFgIl4CbWyJ4z+ylWrYFguReVVkGOnJx5Nk11LW3alDoECm/eHdDBwBVtT1S0tINp63urJqvb3rpmzTIiD0PSA5dw+Y9G6bLt1k8neOPXxtnglQ9lWSj1yy1ePgNsazhdmbBkNZXqp7Ka02VtF6siewLS+soVMYCJa2aceIoTclHqLqtRIZYgaR+z99Imq9/6vo/OrlgLDZ2uJmYuB9K8fXzd4vT3UlWLPI0eevGzW7sqTSeRUm6i4aRNPapLwkkhFMn1qdy7b0661vHR8ewiWDGLimTSMjIxo2j42Nj2yLJhHsGaJG7NkyaNiJN2jRo3TTQbNkE00UEEyJJEImQpQordRftCWieDHFKkcO+U+nt1IP8AT8vemleuWvImszwuYi13acvYx1rrNoslHloOTiJazzEaBmR5wF2DaOMok2WMuRKS3YftX3AiDiVB1jqHkxs20KlIEdEPazR6RCLLqFN5W76ec3melGp/V9NLxYVSX8THMYgG8oAcN0PaHdyWbTfVNyEVqSqzSS2a6pWm3sggY5TMqzsCzMmVySOJDF8yE5U2s1WFynEUzJTp/EpxECmqd8E7Pu3ktxIonUf171F/D2zfs7NbS7DuTb1iohX6zTJ6UPDw1ECZZHO4bUeI1vFV1raEXa7WWudxeTmu6lF+6yk88sUmFpg+4j2gE8NSNg6vacB+vtzOws7PhYoKUGw3NlFvwkox8zTtjaEum2Jdiu39aCWiIfXWrgckbPJNyrJtGiiuLdV+z5d0vHg9u1jx4516y1JqS5T3xKwTGut0bz1u7saTdsMe0lZuv1XWxZIkwMWQrQ8WlYnrBEyijQs0u2Mq7OE99q5CdePQXw7pekH1wYjKU2tru67q6AUipLem8ry9IivOXSbhmRkyxi9olFAcyFssx4mqwkWi0gYh2dvFwcEeHXjVxX5Z9/8AvKtc2OfraW1TwLo8sq90HxtjnsqxZbCYlcJnOWF9ZJg7d1mUFs3Qv24XTVnNXn0RrVFRiYVqC1R3O4VezP8AHfT10b7o5m7JnOaO3ff0ZsYizs3kXqlGZL5jGd2KIlZaesuz3iKpUDJrWyaaV54RM5JOnO/OT0rMLNm0jmbWPj2rZiwYtkGTJizQSbNGbNqkRFs1atkSkRbtm6KZEkEEiESSSIRNMpSlAADi6vV63Sa3BU6nQMRVqnV4phA1ytwEc1iYSChYxsm0joqJjGKSDNhHsmqSaDVq2STRRSIUiZCgHhnO48fy/h/p/sHiP1H88YDGMYDGMYDGMYGEOS28a1xn4+7n5A28yf4e0/ra3X962UV9I0mrXYZ2+joNuYAERfWCTSZwkcmUBOs/kGyRAE6hQyjn7Mro+ycouw7e/OPZqRpxxqSLtVuczzluYU3+9uRMnYGx5FJRcVCKqJVU2znboqZlXDF1KQzhRVIVkDLyp+1X8tyaw4ka24n12V9C18lLsnYbg0QVMKhNS6pcMppZu8In5RQ+P7FdUpWPUVP6btvV7A1KgsJFFG+8vs9PEr/pY61dUSU1G+47A5GOHPIS5Cs3Mk8TYXVoyb65jVDq+DgEGutouryRmahESMpiamikR9RZZdwE4eMYwGMYwGMYwGMYwGMYwGMYwGMY+/n/AMf0/b9flgP6ZWj7EdiXbtL5iQ3UNx1sEvCaO1hLQWw+xrcUA6MDBrW4t23k4nQ8a+bEOkrOvnqTcr5sdVYn43NGt3rUrLXtzbK7k9svYHduOkVr/iNxQhXF95/cuiOaxoirx5WyqevoN0s4jprcdnM6MDVkxgkGs0esnkQCMNJwkvPywq16nz7ZfP3WT181Lrv47o64QnFNgbivswpsPkNuKQO4dzOy9py6XqSrz4lIlCYWrUIoq5YVhCTOLw6Kj+ekyjYbBOOHIbwa31zRtQ0Goav1lWIql6/oVfjKtUKrBtwbRUHAQ7ZNowYNE/MZQ4JIpAZZy4UWdPFzqu3i67pZZZSNLu84wT3LPrS5Ha6pkcrLX+sQsPtyjRrcgKupGZ1ZNMrXKRDFv8jOZOep7KzwES2SORRaVlGRS+p4iirLFj9/9Pl9f3fT9/5YFYn2XTmZXdxcKX3E+WkkUdncWZ6bMxi1lUgdzeo9iWSVtkDPtCmEirosFbZay1aUImRYsQzTqYuHADNNES2d/l4fn9fv9Xy+X7R8R/MB+VMXnd0y82OG/LqU7Ben9+8P8VlZm2WXTVdexCFqqUnY3hndyr9eqVgBKs7L1HZF1DPi0JUziWgVzIsIWAkG0VDyEZ/dY9pA7EdQtkKtyl6qLhLXaOILKRdQzTcWh1XrpuQEhcK1236u2idBdZQnquCtHpWhjnOZmg3QFNIoXNsr+91PZ9N6Erkfwe4crvtg9gPJAWNKqtXoyYTFg1LW7cQ7Ra1PvdlikiL1NMFTpUFg7UQWiEFl9izBmMJDRYWCPp72U98vYozUoHDPgi64fVGz+qxf7y2M1nwdQEU5SUQdOYPZe0a7R6kJkG6xjruKfrez3JssVs4rxGL9NM55WerPpm1vwBezm8Np3R1yS5n34r9W5b3tScg8/DxZzxPOxFA/EDuTmiuJcyiiNmvk28NbLYiZVI5IGIfPYBQM6dUvXRUeunibBagWJGWTa94El05B3UEEnP4vv8szKk7hkHayfrvKhT2ahq3XG7nypOkU5OfWaN5KySpD78I6j1S3XM5b6x16g5McFTOEaXW0lzKB4iChlSRpVBOAiIgcTeYPEfAcyFjA9aSKSCSSCCSaCCKZEkUUSFSSSSTKUiaSaZAKQiaZClIQhQApCgBSgAfLPZjGAxjGAxjGAyBD2irnEtxC4CWOjVGWUjdu8qnUjpmmqNFjIyERS12CbjbtqQMRRBZMrKpPEqi3dtFiu42cvUHJIlMVop5Z7w/3/wBM+fH2S2aQ7fe9Wj8TqrNKK6U0/bWmjXU0xckCOhqhr1V3cuUOwwcFP7i3eNF463wkdIqPSM5ZtUKgQXTY7shEwxrp3Rlz0L1oaQ4365ZkS5md5G26nCsynIUH1L4b0yaZtoNSQXBJRWFib/PTRLZLviumzGd1xLyIOwBSpORS+gLx80hSONej9U6D1w0FlSdR0avUWvkOUCuXbWCj0mi0rIGATCtLTbwjmZmHJjmUdyj525UOc6pzDXL6pq8w5+9kvJXsoCJ91448YI1DhpwQhiNzkrzCsVmJPEStkriDgFvcvRpz08oCLZx6KS25ZRkJfPDpAlaVwGMYwGMYwGMYwGMY+/vxwGMZ5D5j8g8fn8g+vj4gA/l9fr4fL8w+YB9MDxjAfz/Z+XgH5+Py/L6/yD65wU3aKzWUSr2SxwVfQOAmKvNy7CKRMACID5VX7hsQwFH5CIGHw/MfHA53Ga2WXmbw+phVT3DldxsqhUDimuay701fBFROHj+gqaUtLUEz/om8Sn8o/oj+ofDXqz9u/WHUfXCW518anfu4mBT8M7Ogbr5vKIgPofg1ee95+ny929XzB4CHiAgIhIxjIap/2gnqDrpzJPOYsM+WApjFTgNTb8sZFBABHyEdQeq37EpjeAAX1naRfEQ8TB9cxY/9pV6kWZgBvvC9ygCYSiZho7bCZSgHh+kPxOrRxvKPj4gBSib5D4lD5eIT0YyvNJe0+dVjEih2tt3XMGIbylTjtNzKR1Q/MyYy8hFJgX5f/wC1RM36QeBfAB8MVz3tW/XMwOo2rusuW9xeiPlapxet9bMGzo4+I/JSY3EyfJkAoCIj8NUP+iIAkIfPAs25+SQkGMSweyko8bR8bGtHMhIv3q6bZmxYskTuXbx25WMRJu2bN01Fl1lTkTSSIc5zFKURCr0HtNDCzCU2p+tHmZsJBwmJ49UIxFmLwfn5fKSt167k9MTAJROgq58PARAoiHlzTvn735ctLzw/3dQ1erTkfxmre26TLapX5BbHmb6wrVORvaJoGSI3CS4/1WIeTMzAupSJiE/xrDO2j96k/aHdKsit1gj24IV5fuQ75LRvW/NXlh1LXb/auREjFyiLlVs11PqeTjK/oikSKTk5EStjPDayh5uOWTTSlmSNjMePAi7pIlgbn1yB2X2gclJvqE4X2NaA1dXvSX7EOTcOgs+jqNT2r4U3+kqq7TOkxfWKbctlISeZFXOadmwXqSyrSu1zZapKn/W9y35UcP8AVe0ddcTeN0/YORXPQGmutOb1aPnz2zxkPSV5VpNx+naCnAHCfmox+/sbiZthZ00ZAzbetOZKPKpWiJSk1/A1z3t8M9GoaR4sdT+rot/Myrm3bB2pvazsj33Zd0lv05K0XCTmd96pZqLt0TJxsDFgiRrBxbVFBdKTlV5aVlAuG6H0drfjXpvXGh9QwRK3rfVlWjqlVIgqgruCMWBBMs/k3hikUkpuZfKu5mellw95l5qQkJJ0JnLtUw5byrYtP+1SXBNR25rnCvSbdVITqg4eUJ+hEAP5qLGsm1AExB8P0jLvkf0g8TG8BzCt9m/aF6OyNKbU7Y+sjQkag3WVfLXay6OgU2yBQMY66p5fi9OCY6ZfEEStXAicxAAQMcfEwW/f75qvzK5j6Q4KaItXIDfViGIqtfIVnEQjD3dxar1aXhFRhqZTIpZdt8UsEsokp5CGVRZRrFF7MzDxhDxz983oXby7Rezyp2aO13Ue22v8pNizDxSLi63w40yFiaLTiyChouNLZZvj1ppjPhJOQQbkPQAvKrf1xMVkquko2zerX3Rb2tdk1Mquz+xrmdb9SyEKu6X1przZEO83LeK5HyoN1ZKbf1OJvNHq2vH0mDaOMjGpSru0CVmVCwsa64j2rVQJF+s7j/vfsQ5gO+5LmvTV6VU4+ELX+Beg5wDPUqVSzC9Ix2S4av2TU5vTbPpCUrM44ZIObVabLKXuNbxEJEUYqtiW67y0nrUVy7G3DqygGalE7kt22DU6qZuQofM64T0uxFEofUTKeUA/Mcrhh7NLI3YoJcgO0fmbuBssmRORQCQcRZXvlDwHw/Gt12kmRP6AVNwk8EgeIeYwD8sq0f2WzrCqwNz2Q3IraCyYgd0a6bYYRpHpxN5z+qXXlNoqiaZjCJQKiuRUpPADLqK+ZUwQXe0mbB1BauY3GPmLx05Ecdt8I1ei1OiT1S19uPXmxpWqW/WGxLdsWvOrDWaha3k8WrWltZl2KzxugRmwewTlrJP453OwZX3s3F7VjzY2pDBTdD6b0bx+nZpFRme9Tc4re5iJWMiYffYN3elatryGWIcDGIrboCyMR/QQ9EVjEUGzZXfZ8eoWtpJEQ4gxkqskf1TOrFtne88qsfwKXxWRkdnrMfJ4AUPQTaJt/HzG9LznOY2VIrpR6qYb/wDacIdMLfpFN/8AlmM9PfMv0Afjk7I+Jf8A+xB/QN8vMUfAMCnXwTn+r+vbdNzV7YudhOU3IxeYRskTpdlr7fW2K7FWBusZwwltl3N1rc1TvbmEOkinB0WAkj61g00GyJndnjRbxkZYVuHtTXWjAmWQqsLyY2c88wJMUqhqqBj036xzCUgJGu99qTpMg+PnMY7IywJgPkbqKgVI0tNZ60Ou6nGBWu8GeJbFwBCkB4px+1dIPykKJDAUr+SrDx6UBOmQ5/BcBUUIRRTzHKBg2cp+pdV68KkSgaz19RiIJikgWn0yuVkqKRgEBSSLCxrIE0xAxgEhAAogIgIeAjgVtye0Wbo2WYCcX+oLmRulu8ASRkq6b2SJaGMYP0F3JKRqfZzIjZPxA65xmkkiJgJjukSeKhfYTtA757oJF9f9MyFbbKG8CpbFs0+0cgBhHyAp8dm9anSApfKB1FWqZBN4+Pp+PgFoXH39/wAx/mP6xwKvocsPahbcmZKA64eJNJSFUoGkLFdK6dykmcDAUSN3vLxExwIICZU4RDkTfoARMoiIG/kaZ7VLtDzJ/wCLHCfjp7wIKAqWOqM37mBw8fdyB/hrvYTCmJvATGTdCJiAJVzF+Z7QgfL6YwKv4ddftDVt8Vb1296/rqzhI3vKdBpiiCCSgiJgI0CH1RrshSeIFD1k0GZylEQBLwDwN/RemDtjuHol2F3t7/hm6hTJPm+v4XZbT1Gxw8FU0VYveFEJ6iiZlEyrqtjej4lU9NUC+mNn7GBV+D2aZvcwKpvrs35t7cdiYBVcBYSRgHKIiY4FLc53ZyhTGEREDGXUABEREphEc5Fn7KH1zEFVaV2vzGn3q6gKrvJLZmp01DqD4ioJfctFtTCCoiAm9ZRwr4gHlVD5+NnD9v5/r/P5fl+79mPH/f8AlgVw2PstHV+0N4uFOR0mHkIUCv8AbUUmAmAAAVA+GUWON6h/ARMHiCfiYQIQoeUC5aqfs2PUlW1my8loq6XYzcSG8ls3ZtYiKxyCIlM4QqloqySgePgBkvICCgB5TpGKYxTTxYwIyKn0y9WdNRSQiODmh3hERASDa604vixvKHgHquLzIWJwsA/mVZVQDfUwCYRzMEb1rddsOUSx3A/h038TkUE48adNrrCdPzemYV3FNVWESeY3kH1P0fMPl8PEc3XxgawNeEfDBiBysuIvGFmVQABQrXQeqW4HABAQA4JVMgGABABAB8QAQAQ+efvHhxxDMPmNxW43mN6fpeYdHaxEfS8vl9PxGr+Pk8v6Pk/8fL+j4eHyzZDGBrKtwp4bOAIVxxK4yrlTAxUyraG1WqVMpv8AyAgKVQwFA31ECgACPzHOly/XF17TyfpS/Bbh8+ADmOB1uNmnAWIc4ABzpuE6aRdMxwAAOJFCifwDzePgHhudjAjTsHTh1cWYiqcjwa4+tirG8xxr9MSqZyj4D/8AUrVXEMogX5j+ggdMn0Hy+IB4a3XD2dHqJtoLKt+MUhT3q4mE72n7m3ZHiXxAf/pjJLYEvAoFL4iIAjEEKPyAQMUvgE3uMCsrd/ZS+uGxgsrVL3yj1269PwbIw+wqLOxJD/8A9nDS16vmJNwQPABFNGdZmE3lH1AKAgOvLX2Wm4ahmk7bxN7M9zaVskeqR1HuSUR+wlBdom9RATWvXe16I5Z+U5CCZUsC+83lHxR8B8At4Y/Z4j/EfH8/H/X5/v8AngVQXHDz2mHjJ5pbTPOzVfLCFapmMembLdRjyyzBkjlUI19fb9GBJmVcpQL7y025EuPOKiaypEvIsf1w/tAXMTiHOR1P7YOubYmqmay7SNPuPTkc/Tqz10HmSWPFxNolZqi2tVXymduT1bdH+X9JRNtELFXQIjbCzhrDXK9boSTrVrgYaz1yZanZTFfsMWymoSVZqCAqNJKKkUHLF82UEpROg5QVSN4B4kHwDA1B4j9ivDLnLEFf8at7U68y6TNN5K0Fys4rGy4AhiCdb4xr+yoxdoSbNlE1m55hpHPa+4VQVPHS7xt5HBt1/wB36/zD8vy+/sK6nLz2bziFt+XNtLiTP2jg5veLcfGK9OancPlNbFnEfVVQdjRkpOLkKc49UEEGr7WtlqbKKSBZ2NdlXBxIbRtv2BdxvTdIMqr2NajcczuK7Z61iIvkxRn539iimazl01Yme7ILFNAfyjoR9ZGA3hAwVqnFkyNo+7A0KK+BcPxmnXDPntxa5767LsTjVs2MtyLQiQWemPxThtj0R4oIEBjdKU6VGWiPOr50mUqkR5XZkUlVYGalW6Zlw3F+Xy/X9fv+/wC8P4gxjGAxjGAwHz+/9sf0yPTtS5hNODHBTfO+0JBBld2lWXpeo0VRAVXu2rymrX6UdBDw/wA2SvvnK1wk2wHSMpBVuVMVZESgcoUqebUk/wC4rv1i9DV98+k9U1/aMNx3jnMes4cpReotJuZSX3haIxwgdFAUpOSYbQscG/RO2SdoP4BuV4t/2Han0U4yMj4WNj4eIZNY2KiWTSNjI5iiRsyj49g3TasmTRukUqSDVq2STQboJlKmkkmQhClKUoZSf9k34iOJWf5B87rkwcOBZE/wH1XIyJFVjvZeVNG3DbVhRVciBlHTRqWkQTWWRBcy/wAZtsedwkok7SWu3ff8sBjGMBjGMBjGMBjGMBjGMBjGMB9/8fxzXrlTye1Jw50PsHkNuuwt6/Rtfwyz5UhlSBKWSbVKZKAp1aaGHzyNltEoLeJh2SYCX11xdvFG0a1evG2wuVc67Au+9nsAnrpcUDPer7r32PIVnXkAmdc0Dyl5GRabT4tPThDKpoylSgkjJOypCis3NSnkFEESKGybgDQNh+nPjVtTatz2j268xIZZlyP5dtxT03QJNBZZroPjX6iQ0+FrRJPzvYxa5RDWLcIqAk1eHqDWOkXRiy12tzdSwLn8JppoJpoIkTSRSTImkikUpE0kkygRNNNMgAQhEyAUpCFACkKAFAAAPAP7wGMYwHh/X5ff88YxgMYxgMYxgMYxgMYxgMZ5/j9+P7fD6/s/L9X5YH3Xyh44cboz4xv3eup9OsTpgq2HYl9rVVeSBTGMUpImMlpFtJS6xxKYE28YzdrqeQ/kTN5DCAa99nvMFjwY4Pb55C+9N0bbCVRes6rarGIY0lte6D+HKIRNsch/fUIiYfJ2eYakKJjV6Bl1RMmRIyhPn6cPkbzoThJvrkfXUZWb5Rdgt/T6/wDimkRVVa6v4myPYWw8ntiQbx07SduHs0eWoOoouwNHbeSZ2y3vxFy4RCSIjub7Rt2nap5zXPSfH3ixfS7K0jq34hebVZoeIscbGW7cU6LytxUdGtp+Ni3Uu2o9VB4nGzEewFi/eX6batHb4jMhyYk4qbo31tDlFxg2Bwz6/tucltQddupYvVmndeSzV3DV+vbhm2spYrnufbthrURI1WHu902ZN22/NqqvYWSia7CrmRmVyVlZNyF9fgXxNrHB/iRpHjRWSsVldd05kjcJtigmiS17El/NM3+1HOCKC6qcza3sm4jivQVdMoUsZFmVUTYpeG3v39/f7srHq7S9qD3qUv4c4+8NuIkNIj4MJGzzsJZ7FGNjHOBV5ZM9/wBxAdyXx8wkChsTgmUgHjAW8/n/AD//ABod9e5/Ad+9x0Zq5J/4FkEOOdOlGZmCRhKIki3FQgOOi/qkKHlKqVyzVEwCJnBxMY4hZ2OciRDqKHIRNMhlFFDmAhEyFDzGOcxhApSlKAmMYR8ClARHw8B8Nd77y/4maqFUmz+T/HrXSqIHFRG8bo1vVVygmAiYPQnLKxWMYPAQ8hSCcRDylKYwgGQGE9mbqmxVCOOVXYxzZ5CuDmKL8y1oZQycgl4gKiCv+IDrcroqS3gJTiLs5wIYQIcp/BQNgqF7M51PU4iQT+qtm7RUTMQ3rXzdF7ZGVEg+PgolreQ183MU4+AnKCJSm8PL4AUTFENoLx3i9T+vhOE7zY1ZICQxij+CGV32WAmJ8h8htc1S1EOUR/8AE5TCQ4eAkMIZpzdfagurCqlXGCsW89lCiYSpkpOnnzA7kAAf00P8RpqgEKUfl4A5M3P8y+JQ/S8N8aR02dW+v/IMFwa0C/EnlEPxvUQ2WA+Tw8oGDY7q1AqHiH6YKAcFPn5/N8/HcSl8aeOWuDJn15oDSdCOkUCpHpmqqLVzJlKHgBUzQcCxEhQD5ABRAADwD6BgV3D+1Aa2ugnLx/6/eZe4TKeB2AGg4KJ97QOAmTWN+Cj7SFIFC+QS+kV0USmEQOPgAm8G7ue0u/CQdQdF/IZiydl8I6Y2C62qVg4MIeUF1FXGjqLGpIAqIgIFmlCGITzC6T84+S0eUpSlKUoAUpQApSgAABSgHgAAAfIAAA8AAPkAZ5wKtX/Wx7TTsQCk191iceKE0UOJVHl/sUc1ftkzePkUKS0cnab5gTAB9XywL05x8vkRKIgQ3gYP2rDYYHKFy4c6J9Q3mBQGuuJcUAP4B6ZANVdyAJUvER8TkWOPgPgooPgA2lseOBVpP17+0dX0VB2P2x6kqKbsoKrE1nDv2ardVQPE6CAV3RGsSokSEwlKZs5TKPlKIFAAAc8f/Bn2d3YxT7S72+TTdBdPyv4inJbhUjFhEoh6RG6fImoxgl/WurBmMIeYvo/pibLS/gH9fH+I4wKtJfZm3VkKkO2uz/mLsRQRMDk5XCkeCyRvkZNItlul6OiJhE4iZRRyURMIemPgYTc5CeyhdfDZQ7u07i5e296soVRZR1sDV0YgoBfMJwORnpoz8wrCIeoc8mY4eQvpimPmE9nrx/t/T9X6vr/H88YFfut+zK9UEGYBk9abWuQAAAJbJuq6tSiICAiYRqLmrGAR8BAQAwF8BECgUfKIbD1joT6j6kZE8bwypz46KYJAaz3nb1xKr4F8oqLI2zYUy3UUN8zCcyP/AJD4kAoeABL7jA0Br3VP1p1cEAi+CHFNUW4gZJSc0jQrQsUxRASnMvZoWXWUOUSgYp1VDmKYAMUQH55lSO4J8IYghE4nhvxVi00j+okSO486jZETP8v00ytqgkBDfIP0igA/IPn8gzarGBgaP4r8YYgxjxXHHQ0YYxgMY0dqDXzIxjAPmAxjNq8kIiBvn4iPj4/PMqQdMp9YAoVqqVqvARP0iBBwUXEgVLw8PTKDBq3Aqfh4B5A8C+AAHh4AGdlxgAAA+geH7s0e7GuF8Hz/AOH+2uMMtOlqcjc2MVK0y3qNlnyNXvdTmGViq0o8YoqoqPYpV/HhEzrZMwrqQUnJe5eR+DVVPeHGB84rUfTf378VdzM7PoHWSkfbNdRc/UKRtOB3Jx2k6/D1m1OHbqeV12ntK4tpWtNZ9WQlTPzMarX7EYkxNoPmqCc3KpPJFInqo9o75GeVPfnYBJ6frrw5fjEMryS2Cd4dEweB006lo2J/BkmBQOYwtH1kYNBOUDFUEwJiF2HGBT3hPZOWNoUQluQHYNtTYk24N60maE1uizU85h8RTRnLrsS8O3Zg+Y++OI1EVDG8RaJ+Hz2b1z7KZ101Ryg9vN85MbUUTUKdSLmb3T6vX3CZfDxSO3puv4ewkBQQEFDo2hM/l8ATFMwCc1m3H3/Tw/tgac8YevvhfwzbFT41cddcaylBZlj3FvZRKs7sJ+yKkZMWslsa1OJy9SDZQplDKNXlgVbHUVVUMj51TiO43/rGMBjGMBjGMBjGMBjGMBjGMBjGMBjGMBjGMBjGMBjGMBjGMBjGMBjGMBjGMB9Pp9/nnHS8REz8VJQc7GR83CTDF1GS8PLMm0lFyka+RO2ex8jHvEl2j5i8bqKN3TRyiqg4RUOkqmdMxijyOMCqvzi6G7xpzYLrm503XiV458gqqi4lFtC12SaRVLt6RyGUmGOu3kyqpCQR5kiZCPNX3JvJatsYmIxQCqM26bF9nrrM74apv63p8RuddWNxW5sVd4FQkmFwYOabSNk2xkoLReLYNbAdF9r7YDo4JGUo1iMDGXdrECoTD1d6hXWVi4R/pkQ/aF05cauyypPJeeYNtYckIiG9xou/a5GJHmCgzIqaMruw4tNRqne6YRVQSlZvF285BkUVUrU1FlWftZAJePv9X6/y/v8An+z5Yylnxy7TebfTRteH4U9tdStmx9JJoIsdScioMzq3TcdVWixGbaVhLOuRFTblBj252yb2CkjMtp0NESMnLV8UkVVSW+dMbw1DyJ17CbX0ZsepbT11YSGGKtlMmGsxFqLpFTF1HOzNzivGTMeZUiUpCSiLKYinIi1kmLVyU6QBlPGMYDKB3tG3Le3c3Obuquufj0i9uUfp65MKm+hIMVHBbryaviraDVi/TKkJVC64iXqNVK6E4BGTk1fUHnlQaFVLa57aewqr9cnEK6bcO7j3O3bUi8omg6k5UaLOZ3ZUrHuPcpxzFrn87uq0NDxtdqUFL3VZszZ18zhvJ2OJIvWo9mB4E2HaW19gdmW8WTyabQcraKxpOVsI++PbdtSyndhtTaSh3aRl3R68wknVYj5cFVUX9is9r8DpydXEwBbd4McUqrwl4n6T4zVMGbhLWVNYsbHNskAQTtV7kxUmb9bTgKKK5gsVvkJeRaEdFMuzjl2UeY5k2afhtljGAxjGAxjGAxjGAxjGAxjGAxjH1wILe6vlpseuVPWXXfxUVO95j8+HrjXVaFku4bL6102/FzG7F2XISLUfWhCHikZiKj5cgAtFxTG6Wlkqm9qKJVZKuFPEvXfB7jLqvjPrEgrwGuYH3eTsDhs3bSlyt0o4UlLdc5kqBfAZCxTzt69KiKixYxgZjCtVBYRrQhNatYcAp6B7P+SHYbs261q5lumqNd6d48VNlFSqUrqmpxsPGF2F8SWk13LBKSmp+JOtGvYJUwOWNktHvSMUEiowWk9wGMYwGMYwGMYwGMYwGMZGZyg7h+uXiOEgx2pybosnb2CQmHXmsHKm1Lydx5hKSPdxFHLMNa49UABUKW3yNdQBLyKncETVRMqEmf39/vx/t+X7Pr4/q/X/AG8MrFH7s+eHMFc0T1d9Yuy7dXnq4IRu/eTnmp+tgRcG8iLwzCPmq7UVQRSAz86bfdL18VH0iGhllFSJKewvVp29czz+/dhPZrKakocic6j3QfDxktAR60W4KKZ6/NWWLbUGIcAkQxzj+I4vbrcynpD78uchFEQmJ5M9mHBHiCm+S37yb1jULAwI8FaiRsyNz2MKzMgGO2HX9LRsFubKKHMVBFR/ENGplxEh3JATWMSH2V9oD2tyQkX1W6veufkHyhdEUVZp7U2DGL0XVkY6TVBAHbwYUJloowM5MVEErPfNdPQ/7plU0hSMQd4ONHQv1hcZBj5KK48xu47kwORYbzyIfDtqVdLpeUyDs1Xlm7TWDB6guUzlF9C0CLeJuTAqC/ii1BvL3FRUXBxzKHhI2Ph4mObptI+LimbaPjmDVEAKk2ZMmiSLZq3SKAFTRQSTTIUAKUoB8sCs6tw79oG5sHUW5Qc4NacDtcSigC61bxSi3UhdWLVcBF+xGzV6WZTSSSyHkYoHX39a25B9dZWOOBTFkexO+iLq44aaq2vym5RMtpcrJbVtJte1rzct97KmHBJlxWIV5KukkK3UVKvHTb2Z92JFRMVbzXRw9knTNsCj14dqBbJ//P3/AMfw+WVXvaqOYKeq+JNA4l1uUFG4cmbalN29s2WOVdvqPV75hNOUXJUQA7cLJsFSnpMznWKm9Y1yyshQXT9cUAqd8R7mhrZflr2SuK1XqY/1eSWpnG2sV2KbwtUhOUfJktti6SjTotoaPYoMNEasabQ2bDtWTZUsHL1Cgiq3QF6yUN9Bbpp4UJ8FuBGoNZzMX8P2peWJdxbtUWIUJEdlX5hHvXcJIKeiicy9JgG8BRzFMKpBWrq7hNVX3k6p6hfWHxKDkXyv4OcLHkSovrLihDPOdfL0StTKxk5uPYqVOstQotgKBUkVHEBUGeiNUSsBIu1ncTKJbrFk0bqGmmmfRD/L6/T+vy+n0/0+QCH8wY+/5B4f6f2/UGMYDGMYDGMYDGMYDGMYDGMYDGMYDGMYDGMYDGMYDGMYDGMYDGMYDGMYDGMYDGMYDGMYDGMYDGMYDGMYDGMYDGMYDGMYDGMYDGMYDGMYDGMYDGMYDGMYDH39/wA/5fLGMDBPIzjNonlpq+b07yG1rW9nUCcIIqxM+1EXcW/BM6TecrU01O3mavYmRVD+4T8A/j5VoB1E0nQJKrJqU9uQnVt2FdLGypblp1V7FvW3tGKLunmwNNPItS22SErSBFXSjDYuvWIIxu3acxbEVIjd6vGw9+qSSh3aTaIK1d21S7/jAq98SPamuFe0YJjFcsK5c+LmxWqKKE3ItIGe2lqqQeEAEFnMLJU6Lkb/ABQrrkO4UhpqkrIw6K6DULROnSXdh3nk97UL146lqr9Tj65vXKa/KtlSQkRA1G06wpSEh6JzpGtNt2ZX4GYYxxFAKRRWt061OVTCBCIJpCdyjJFyi6g+unmDLyFp3TxjpLi9yahnEhsOiKzGr7tJPjnEx5KfmtfSNdG2yBiiKQubehPnFH00w8AQbijgPT/s+PVDp2fb2dpxmb7EmGShFmYbgulz2PX0vKfzim4pU5NHo8ukcxSAck7W5QPIUUwECKrFUCpzqPjz2Ee0cctWW893nmNf8aYB8pDvr+yiXsZq7WVGYyQLSGtdFR0wd0jbb9JHASSciZWYVbyZk5m+SSbRrCwy/wBCLT2o9e6E1dQ9M6orbGo661tWoyqVKvR6ZSIMIqMQBIhljgUFHki9WFaQlpJyKj2VlXbyTfrLvXbhZTukHAwdYh42vVqGiq9AQzNGOh4ODj2kTDxUe2ICbZjGxjBFuyYs26YARBs1QSRSJ+imQpflnK4DGMYDGMYDGMYDGMYDGMYDGMYDGMYDGMYDGMYDGMYDGMYDGMYHDWOvRFtr09VLA0F/AWeFlK9OMAcOmgvYeaYrxsm0B2xXbPmouWTldEHLNy3doCf1W66KxCKFjb41dNXWxxSXbSur+LNClLY1UFdK8bSTfbctiDoFfOm8in2w3VgZ1l0iQE26atTj4H/spiKgKLLOll5PcYH8kIRIhE0yFTTTIVNNMhQKQhCABSEIUoAUhClAClKUAAoAAAABn9YxgMYxgA/bnzLuzXk3W+cPbVuXaFudBYeNnF9aTrzNkqq4XhZnVfHxw6SWrrV2mJiNUOQe5XTiqVmSMkg3Rltt1wHokSSUcFvgdrfLFDhbwE5GbxbSpIq5taO+pWrD+ocrtXaWwCGqlLXYpomIsurAyMkNqdpJKJHLFV+RX9ZIiJ1SfNe68eLli5m8kNLcUoE0jHJb1vzGS2dZGzESO4LR+vPfJ+2v4+ZLKFRdtnwR1jduoGZjUWTq6U3W6raQUeKFTbheL9nA40WOi8Tb9zG2ygo63lzz2XObjsM29QSRkHFBby80NQUVTKUwoBaLBL3jYBFEVSIvom2QAKN01GRTHsT/AH9/f+mcDVaxAUir1ul1OJaQNVqEDEVeswUemKUfC16Aj28TDRTFIxjCmzjo5o2ZtiCYwlRRIXxHwER57AYxjAYxjAYxjAYxjAYxjAYxjAYxjAYxjAYxjAYxjAYxjAYxjAYxjAYxjAYxjAYxjAYxjAYxjAYxjAYxjAYxjAYxjAYxjAYxjAYxjAYxjAYxjAYxjAYxjAYxjAYxjAYxjAYxjAYxjAYxjAYxjAYxjAYxjAYxjAYxjAYxjAYxjAYxjAYxjAYxjAYxjAYxjAYD5f1/qHhj/n+n+/5Zjbce1qforU2yt0bBfljKRqqj2e/2l6JkiKJwlVh3cy+TalWUTIu/cotBaxzQDgo9fLN2qJTLLEIIUdPajOWsru/ldpvgLQ55mStaeSgrPf0XUozjoRbde0mySVeJYnzhUWjBnQ9cSUc+SlXSzVKNT2HZwkEwRZpLhsX7KXxbZSVn5O83XEMo3r7VOO426YcSUNHsXziOZpwlnvk05KxKEeWePGR+t2MtLRfrBJTEjbirPDqKvCr1U9j7xs+8dl8peXuw1kwvO3bLbG0S0SkGixWVo3a8mCTjFvGPkSLylOqeokrrU0nUemmpV5mW1uociBXbQo/TZ6kuMZuIvXfxe03IRYxNtS1ywvexGqyZiPkNhbNWWvtrj5ETgB1HdekJ8auBjeAJtINq3SAEUUwAJHMYxgMYxgMYxgMYxgMYxgMYxgMYxgMYxgMYxgMYxgMYxgMYxgMYxgMYxgMYxgMYxgMYxgMYxgMYxgMYxgMYxgMYxgMYxgMYxgMYxgMYxgMYxgMYxgMYxgMYxgMYxgMYxgMYxgMYxgMYxgMYxgMYxgMYxgMYxgMYxgMYxgMYxgMYxgMYxgMYxgMYxgMYxgMYxgPv/fK8ntPOzbZr7q3sEJWFHSDXbm7dV6ytzloqKCiNUEtl2E4TUUIYqnusjM6/hIh4kQRB01kVma5TtF1yGsN5i/culNTchtdWDUm79f1jZ+trSRoWdp1ujUpSHfnjnreSjnIoqeCjZ/GyLVs/jZFmq3fx71ui6ZuEF0yKAHzlOhHrptPPPk5TbheId2TinxXsrbYV8F8E2pWr5sZd0xkoChRyTlyvDKT1hGHqzjYBYxJmkOuahFsZlIslMQTp/wDS7+/v7/X8/wAgxrqPTeqNCUSG1jpXXdP1dr6vkMSJqNIgY+vwjVRQC+8OztI9BErqRenIC0jKPBcSMk58zl+6cuDnVNkrAYxjAYxjAYxjAYxjAYxjAYxjAYxjAYxjAYxjAYxjAYxjAYxjAYxjAYxjAYxjAYxjAYxjAYxjAYxjAYxjAYxjAYxjAYxjAYxjAYxjAYxjAYxjAYxjAYxjAYxjAYxjAYxjAYxjAYxjAYxjAYxjAYxjAYxjAYxjAYxjAYxjAYxjAYxjAYxjAYxjAYxjAYxjAYxjAYxjAYxjAYxjAYxjAYxjAYxjAYxjAYxjAYxjAYxjAYxjAYxjAYxjAYxjAYxjAYxjAYxjAYxjAYxjAYxjAYxjAYxjAYxjAYxjAYxjAYxjAYxjAYxjAYxjAYxjAYxjAYxjAYxjAYxjAYxjAYxjAYxjAYxjAYxjAYxjAYxjAYxjAYxjAYxjAYxjAYxjAYxjAYxjAYxjAYxjAYxjAYxjAYxjAYxjAYxjAYxjAYxjAYxjAYxjAYxjAYxjAYxjAYxjAYxjAYxjAYxjAYxjAYxjAYxjAYxjAYxjAYxjAYxjAYxjAYxjAYxjAYxjAYxjAYxjAYxjAYxjAYxjAYxjAYxjAYxjAYxjAYxjAYxjAYxjAYxjAYxjAYxjA//ZAABRDBQAAABTYW1zdW5nX0NhcHR1cmVfSW5mb1NjcmVlbnNob3QAAKENEQAAAENhcHR1cmVkX0FwcF9JbmZvZXlKamIyMXdJam9pWTI5dExuTmhiWE4xYm1jdVlXNWtjbTlwWkM1aGNIQXVjMjFoY25SallYQjBkWEpsWEM4dWMyTnlaV1Z1ZDNKcGRHVnlMbE5qY21WbGJsZHlhWFJsY2tGamRHbDJhWFI1SW4wPVNFRkhrAAAAAgAAAAAAUQyvAAAAJgAAAAAAoQ2JAAAAiQAAACQAAABTRUZU';
+const SIG_EMP   = 'data:image/jpeg;base64,/9j/4QEfRXhpZgAATU0AKgAAAAgABQEAAAMAAAABAgkAAAEBAAMAAAABAZcAAAExAAIAAAApAAAASodpAAQAAAABAAAAcwESAAQAAAABAAAAAAAAAABBbmRyb2lkIEJQMkEuMjUwNjA1LjAzMS5BMy5TOTM4QlhYUzdCWUxSAAAEkAMAAgAAABQAAACpkpEAAgAAAAQwNjUAkBEAAgAAAAcAAAC9kggABAAAAAEAAAAAAAAAADIwMjY6MDM6MDggMTQ6MjU6MjAALTA2OjAwAAADAQAAAwAAAAECCQAAATEAAgAAACkAAADuAQEAAwAAAAEBlwAAAAAAAEFuZHJvaWQgQlAyQS4yNTA2MDUuMDMxLkEzLlM5MzhCWFhTN0JZTFIA/+AAEEpGSUYAAQEAAAEAAQAA/+ICGElDQ19QUk9GSUxFAAEBAAACCAAAAAAEMAAAbW50clJHQiBYWVogB+AAAQABAAAAAAAAYWNzcAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAEAAPbWAAEAAAAA0y0AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAJZGVzYwAAAPAAAABkclhZWgAAAVQAAAAUZ1hZWgAAAWgAAAAUYlhZWgAAAXwAAAAUd3RwdAAAAZAAAAAUclRSQwAAAaQAAAAoZ1RSQwAAAaQAAAAoYlRSQwAAAaQAAAAoY3BydAAAAcwAAAA8bWx1YwAAAAAAAAABAAAADGVuVVMAAABGAAAAHABEAGkAcwBwAGwAYQB5ACAAUAAzACAARwBhAG0AdQB0ACAAdwBpAHQAaAAgAHMAUgBHAEIAIABUAHIAYQBuAHMAZgBlAHIAAFhZWiAAAAAAAACD3QAAPb7///+7WFlaIAAAAAAAAEq/AACxNwAACrlYWVogAAAAAAAAKDsAABELAADIy1hZWiAAAAAAAAD21gABAAAAANMtcGFyYQAAAAAABAAAAAJmZgAA8qcAAA1ZAAAT0AAAClsAAAAAAAAAAG1sdWMAAAAAAAAAAQAAAAxlblVTAAAAIAAAABwARwBvAG8AZwBsAGUAIABJAG4AYwAuACAAMgAwADEANv/bAEMAAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAf/bAEMBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAf/AABEIAZcCCQMBIgACEQEDEQH/xAAfAAEBAQADAAMBAQEAAAAAAAAACgkGBwgEBQsBAwL/xABCEAAABgMAAQMCAwQHBgUEAwABAgMEBQYABwgJERITChQVITEWIkHwFyNRYXGBoRgkMpHB0RkzseHxJSYnNClCQ//EABQBAQAAAAAAAAAAAAAAAAAAAAD/xAAUEQEAAAAAAAAAAAAAAAAAAAAA/9oADAMBAAIRAxEAPwC+DGMYDGMYDGMYDGMYDGMYDGMYDGMYDGMYDGMYDGMYDGMYDGMYDGMYDGMYDGMYDGMYDGMYDGMYDGMYDGMYDGMYDGMYDGMYDGMYDGMYDGMYDGMYDGMYDGMYDGMYDGMYDGMYDGMYDGMYDGMYDGMYDGMYDGMYDGMYDGMYDGMYDGMYDGMYDGMYDGMYDGfFfv2MWxeScm8aR0bHNHD+QkH7hFmxYMWaJ3Dt48duDpoNWjVBNRdw4XUIigiQ6qpykKYwY/8AJ3nF4o7G6fe8s6vU2bF2eTQsznUl5utPbwWvN8N6WSVXtC2spMky+mVgYM4Kck2oWWCrppCOhpIUypyLY0aYNisYxgMYxgMYxgMYxgMYxgMYxgMYxgMYxgMYxgMYxgMYxgMYxgMYxgMYxgMYxgMYxgMYxgMYxgMYxgMYxgMYxgMYxgMYxgMYxgMYxgMYxgMYxgMYxgMYxgMYxgMYxgMYxgYeeenoe9a85KrXL+j1FnHRffeyYTmDWMUwcuW0snX7Su2Q2TOInaGK5RjCQ7+LpEo9TBUY3+kBnIKIHQbLnSzLuGj6hpPzceFLirUSaIxvJ/J9gkLHMtm6KRnqq1W3hK2OXmgSSAyUvcJKru7HJAYQQNJ3pJRum3F2YM9X87qG8jPm+3z0q6FvM87eMeur86aS+RFs8iJ3fto/FWewrfGrgVRm7XgXCFzag8bHdGK0Q1lNtHLUwplN0l46HwdX/UJ+TbplRRaWrHN1UU58p65RA8fEyzGag9VorsD+w4C3lG+pNmv2qiKoIvfx18+TE6SpAAKtcYxgMYxgMYxgMYxgMYxgMYxgMYxgMYxgMYxgMYxgMYxgMYxgMYxgMYxgMYxgMYxgMYxgMYxgMYxgMYxgMYxgMYxgMYxgMYxgMYxgMYxgMYxgMYxgMYxgMYxgMYxgM8D+T3rZvxDwv0J0Ki6Qb2yuUtxX9ZpKiQxnW07uslUqCYjUwCZ8hE2CWa2KVaJ+05oKFlFRURTRUcJe+Mm+8phydxeSnx7+MWLULJ6+o1iV7W6tYgCi0ean0RN42odXmfiTMVEtgRQtFedtVBWMI7Hqb8xWJSoOlQ9QeODTzDxh+ImPt+wGpkrrA6b2B17vlWTVOEk9vc5UXWxpeImnCgFWWl65XI2vUB2qCiyjl3XROgu6OsVZTw39K9rKbQ5G6G6XtwKL23pXo+cdrS6wGFaegqBEt0yyiihvQTGUvtv2OiYge8CqIKH94nVORP0X9Sj0Ylovxh7ApjB+DO1dIXKnaUhSoqiV4EMs/UvN6clQKIGNHuKhTZGsv1jl+FI1oZpGMC7puU/u/wAUGglOZfHNyHqF2z/D5qL07AWy1MjJimszuez1HWzrgxce4pTnXjrLb5OPOc4eo/agBfQgFKAaF4xjAYxjAYxjAYxjAYxjAYxjAYxjAYxjAYxjAYxjAYzNPuvyw8feP5SNrG2bZMXTcthIyGqc/ajjELrt+d/FDGSiV14EH8fH1yPlHIFQjXlnlog0wcVCQDeZXRVQJ9R4/wDyv6F8gFp2RqytUfb2jt9ajj2s3fNH71qjeq3ZlXXrlm0RssWk0kZIj2IbuJWFayRJBOGmI13MxnzRAx8jGST4NQ8YxgMYxgMYxgMYxgMYxgMYxgMYxgMYxgMYxgMYxgMYxgMYxgMYxgMYxgMYxgMYxgMYxgMYxgMYxgMYxgfUWCehqrAzdosck0hq9W4iSnp6XfqgixioaHZrSEpJPFh/JJoxYt13ThUfyTRSOcfyDJ6vBhCzvTOxe4vLJfmkgjJ9e7ilNdaMaSoGMvAc7ahfBCwrZkcQEBTePWMTU5YpFPhNL6tVdItmoulgV7j8/e+bTROL47mXVJk3e9e99lVflPXMImZyD15EXp82aX5yQjYhzjHuoZyyo0gf2rnRPfWahWjgoKATSjS2ttZcK8hUjXKDttDax5l0mknPzvsFJM8XQqytMXa4vSHUEwO5l20nLTKGE4Ao9fOjh7fX0AJbfMA6N5DvN1wt45Ys4zWu9LOYSzbijW4iugmtbistsbXaSaSfq2KZDRtJqbeKcvzHFpI2d41TQKLw6T6zMAKUAKUAKAAAABfQCgAB6egAAAAB6egAAfkAflka305dVsfX3bXfflI2RHmO8sVomKNQzvBBQsVMbMmi3Oxxcd8X9QipQtfxNDqTRQTHV/BrKZuU5wOsoaynAYxjAYxjAYxjAYxjAYxjAYxjAYxjAYxjAYxjAZih5IfJdftZbDrfB3Atajt2eQnbSaSTOHKklJ1DniqPW6blzsvaa6nrEsXDKKXLLxMNNrEYM2Jm9ks6DiKWhoO2feeUzyV2HmFei8n8nVxHcHkJ6SFOE01rdokjKNdexMmZ20V23fWhzgzbRUWRnJOoBjMqNot8rESs9OqFqVZnQW7X8aHjcqvCVEsNquNiW3N19u9ypaulujLEd3I2W7WaTeqS7quwr+VVcSLClwz9cQQRE6DqzSSH7STiKS5oyKhA4n47vE/qnjA77dOzJZfozt/Y3zTm5OntgnVsNhcWaaL807Fa4Umk1HtVrBVVDMhfl+KzWRskRWadoR34dXIXOG9OkKL9VPplGLFJkpubimUa2P7ZP4zSy8VTNrvUQfmD0+ZVNvqiBEhze8SoRrFL8gSAS1DZKNsx+S0fVhc8N2pRVHXHLk2wkBSOBvtjvtF7ylCGcgHuFMDJ3xkQpT+wRMu3U/RQvuCrnGMYDGMYDGMYDGMYDGMYDGMYDGMYDGMYDGMYDGMYDGMYDGMYDGMYDGMYDGMYDGMYDGMYDGMYDGMYDGM8md1dQQPGPIu++l547QR1br6WlK2weGKVCdvsn8UBrutqep0zfHYbxK1+HXMmJlEW7xZwVNQERKIY31oqnkD8+1mthkVJPQPiY1krTIZVQv3MHKdQ7NB0hMrplMJkiSMEQ02ydiByLsJ7TMA4Br6O03Wc/wDqUOqv9njxt27X0NJA0u/UdoidKxKaCokfoU05VbTsySKmAlBSNcVmECkyQiJxIN5aeiY+8VE+7/BNy/Oc8cC0e6bFI4c7y6ul5TqXck3Jp+2dkZnaopy9VbyxjgVdu8Z0g0A7lItRNsEdZ5SxlFmg6cOvfg95ZXK/kv8AO/yfwBFKnmNYaGc1uL2M2alVetEVJtsy3Nvp4ZUpvs0Dm1fAVOoGE4ejWxRKjJ0oq4OVikFCHhB5cHkzxp840mSjvw267Brh947DIdMEXhrRtoEbKzZyKQAApyNcpilSqDshhMYp676GN6gIBrNn+aKCLZBJu3RTQbt0k0EEESFSRRRSKBEkkkiABE000ygRNMhSkKUoFKAAX0z/AEwGMYwGMYwGMYwGMYwGMYwGMYwGMYwGMYwGZ9+Snvql+PHm6W25LRI3fZVlk21C0TqVkqoM1tDac4Q5ISFbtGZVZM8LGiAytnesG6zhCNRJHsCLTsrCMXvtq8Xepazpds2JfrDGVOj0auzFtt1nmnBWkTAVyvsHEpMzEi4MAgk0j2DZdysYCmN8aYgQpziUgzfcG0e0eW3t6X8ru84CYjuX9Azclr/xyaynkRZoyLiCknCVg3tOwyhTEXkyS6BXzB4Y64luZW8ek7MTU0Kq6D194nPHvddMp3Dt7sxT9ufIZ1IK9n2XYJgiK59NVGbFs6itNU9AhlWUEWMZNo5Czkh/iZNRYxtNizKQNXaOpPa3GMBkh3juff7UP1JPkZ6ERcFf1jR9LtutYeQaAVZiMxWH+t9CRCbdZMwIg2kIai3iSIul7yu1iHXJ7yrqKhTD2D0JC8o8ub66MnfhUaag1hariyZLj6Jy9iZRyqNTr/8A5iYApY7Q4hoJERUSD5pFP3qEL6nCfD6VTRs1CcsdBdW3EF3Vr6f3Ws0aTL4oKvZyr6rRk0VpwXPoAgaS2JdNhs3qaYFBRxCEWUE4/EVIKn88+9R9QaX450nct/77trao6/pjEyy5xFBaascysmsaIqFQiVXDU89brEukLOFiEVUvlU+V49cMYpm/kGne0jIR8RHvpWWfM4uKjGbmQk5KQcosmEdHskTuXj588cqJN2jNo2SUcOXLhVNFBFM6qqhCEMYIuuqOgI/yE3bpnyMbHIq98anjIjrDA8o0aYJ/9k9adbLqN4Gp2mfjX5kkZynqXmVqSjpsszXA1Oc1mBOyOM5sWLWDUnxA+YHdnkp6K6v1/ddCVnVur9UQdRtuunsS/mHlyrrKzSTiPj6ftR47fPISatU/HtnM+grBRdP/AGbWg56AkIqXcFK8jqCMwS+nT5vktRcBx+9L2Vd/uPs+7WHoS+2OS96k5KQks/eR+v03zk5UyuG7+HSfX1schPT7rYEkcVFAUIUm9uAxjGAxjGAxjGAxjGAxjGAxjGAxjGAxjGAxjGAxjGAxjGAxjGAxjGAxjGAxjGAxjGAxjGA/w/0/X/LJwvLs9X7c7h4R8S1fcLu6VP2hHrDrkI5ZI5GeoNeGli1qrS6yZVBZhZzR1pQFo7MAozEvruUMwcJuWKoUKXm6VnW9KuGxLrLNoGm0KrWC6W2deCJWkLWatEu5yelnRigIg2jopi7eLiACIJImEAEcwD8G9LtXRt7698u22ItwytfZ2wpSk6KjpEp/u6lzTrGXLX4eObCcDexOWk61CQMgCayrd6vrFnNNipBKKfIG8Wy9gU7SGqb7tC2rIQdB1LQbLebEq3TQbt4qqUavvZyT+1Q9UG6ZGkVGLFatyikmHsTRJ7SiUAj3+ma13aOnOte6vJntJkZeesVimqjXXiyizpmnd9xWRXZmyEYpVQiZUTVGvs6fAsCkBMraCtwskG7dsIJl0Y+py6qNofx4r6fg5JVjdOrLtG64RI3OQjsmu6udtcdkPCmMb1Fo7IzrVNkSJkOZRldFU/3AMKhfanhI5YNyP41+c6HKRv4bd73XB3dsdNQhE3gW3a5ULKgxkCEACkkK3UVarUHRRFQxT10CmUOICYQ1fxjGAxjGAxjGAxjGAxjGAxjGAxjGAxjMC+9PINunc27H/jF8Xajaw9TSzddt0D0SQ5j655BpAmI0sDx/YWiD1AuzEE1yMTGboO3FTlXbSDhmsnsl23j62HOe8vLHMa72834U4C1yh1R37akVmqtZZribWuhG50ElFbVt6eBZnFA4h0HCTx5WlZ6EQh0VWjq3TUMDqIirBjRvSkeRjiPvLxNXvoPyBbP3VvPsPqOKp+1dUVGemaxz7TddhsPTcFbNeV2moPI+AsdfkmmzHiZ5I9MqEe2eRTN6xgFZRg3mi0lePLxw6N8durF6nr4jq57SuShJrdO+LWiRzsTbFsXOd2/fykgqo7dx1fSfrul4Srov3Tdh8yz1+7l597KzkjMB9RJ1w71x5WOJEqVGubbb+UtdsdqVmAjGIzKzjd13tctMa9rryGIuis8bLStG1jIyzVn8j9zBTRyR7d8+BuyVDTbyb7DvPkl66pPht52tD2F1vEpRG2PIZtiuLFcpVTXkPIR8nD6fTdtwVSSsco4GIeO41wJk17FNUxo8J+Gwl0apUO6411SNRUGn6u1rWounUCgVyJqdPq8Mh9vGQdfhGiLGNj2xBExzlRbok+RddRVy6XFRy6WXdLKqqZoeILgqT4p5zdWLbi57L130rMH3N1PfpFY72dk7zZHEhNsqc6fqCYVkKMlOvmb4zc32khb5C1zjUQaSrZFDWPAYxjAl8+qx6HNrbhLXehY16ZvM9JbgjySrQFvjB/r7UDdvcp0hki+plioXt7q5X8wBMnr71P6z4gzbjx36ELzBw1ytok7MrGToOlqU1tLcEAbAF5motOzX5YUA9TJGdXWbn3RynMZT3rCKp1FfeYZWvJm7HyKfUM8mcZRahpnXPOj2iR18Zoh91HHNHpG6E3aoZf2naNlHtFj65QnJ1SHTbz8MVkqRd2IMs2/8t/e+ytRE13wxxWQtp8gfW7j9m9cMWB25w05RHf3aFh3FZHCvyN4RRgxaSh6u7kkRYx5IqwXV+CsfTzRsuHmLyP7/ANo+RfpF14beM5leIrSSbCT8g/RkOYr2K1hrVJ+3/GNPxDlFUrd3apcDIsLNEC5RVlJRdGgODpxiGyhh/GfmZ19UBk/GZ4FORmBanVLjcqta71HRK5HcpA0ppJSNeg7JZ1ypmUmHi5FNubcvDmQJ93IydZjbAdo6VdIeyg7x18H6x8bnNTfXkfMs7BeZYV9hdEbunDg2lNkbDWZndWS0TMxJqGeNqvCgLxGtsZR8oSIifuX75ZaalJ6UkMEvC+jIeRXyu9zeVazNXTigUJ+71FzwEimoQGKM/HkrEAqwSUQJ9lJVzSNfbI2NoQrUDye1XTs6bhw5cqlCtKlU+va8ptRoFRj0oiqUasQNPrEUgH9TGV6sxTSFho9H9P6pnGsWrYn5f8KRRHOT4xgMYxgMYxgMYxgMYxgMYxgMYxgMYxgMYxgMYxgMYxgMYxgM+K+fMoxk8kpJ41j46PauHz9++cJNGTFk0SOu6ePHS500GzVsgmos4cLKESRSIdRQ5SFMYPlZ546055gOseaN3832d+7h4jceu7FSzTTE6hHUHIyLMTwc6kVMxPuRhJtGNlTsFRM1kU2hmDxNVo5WSOHoFq6bPWrd4zcN3jR23RdNHbZUjhs6auEyqoOGy6RjpLILJHIqismcxFEzFOmcxRKI/wC2Sx/TldY3Ootd5eKrp+ZnWXQ/Kt4tP9HsVbpcroHGsIdaPr05Qaao/Rayb6L15YmLmyQZDHeouqPeI9aukb1iuFRaVOYDGMYDGMYDGMYDGM+msdhhKjXp212aUZwlbrENKWGwTUgqCDCIhIVivJS0o+XN+6izYMGzh25VN+SaKRzj+RcDA/zq7VuO1I3nTxT6Llga7q7+2DFxV0dtjKGXpHOdNkPx++2iQIgkKyUc/Ug3CzoEVvdJVSn32KM3cEcGIO4OndUUjQ+qdcaX1tFlhaFqul1yh1KM/qhVQg6vFtYlid6sii3K8knKLYruUkBRIrIyTh0+cerhwqYcA/EDXJrubrfq7zJbHinyFcvsxLc5cWQ8wkf/AOgaKob9KKnbawbregNHthfxaEQ6WIig6Z2VTarMDHZy/opvruzbVU0Lp7aO7b06BnTtS0C27Esi3yppKGiKhBvpx42aip6go+eJshaR7chTquny7dsgmqsqmmcIufKqobyV+fzmLhqPP+Naz0c8pNPvLFuQz6PMio3DeW/nn/F9uk5Pr9lE0p77/RJCXrJGq4KrlM3G5JJJJBNNFFNNFFFMiaKSRCppJJkKBCJJJkACJpplApSEKBSlKAFKAAABkVn0x2qrX0h1P215MtrIff2CbsE/TIGRVBRZqrsXcFgDZu0nMYdQP91VrECSqQrNMpvRGFuyzNNJJEpS5atgMYxgMYxgMYxgMYxgMYxgMYxgMYzF7yw+Qq66GJr3jDkFojefIJ1i4JVNR1tmo3WJqmsyp3TOV3JbxVKs2i2sQ3bSi9cPLESjEhiJu2SoqwFOlGb8Oq/Id3buzcu8CeLDxpvW8h07b2Bx6K6DaOVT1Hj/AFoqdBKeeuZqPFUGuyjx7gEvVI/4lWFZCJiYBB5sSeiy1nRfgbgfSPj10ew1DqRmtLzkoqlPbW2xPN0DXvb97VTOL+12t+U7hYiBVl3SVerpXbhhWo1YzZuq8kHUrLynX/jL8dVD8deiBo7KWPsPdWwpEbx0LuyV+5cWHZuxpD5HD9cX8iZWVCrwq7p01rbF6uZyoVd/PyxlrFPTTpzo9gP8/T+8P1D+/Ip/HJrKo+S3z3dvdqW5dK3645XvxX2sEfYV9Bzc9DPX2o9DT/zAt8BI+Mqus5i/wySJTCrY2MNIGN6NnZXGvn1BPe6/GfENio1ClVm2+un2dj1hr5OOEVJev0pOLKvuLYaKaX+9NiVumPTw0fLNjouISx2mCnEVPZEuBJ5i+lR0MOvOBb5ux+2+OV6H3VPO41yCHsFzSNWM0aNDEFUf3lwb3QNj/vFH4kwV9hSgoCxjBTz/AH/x/T/0/Qf+fr+QevoGMYwGcI2dsKtaj1vsHat0dhH1DWdItewLU/MYhQZVynQb+wzboRVMRMPgjY5yoHvOQvqUPUxQ/POb5Pz9Sr08noLxq3HX8XIJtbl07ba9pqJRIdT70lVIsa4bEkEiJmKUWStcrv7JPzqichf2wbEBMx1SGTCfHxE9LVHTVi8lXm96lRUfPyy8rr3WdbQXFZ7fN8dA2V/suZolQXckAGzqHi4StRir0iIp16hTk5JmZljItw3NSD4f+KtpwjrY/ke7bZpTPcfX637Qi3lEVhc6G0q/QZHqGp4Jm6VX/Z9yrFM4k8vHo+x1CwMdV6c6+N/DTysngN9PxwrOdlP9V7N2zGPA4y4vtErbqJSpNgqlWt89eXJZnNWW6zcY5VdMpdlqyCYUWpPXA/LHyjam0Zkg2TLK36MG8z9fy9f/AGD1/wA/y/X/AFwMJvqI+xv9lHxz7ArNdmRjNn9Nui6KpZWy50pBtXZ5so72rOJFRMmuVq1oDeVrgPUVUhj5u3QC/uUEQRV9N+HLkIOKPHpoDUkrHBHbAn68O2dsEOmCb0NjbMKhYZSLkgBNIpntOh1YGgioQggdvU24/KuYTOFMBulXRfLd9QrqXnBkmayc2ePxKQlNjt/U7iDey9Cl4mw7TF0RJRQAJZ9ohrrSEyj8jM6rSuquEgAyYqK2b+n+H/MB/t/h+ofmH5fw/L+/8gYxjAYxjAYxjAYxjAYxjAYxjAYxjAYxjAYxjAYxjAYxjAYxjAYxjAkG+oG57vPHvSPOXme5kjgj7fry71Krb9bMA+1aTLhsmMJT7BYTpiqqaIvlQVktIXddNApDRK1PZolM8fuFzVI86b2o/TuitT9A63d/eUrblGgbvB+9Qh3TBOYZJrPIOS9noVKYr0iDyBmm/oAtZaOeNjFAyQgHxultA0TqfQe2ueNltPuqXt2kzFOlzgkCriLVfI/JEWKOJ8iQBL1ibQjbHCqGVKVKWi2SphACCGTC/Tlb7vfOO4+pvD90M6FhfNKXa43TUiTo4kbO0YuVSj9m1+AOsUoLxEsC8Dtanpt1FjSURPXGdJ6tE/cAV14xjAYxjAYxjAZgP54d33ewa50n41dCPRDoHyI39hrRZRqoJ16boyMkWLrZ1slUUv304aQbfHDSZVlGqb6mo7AVbOBWiFCBvZIyMfDx7+Xl37OLiotk6kZOTkXSDKPjo9igo5ev3z1ydJs0ZtGySrh06cKJoN0EzqqnImQxgnF8WcW48hHe/VXl7tzR4rrOuvX/ACfw3HzDYyf2GtqgUULjsCMRVcnWZq2I8i+MHtK4bJTV+2bEJuAGPKkiG8nPejqNzTo/VWgdasfw+jakpEBR6+mYpSuXTeFYptnEvImKPovMTj4HU3NvDGFR7LSD12oc6q5zZPt9Ur1efTHC1Y54gJP7S29WX1CHk0EHBUXYar1ipG265rJiT3OCkfWlfXcE4TD4UXsXLTDZVU6XyNl6a8hM7MXDy0/UTav5ojThYtF8w2CKoVwSTMmvDq13TTp1sToEz8hRWRbup+7A/wBPGc/1orrR9dKoiUR+IgU6eG7lIvHXjp5x1bIRxY672Coo7Z2cUxRK8/b7aZErXJR0l6lIUz6qxbyFpBxTL8Yo1hACqOAD7hXT/H6/3/8AT+P/AL/w/Mf8PVgMYxgMYxgMYxgMYxgMYxgMYz4chIR8QwfSsq+ZxkXGM3MhJSUi6QZR8dHskTuXj588cnSbNGbRuko4dOnCiaDdBM6qpyJkMYA8a+QLuDWHj75jvXQ2ylSPXES3GE11SEVypS2x9lyzdwWq02LL6isRN26RM+n5JJJb8CrTCYmjIORYkar+C/ETw1tOoutgeRDuEiFl7x64BGwygSLYRU0LqZ+1aKVfUtcaODLmrjz8HbxKVjjW6gHg4yLr1JMYVq/MO5jybzPEPvNf5AJDt/YUO/V8e3EtjkqJx9r6yt3Awm6dysHxFpzeL2MWSSavY2Mcs4uXI3dkVTTXbUCuqFWc1+9M3VPn+f8Ah/d/8/r/AGB/D+IiDP4IgUBMYQKUoCJjCIAAAAeoiIj+QAAfmIj+QBn9zG7zk9ZWDmviWeoGrSu5HojrueZcvaKgIdYE7A6n9mENDWOYhwAPek7ia08dsomRKq2BjbZ2qf70iquiYQjG80/T63bW49r9RJvyyWnGezR494/Ynbqqx89TNOotb1vDa0CYHBCklXtvtOvE2kmRmcJSo7VCCee1zUmZw/QM4A0AXlnifl7QKjMrGW1tpekRNsQAgJAa/SESjO7DdFSD/wAoH15lrC9BIwqKJg49qqqqpTqmiJm+WK1bPL545PFpTyt5ygcVV3WMVuBdokReItuxGSEh1h1DaHTgUSlALSu8RoCZngCZkhBQddTMqqzbpq/oaf2f2f8AX+P8f8P4fw/zwGMYwH6ZCj5yXtu8mfmN5v8AGzqqcKhH6wYxlNmZH+ukoyv3HYMU32nuC4C2aAKbwlM1HC1cz5mU/wAyUrWJmMcOmqxl02tcff3aOvOA+Wdl9J7EMV4nV2BIqkVYqgJvb5smdKs2pdOZfvlUKWTkU/u5p4iCh4asx85OmSVRi1CGlg+mN1LdOmeruxvJlugxZ+1Lyk3UIecWRUI1dbV3FKhe9mScMj6mTj/2Zq6cPAsmKaxkGMDfTR7dEqKKJkgsE550HrTl3Smt9Aafgwr+utW1hhV66xMYiz1dNqUyr6YmXZEkfxCwWCSWeTlgkzpJqSUzIPnpyEMuJQ6D8kHXkTwvxdvbpB8s0Cfp9RcxmuI12AKknNp2k5a7ryLFqJVTumgWWQYyM0mmkoLevR8w/VKVuzXOT3FkaPn+2Rbu7++uO/EFpubORMbdXLnuJwzVUXaxVuucc5cx7uaZpCoc/wDRPpMLJsVwQWqgrRt3ASfIu29iYeufphuRZbW/LWwez9kpvH21ux7e9lmEvM+9aZNrCoTU01ZSS6zhU7kjm9Xl3bbM+XFNH8aim9SkxFyiDJfKdc4PrLXVR1Brmh6ooMWlCUfWtOrdDqEOgUgJRlbqcO0goZmAkIQpjIR7FBM6nsIKigGUEAMYfXnGAxjGAxjGAxjGAxjGAxjGAxjGAxjGAxjGAxjGAxjGAxjGAxjGAxjGAyO/6hHUd34u6+5J8xehIkxZmrXKr0PdKDNJZNrLzVdaPiVR1Y3SCbk6MZsnWQWXT9jkDg1btYuHq8e1E0lLEMpYhnmnsXmGj9l8ybl5n2EUhK9temvoFGU+BJy4rVlbqIS1OuDBJUDJnkaja4+GsbEhyims4jCIKgZFRQhg7J0tt2kb+1FrXdutpQkxQ9rUmuX2qP8A1SBZSGs0U2lGqD5FJVYGcqxK4FjLxyiguIuUbPI90VN02VTL2bklX03fUF81Ja+h/EV0idaH2pzfbrrYdVMZBdyZNSFYWQ0ftSlQbh6Vsm5iY2yvWWx6b9oidSwQN0tM62AIeKROWtXAYxjAYxn1c3NxFahZex2CSZw0DX4t/NzcvIuE2sfFREU0VfyUk+dKmKk2ZsWaCzp04UMVNFBI6hzAUojgYYedLoq8I6t1V47uenpzdM+RO3I6ciSslD/NUNMLvWLTa9umDt1gUj4aTiHpqw9XdJfAvVHN9ftlCrV1ZRDWvmDnmhcn8+6l5z1k0BrS9R0uMqkYqZP4nEs8QA7ufs0in8qpQl7XYncrZ5oU1DJnlZZ6dP2pmAAwr8TcTKeQjtTpvzFbFi3YUdN/KcxcKw8ygsirXdRVBZ40tV1YtlhTO1d2FSReM1xOmqZrZLRtWLKoCJEClpMwPL3a/RsRyPyb0D0jLmQMTUmsbJZYdq59nwStvM1/C6NBH95yF9bBdJCBgyepw/fkC/kI+hRmR+lK5vl5SE6k762GR3KXHattW1DUbJJAj99JMmr1nsHbs4B/jBVdOzXCRp7ZV0kKKAyVTlEPYqch/g5x9V/1CvV+fND8c1V0qtZ983tTYlxi4/5F3ylF1qdBpWYh0yTAVFkrVsGcYSMWVJNVRV/r1ykX2CBQW398cXL7fjbiDm7nUWjdnO0PW0QtewQKT2uNl2ky1v2Q4+VMTC4TPdZ2bSZqqHOcGCTRL3fGkQpQ9tYxjAYxjAYxjAYxjAYxjAYxjAf8/wDL9f8AL+/J7/NHvPYm7rhpLxAcvTh2G7+yXib/AHnbGBvuEtRcuxJnjq3v577YRdx6lyQipIQJ7khkqzXZuuHL891hFFNrehN50HmbSG0t/bQkvwuh6mpkzc7EuT2i6ct4psZRrERiRzFB1NT0gZpBwbIogo/mJBiyTAVFyBmLvhD0deNo/wBNnlo6Shyp9Cd3TruT12xeis4V1dzFHu2regVGAWXOB0IqxM4SDctTnQBZ/T6tQpAy33D2RBYNoOetDa55g0lrPn/UkOEHrzVNUjqnW2RzlVdrItAOq/l5RyUhPvZ2wSrh9PT8gYhDyM1JP3yhSncGAO5cYwGTEtbXW+9PMttjo61uzOuPfDDrqyxELIHSK8rk70e7bS8nfbIzUF19qs5pv7PSa7hdkucG73VOvXzhu3TmCLLa++TzsBhwzw/vroQXjdvbYKpOa3qxuuUqv4htm5AavUFIrUSKfeNoybfI2OXbe0pTQEJKqGUSImZQk/e6dfPPFn9NtbqtPC4a9Adds4pvtCQfOFQmpTY/Tbhm8ukNNu1yi9dSlX0XEy1SkiqquPu5SvvnIrnSerq4HS/00VUnuo+6++/IrfWiyso+czEZELPzC6Ihbug73KX+xpxS4h7E1ajW6ixgCppgii0hrW3aNEitzARG2XMDPprtAf0J+LfW9nesgZ2Doa9X7d0sVVL2uyx7yRb0CoFMsYPcdm8qFBhLAxSKYUUyTyyxSEXcuTH3zwGMZjV5pe1rXzVzzCaK0GDuZ7G7PnQ0PztWoJYv7Rx7mzLMoS17AapAUx2wVpjNtI2HkDmQTZWufgpI6hmUZI/EEkv1FnkBf9fdFvdY0WaO75p5rtc5rGkOWBnf4JsrecW2Yn3LemcmhGvoGfjqI0kISiR7csyxfs0J6MtcEL6LtMoRGz3w/cin4o8e/PunZaPNH36SrP8ASbtdNZMUnpNj7KEtnnIqQL7CFF1UGbuKogHKmX5GlWbGOKqplFlIlPGFxvSuxfKxq7StSIzuPMXFLL9p7pcGrP1iNoJ6pnyvZS2unRUWB5WP3jv6b+5rbKZN+0EfpJzE1lcZBvQ/aX9J38/5/P8AT/H/AK/l/wCuB1RvbclM540vtPeuw3gMKTqOhWjYFkWKchV1YyrxDqVUYMCH9PuJaUO2JGRDJMDryEo7ZsmyarhwmmeT36b/AFDduqel+x/LZvRkZzab1c7JQdbKuEDnZIWG4uWtp2W+glFiofEwp1ZPS9d1pw0RUbhEyllhhM2UjlUR7f8Aqj+rrDE6i0b4/dUmeSmyuqLfE2G3V+GOcZV9Q63Y2MbRauZuVZH5R2HtNRmeMD0WSWV15ItFwRBwkZTf3gnlav8AFPIOhuaYNJmZxrahxbW2yTMhSJWHYswU89sSyFMBCqHRmrnJzb5iRcyqzSMUYsPmUTaJmwPXuMYwGMYwGMYwGMYwGMYwGMYwGMYwGMYwGMYwGMYwGMYwGMYwGMYwGMYwGMYwI+PqDtC3vjjp7mvzM81x4MrVTLzVKjvVuzIZFpKysUzGNpU1Yzo/OsaEv9GRmtM3N38KKSEajT2CBzv5j5Aqh523vQ+ntGas6B1i/GRou2qXC3OBUUEPumaUm3AXsLJEL+TeZr0mR7AzTX/iaS0c9amETJG9fj9JaBoPU2h9q887QY/f0XbVNlajNFKUDOWBniYLRU7GiJiAlMVqbbx1hhVxN6N5eMZr+g/H6DLl9O90Be+VOg+mfDd0c6+wumsrtcrhpYztUStpB1FfCvsCu14pyKGUhrVXSxW5KekRYqasU5uMsoHzPALgV94xjAZP950N5bFukFpHxa82vDj0L5AbInVbS9akFwOveb2Dz2bHt06gQoKoQc22ayjGQVKoQ7qm13YjduIPk2ZT7m7I2LTNRUC6bS2LPsKtQ9e1ibuVuscosCDGGr1fj15OUfuDiPqYEWjdQyaSYHWXV9iCBFFlSEPgH4ZqFd+ud39H+ZXfNfdxU50RIyGquR6lOt0wda35nqEp+HpPGiQoC2Sf2ReIjYY81GHRNJuIS5zaR1o29qCqG5vPmjKDzNpLV+gdXRgxVC1NTYem11uoIHdOG8U3KRzKyS/6upmckDO5uaeGD3vZaQeuzgB1jBnceM8A+UfqgvGPBPSm/GckEZboDXshXNarkMP3Bdo31RKla/dNkSCCzkIayzrGwv0UTEOWIh5FwZZuigq4SCUSplJ5ePqS5GxK+lj0FyXYTvmapEVn0OtQOYpUrOuk9yxwbOIbYW/JQk0ZsqBEXkBaX4C0clTXItdz/j/b/wB/7v8AD/n/AGfmEpP0o/Kxtfcp7c6ysMeYlj6Ov5qrT3rlM6h1NZajWfxSz9k4VADE/Gtkyl1j5QiXvIuemxSqq6qiQItqtsBjGMBjGMBjGMBjGMBjGMBjGdC9R9C0jk/nncPR2xlfbUdQUaZuMgzIuRq5nHrNEEIGrRzg6aySUxbrC5iavCiqkZEZaXZlW9qYmEAwx8qUtN+QzuPm3w+6/evh1fEO4Ppvvibh1ViEidX1py1lahreQfNSEdRElZCKsXTVQqqhU5676wmQTMjGPQJRtCwsTW4aIrsBHM4eBgYthCwsRHN02kfFRMW1SYxsaxapFKk2ZsWSCDZqgkUE0UE00yABSFDMOfBXzpf4jTGzO9ui2gL9ReQ26r7utLp4xFo9rGp3K7pbVlPj2y7cisTEPI165tzNizVK0GuTFNi3CJVq0gCW7GAxjON3K3V7X9Qtd8t0kjDVSk1uct1nl3IiDeKr1bi3UzNSTgQ9RBFjGsnLpUQARAiRvTAnc8iIrd6+W7hzx0R/yS+nebGw9v8AVjJAyq8W4XhFQb62qFkbFMUpQX98PEOSmAnvht3IOG7kHLYyaed/1WO3JvZu2eJuEdf+knZpt+62dJwKDj5FJC07CnUtUaiZnRT9wNnIKtL8mAKkOsohNNVEiJp/m5018CVPn93I9g+U3ZUOZjee7t5WL+j1J4m4M4r2iNZSr2uVmFYrLqqe1qWZbu6y4Kkq5TctNewC/wB2r7SpoYy84HN5NvqZ7zt4pjT+p+aLtZ7nEO0U/miyVXmtox1pquUjFzB7G7ewbZGs3xuC3ucuAkpE6aSB/cLQLaNF6ogtD6U1FpKs+0a9qHWdG1nDHKkCPzR1HrMbW2ro6YCI/M7SjSuVzGEyh11VDqnOocxx7UxjA+msdigqhXp622iVZQVaq8NKWKxTckuVrHQ0FCMV5KWlX7k/oRuyjmDZw7dLnH2pIIqKG/Io5At1Z15Pbbq3VHmNvTZzDKbGc2TgjxUU6R+Qjys0943sUXuHodm0dFVcRU/DUdza2zWZbpghH7PvUzEJukT1+uLhvb5wNv7A3TLc+eI3nOXFluXuGxt3G351oQzv+jTmKsPFX1tmZtFsQz1mzsq0U/dKKoqFCQrFIt9dXTEbKx9+BHXGtqr5DPLXyv4pOek3jHknhyJj9Bqlj3JXCUbC6+btJ7pq7O5Juugma2SH7ONddO5tb7Vebu1cj3ZyKSEx6rhvF9NTxCnzJwmx3naogGe1OvXMbsp4q5QAr6O1LHJPGmoogDigRQG0vFv5XYaZyLKpuGt2jyre1VkCadEjhw3aN13btdFq1bIquHLlwqRBu3bokMosuusqYqaKKKZTKKqqGKRMhTHOYCgIh8GDhImtQsPXICOaxEFARcfCQkSwRK3YxkRFNUWEbHsm6YAmg0Ys26LZuiQAImikQhQ9AAMxf+oC7HDkTxx7UbwUt+G7N6I93PuvwQXOlINkrxHPg2FPNhQKLhoMJrppZE2cskduMZZJOuHTdJO12ZFAw+4DRX8vXnu3V29JEeTPPPIzprJ6uM6TKMYCddUkaVzwwIQpFvs3E3Ix1v3sCBXXqjYYh8T51WyooHt1zDX6evjYnJXjo1vNT0Udhs7pVQm+72LtqdtIs4y0MWqGta8qCxhcJoRlAbQ0soxXTbnYTtksCZm5VTqqKblYDGMYDGMYDGMYDGMYDGMYDGMYDGMYDGMYDGMYDGMYDGMYDGMYDGMYDGMYDGMYDJC/qMdE3jmTenKnmC59ZfaXbUN5qFL24duBiNn6kM9UkdaTU+mkYTKw9gjhseqre5VSEruIkajCm9xFSlGvT+f5/XOheo+e6V1fzvuLnLYSIKVXb9Em6e9dfF8y0M/eofNX7OxS95ANKVOxN4qzRAHP8YScSzMqU6YHIYPn8375o3UGh9T9Ca2d/d0rblIg7pCgY4KOY78TalNIQUiIET9kvXZUj6AmUfYQEJWNeIe31S/Puv8An+f0ySX6ZjoS4awkupvFfvRZSK2hzhsG3XCjwjxYolbxTaxlqW3qxDHXBqsvGQt6LF3CJFFoqeURvk5LgdNkgkUKCPIL2fROBOUNpdK3gEHq1VjPwuhVVRUya162bOlVZ0ioofGci/wSEoAPJ102+ReJq0dPTfxKJxihBDI7y0X+2d59S6X8Lmh7DIRcfa3ERunvK9106pnGutGVo8fPwlJej6kaC9taryFnDNHJx/8ArT/VbZUFIyelki0Ka/oVQ1ZRadrPX0Cwq1F1/WIKmU+txaYpR8FWa1GtoiEiWZDGOcEGMczbtyGUOdVQqfvWUUUMc5sivC3xhedFaZuvUvSiakn2f3DZV937vlpZFI0vUoawunUxSdYMznFRzFsoeNkQmpiBKomlDTcqarikoyqUQZPaTAZGZ9VD0FYth3Dkbx0auUVlrbfLRGbUtVej3f8AWyc/ZpV5q7SdccIoCImVfSj27yCrF4P7pzVuRI2ERaOAstcOEGjdd06XRbNmyKrhy5cKkRbt0ESGUWXXWUEqaSKSZTKKqqGKRMhTHMIFARyFTxuIL+Vj6gXePacuQ8xp/nyYnti0tVwUykWpGVMiOoebIxNL4wBhJrsGhdrETRKgkpPVKZdLrruXKv3wWX8oc/17lbmrR3OtXBA8Tp/WlVpBnrchyJzMxExaBbJYzlOBTg5s9jUlbC8EU0gF3JrGKkiUfjJ6CxjAYxjAYxjAYxjAYxjAYxj/ABwGTbeV6Qfd9938f+Imou3K2uG0ow6v7ccxipkvtNU0xcVKrSHr1FMVmDiwkM8SIUfuEkJ666xmVWxk2gmChbY9/qep9e3naN8lkIGka5qFkvNvm3JgK3ia1VId5OTkgqJzkL7GkaxcLiX3gJvYBQH3GDMGvAnQLTt6G6o8pW3YtdntDvnc1hk6U0fAoorVdA69l31fpdejFHA/cIx4yreQhEgMBySNdo1LkSuXRTpq4FBsewYxTFlFxbJpGxsa0bsI6OYN0WbFgxaIkbtGTJo3Img1aNW6aaDZsgmmigimRJJMqZSlD5eMYDMK/qDt5WajcMt+c9YmVc7o7n2nSOW9exDM6hH7xhcZZuvcxIBAN7mMrEt21Bf+hVVQG+NfjbqB71Ed1Mm9tok7n+oQpVQ9pJbT3iv0ktdplMzlRxELdC7YbxruJIj8RhR/FI1tM1N+UpREG0tquTbPF/nR+xwPcXUtxqvid8RdxLSHqTFXnTm+C1Nq5+l7GjuV2lLRcZrel2Izchvmcv39+nG10sBW4/cHRJMvlFUE0l3SGRX0nPMB6dzhvbrSwsPbN70vzXXlMeugUO4PQ9WJuFZqSZKiHs+2n75YZWLfAJjqKPKKgY4JlTIKvU31YPSUpLocr8G0M7iUsd2sJt23Kvxi/rIvjg4f6309CfaIeqjtOdm5LYLr7J0ZNEZCDgnaaS6pEVmdRHEXOMZyLyRz3zfFkbgOptYVquzjhqBPgk7mq1/Fr7Op+wAL7bBdpKfmxEoCUDSAh7jeoGMHqbOIbBvlU1ZQ7nsu9zDav0rX1Vn7pbZx6cCNYit1iLdTMzIrmEQ9SNI9m4XEofvH9gEIAnMAZy/J7PPVtG4bNrfNvi30pLgz3F5AdpwlftThv8p16poOlSrSduthfggn8zeOdSLFk5eCRdP8TqtUvUWdFy3WckKGefOe/wCX11obyL/UOb2YCy2Zv0LBqLhun2VL7lasUBjMJUfWcOzYLIukDpytqia42sa0UYzZ3C66uNn9StLJIqG5v9K3x/JxWtt1+QbZKTmRvG/Z2X1vrqbl/kcSrqj1+w/imzbR98ukKjoLxsxm2i3a33B1DPtcOVFSh9yBj+M/OvODt/oThbwecfoJp1bTSOsqy9gWrlNVk22HaINjVaC2tR250UBW1vqtd3c7DMrotzijsGbkHxgVbKqEtS560hTOatGan0Frxr9tTNQ0Kt0OB9yZE3L5tX41BkvMSHsExVZaceJuZmYcmOc7uUfu3ShzqLGMIdxfz/PrkQ/lGdyPlc85/Onj2rjxxJaV5ydso7aP2ThYGCS4t2ezeh5YHJVkUWr5GmRFb1awOqT5WtyjFWqKi5pFNuNenWHQdX5R5r3d0ZcDojC6f11ZbmLJdQyYTcxHsTkrNZQOUQMV5arKvEVth6mTIL6VbAoqkQTKEmF+lu58sV5dda+SbbSRpXYG779O69qk+9bEK5emfTiex912ZsqsCy6jaz3OUq8Wk4RVSBN5VJ5oqZ0JzfbhXqzZs45o1YMGjdiwYtkGbFkzQSatGTNskRFs1atkSERbtm6KZEUUESESRSIQhCFIQAD5OMYDGMYDGMYDGMYDGMYDGMYDGTEcv+SrpjqTz8b75ppl7AeO9GU3aFTkdfs67Xn8c8ldUmgaZNXd1aBjkZ9CUfbkllkGD9rJKxxq2aNgU2ToiqsuenfAYxjAYxjAYxjAYxjAYxjAYxjAYxjAYxjAYxjAYxjAjD8x8JJ+Mjy+8h+U2ksHLXWm3JVlXN5NYht7UXsnXYtCjbNauEGgCiq+uulptlIwCLlksovcKhK2ATuX7cDN/YUJ6+arykGtRFwnfHN4xre2b15MSFUrfQHVZBTdrvzoqfOxsdXq7xggr++V4xVqkTFeqRY/bLxMv/f1NuxaZd+dtR8O1aivttdT7x2PGbL1LUoBIHUzR67q9jOrW/YaxCm9UAkoB1YqbHoOQQavot3dZf7ohKi6TU7T+mL3Vr3ZHjQg9d1eCg63dNFbLvFQ2W0iW32riySVlkj3at36TAxlVnTucrc20riz5wuqZV7THzdsmzjmjFi2CiX09Py/sAP4/wAj6gH8P19f45/MYwMcfPF1wpyH42d2zsHI/h2wdyt2/PuulCLJpOiS+zGki1tEizMIGVRdweuGF1mo90gQVG8syjfRVsc5HBPMv0zPJP8As9ePRht+ejzM731laXG0HplykK7Q11Ai7q+ro9T2JgBmjtglPXqPMKqxvtb2X3mSOB26WVf1H12svYnkP4n8amtXyqjlg8rJ7ADf0VbMdhdA2SKhWDmYbAcB9lH13CsrSZwt8STSIt0mqYwJmVOW07X9GresaHSdbUyPTiahr2o1ujVWLT9vxxtaqcOygYOPJ7SkL7GcZHtW5PaQpfRMPQofkGBy7GMYDGMYDGMYDGMYDGMYDGM49bbXXaHVLNeLhLtK/UqZXpq12iekDGIwhK7XY1zLzcu9OQihytI2MZunrkxEzmKiicSkMIAUQwQ88W4bfsOu89eLPRckZPePkD2LC1qzrMylcLUnnytzCEnerbKoED7hKJdrRp1nhklkjv6hU9hNUwWFI6J9y9Q6spuj9V6605r2NTh6Pq+lVuh1WOIREpm8HVolrDx4uBbpIprPV0GhF3zr4iHdvFV3SoCqscRwL8PdLs3a/SPSHmb3LBPY1PbkpK6P4vqs6kYy9F55pD48NJWJiBkStAdWeQZDAqP2IIq/jjHZ63odhaUjKUc4DGMYHBdn7Fq2oNa7B2zeH4RdL1jSbVsG3SI+wfsa1TYN/Ypx2UFDpEMZCMjnKhSmUIUxiAT3l9fUML/p4Nd2id5t3t3Zs5mCe1fIP0ZsbdUouchwXb0eDtFhgatCFFdJNz+GMbU42PIwBQI3ZDXZqINHs0mfwquOTfUNbkstY4ghuZtaLGU3F3PuLX3NdHiWwKGfvYqdnWUnbzIgQigAyfoNImlShgTUUBvdigil8hwWR555HNm1zxY+HO0VXXb78NlaPo6ncraXdtikZyTi5WOtN9eMbS39VPQZ6Hh0rFsp24WO5VdPoN44cA+XVUKuE53KQf8Ai3fUbXbfLj3WHR/PFtl9lQCxm5XUOpQ+f1o2haRFooImZoGtOwT1rYR2KguVXibmyKpJmKk4cNr2fUf0Af8At/D/AF9PX+H8P1/PJb/pV+Tx1PxlsHp6fjDNrR1DfBa1xw4b+iwaq1IvLVyEVbqLACyBZi9SOwF3JUSpoSDKNr7sxnBEmp0akMD/AJOYpCmOcxSkIUTGMYQKUpSgImMYxhAClAAERERAAAPURAMk+5a3xUNtdd+T3znbbA8hzzyRTLBzVycKiv8Au85B0NkZazSdOdqFXSQlL49cxjaurImdtl5Te1ii1U252YJBqF5yOs5jlXgHYqNBVcK7q6IkY3mvTEZGCCk25tO0UnkdNyMS2TKq5+9hKS3sruKdoomKhZz11qdVBd+2MM0vmOUW444g4B8JmlSpzO0bLF1PZvQsdViNTvLhfLBPLJVuumFFRVSRG7bnk7TPMGj5RN8yj6Rr0iTlaOcpEIHev02vP946w626d8r++0DzM2W2XGv0CTet1BaOdt7Q+SY2PNwIrpm+1aUShyzOkRDZq4Fo1ib24jUkUwiUio2zf454x8e3JcHw/wAcaI5qiE2J5OgUpie9yzFIpU7Js2wGPYNi2AFQD5l2z+2yUqER90quuygEYmKBdRCPQAPZ2BJZ9VD03Npas544E1sV5K37pC+Rl4tMDFmKZ9I1OqTKMFryrqoHVICxLts+QRkYz9wwBIa4EqizcpilXoi4W5ig+NeRNA80wabf/wDFuvIiKsLtqVP4Zi9SQq2LYc+mKaaYCSfvUvYZlP1ATkSekTMdQSCc0l3Jn/8ALH9RjtPpF4Qk9objt++mqOsP+8Qi8fpx2GvNJnjFTmXOiraNkLSO82CRxKJjsZgABr7U25LgsBjGMBjGMBjGMBjGMBjGMB+n6Z0f0xu6A5r553Xv6zHblhtP6xuewHCLoxypyLitQT2RjIYnxiVVRzOSiLSHZopGBVd4+QRSEFFCiHeH8/2/9sl/+qS6ckaHyLq/kikLO3OweuNlsWj2Giljnknuu9bP4aYexwNW3+8/JYthSuvI9gmoZNKUbsp1mmV0CTkiQdOfSo8+WFXXfU3c+wG6zizdAbDLRKtMPSpgvIQ9Uev7TsSeaGL7lDM7Ne7K1jFxUUARkaK4KCZQJ8q1ceeXOJudY3krknnnnGNSaJm1NqyrVicWZFSI2k7kDEsjfJ1MEClTMaw3V9YJ1ZQoGFVaQUUMdQxjHN6jwGMYwGMYwGMYwGMYwGMYwGMYwGMYwGMYwGMYwGdUb13ZrrnDT2xd67amyVzXWrarJ221ypiFWXJHxyXqmyjmonTF/MSzxRtEwcYmoVeTmHzGPQH53KYD2vkzHf1glvK55BNfeKbWz56fmDm+Ygt5eQa5Qy5mzeUkIgUXFP0oynGx1EzOjqyCDCRYFFRRG0S7mVO0LIalekAOxPDVpDZHSGzdt+ZTqaJFttXqNF5W+Y6S+EHLbTnMbJ99tB/gyTkhjMXttaxzNsyk0E2rmRrjeQshTnS2VKpnzd8fxzeL76grpbit0YYLSHXZJCU1e1U9zaHI5lmz/bunSsRIYqKiVfQkNh6aaCo3Ko5nVgRTUD0AXFmMHCQ9ahYeuV6MYwsBX4uPhIOGjGyTONiYeJaIsI2MjmaBSINWLBk3RaNGyJCJIIIppJlKQhQCQ/6oXXth0vsXgbyQa2ambXXTmzGWu5eZJ7ie+RrM4G6dNtFnCIAqizaykJtUrkqnyprllyJJgmPyEdBYJnxXz5lGMnklIum7CPj2rh8/fO1k27RmyaIncOnTldUxUkG7dBNRZZZQxU00yGOcwFKIhxTWt9r21tc0DaNScle1XZNJqt9rLwolMV5XrhBMLFCuimKIlMVeOkWyoCX1KIH9QH09PXMzzidKf7LvjH6bt7B+LC2bAqZNG0j2HAjpWe3AsFPkl2ChhD4n0HS3lstDZYv9akaCFREQVKQwBOX4TY555E/Nt1t5CrIzUe1HVzi73OlquWqqyUdKbIXf6s0pCufuhMVNaG0zFWkzZUwAujI11m4bNmwlKZpc5k5P0wnNA6V8cyO2ZePO0tHT+x7HsQVlylI6/YWqKG1/R2ZiFIBwZqrwdns8eKonMq2tZXBRBFVIpaNsBjGMBjGMBjGMBjGMBjGMBmB/1EO1LTD8Z685moM42gLn3H0Zq3mkJNysmgSPqFgkVZezvllTqJiSOXeRlbrs0BTplUhrE/RVWSTVN7t8M8C93eNvmzyLR2p4jo5G/OIzT9nl7JAM6NcnFPLMJ2JpHx1jr1kXbM3Tt1BTsdGt2D0YtxDzjdsZwWKm447lc5w9WaU1JS9Cah1npTXcclF0fVVFrFBq7NMiZThD1eIaxLRw6MmAA5kXxWwvpR8p73EhIuXT5yqq5cKqn7OzjlOqVeoFRq1EqMeWIqlJrkFUqxElcvHpYuvVyLaw8NHFdyLh5IOisY1m2ag5fu3T1cEvldOFlzHVPyPAYxnHbha4Kh1K03i0P0ous0yuzdrsUmuYCox0FXYx1Ly79YxhKUqTSPZuHChjGAAImIiIB+eBPBsn39s/UMal12AuJPUvi/0O92pZUCuCLQxd97VQi3MIkYQKdMsghHz+t5dugl6OUn+u5YjhyQqCrIMxvqfNz2jozq/j7xt6kULMWBOSr9mmodqosdJ5trds0jQ9ZQcmmmVQ6Lyv1sjuZBRJuoBYrY6a3yKCB0kNQfAU2NMaJ7R8nu5PhrUt2l0NtPbj2clTCZrAaR1TI2RGNQ+6Ep1EIir2F7sqNFJsAoFioCMAny/bplJjn4Xa5PeTbzW9F+Q+8RTl1R9TzFm2fClkG6qqEdYbem91vz7T3QqAdMXNS1rFSsmxWFf5W8jQI1dNEQMB0Qtk570rVOcdF6i0LR0gSqen9d1LXsKf4vhVfN6vCtIo8q8L71TGkZhw3WlpNY6qqriQeOV1llVlTqH7hx/jnnnrLoercnc1bs6OuJ0Rg9Q69n7f9msY5AmZlq1FvWK4mYggYHVns7mIrrIQMQPu5NADHIHuOAYE7xutX7S82if7ZzCbfkXwvafmd77XnHTkVaqG+3jFC0pupACoKpfc01CKjpICqJCqye6euTcjxMXhmi2Znhwp9r8sHmH315KNtxL4+utJzyl3pkVKgquzi7fLkc1XnyiJG+Y7Q59bUSGe2t8vGujlbWuuV1+4ZijY/kHzJ0Tta1cf+HCKhbPJmP195oNtWzqDeU0AKo2FHQB5dCcim74wpgs3abAfScdMxpD/AB/iMdftix5HTxFqqmlXn4YOJUuFOA9Pa1mYksZtS+MCbi3V8rcqEilsO+sGD1SuSP8AVJqi4odbQr9FVTMdVL7yvPHTc4ldiYwar/z/AD+uZg+YzrwnFXj03/tmOkAj77Ya6fUupxIcCu/6R9mIOq/FSTD3KJkM7qMQedvfsMYxTt6q4L8S4iCCun2RTfUK3a09y+Rji3xWauklSpxk5W5nYR2YlVRjLpuBZr7ZaZa+5Qfbq7TUc7u6ZypEP+FXeWD4nQggUgaLfTDcjm0FwK53jYYtRjeutLce9e9yRNN2TVtMGRq+smqpQTFT4Xy61xuTBQ6xyrxdwYKFTSERE9IecQ17RKvq2g0jWVJjEoama6qFaolRh0fT4YqsVKGZV+BjUQKUofGxi2DRsT0KUPakH7ofpnL8BjGMBjGMBjGMBjGMBjGMBkPsDcEvL79SDXJiLAZ/nPh867yDcJEF9CP4Hnuccu2NhEolJHOW196HsMe4auVUxVk6SaKbLA8TjCELud57O+/9hfhW2I1CX/D949D/AInp7Un26wJyMMjJxph2Bf2/qmoJC02rOjIx7snodpbbDUziApHUEuev0oXKiev+Vtu9Zz0b8di6FvpqXTXixDHH+jHUijqOcvGCxwL8RJzY8lbY6URSA5FT0mKUOqY6fxIBV9/y/n+fQP8A0/tYxgMYxgMYxgMYxgMYxgMYxgMYxgMYxgMYxgMYz4j+QYRLB7KSr1pGRka0cyElIv3KLNhHsGaJ3Dx69duTpN2rRo3TUXcuV1E0UEUzqqnIQpjAGa/lh7yT4G5QsF5qiCU/0Bst+jqnmmiJMyzElaNt2kgsomQTrpRM6m4qoEV/aCUZIoKJybhCKrRlEnliYib6zxJ8FLcIcvoQ9/eDZemN3TzvcvUN7cvhmH9g2paRO9cwxZhQgKu4qntnRopJUFDt5KwLWa0IlRUszhIuanFse58vfkiufkhusXIK8fcWy0hpzhWvS6DhswumxmTkjq17w+0UIVB4DRUW82zWOQFW8o9oLAV/xbW0gkNOOAzJvzic8E6T8X/VVUasQeWOh0c28KkYpAVdt5fTTpK+SRI9P0H5HsvUIizVtJIhDrLFm1EW5fuVERDWTPrJqFirHDS1enGSElCT0Y/hZiOclE7Z/FSjVVjIMnBAEomQdNF1kFSgYBMmoYAEBH1wMQPpzuhT768WmnIyRflkLJoKet+g50wKeqqLSpPkJ+jt1EjCJkyMtbWymxiQgPxqiwOdP2fvIpZHfVP7dse3dt8QePHWhvxS23Cyt9mSldTWE6cjcthTp9N6SaKFQKqZu8IutsoihFEVnBmk8xWRSTTUD7rlX0wstLaM6K8l3CVgfHcr6s2GhLRaCvokuWV1leLnp7YL86PtIBjSBk6GU4kRSBuZn7TAYF0ypdDcdlN5K/qVt0b/AHYqTmq+Wpm62WtHWAhok8TpZFjpHUqsacBOVEZW6vW21Y9Aog4cLtJJ2qRIQdEIFneiNRVrQGlNSaNpyRUqvqHW9M1xBiREqBnEfTa8wgEHzghPcBnsgDEX79Y51F3L1w4cLqqrKqKH7XxjAYxjAYxjAYxjAYxjAYxjAYxjAYxjAf6fz/nmI/1Bm/JLTPjZ2bSqiIuNj9Q2Op8x0aJbLFCRllNkvVj3BizZgqms8F/QYa0QvtKYEEncwxF0YyZwQcbcZN13b7evPOP45OQ0Vk5Oicn1Kz9obaYJtvumjext3pFqAym0FSAkodrMVCippFMJm6cfsRQxyrqrg2KHWfmLv0T4xfCJqvjKlyLVne9nUKi8utTR6hk3MhCx9bbzHQt2BMopFWaWcqElBTRiAUpX+0WiiTQiAnBv6x+nT5CHl3xwa9tU/Ffh+xenXy2+7UZZNUrxKs2Bsgx1TGGOqVNQGf8AR8yiLORqKRAaSlumEwFUDCurgN5NJl/5fvOvqHh+nvXb3T2h7IGn7I/iveqhHt604Uu/UdsKuiuJGMmzRhHGu26qjhmi5mKVAtUvY9fJ/cXkQ8TF1+Ji4GEYNYqFhI5jEREWxRI3ZRsZHNkmcewZt0gBNBqzaopN0EUygRJFMhC/uh6AH2P8/wA/rk3PncsEl0rtbhHxQ1CTWYqdRbfj9t7/AH7FwCLit87akWeSEw/fiY4Ilj104+5XJmqv8Cf4zqdiiZ+0SWWFSkbPzyO1e4AtF+8mvkCh5Yh5jb9hfeMLiZ6go5IpHavr8aye9G7TrixFClaGDXwVpqykWLz8Rjprooi6abZFJZBQO0Ob6/Heabzsq7DaRCK/HPILaDVpMKVBQtcb6V0PJBCaXqjVudwokm32ZsJx+27+CMqqRevSNualQM2ZHTLfP/7f9f8Av+X9/wDjmBn06PD48j8BVq/2qHNHbb6ucRu5rh9ykZN/G0hVkshp6sLgdJBUiTSpPVrgo1cJA6j5q+TbFU5yNkgJvngcWvN0rmt6TcNiXCRSh6jQqtYLpaZdcQBGLrlWiXc5NyKwiIACTGMYunKgiIB7Eh/MP1yM/wCnpptm7i8jXbHlN2bHOSkjpuwQ+viPASUbx1v3A5eHPFRbgvyHE2sdPxTGlin8gAEVc40fkdH95k9OfqYeth548eEtqaBkDs751jZ2uqWAt1ATeNdexAtrRtORIBjgCjJ9EtYmhSSfsWMLa/CJSkMUF0fX/hJ5JNxx44tBUCXjDRd/2BDqbx2igqUibsl22i2ZTCUbIJkL7SSNWpyFRpbwoHVD560YSrHKYogGsOMYwGMYwGMYwGMYwGMYwGfGePGkc0dSEg6bMWDFsu8evni6TVozaNUjLuXTpyuYiLds3RIdZddY5EkkiGUUMUhREPk/4ZhL56+nbpr/AJupXG+h1lHXTfkGu7LnjXkaxXUSfx9KnnsZE7IsCp2hzu2LB2ynIukLyH2ypWjW2yMoT2/gyp0wjR80fXNh786QmegotzKL6TQu07zxyZBppt1SztF1WSNebCvn4UVws/Rd3y63WuSVemGrIPxqNcvag5cme6/XaF/Rh4e59a8qcgc4c8N26DZ1qrUVNrVh+3FMyTy5hEoSN8lSCkJkx/Gro+n5cxkzGKJ3pxA5y/vmhma8y0i++dPi3x8a3L+O6h4dT1RrywOzIJJR1skNJRst0t0NY5xsiAN273YG05K6wMyscqLlZw5j4duokRvFIo/ogf3+v+X8/wCnp/p/EGMYwGMYwGMYwGMYwGMYwGMYwGMYwGMYwGMYwGT4eaHoHZW5bRqTxB8mzibToDsgyg7stzQ4vWeleZmqbhW3yVqRYe57HhdY5tIlUS+Ruu9qMPOQpAK9ulcXU186+6k1xxfzhtXpXajn2VTWNaXlixSLlBrJWuwuVE4+q0uFUcAZMZq22F3HQUec5FEWyz3712BGTVyqnlR4TOWdhmg9p+TXqhmLnrfveQPdiISDZ0i71XoF44aOtea7i0HgidgzlouMgJwGxSlUQqkbr2FdlSkYGQFUNfeb9Aa75Y0Vq7nnVEZ+FULU9SjqpBJH9ovH32pTrSk9LKkKQrmcssw4kbDPPAIT7yZk37kSl+X2h3bjGAxjGBAbc+izeNDzc+Xe+P3ZYmcuHOfQb/XXyLg0TfbD2xAar3rrMWxxD0VVVsJWiSqqJFVkSfiIEAyqayZtNfpO+c1KdytvbqCcaD+Pb+2m3qEA/dFMs5c0jUTJ0ko+QdLAKhU5S9W63MZAiRvR04rLRV0ZQ7dAqGJ/1UdejYTycQ0kxQIk5t3MWqbDMKFIBDOpFtadl1NJdQQ/NU5YmsRbYDj+98bciYf8AZcZ40tBl5i4G5N0idqZlK0/S1Rd2lodH4DIXm4tD3m/kFL1ESCF1sk+Ie8flOA+9QAUMYAD3DjGMBnkbs3uPm/gbUx9xdJXgtWrziRTha3BRjU0zdLvPqFBT8EptabqpOpd4g39Xcg4FRrFRDIpnkxIsWwlVP3/ALP2ZRdNa8uu19m2OOqGvte1uWttvssqt8LGIgoVoq9fulBADKKq/EkKbRo3Iq7fO1EGTJBd24QRUly8fusbR5qO17V5UOoamunyjouxPdecM6Osax3cE5mKxIN13V/moVf3sZM8O8TbTdgdgmsxntmuUYVN4vB6rRhzBtJwr5X+MPIc4sMDoC+S7TYtVbKSU/qbY8ArTNis4UiyTY0+0ijupGKnodJ0um1fOq7NS54dwq2Tm0Y0X8cLvSPJovPhSGnKEzy35cdKwzev72503pUKXs93CsVmJts6YvDGZjZKtXZ7HICm7BIG6lMYvpc7QBhL3Kx5pQzppW2Ab7c8b+1f1LpTXXQOmZ09j1ntGvp2Grya7NxHPfhK6cx0jGyce6KCzCYg5lhIwkyyMJwaSsc8QTVWTTIscO58YxgMYxgMYxgMYxgMYxgP8Mji0D1zF64snnZ80s0unJEQvpOUOVlpIpCsbM7pKbGs0yKYkUBUHbGXVb6SnpxlHpqlZRjKwSDkHApOFkqUvId0CPLHDnU2+274Y2Z17pm4u6g8Kf4hTv8ANx5qxrlP5AEDJi4vc1XW/wAhPVQny+5Ih1AKQfz4Oj1bs85b8YXiX0zHSL/YewG9f6d25AFMskpPby6yklHOjq/OtkkvuGK9J0xYYGTfqO2apW8XdGT1dUFY5yRAN1fpU+SZZxCdA+Q3ZiDyTtm05uS1NrSdmBK4fyMS2l0bRuK4fOsCyzo9muZK/AkkQO3cJvKlaW6vzov/AHBYrnn7lPnmocnc4aX5xoqaYVvT+v4CnovCpAirOSrJoC1ltLxIBEqcnbbK4l7PKgn6JDIyzsUiJpCRMnoHAzN8wvVv+xv47ukNuRsiaOu0lTVtYaxUROZN8TYW0TDToOTjTAYpfu6m2k5G8CBzgUW1Yc/urm9qC0JXEXKq3fHdnJnCqLd260dyzWHMrvNVEiYNjqRU6F/6TkXTln943XVtW151jz/VrQh9ynJ1SI1vJGKi2R+JtsH9Vr1yrGbN5W5ar0gYR19GSvTVtat141yiW5SK0pS9MGko2SaSMY7GvLxNwmJOEkGTs0lBWBIhkWrV4V0p78+mJ4U/2eePJLqO6RH2uz+tXDKagxdoex9B6PrazxCitU/kOoKIXaRXl72ss1FJOVgX9JFykZaLIJQphaNGrFq2YMWrdkyZN0GrNo0RTbNWjRsmVJu2bN0ikRQboolTSQRSIRNJMpU0ylAoBn++M6I6g3xWeX+dt09C3BRIsBqDXFpvLhuqc5PxV3CRa68PAoCT94X1imhj4GPIUSio+kWyYnJ7/eUI++8B/wDFS+od0ZyG2As5pDlFzEQt/RSAHMM6Z0dEm3t6nfEP8wN152VJDaQemMiQgSsNGlBA5Ti5Xt7/AIfn/wA/7/y/n9fy9f8AnH59LRoOy3h7195H9qpqSd73ZepfW9asTtNIjiSUkJxLaG7J1MD/ACLnbWO4yVLaJLkOkkV7WJhsIuTlN9vYHgMYxgMYxgMYxgSA9o6Q8u3jC7F3n2VwIvbumOaOiLsvtbammH8ZL7YXrdhevHMrYIOboSLtS6oV5moo9CrX3V7mOkYSpKNKrYzNGFdYuZb03y39UDxZsf7eodYVHYvIG0WKhI2wFnoCZ2BrYksT0bqot5yrxCl6hVjuynM5Z2jXsYxhEVUSurG9Ik7do0x55l3zxfyX1AkcvQfOendtvBRTQRnLnQ4CTtLNJJMEkyRtuFkS0RYESD4iDHTDQQTACAIFAC4H/em+z+RuhU2xtH9M6L2m5cgl7YmlbQp05YUDrAUU0H9bay55+MdnAxRBnIxrV0AGKJkPQxfX0x6fx/h/8f8AcMwA2l9M74ptirOHNf1ttDTbhyUwnPq3btnOimscPzXbsNl/0kRrYxTB7yIIM0mJB/cK0+P9wepY/wCnOcUQAb6U8pHkB1bFpnIDdgx2KJvhRS9ARTA9Uf0Vv7kwD9w5GSRSh6e1IvtEBCk569ZRjJ3JSTtrHx0e1cPX7984RaMmTJokdd07eOnB00GzVsgmos4cLqERRRIdRU5SFMYJSeTdkQ3bXcfZHmw2um6Hkfg2g7A1byI1ky/atJJpQapNz2wNkskHhXDUXi1fkZuVbOiCVcknsmJjfeZ7SSJpeFPJ7xv1NzvbeeeO9Y+VLvXqDoLtW2rUeM0tet0X6PojHVb4jqBs1n2KiS9T6TurPl3y0YqwesmcK6r0XeJV+dZnWV49zwny8eJbRvi+8f0HLQ/UvVOy7rcNk1TWVH1zYb7Cwuk0X0uhOXbYNiS1ZDV8XCbNVhXJUEiKWdZBlMT8YrJKyjxUh3Af5/TwbQ04j1f215HOwd3aj1PISaEpDw0ptfYlYqR56+73vD3YmwpGtEssmydyr+BZVthErfZEXdHa3cjVBFYy6xUaCdq/UU+OqoTatL01L7f642Kf1bx1M5v1TY7KrJPxUImRuzmrSnUYaUblFRNRd7W3NhTIkJityOnYA0N4o8KnhL4etXC/P3RXS/PUHtnd23YaW2Ks9vUxb39djahN2GUHXse1oxbC3pD1s8pKEFPqvZGtunrh3MuEzOVWaTYApj1bpHTGjoMK1pbUutdSV72pFNC60o1ao0WoCQCCQrMa1GRjZY5Q9R96qZ1BMYxjGExhEQwgV7P85XXyh4zlXx81HiiiyazRsnuTtOyuDXGKaLgBlJVDVR2EHYWD0gAY5WrnXl7YEST+JZQy7pH4Pd3A3F/XHPNqu21OuO/9o9cXrYlZaQ76gu4wlW0hQpJCZ/FDy9DqSbxRk1lPgKMX+JREFTm7qPcOUnkGqCUd9hqDjAYxjAYxjAYxjAYxjAYxjAYxjAYxjAYxmXHl07wPwhydN2KkpqTPRm45JPTfM1OYtQlJea2pbEhZNJxCHIYXD5jS2y4ziqZEF0X03+ztbWAi1jaiIZsdSrvfLt5TajwzDAeV4h8fM5C7d6/eoHUPA7L3gmLtGradkilVQSeNGRyPaq9bpmKukn/S4YTEeQkKqemlBBFsii2bIpN2zdJNBu3RTIkiggiUCJJIpJgBEkkiFKRNNMCkTIUClD0AADNLxOcGJeP/AJIrGuLK4JPb12DIONrdHXZV6WZkLLty1IN1plkewKAZ3MRVTQIhXYt4uuqSSWaSdkApHthkDK6ZYDGMYDAfqGMYEJ/1E2to7afmt4B1wb7JyptPWfMmvZKOXApyKI2nqzbNcSO+TOAEM3epS6jb0Mb99NooU/tL7RG7Af4fz+np6/kH/qP8cgD8v2w1LH9SBzfFN3AqONSbR4NpiZDHAStFnd1p+0U0QAREEymHYZHRij6B7nBjiHof1G/3+z+8PX/1/wDn/AcD+YxngjyZdt1vx98cbW6LlwZvbPFsE6pqitvTiQlt2xaUnLSnw5igU4qMWSiLy0T6ZRKoFXrs4qiYV00ynDC7y/7a2J5Ke4NQ+FfmuyLx9IYSsPsfti8wxmjlvBQkIpF2EsI4c/KKKqWvYRdpPOYVwYG85s6xUKuOTspGBcFGn/TupKBoXVlA0xqyvs6trzWdWiKfUoJkmmmmziIZqRsidwoQiYvJJ6cij+XlHHueS8q6eyj9Zd67XWPhD9PHxJZ9RaAtncO+zvp7qLu2QV2nYbDYSKGsEfrKek3VmrhHYqJJkQk9kSci62bOqMiJIvWMtTmjlFJzX/hTonwPDPkz0sXoXx+df6jKiK7+y6Fv76volS+f5bbUYda6U1P4wEphA1rrsMUTE9VCFEVEynOUpRx1+lO2w5unjwvWt5ByZVzpnoq5xESgJ/cRrVbrWqhdmQEAR9U/mtcpdlTJgHs9RBQDGOooUlNiqKLhJVu4STXQXTOiuiqQqqSyKpRIqkqmcDEUTUIYxDkOUSnKIlMAgIhkgf0i5zk0/wBuMwSMg3bbb1gZFIRESpHUq9rSUSD1/P3JkbIFOYf3jB7fd+gYFgGMZ/BEAARMIFAAERER9AAA/MREf4AAfmI/wDA/uMj483Hm1tMbtemcQ8E7ekW7yUVaK763zzuhD7Y2BFHdvnbVTVOoG0NMskFb5CMmDiXs6kZZ69KllHUJVErVUjtrY4S8E+OzY3lG2wO/t0cGdE9g7HkuWk6lJ3LRXY1xW29St/jMGmVbPR6+ElIqR9G2izj4YzlOmMDOrQ8bvAQJsWuzrCIj7CF/uM8EeN3vah+RPmavb1q0SpTbYxk39J2/q94++9ltZbOgCo/jlcdrKN2bhzHOm7llO12QcMWTh7ByjIHrRjKoSccz974DGMYDGMYEzP1Qm6Iqtci6N50kJmQhWfSG/wCEXvLuMaryLxppnTTQty2FMJRjNFw5f/s5NSNCnjkK2cEImwOc6YmBIS5WfTg8+zfYnem/PI3tKBbp13Ua8kx15HAQXMLGbU2IxWjISDr5ngqipDad1Ek5gY1oqkVxFlnqK9auU1472m6F+qg3u/2R5Bdf6Jrrh67b6H0rAwi0WyOus6C/bieOLZNotWrUfkOrM0ZxrhiZoCaqjsnuTMRUiqJC2N+J/jVvwnwhorRLyPRZ34K6S+7hVT/NV3tq+JozlvbrLAJSuyVcyjKixjsqSH3EHVItRVEi5lfcGjGMZkp5re7G/BPB2y71ByKDXb+z0ldOaTa+9MztK53COfpv7YmgC5FQb0GrN5u1JOzIOWH4+yrsRIJ/HNIlOEXduo8z5sfO9sCvQzt0/wBV2fcsiyl7BHKH+0heYtDJsqirPMVUlUyxituq9YYkiFEzew10vLE6plFXiqp/0l69XoSpQEHVa1GM4WuVmIja/AQ0ckVuwiYSFZox0VGMUCfuoNGDFsg1bIl/dTRSIQPyDJlfpf8Ag0ug+Uprri8wv2uzuqjImqBniQkeweia67ULXColMoIoft/YU31ucGIQpJGAa0d1+YpBlQWAyVX6qzqR9RuWdP8AIdQdOVbf07sNObs8RGCu5fPtcasdRki2h1WLT1XOpZNmS9IcRBTFVB8pUZZq3brrJmUbVVZEXNp/+Kf9TMyizf8A3Bo3hh03K6+P0k4gsdzXIjIvCu0ij+GrtLH0zYiQrsFDHSka4qRJYr5NuDcwVReOzl1nxlxRzpzik1atpnX+uIgLyozBIUX2yrH8tp2PIFVTMf7hJzdpqcMzVOqsYrArREqpk0U/T2ljMefKH5htL+OxjEa4hoN5vXrXYTdslrHn2oqLOJIHEysMfXp29rRqD5/DQslKmSaQkGwZurZc3Xqyr0eVqD6cig2CWWRbpKuHCqaDdBM6y66xyppIopFE6qqqhxKRNNMhTHOc5ilIUBMYQABHPCO+fJdxToXVW5tnSnRembq50nVFrLaNe6+2pRLbsNRwvIM4CvwSdVg52RmmT6x2qUh60xcPmKDJu/k0VHq6DZNdVOFy27T8r/md3CrpMmxJLcT/ANzWatektPSy2vuRdGw60oRJNLcVxgXQRVsVK1ZyjdFmFkvthUSl0W9d2Q+tEXOUZp1boLxQV7bnkyovAGv9krbvhtYSBZPtfc9GbvYvWsJE1WRjpDY9IpCxzklVmUBIN2Wq466Sp2zmc2lOi5b1qLh4FBw7DeHlTgHonzjQc13T5Fegd76r0zsyWkVOaOZ9IW1KoQVeokW9dsGFnM1s8DZIZtFuFkDN4WTNVxtt5BgNylp/8IkYVs592+D3am4aBsvvHxpbu2BYdrvuHNrQyOoNi2946kbVM6avQzhYCFlHjpZRUzWDawkJORqCornjwuzyDZuzQkLDtGdAVfgIWpwEHVq3FsYSuVuIja/AQsagRrHQ8LDskI6LjGDVIATbMo9g2QatEEwAiSCKaZQ9pQDJwvGmom686Hmnct0jmQSJptoo4A3uTTcosmzdZEwh+XvWXaODJl/UhW6hPT1AfQKVMYxgMYxgM4JtDZdJ0zrm8bZ2RPMqxQtc1eauVun5BVNFrFwMAwWkZBwYVDlBVb4UDptWpBFZ46Og0bkUcLJkNzv9cmW81mzLp2b0Xzb4VtCTz2Mld1zsJtfre1wx1jhRtI1c7mwsIKWMRJZj7naEQ7vqsZImbnczENq+NKcULeCTgPkeGHWuwO1ej+gvNP0NDOI59t5/N6l43psogdM2vdFVx8vBvZliT3GYqrvGrFvSkJhiVE8lLstpTahDoXFI2ZnfVFbDnege0uJeEKA5+9nGsaxkVI5t7liLbE6KvcXQajGP25P31H8bGU9m/ZpF9DFZXARIYRdiBLV9X61pemtcUXU2uINtW6DreqQNJqEEzKBW8XXq5GN4qMa+oFKKypWrUguXKgGXduDKunB1F1VDjDzyWh/4g/1PG3tvPiqTlH0BsDZ92ZKJiVRgFc50i47ROqJVmb0VRbNXVzLR7YmUhE1XLldwuoBHrpyuULidZUGB1RrbX2rKsl8FY1pR6nQK4gJSlFCBp0DH12HRFNMAIT4o6Obk9pf3S+30KHoGc4xjAYxjAYxjAYxjAYxjAYxjAYxjAYxjAYxjA/4UUTRTOssoRJJIhlFVVTlImmmQomOooc4gQhCFATHOYQKUoCJhAAEcmT5IS/8AFz8p2we+JtFSX404DkH+lONWzki6tf2JuP5iOrZuaIUBJFq9QYEI3srcXCX3KRJjUChDg+qsgkn6Y84XU2xq3rTWXAPLy5nfXnkAsBtT1FuxeLMXVI1I6MZnsq/PpRqqVWAQXYqmrzeTXIQrWDWu1jZrkcU4xR06415Y19xVzRqTmnWqKZoDWVWZxb6aFogyfW+1Ovc/t92l0kPUv4tbLG5kZp2T3qEag7TYNjFZs2ySYencYxgMYxgMYxgfmcdcXAdm/UbyUqkqd6dHyM6J1+QSenvMprjYutdZA2J/xfvNj1X7Qn6/kkH5ev7ufpj/AJ/xD+f4/wAAz86DYHGmwdC/Ui6VpV9tdSu8vtft+ndaxknUTSx/gqtw3vP7Wj4+zx8rHszxNqatK86Wm41k6nIpugu2XaT0iiscyf6L/wDP+np/6fl/hgMjv8qLh/5OvNRyf4xWL1y70Xz8Vhsnf7OOcpopLSUjBo7EvZHbpMDAVZLWDenUavOTA4WhbLe5pIEExcOSjXTdrjX9eUy3X+2PiRlVo1Yn7jZZJQAEkfX6zFO5qZfHARKAkaRzJy4MAmABBMfzD9cky+m4qs/050n5DvKJf2S4y22NkzGtqQs8RBYYwtrnW+1L3CtHYiKaSVchD6jgGKTQTlSjiKNjHIkCZVQrqYsGMWyZxkazax0bHNG7GPj2LdJmyYsmiJG7RmyaIETQbNGqCZEW7dBMiKKKZE0iFTKUA+VjGAyQD6RuOcMtUdxfMKo/Ht3WEcIqF9oivHVq4fOI/mP9aIuk/kKH5lECh6iH55X/AJPD9PLy7uvmXWXajDdep7jqh/b+v7a7qTO6QikC8slUg4WOZM7BCtnBU1pCsuXLtynETrUikHLARwpDvHaSK5yBvFs/Z+v9La9uO19qWyHo2uqBAv7Nb7ZPOPtoyEho5IVXLhcxSnWXWUESNmLBmk4kZN+u2jo5q7fOm7dWNvcXRvXvmF150r0pObPvPE/h753gL26eNKcoeK2v1CFObOHX7OEegQpJeRs65I2EeNnziQ1tTp6UjIBvXth2iOnHLfsjyD7ktPma72P44NRX0mveFuSpB7sbtPeaUqjH1eVcUJf2Ws7ywKqlgCRVTdi6p9HbTS/4U4vCVk2DIoSFdpkc/j88fL15TK5vLUNO8dXjipA1jh+t2KuadVt0TCpRTLe9opj6BloGia4SkgTkFaVXps1aslknDkLZrXYpWtS9iWjYeejz3YPOfh10F0R12bavOXLSQ6Vqe65xi97H6YhG80urqHn2NVlUK1oDW8rNrHlELPsR28tS000Z2CZkbpXRqEfPzjKBrew/vf0JuUuUtI8WaRqfP3P9STqlAqaay3qut99P2WfffEaat9vmTJIrTtonVkU1JCQVTRRRQSZxUW0jYSMi4tl9NxhyfrDivnLWXP8Aqyr16vMKfV4VC1yUGxK2cXq+liGLa3X2wPVCA/mJ2zyrZZ6u+klFFkGn2cUzI0i46Pj2vqXAm18b7RtoPzjeYDmKuAk0pWwobVHT8dDMwFONjZ+wR9csdmWZtBIVJiq9mN6vEnZGYEQWRj49MQFJm1IhSVk4HLwOHn1LvkqdEBIzOI490tErHTIT3kcv6vzDINiKqFL7vkMRF4JimN7jJkS9fUqZPZR/gMYxgM+JISDCIYPpWUetI2MjGbmQkZF+4RZsY9gyRO5ePXrtwdNBq0at0lF3LhdQiKCKZ1VDlIUxg+WP6D/1/T/PMB/qOO0Tcp+Pez0CsSv2O0OrX7rSdaI3WUTfsqI6YGebfsCXxqInFqnU1EqUsqmr8zWQv0S5Iiomkt7AnV8dOuEPLZ55dvdUyjBeZ0ZrLa1j6McHmmQqpv67UJpCr82VKSRdgKab50aLqEu8inbZZBzB02yRxkiF9Dk/Qj/P1H1/9/4+vr+X6/n+X8f8Pyyfj6bvjNLmDx7VjZ89Hkb7J63dsd1TrkQ9XCOvFWSjTTkN8wEICjI1Ucubw2KIGOi62BIoGVUImmVOgbAZAx5I9lPPMp5t9K8NUqXfvOf9J357qV0/glFHCKxa+qNn6e2EzUQcLM03JWVTe0uDlCLFZO21MgH6I++VOmrU75je5keA+E9qbZhpNFnte3IF1RpBuKgFcm2VdGj5FpOt0wVSOoWjwLSdvJ/T3JKqV1uxV9DPkwNNH9JhzOva9w9K9j2dmq8RoVcjtN0iWfnVcGd3HYDlO136RRWOJhPKQ1cha8ydLrKiqZrelg9qgrHOQLi61W4Km1yv1GrRTODrNVhImtVyFj0vhYQ8DBMUIyIimKICPxNI6Pat2jZP1MCaCRC+o+nrn3eMYHmLtPoeM5O5O6E6MkzoB/RJqy12mHQcgUUpO2pxyjKkQhwOYpBGfuD2ChUwOPtFSQL7vUv5ZOX9KVzvJsdIdI9oXdJw+uPQOzv2Fr85JidWRkKvQPnm7dOoLCX2KIWvYFrfMJM5zHWVkaIAiRAiZTueUfVc9HOaRyPpbl6vO1RsPSW1vx2djGfvcuZCg6fRj5Q8as0QEVQNI7Esuv30aKhDfdr116i1SVURVO23d4G54iuM+H+c9BugYQqup9RQRb27UVQaRpLzJtVrftSaVXMoDdszeXqZtEsdVZc5UG6/uWcKAQyxw8/eWvyaUTxl81udhPW7Wzbo2EaYqmhNermOCFgtzVkkq+sdg+JRNdGkUZJ8wk7Mogomu/XeQ1cZrtHtgbvmkWXjU8fnTXmE33sjel/2BdIGmWmcmHHTHVLpIC2eYWtLAyMrpHR6b9EWZJmXrLpOCuUym1LA1WjO0qMjGJ0pZSvbW9u1ykNfqKPMns+etr2zr8I8t11evxqldlFIkJakxMnJxVLj4+SKdz+Ey+8r0FivjySaskJgdewjuEI+YycJEP2tveqNTa10Zrup6m1DS4DXuuKPEIQlWqNaYkYRMSwb+4RAiYCZZ08drmVeycm+WdSctIuHUnJvHkg6cOVQ8K7Mo+jfFZ43d/uub6RDavrWj9C7Es9b/C2yKszYNhsqi+bVefts64AZC02qcth4VF9OzTh26UFVJBMU2LVqzRyc+lR0XGVfira/R0tH/dbD37vGwRzi1vSi4lJGi65jouNi2gv1wUdqlNepXYD5+oK5ivHSqB1wMszKfPW31Il9d0nxLb5YMnH2rjYVr07QvkKIfIZo72bW7LJtkzCHp6PIysPGi/qBRFqs4AolMYo53B4GKa3o3iV41jEUQRNLUq3XJyb1Ax13F62jebeKyhwABP8A1c0kkkA+optkkEAH2plAA15/n+f1yV3wo7UoJNqebfyMbMt0JStK3Dqp3Htb1ZJFJrDQNO1zL7ItA/M/MBQcqKV3ZdAZt2rZNZ3JPfw9jFtVnjxBsvr15deuWHFXj/6C3CSUQjbtJ1R5rLUqRzKlcvto7EZuoCtqMSICQyi9cbKyl2cJ/MgAxdWkTFVBQpCmjA8UvJe/vKTQNW8gMndj1X45ufrw82t0pa4tJWFf7y3Zal0H7iDbOSqPmEtaImrt4Kj1ZM6ruOpFSiB2TNsEbJaoOqAGkW/OmOx/NFB9KbS0/c9gcieJflnX2ybhaLkzFWtbF6ZkdXViQusjCJvWygriZ8jDJieIK6d07X0Y4ayduY3C3qxlbL4SqXlh3PzD4HtX6gqm3LY26M3XurbNL1hcmk7IhedTc50WTrMhZJaDsZXH4rDPHtrk5Ci0l6oqLiOh5Kzfss7jndLjzxVSXmCV1vx/4ZOmqNrGvQmvKJFachtFUCn15oVnHMY/ZFmr+uRimKACdVdU8XY5WSk3jlVd8+MSSlZFy6equXCv5wWhNVXbqzbnNXO8bJLv5u+X2uaVobcgkKNOqVivUjOzsm6afhaZHMOlO3yz2YkkMssqyCKs6L1r9qWOFsH6oPjXntoWzgDjm3botMxddnW/nfVtvtNpsJwVsE0taatHz8c5nnIkIu+myw0lHIS0g++STkZBJw+lVl5Jd0up7c/1/u/t/wCWfQVOsQtJq1aplbZkjq7Ua/DViBj0/wDy2MLAR7aKi2af9pGrFogiX8vX0IH5Z9/geZexuq9bcUc3bU6W2osYaxrSurSLeFbOmzSUuNldnIwqtJgTuRFP8atU+5Yw7Q50zoMSuVZN4UkexdqpY7+B3mTYs1Gbq8p/T7I5+l++Zh3Za8i9bKJL0bQK0k3kKtDRJVVfe0iLiMXX5CLZKJmBCh1LW3wqJqGepG8p9WzUj5svKnTuGKLJLSnB3B0822L1ZPxEgipX9j7Nj1nDE9STXRD2vhTkSPdTxKaSxHDRM+4LQxUdt4yMUysOPj2MSxZRUWyZxkZGs20fHRse1RZMI9gzRI3ZsWTNsRJu1aNW6aSDZsgmmggimmkkmRMpSgHX26b+nqfTm2dpqkTUS1rrO+X9VNYfRI6dNq0rYjkVH+CZixolOP8AAojken0jOs1peX7g6JnhUfTTtXV2tIuWXH5HK6ss5t95vouFjAJjqPXaFGdGEpg9yiahlSiPxCFMPlPlXcL41+8HzIxyOB5M3wwKdM3tOmlL65n4lychwH1IYjd8qYpgEDFMHqUfcH5Y1fSZwLVj49tzz5SJi/nevbs2XWIICoLCF1DpJNi3VABESik6fSi5AMBR9jsDenoYBEKi8YxgMYxgMYxgMYxgMYxgMYxgMYxgMYxgM4zdbnVtc022bBvE2yrdMo1bnLfbbFJHMnHwVarca5mJyXenImqoRrGxjN08cGTTUUBJE3xpnP7Sjyb/AFyd3zjbduW8rHzj4gdCSirfbXbtqhZXcktHCZRzrnmaqTakvYp2RBABcNms65q05IL+33pyVaoNqrzpusnYG6awcW8P9Ds3cfUXRPmh3PEPWrPYsrYNG8SVaaSN76ToWnyDmvSlpZEEpW5X80s0dVdV61TQUGfDay4kFrZEhykvOttOamo2h9U660vrSHSgaDq2m1+jVOLTBL5G8JW41vGM1HiyKTcryTdkbi9lpE6RXEpKOXcg6E7l0qc3ZOAxjGAxjGAxjON3K2QVBqFqvVpfEjKzS63OWyxySvp8cfBVyMdTEu+U9xih7GkezcLn9TFD2pj6mAPzwI3+fkw6i+q13zdJMoPYzmuHvykQyUOYzaP/AKLdWVXQKZ0kxOPqJbfbntgAphOVOWdncJlIBEyEtEyND6ZOuWHoXrHyN+RO1x6jNxsazylTilVDGXKaZ3JsN9um/wAO3cGAQAlcShNfJCmUwF+CUZlTIVNIAyy/Awo+o16MX5/8XW24mKeiysnQljqnPsKqRQSqBH25R/Y70n8ZDFOog/1xT7fCLG9QSSPLoCr7vcRBXv7wk85E5j8Y/K9LdMjMrNdKIlum5/MkVJ6pYdxrqX1JtIplAAI9gK5MV+qHIYoKppQCKawmXIoc2HP1Tc0/2rtvxucfwTlcXmxb9apqTYtze5RV/c7NrvV9DcoJe0wGcJKPrwkiJyHATLlKUogKgHsMhYeOr0NEwEO1TYxMHGR8PFskQEEWcdGtU2TJqkA+ogm3bIJIkAR9QIQP1/XA+zxjGAzOnyx9aO+J+AOit8QL9Jje4+okpusFTGOCxNj7CkGtNrEi0ImYhllq0vLrW9REVEwOzrzoTCIF9ptFskS+q33S1nde8j8T1SbZudh7T3C32jK1dBZQH7eFiI6Y1xRHMuVIhgSiLHaLrPkYEU9/3b6punCSJ1IsDkDIPw3cfbO8hkVK8uQtutOs+R4mbhtz937Lpzx82s2/7nKi5DV+hWtjOiRBzFVitC8fLREu2eM65b5fZVukELIqbXiRdFu0dNamsHnb8Vnj90ZRa/SNKcuQ1Ivp9f1hgVvFsZplO2ffl4NIEAx15B5Y6Nq+juLDOSjhzNTazty9lHzpyoVwpUVwXxNqbx/c1UjnTUjYyzKDTNNXW2u0ipzWxdiSrVmnabzOe0ynxuZRZk3ax0eVVRCDr8fDwDQ52sWic02HDyxugvqje6dmOTA5Q0fSNoRDJwYAVSaPNfs9S80pskDfmVsudq5mjnIT2GMKMgJ/6w6/uCxj1H+f7/1/09f8x9f4egsZxq526B1/T7XfLU+JGVik1qdt1jklPT44+BrcW6mZh8p6mKHsaR7Jw4P6mKHtTH1MAfngTo+LVQ20PNL5tt1NjfPF1G16u0X92U4CkaVrKkxT5BmUDG95lWC2nDIOQKAkQMJCCIe9Mo0p5N39NDWZuy8vdL9bWxt9vaeweudn7HVH2mMVaGilkkRMVyf2ndAleJnYDcTgUCF+EA9flFYhKRMBjGMBn5snn/6Wmu6vKOXQetHwztZ0jMQPL2u45BYqsfJ7TmLIgz2NJJFQFf2vXWwJBCjuFUzKFcsKNFLEQTUMcpr0fIP1PG8V8Z9BdKPFmZZTXOvpRWkM3xk/gl9kzxkq1riHUSU9wrt5C6y8IlIETSXOlFg+d/Aom2U9Pzv/AAgaHmeiPKhybL3NGYmfs7pcOm7NJTTE6qUgw1SWZn69cU5dZdVaZVld1QhIGR9zRFJpKMgVO8fLLrN2Qfpp6zoUJqvXGv8AWFZT+Gt64pFUoVfR9hU/ihKfAsK9FJ/GQRIT2MI5uX2EESl9PaAiABnN8/n5/r/Z+Xp6/mP/AMAH5f4h6+mZ8eUjtWM4F4l3N0ILhr+2zKH/AGL0/Fu/jOE1ty5prxlMS+2WTWSfNIBX7u6zbE4F+5rdWmUk1SKCQRCKP6kTtNx1j3DJ8+0ycIrpri+GsNcknSKz48NJ7bXI0W2dIulY9vIJoO2M23remIQ8mwTQY3GNkEDPkI+wHc5XN4JeYzct+MjnWvyceLC6bahnPQd9E5fjcuJrbpW09Xiv0h9VUJKJ1unRK3IoODC4SeQi5FionAWyMGPJ/J9m6AuvJGsrb+Ivr95E+iBn5yZfKyRrQlzJqy0SI7GuJnIrgaUjNk3ZlsaZeKuk1F/xrnRhIIPW6T5ydX9UFgxZRbFnGxrRswjo5q3YMGDNFNu0ZMmiJG7Vo1bolIkg2bIJkRRSSIRNJIhCEKUpQDA+XjGcWvNxgtdUq4bBtLoWVZotWsFxsb0AKYWkFWIl3Ny7oCnOmQwt49i4VADKEKIk9DHKHqYAjB7RE3kN+pd5253bGGb1nyi41+jaW3tBaCOnq+Pd9EbIK+IP7xSzU6+iNVS5zAmZV6waM0jFIRJ0bW76jHuY3IvBc7rqqyBWu2OtTzumqr8aqqTqKoSkWkfcFpb/AAOGzgDMqzKsai2XbqCoxmbzDPxSWRaKkNl19MVTJ7ojqbyBeRfYDUy0/cbC9qEM9dmF6JbFuG4vts7IQaOVSACKkE0iKJHoKIlIcI2cVaJlbtDGRWyD+oK6jk+0vJZMa7oD5We1/ox3H8063+3VTUhZjYDWVbqbOfMF2xnDRV6vfZstYcOUV1juIis15womiVRFEAra+nM5dhud/Gdqy4mjStr30u8lN4XSQURErpxGyzxeG1wwI4UEVTxTWgRMJMM24Am3RkrFNOUEhF8s4X3gzrXTGs4bSuntUacrgFLX9Ta1o2tIMCkBMv4PRKxF1eN9qZf3SALOLRECB/wh+X8M7KwMZPPxzbeunfGNu+razg5C0XqgSNO3FCVeJbLvZWwM6DNpOLYxi2TVNZ2/k0KS+sslGRjRBw8lX7BtGM0VHTxIuTucB/Uu685G4v0rzNbOXdibG2Lp2rO6Wwlq/dK9A1u0Jo2OYcVxFUHkRJzUMsjCvY2MfClFTR1pBouuggKa6aKd32ZjeTTsznrxuc92fpC31DXsxt18d5EaTqDmKhmtp2Ns90iKrRMr1BsWdSr8IdUk7eZ5ssU0ZComRTcGnJSEZyASCOdm9n+fzyM6R5X6njZrQOjYVrJ7altLUxgpBvdW67j6s5ki3KfLaWT+yOL5fGL+uQVcsFxiWzEYu+V6xVisRlSsqLiUvV0LoXU3MmpqZo/R9MjKHrShRKcTX6/FlOb2lD1UdyUm9XMo9mJyXdnWkZuck13MnLSLhw9fOV3CxzjiX4EOIdm6s13s/vTqdR5J9ad2SgbEnVJ1B0hP0/WMy/Us0LCSDR2BDREtcZN4W1ysKkmklDQjakV47Zk7gXjNKhPAj7+rR6RcxmquZePK0o6cTO0LtJbjt0fHlMq7WgqQ2VqNHiVGyQncO0bFZ7TOPm7dNI3ukKY2MHqoVMo54/Tb8zp2byf3ux2Bqu8j+KNP2eGafcSbW0RUbt2dkUdaTH7PyjcpY8K7KSUtuq0VlVmQwkQWarFFZyq6f5wryhb9b7m83u9toOxLLUbgXXU8rXiOfa+YNbZznRJOeqUXItlf92/DZfr+zxNXftlSrImbzR/uGzw51GK+1P0oehTU3jTdPRMqmoaxdC7pViGz1chlFn1L0/FqRkY7M8VEyq51bvbdiIr+oiX3tCKmUUVOcEwqezFPzieRV5wzy6NM1LIOXXWfSyzvV2g4GvGUcWyEXlQRi7BsyMjmyLl0q7qxJNjH1QpEjqvb3N1pJFB42aSaaOmvTPSOpuRtH7A6C3ZY0axr3XUItKybgwpnkZZ6cQQhaxXmR1ETStmssoq0hoCMTOQXck8QIoog2Ks4Smk8TWhtyeT7sGweZ7tCCcMKZXZN1XOHNVPDqmgIGNr0hLMWVnjma4FB3Ba+UXkkYaWOgn+1e2H9nvJUI9evxpHAbDeILx8Rvjt5Aqut5lBq83lsJZHZXQ1mTcJSSslseZZIgeuNZcEyqvYCiR5Uq7FCCqjZ4+Sm7IiRJxZH3v1MxjA6G6m1CXoDmjoPRhipibcGltna1bGVUBEiT66Uyar8e6BYTEBEzR8/buSLGMBUlESnN+QDks/0k+6DtqB2FyZYSrxVkomx65uSOhX/ALkXxgtUOTXN6R+0UD5G565Ja9p7eSIoBBBefbEKUVAW9tiOZvcw+K3lXkbqvoHsLUDO9tNp9Gks6NsjZuzM5GkVlpdblG7BtzGjQLWEjncUynrbERkoojMS88EWmzSjYAYmKE7I4aQ4xjAYxjAYxjAYxjAYxjAYxjAYxjAYxjA4vd7nW9c0y3bBuUo3g6hRazPXC1TTr3fbRFcrMU7m5uSce0BN8LGMZOnSntATexI3oA/pk9HhJoVq6v2/1J5kd2QrxpZ+m7bNay5igZtE51df840aRQhEjRJXAOUWy0w6gYysPXsO7I2eyFPtEqUBTtbsFObfUB7kt8vprRHju0y+Am7vIluGt6mRK3OKi0DqeJn4Fzep+RIiILNIlzKSFYipRVwdm0d1M13OLz4Yt6Uu2Gh9NU/njSuqdE6/a/aUvUNAqmva6QxCkcLxtVhmkQlIvxL6/cSsqdqeTlnihjrvpN27eOFVXC6qhw7ZxjGAxjGAxjGA/L+P6fx/wzFT6gzopPnjxadAA2eps7JvFKF55q6Z1gSM9Psxdcl1ZkAo/IqY2rIi/LfET1KYUf67+p+TNq8i7+o1uE/2H3dwd4v9ZyB1n7ufh7Neisf3yxdm3BNNazBu5T5v6lNWg65hbDclRImYqcLbzrKfOb2IpBsn9PZzwbnvxZaCF8xFjY94nsPQ9jAyfxi6DZLpuWjvgAQA6hXWqYPX5wVP6+//APzEUQSENsc45TqnBUKoVai1ZglF1il1uCqddjEf/KjoGuxjWHiGKX6B8TOPZtm5PyD0KkX8vUQDOR/l/H9P4/4YEYnfSw9K/U/8N6eb+5+00Gw0nJP49EgKkayFCJeOrJF05L7TeoqQq0Eo4McRTBm2QD0D1MJ7O/y/u9f4/r6/oIh/D/l6/wB/5/pkXnGZjbZ+qn6/uDwQdra0htxlarFEDA2CmU3X2iUAEw/mAoMJEzAQL6CUREn5lARG0PAYxj9P/b9f8sDyF3b2Lrzg3lzaHTOxyKPo6jxaLatVlqoQkjd73OrkiqbT473D7iGmZpwgMm9ImsENANpifXQUaRTguQD3vWPSV08i/i16D7UsDmZ3f3vvnQm45OqvEVI2LoGnpzf1Kpeq6U2gF24KV9IK3GyEs2h037srKuTNcj5JJK1NbI6kN49+2P8A8dPyg0flSig5nvHdwHa1L90Rc2J2r2n7h21H/exjOuRr0gC2k4yQdpSGuYQ7ZyKjmrK7auMYq7jl4I6vVf1KiY6H7T8U/XijNRCq68uyKUq8ZtDKt4sdMbX1vs1gz+3QTH0UdRszNKxzVMgmckinhEk/6gQELJv5/n/p/bkHnKPXWovEz5rvKQ87KWtdPgNmWXbcnU56OqE3ZpKVLed1R22aGYkZFNXDwGVwodjCcTlzGLFprMU2yzr3uUTBdtHSMfLx7CWinrWSi5Rm2kYyRYuEXTJ+wfIkdM3jN0gY6Dlq6bqprt3CJzpLInIomcxDAI+Xt+8Lcc9STsVaOhuatP7dtEIzCNjLNcqVESNjbxhVRXTijTwIJSriJQWMos3jHTxZg2WWcKIN01HK4qBjdVfqeuDti7x1TpLW2tel7U42jsKpa7bXBWkVCIg42Ruc2yr8Q9RiVL47t0ughJyDQZNsjX2r1NkKisahKuyEj1e4PqH+on2i/H9YtOUc7l5uPsqxR3OOvq9FlOvMSUHZ1UDbLUbMkxA7tq/qJj0M5CH95ZS/wgCmsQ6iY6OR2huEuJaTZNtQmlOaub6dryGe2Wz7DgdZUCiDBxbFIRcyUjY4mCZyrhcwGK2bgZy5kXzhVvHs03DldBupPvxExuvmi8nr/wAlN7gJSI4h4xk5CjccViwxarAbveo9UzhncXTUywAeViZN2TZVifonOMRYEda0j55RGqyyhAod4X5uZchcfc7c3NPgO61Rq6twFjctBT+1kby7QNObCmGoEACg1mbzK2KWQL7lDlSelBRZdT3KqersfwD/AJf3egenoAf4f9sYDGM+M9es41m7kZF22YR7Bsu9fPnq6TVmyZtUjrunbt0udNBs2bIJnWXXWORJFIh1FDlIURAI0fqueo5iZW5m8f8ArxRzKTtwl2+67/BRJgXkJFw4fSFA03WvgQAyqykrLr3eUVi1lE/kdMaq+BuqYWayXJPp1+aI2ld093WJk2RcRXJuutb8XRsqmt93FvNgNpEFd6y1ZUE6iRWNg2hqeft4rIGOmLe8lFo6XbP1jKZoc3bCZeRHzQdNeRS/MlJjnnjyA2d1moi/H2xyOvObqutFc9QpRcEFuwkH0hXqveZJim1EHysNb3Ql+4Xcvi0TfTOa2l4Tx5TG8rWmdxcuqOg9t7hl5x0VQr6XZsZRtr5BVYDiPogaep9plGwgUvyDLuHAGUTXTMIUOZCn569wXjyOeTbnjxa6KkvuofXVsga1ZXDUoO4wm39gNGspdLPKESFH72J01q/2LyAJOTOI1yGwGHsK7TMllf8A3F1RVOKeUt29M237Vw11fS30lAw7pX4iWi7yJ0oWh1QolVQW9LJb5GGiV1ED/M0ZunL309jVQQih8PUbP6j0F5KvOXvA6szfatVtl1PSdhnP6s9k33tBdN7b7cRRyIlA8hd7jQ6S0lEG75JYLPeIxIpnccq1OGn3iV1PSNy+Xjr7dWvos7fnzx56rpnCfNiHokLFuNbZL0GUm2DwqKYSbyTJSNmWiYfpETO+cbYCVfGOvIpnWrNzCz6dTnVzojxlaxtU+2XTvXS1ktPRNsdvhVXkHrS4uG8LQ3Kr5x6uXKElrutVexEKc4pkeT8guT5FXThy43TwGZOeczaLzUXih7Ps0e6O2ezetYzWKIpKikss33DeKrqqWQTMAlOb3wlwkzLkARAWxFxN+4BvXWPJzvqjrepWvFy8hiH9pNg9B6hqCxfUA+VNkjbL6BB/iIAtSElRKH5+qQG//rgeOfHnt9r42/psbd1DGLNonY20JDctvo3zJmOs421dr040HrN+o2KX1fFjGNHrtscNyqEBWAiHIqLtgTVMjOnsrluQ5S394i4rYJnhJ/etL0H1LtJ9OuV1gCy7j6Ytapmz8ztRZVu9h9T1zWbCzJKqir+ON5Z24Iis6OmXYnteuLT/AIzfp4+C2i6qDLq25aWtk7HMzCk+cM7BG01oRVVJExVxZnc9IPZAonErdR0yReD/AFzIiiOwHnm8RFz8hOrNVXvmxKuR/QXPaEtEVuqSD5pV4zYOvJn8PWUp8dOOVW0LXZutSkYhJ09STPHQfskJ2PfSUaV0zdtgoa9P+v8AoH8+n9+Mh8qfk6+pI5XYMaVubhW1b4bwTVtEKW2z817Ltkq5IwTTboqudiaAmmNMlny6KIivKvWso6lFBO9WcOnB1nCvY6nlH+oo69KTXPOfj+U56kJMwMnm0JvS95gfwVVYwIncNbl0RJMdVxxGqZ1F3LZ7Xp6UKBEjtAKp7UXAVCdrds6H4K0bY95b5tTOIi41q9RqVSQeMwuGzLYk0UcR9Lo0Q4XSVlZuROUhVlSgVhCsfnmZt0xiWbp4lNh45eT98+Yjp5n5X/IfDEb6Kq0qonyPzjIN1XNNfx8NIqrREkWIk0iEf65rUmT7xeRkGQOtuXlu4lZNJKoxSUPLdm84fTt7O29tGA6P8u3Udl6nvLNVvJl0xGWSzzdPRUA5XSUFZr/OrR0g4rbc/wAKTyjUCs1CvkXZg2b2CWhFFGriqqKiYuBi42Dg42PhoSGYM4qIiIpk3jouKi49um0YRkZHs00GjBgwaIotWbNqik2bN0k0UUypkKUA+w/L/T/v6fw/n+0P4fEfruWzF65ZsjyLtu0crtY9JZBuo/cpInUQZJuHR0myB3SpSoEWcKJoJGUA6xyJlMYPl4wPy8rXzv0ZqDhLvvqjprWew9YbN6O6U1JzsRvsam2GmTs6nKXW19KbofIMrIzZPHkQ6vmrNaIpyLUrlg4kYiVYi7VWZrpkua8SAa75k8PHJFmu9mr9F19X+f09v3G2WKRaQ8DBtNhys3tOdlJWScnTbN0yO7Y4Ex1DiooqYiBCnXORI3dPk/4Hg/JFyXa+cJK4r6+nVJ+AvdBuZY78ZZQV4qovSRp5uHBw0WkoOTjZSYhJJNq8bPGqMp+JNTOF2JGbmb+kfTS95bDj6dqDrLyQyElzDQDRzKs6wo1u3DsdhGV+I9pWERU6Xsc9Z1/QFUW6aTWNds4yxNIRMiXwRT5Fok0MH0t0vu1PqUO5oPU1BaWukeLDli2trFe7OoRzAyWyXxSu2yMquKyQKoXnYDJN/B69gV0zutdUR3O3CZbN56QdwLqzqi0eoayplV13r+uxNRo1Hr8TVKjV4NqRlEV+vQTFGOiIiNaph7UWjBi3RQRL6mOJCAZQxzmOc3U/L/LukuOtMVPQnP8AS2VK17UkDfC3S9HExYJhyVIJa12yYOQruw2qcWRTWlZd4YyhyptmTRNnFMo5g09BYDGMYDGMYDGMYDGMYDGMYDGMYDGMYDGMYDGMYDGM4Bte8t9X6t2Vst2kRdrrygXG8uUFTCRNZvUq7Iz6yShimKYpFE48xDmAxRAoiIGAQ9QCePjtr/t6ec3s3r2c+OY1X4/K+z5L5/AVk3cchsJ6axQt/skWuT3tnThs4R2sKzhuRM34Zf6yX7lyWPRUNS3k/f001DdQnjTY7amQFxZ+l99bs3LYZRdEQdyDxKzl1iKh1lAFVRsZbXTp6gQxzpEWfu10/wCscrHUoEwGMYwGMYwGMYwOOXG212gVG03u3yjaDqdKrk5bbRNvBMVpD12txjqZm5R0YpTGBtHxrJy7XEpTGBJEwgUR9AyMTwQVexeQ7yndi+VTZkO5GCp0pOMNXoShSrGhLdslutWajCsnCh3JFz6w0NEOas+TRP6ontEC8SXKU3xq6Q/U29mJ88cGm0NW5gWOyeuJw9DSRaqokfNNTVhSOnNpSHtMp7ytJdNeu0F0UyChHMdc5MqSiKrYFCe8vDNx2PEnj00VqyYjjx2xLbD/ANMe3UV0wSeo7G2W0YS76HkCAmmAPqdX0a3Q3AlA5TDVQOVVcpgVOGpeMY/1wIt/DgCU59Rl5XJo5zKfhaXZTJsBwMBvej2DrCHKoAj6h7E2zJZIgCICJFSCX8imDLSMhPse4XPhC8+nRu7N+0+2PuduwENn2FlcKxFGkjrVXdF3re1H8/X27hRihMyOu9mQx6rb4JF4nLNYlV1Jsmj8khX05fdx99SL4h2kSeRb9GWaTdlTFQsEx0TvFOVUMBAMCJFZLX8fCAqYf6soqTCaIHARMsRP0UwN1MmP8tvf+4t/bkYeIHxtvnM50Vs1c0F0dtqtvFU4fRtCUTTG2V1e0R4LBAyTaKclPsmwtzi6qcW5JS4crnYc+RhBefL/AOZvv/ydzVg0L4eOXrrT6k9UcV219abRRZRy9RZOkTpvHbSS+Z1rrV0qDBUH0Wo9sV72BIMzKL1OqR1gatlkdn/Fd4tdb+NrVEogpLk2l0ntNVOc33veRRcnlbXMqrrSH7N19WTVcyjKlwz505XTM8WCWtcyq6tViBN05j4mCDvrx/8ACWnPHjzlVtAaiZfdKNvZPbFvbxukjYNm7EesmjeeuM0JBP8AbkX+0QYQMMRZZtX68yjIhFZydqu+d8F8ofj7p3kk5RtWgZ2Ta1W5MpBpeNRX1wz+8JTdkQbZ83i3T9JNNR0tXZyPfyNZs7dn6u/wWWcPWSZ5RhHiXRTGBEZobyfeU3w6VKH5T7h4fu+9dU6sR/ZfWu24N9Pxn29LjPVpCRMLtiLq11oF/rEOwQbJVuJkka3cq7CuGkVYHbdNpGxEf6ZH6qONviJ61oDx3dBbO2q6IDaNqI2NuuiWRWIJEvejS6bc7HIERcCUQZIQTJd8mUUSumJzgsnW1jAkTgeC/Kv5lLrWr55RLK55M45hZlrYYXkfXyqletVuI1WcmZfi1dUfTj6BkSkEWz22bWkH9vi01HRKhRoFtLjINKrtWas15pHXVO1Lqeow1D1xQINnXKhUa+2FrFQsQxKIJIIlOdVdw4XVMq7kZF6u6k5aRcOpOUePJF25dK8+xgMYxgMw2+oV7EDk3xx7LiICVPH7L6SXLoCji2cHSftIy1sXbjZU6kCQlcposNeMp6ISfoKoGj56xV9X5vkOkkruT6+n5/2fnkD3m4uNl8mPmY0J49ddzKx6lqycq2nV3LI6jhpEXK/HjLnva6kTErhIVKZS2cRGSqYM1TouteyaY/cEMVMA+h1hq8vCP02W/wDd0wzPD7e8jl1pNJhHKpSNnyeqlbI5j63CrCBBWWaTmva9t65MvYv8bmMvMac6ZPgWIe0bgbR/+zbxRyzo5ZmMfK650ZrqEszYyfxG/bVWuMZK8uDJe0opHd3B9OOzJH9TpiuJDnUOUTmwO81tOrOw+mvC54xKPFEa6+ebirltslOah7mcTqPWp6rRYNNBv6j8qcXrtlthBH5SlIRFh7BUAiyxk6bdqbLqOmdZbB27f5IsPRtYUuzX63SY/GIsq5UoZ7OzC6RFVUE1VyMWK/2yAqpi4XFNAhgMoA4Ea31OHTt03/0Lzj4sdFC5n7C4stNtt/gIpZb5J3bOzFiVzTVGegkcPYMNX5pxbnyLhByyVSvNZkvek4hj+3sbzF6djueOL/F/4VdCOm42Peu26TX7A+YtxIvPrwkxGRk5a5tokCCaTa87m2ca+LqOgKCSlWeFBVFvHrGJ5h8AOtLX5CfKV0r5Kdxx5n7PW0xYbtEJvkQcx7Ta24V5qHo8HHKLFI3cstaa3ZWBvHkTRVcQyzelPhM2WFisr75qqx+8Pqb7RZCkNNap8buoHlbZqnEhogL5Fx7yCWaqJpKGISdjttbYtj1qp/8AtLl1mgDoSox6bRMKmaFSa5rWi0zXNQZFjanQKnXKTWI0ntEsdXqrEMoKEYgJCJlErSNYNUQMVMhfQgCBCAIAHLMYwGSf/VwWAzbjPmmrepgLM9OBYDAAiBDGrWq77HFESh+QmALYb2CP5lATgH/EOVgZI/8AV1RblXl3k+ZKRT7Nhvyyxa6oF/qiOpfXkg7aJnOIegKqJQb0UiD+ZypLCH5EHA65ssQTZfmV8F/NDEQcwXLnDuqdgzJxEyhYqegNV3K4IpLoAJ/gMshrjXJUFTlIoLiYbgoBUk0lTWTZHN4v5dnvX6gzpXZBF03kLq3h/XMFVzCIOCtXMZrfljXZgaK+hiJldfPb3yxyKeorPlyEAUlje2xnAYxjAYxjAYxjAYxjAYxjAYxjAYxjAYxjAYxjAYxjAYxjAYxjAYxjAYxjAZ4z8jaq6Hj07wXbHVSco8Z9QKt1ECiZdNdPSF4OkdEoCAmVIoBTJlAQETgAAIZ7Mzp3oiiONo8/701k0RK4d7F07s2iNUDFKcq7i3Uqbr6KJiGASnKopIFIJTAJTAb0EBAfTAzr8DQNC+JDi4GZzHRGj3MTiIB/+0bbewjvi/kYQ9pHwrkKPr6iUAESgPqUNdswS+mq2KS8eJ3T9fFwZd5qTYO5tbSPyG9VUFj7Bl9jMmh/X94Abw2wotNIp/3k0CoplAEyEAN7cBjGMBjGMBjGYGfULeQ9Liji+a1tRpsrLf3UjKc1lRitHCQSlVojhmRttDYPxgqm7ZnYwMiFWrci2FN2ztlmi5lgZT8AegiGLUQdPzl+fo04gf8Aabjni1NqszV/rlq3YqRqSwmPGiUphZtnpt17ok1pApTppSj7V6J0VyO0quIEuY9PT8vyD/t6j/D1/u9PX+0P8sw78A/j+Pwxw5XpS7Qgxe9+jzxe29rEdJfHKQEW5YKF1rr13/WGFMalWXysnJM1Uk3MfbrZa2KplE0G4k3EwGMYwOo9zaD0h0VVBo2+dSa63DUPnB2jX9jVGDt0azegX2lkI5GaZPBjJJMv5IyUeZs+SAP6twT9c8cwPh78XtcfEkY/hfnNw4IqVUE57X0ZamHvKb3AU0XaPxiMOkIh+aJ2gomD1KZMQzSLGBxuoUyoa/r0dUaFVK1SKnDIi3iKxUIKLrVei2/uE/wRsLDNWUaxREwib4mzVIgmER9vqIiPJMYwGMYwGMYwGMYwGMYwOoegdzVXnbR23d83ZUqdW0/rm4bEmyfL8SrtnVIN9MfhjQQIoY7+WVapxka3SSWWcyDts3QRVWVIkaLj6YfT1q6X7X6z8iG2SjMztcCfbM5twiIIyO5ehZ2Wsl4m4xRU66xHMJVmUzGu0RX9UWOwmhBMt7vVPUb6pXps2n+Aq/oqHkTtbP1Ls2LrjxumoCK62tdZGZ3u5rpqFMCwlGzk1vCvECACTmPnniDhT4Ti2depvA3z7E8f+KfT87biI12V2nC2LqTZck8R+1K2YXhkjKVp8+AxRXTJGahg6QR2Vb1Omu2dmBNMDAkUPE9NcD1R9UJfZ5MikpVOB+WTVuPfKnBSNZ2qerbOLfNmaQqGKV+nM7/ubQ3vSBX7mtPli/kzaLZz36onqlbSPAcRouvyn2Vu6r2ExqLxBJQiTs2rdfg1ud9dNlAEVgIvPF17Wn6SZCJuomzSLddYqRxQc9b/AE08XJbokfIz5A7RHuk5rqHqCSjYdzIn+R0yiol1N7Kmo5mAHMmSPI82tBxZvgEzMhqw2ZNBTTjjJlzI86qj/t/zkcw8RNnK5q5Uw0Jp+ZZoqLAWLebisTPYmwrJ6oiKyKiWuLNV13J0AKcrWuoKkD5P3hDbPxYUyr+K7wgf7QOwI9vH2OX1bb+vr+g9bqtHUxOXSBbu9U09YoD96g/fVNpripJsVjomb2KQeidNio5cATrH6YLRFhiuWN3dnbFFZ/sjtHdU/YlZ54j6O5io6/l5+MGWFZT98qszs6d2gu8KkUqLhNpGridYSp/D1v8AUzb0lTat5b8ZejGiK+xOp9hVA7umwxVEDI0SsWGLrGsauZk2KBEY63bOdRqsSKLdwRD+jSRSMiiAICrSJzJoutcx886W58qJUxgNO61qVBaOk0vhNKuICGaspSecE/X76wyyb2dkTj+ar+RcKiACcQAO8sYxgMz+8mHj/ovkm5bn+dblZHdGlE5+Iveur+xi284rStgV5tJMYuXcwrhyxCYiXkVNTUDNxiMlFunUTLu/spJi9TbOktAcYGAnhk8NFz8a9u3Rtrcu6ILcO1NoVus66hj1KOl2sDXKFWHCboPvJGxpJTEtMy5oyuIAgRqyYwjOBBAHE2o+K5j9+8YwGMYwGMYwGMYwGMYwGMYwGMYwGMYwGMYwGMYwGMYwGMYwGMYwGMYwGMYwGMYwJe/EVOF4P8kXf/i0vvugInY2zJjqrlAXSgpsbRT7AyVeysPFCUp27yWb68a1cXH26iAEda1vCKqBFY74EahMwo82Xj/2R0JS9b9jckC/h+6ONJRteNWvoFYUZe/UqHkD2Cc10VAC/HLyrV2VeeqEU5FVrMLOLLTFmjhK8LHQ9XeLjyRa58lPOjDZ0C2a1LbNOUaVbe+pxcHM/oF6Kip712SLk5361LtP2rqUp0m5FRU7VN9CP1hnoCbRQDSnGMYDH+OMYHDth7ApeqKJcNm7GsUbUaFQa5MW64WeYWFCNgq7AMVpKVk3ahSnUFNq0bqqAkimq4XOBEGySy6iaRojOIaTdPPd5a7r3FuSDk0OQeXJuvmodKmjqHjlG9dfPpPTWqiF+3UjpBd/LoO9r7fZEO6aLHfOa889sXa4X4+//Pt2zsfrzfWu/DRxS4Xs9zuV0hGO/XcHKIIxUxZy/HNQeqZSUbisVpXNetmauxduu1fe1iV4mJZuxSXq1kYHpg4J4y1xwPy5rTmvW6abhCpxoSFztBkvjfX3Y8ykg5ul2kfd6qFPMSZBSimaqi34LXGUJAIKnaRLbA9i/wAP8Pz9PT9PX8vX/QP9f82MYDGMYDGMYDGMYDGMYDGMYDGMYDGMYEDHn7mJftzzPc3cOVx6ueNpqGlNMOW6CgHLEW7e1kjbjc7GBxEyaINaFY6Ks/N7Dfbo1w6inv8AaJC0HefvpCP4z8WN+ptB+Ctze6Ea7ytrmPj1DJlhazZIZ+W5FaIEOLorFlqSs2qAauyKplj5SXg1FFzqHRbup8OQkidA/VSbTtUh6ycfrzoXqp+Y5jCqQUNQUi96vqi6ag+4vwMpaOrrhocv7hiN0CpmEpiGz3V5rJU/aHmD8Z3jnhzhMVem2GC2ltqJbFBZIze1zoWm4x8k3/MTva/pHVchPNfkJ9skxuhzGUMCrkqIbteIrl0vIHjv5l0+8YgxtytBZ7D2KmcpgdBsHZ5z3mysXonIQTLV1abRqaJgTIBWUA0IAGEgqHkUU3PqzXH1N2+OiOkrdH0vWOh7/um0z87NqGKUqFB5+laDQo+Pae07qVmZGXGrMKvCxyakjNSykXHRiSy7pFNT9A8Q/P8A0/u/y/h/n+voOYR9u/T38U9zdIO+mbtZNw65uFqNDG2dC6xm6nHV3YC8DGsYZpKLt7BT593X595ExrKOmpKHckbyibYkgaORnXD+YfBkf4lq3fPLl5Yt1eV3bNbkI3SOh5RWuaGr8wZFZvF2hGK/CtaU9L7dX7Ny/wBd0aTd3+4uWYGbE2LZ4OXbFEkqII2mZ0pzvztpzlPUNQ0VoWkxuv8AWVHZHawkDHmXcKqrulTupKXmZR6q4lJ2fmXqiz+Ym5Z07kJF4sdZw4MHsKTuvAYxjAYxjAYxjAYxjAYxjAYxjAYxjAYxjAYxjAYxjAYxjAYxjAYxjAYxjAYxjAYxjAYxjAYxjAZLp5FODOgODehpXy0+LiLOed97+Y7B5cjWzhxWtsVN29QlLfaYWrxqfySCEqdBaavENGAWaiZ1NPZFP+OXQmEzVF4/0wM7/Hb5NuafJNq4t10vPhEXuBYMD7P0vY3bVO/64k3RQSOLtqkJCz9UdvSLJQF1ikhiZdIoJOUYibTkIKO0QybzyD+D2cltoG7e8W19Nyh2VDv31gmK/XZP9lNcbYePRM4l/iI2bqxlSs1iVExJ1nIMX2ub0ZY7e4Qses/lbGv5Yj/Pt5H+YYpKkdzeJrakheIFEkfI7KpKt019UrQ4ZJkbnk2LdXWex6VMC/VIdd5L02/K14XfzpxcY1bgVq1CurJ8vN/5jIbhiiLc6c+SSNt7a2vHJRdfiIRMk0tpeEsSZWrK6z0e3I5Mtd5cHSRdaU1Ruq5fulUbPKtfwRtGMLRnDcvMb5nu9Gy+ufH947rroiOspTRCu4bNFTtueQqTwp24PmGztgVfWWmKW8USOdwBpiOsL9mRI6sU6By2B4Hu3xPeCCP5Svh+vO0rkz6L7Lm3qlljnUg8kbXVtV2GU9HUjYkp6ygeVv8AtQ7lRb5L5JINWsGsdUK0zWfJktDsPneBjxGy/F9HmOpen4w0t2ZvJo4fPi2Bc81O6gpdgVTlXlceybtVyqtsm4PjBL7JmPnVdNzizqqTgTM7A7nKMMYwGMYwGMYwGMYwGMYwGMYwGMYwGMYwGMYwIEvpw3sdsTyu9n9IWd8yYQkFp7fWxJGZlXJG7aLd3/ddMkV5V8/XFJu3aNa9+06r94udIiaYmUMIJgqYnr3wWC/768tPkC8mtjbOXlarqsjVNTrSaShF4xDY0ieua/bIGX9VRkqdobXSdWlEylSIinZkzHbtgct0U8UI7hLyxc6746o4g0Pz7t4iPSz9TT9l2VG0GbQpFv0ijdJGSYyTTbzlolR6xr26NUWhrhMOJhmoMW3f0+RXaHczcK7vC8WPj6q/jb5KqWhY6SY2e+ST5ze9yXhk0+2bWvZU80ZISYxnzJJPBrdcj2MdVqx96RF24iYlKUeNGcjJvkCho7jGMBjGMBjGMBjGMBjGMBjGMBjGMBjGMBjGMBjGMBjGMBjGMBjGMBjGMBjGMBjGMBjGMBjGMBjGMBjGMBjGMBjGMBjGMBjGMBjGMBjGMBjGMBjGMBjGMBjGMBjGMBjGMBjGMBjGMBjGMBjGMBjGMBjGMBjGMBjGMBjGMBjGMBjGMBjGMBjGMBjGMBjGMBjGMBjGMBjGMBjGMBjGMBjGMBjGMBjGMBjGMBjGMBjGMBjGMBjGMBjGMBjGMBjGMBjGMBjGMBjGMBjGMBjGMBjGMBjGMBjGMBjGMBjGMBjGMBjGMBjGMBjGMBjGMBjGMBjGMBjGMBjGMBjGMD//2QAAUQwUAAAAU2Ftc3VuZ19DYXB0dXJlX0luZm9TY3JlZW5zaG90AAChDREAAABDYXB0dXJlZF9BcHBfSW5mb2V5SmpiMjF3SWpvaVkyOXRMbk5oYlhOMWJtY3VZVzVrY205cFpDNWhjSEF1YzIxaGNuUmpZWEIwZFhKbFhDOHVjMk55WldWdWQzSnBkR1Z5TGxOamNtVmxibGR5YVhSbGNrRmpkR2wyYVhSNUluMD1TRUZIawAAAAIAAAAAAFEMrwAAACYAAAAAAKENiQAAAIkAAAAkAAAAU0VGVA==';
+const SIG_ESTEBAN = 'data:image/jpeg;base64,/9j/4QEfRXhpZgAATU0AKgAAAAgABQEAAAMAAAABAdUAAAEBAAMAAAABAYgAAAExAAIAAAApAAAASodpAAQAAAABAAAAcwESAAQAAAABAAAAAAAAAABBbmRyb2lkIEJQMkEuMjUwNjA1LjAzMS5BMy5TOTM4QlhYUzdCWUxSAAAEkAMAAgAAABQAAACpkpEAAgAAAAQxMDEAkBEAAgAAAAcAAAC9kggABAAAAAEAAAAAAAAAADIwMjY6MDM6MDggMTQ6MjU6MzcALTA2OjAwAAADAQAAAwAAAAEB1QAAATEAAgAAACkAAADuAQEAAwAAAAEBiAAAAAAAAEFuZHJvaWQgQlAyQS4yNTA2MDUuMDMxLkEzLlM5MzhCWFhTN0JZTFIA/+AAEEpGSUYAAQEAAAEAAQAA/+ICGElDQ19QUk9GSUxFAAEBAAACCAAAAAAEMAAAbW50clJHQiBYWVogB+AAAQABAAAAAAAAYWNzcAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAEAAPbWAAEAAAAA0y0AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAJZGVzYwAAAPAAAABkclhZWgAAAVQAAAAUZ1hZWgAAAWgAAAAUYlhZWgAAAXwAAAAUd3RwdAAAAZAAAAAUclRSQwAAAaQAAAAoZ1RSQwAAAaQAAAAoYlRSQwAAAaQAAAAoY3BydAAAAcwAAAA8bWx1YwAAAAAAAAABAAAADGVuVVMAAABGAAAAHABEAGkAcwBwAGwAYQB5ACAAUAAzACAARwBhAG0AdQB0ACAAdwBpAHQAaAAgAHMAUgBHAEIAIABUAHIAYQBuAHMAZgBlAHIAAFhZWiAAAAAAAACD3QAAPb7///+7WFlaIAAAAAAAAEq/AACxNwAACrlYWVogAAAAAAAAKDsAABELAADIy1hZWiAAAAAAAAD21gABAAAAANMtcGFyYQAAAAAABAAAAAJmZgAA8qcAAA1ZAAAT0AAAClsAAAAAAAAAAG1sdWMAAAAAAAAAAQAAAAxlblVTAAAAIAAAABwARwBvAG8AZwBsAGUAIABJAG4AYwAuACAAMgAwADEANv/bAEMAAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAf/bAEMBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAf/AABEIAYgB1QMBIgACEQEDEQH/xAAfAAEAAgICAwEBAAAAAAAAAAAACQoHCAQGAQMLBQL/xABDEAAABgICAQIDBQUGBQMDBQAAAgMEBQYBBwgJERITChQhFTFBUfAWImFxkRcjgaGx0RkyQsHhGCTxGiVSMzRDYnL/xAAUAQEAAAAAAAAAAAAAAAAAAAAA/8QAFBEBAAAAAAAAAAAAAAAAAAAAAP/aAAwDAQACEQMRAD8AvwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAB/t5/H9ffjOAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAM/wDb8s/r/f8AAA8f5iNTnt2rcWev9iygdgTUnsje1ow3ba9426oRbWnb1tk5Qh04H5uDQX81SClXuUWyE3O4SUkMGXJWIuzSbfMUpqt2Kdod4rm0mXXr10QjXdXYJsEpGEi6aINZSg8ZoBykRWUvGypNyVxBIT8NGrpSaEFKFXYQKK7KVtbVfLyAq9rzd169TeoeGqrvdWzJJXkfzfv53Vg29yh2HhewWNzaJzJlptjrvE3lyvUa+TKp4/EghhKy2Fqlg8y8RjzsoCIDRaI093n9jXuW/cO/I/qh0DOYwvX9LacizWrkkrFm+iCtvuybutT9VlHSGf8A9y0ulaeNVlzZlNWxzlogmfVLmNx654dIVPr3OTj1zq35ys05VbrV4fkXork7Y5a3w0tC22URgGFgavlZGRaRaEnPSUfXFpSLYQ9pg5iXgX6MxYGJpCJJb8/r/D+H6/XkRQ95LGPkOp3mw3kk01W6er4x6kVX/lxIRl8qEjEqY8//AMiMo0Zqo/jlVMmP4gJEtLbXq299P6s3ZR1lVqftzXlN2TWTr+jDksHda/H2ONReEJkxUXzdrIpN3zfOfW3eJLIHwVRMxcZMEQXQjZJG09RnDCTk18uXLanX6tpKZNk/pjqduXY9RiEMGz92GkVBsmuC4z/d+x7fjGC+BL6AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAMVbr3lqHjlriwbd3nsOr6v1vWESKzNstsinHxyCixvQ0YNSeFHcrMSK3htFQkS2fTEs7MRpGsXTlQiRgyr/AC+v8v5ef1/sK9XMLsv29ye3BMddXUgdhed5ufVGb45coLYd6c4sVc7laPn3bOxtWsiwl7039pyyQkGWH5YmTTPD1RhZLx6kavgWW21zv72pKQpnHHF14L9YyUovHW7kJNN3cTvTlFAJOMspOC1xHJZT+yavJoYct3BGb3MARH5lO2WiwusOtZknp4icMOOfBnU7HTnG3XkdR6wkdB7PSWc5kLbeJ5Jsm1VtF5szgv2jYp5ymn6cKrmTYRjfJYyCj4qHbtI5uGEOuvrX0l1362kIWmqO9g7ovy323vHkLb0Sudi7XtLpwrIPl38i4XfPo2tIybp26iK2WSeERWXWk5d7NWF7IzTyRX+X+P8An/H/AA/Dx5z9M/iAA/X68iGX4gu2Nal1E8ul11EyuJ2L1dU45E+clM6dWPdmuI9dNL0mL5UbxikhIZwY2C5SZK+cH+iR5mhU5+LE5CNq5xg4/wDFiEcGc3DeG2z3uRiGSSjt6rStWxazFFqq2QwY5MzV2utbUicZIZV+tW5FBoRT5dz7YSfdAsKvA9Q/DNi4SMiovWdmzRSmxnGTIWTee0LE1V8Z/wCldrKIrE8fT0KF8eceM5mIGsPCjSi3HDiDxl0Q9SKlLap0brKl2DCfp9Ktph6lFIWt1j2/JP8A3tk+1XefTnOMZXz+8bxk2dngAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAEHHOjtvkqdtg/Bjrz15nljzzsiDmOXjYRVu81Rx+NkxGzqybdshXKEXh9XcrpuJGuLy0TGQZ/a/bSfhF1GMHNBufz27H+NfXlr1K07nsh5O+WVs6S1RpGp+iU2jticTUTaNo6twSXuKsor59du2k7XLlawUYZQrbDh5MuYyHkYntEdfHJns/2HW+YfcIyPAaygnR53jX15RDmRjKdRY94um5ZWPdjXB2r6asjpkRFKRgpf1Tc4Q2G9r+wK6l/ZqltTwI6imenNgp8yOcOxHnMDsAsRUpCS2jcVDStK1GrlLw1r+nK88aNWUXmBSVUjmNnLFxmY9rjLWlQFKjVnrN9Nh+GMfl+vv+mf6/5fcA4EVFRcFGR0JBxrCHhYdgzioiIimbeOi4qMj26bRhGxsezTRaMWDFqik2ZtGySTds3STRRTTSIUmOeAAAAADiSEgwiWD6VlXzOMi4xm5kZKSkHKDNhHMGSJ3Dx8+eOTptmjNo3SUXcuXCiaCCKZ1VTlTKY2KJWh3sz3sd7iu9VWjx7xJ4jv4WxV9J8ksVhnXer59651TEu2SzjKRZTcWzsurrMxKmMmzWDWWOUK4ShClPKZ8S52MG45ccGfDfVc0cm8OVMQ7YWwsSuf7XqGhVnK0RYVMpIpqHK62q/ReUCLR+93AIXs6ZkXbVgdTePo36+1ev7hDU69dYfEZvjcy7fbG7SOEsEkYSal2CKVY165zk6hk/7Pq1lrFyLUih2pLe7trxpnKMhjOQmR/P8Aj/l+v/IAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA/BtNprNIrk5cLnYIaqVOsxjyasVlsUmzhYKCh49E7l9Jy0tILN2MexaN0zrOHbpdJFFMpjnPjGB03c+6NXcedY3Dcm5rnDUDW1DiF5qzWecXyk0ZNEfBU0G6KRVXcjJv1zJsomHjm7qUl5FdtHxrRy9cIoHrZsKdyY+ILusddNhFvvF/qFqdiM8o2v27xauba5mu4OSSKnPW0zVdTEdQzuGi2Wy6Xvw8IcxmNXWsttZu7pVw7Vsrmty97h75dOMXWA4kNH8PIV6er7z7EZ+NnYmTsCJc5JN1DQUef7JlCu3zNX0JO2ajK1vEFWzt/LazhXDZ9Y5keCvXtxs69tWpa50NUSJzEmk2X2HtSwlbyWzdozqRcmWmLhY/ZTWOh8wddaMrkaVlW4P31/syMRXdPXLrajWestfaaoVW1dqqnwFA15SYlvB1Sn1eObxUHCRjb1GKg0aNylL61lVFXT10rlV5IPl3L98u4euXDhTvIB/n/AD/pgAAAAAABrtyv5Qaq4baA2PyK3LNow9L13BOZHLb3kk5S0TyhDI12l1tBTP8A72y2uXM1hohtjHtkcOvnHqjaNavXbfPcpKRkJGSM1NSLGIh4hi7k5aWk3bePjYuNYN1HT6RkHzpRFqyYsmqKrl28cqpN2zdJRZZQiZDGxQM5t8ht3fEN9gtI4acVjuo/idqCyyUi0tyrZ19iKQ8eslDXnknd0slQ8tvkHCtf1PXHh0XiqEuzj0sxk3e5tBoGSOn7jjtTuB7F9mdpPLKIXc6m1fsBGdp9fdpqyFQmdmxRW6+ttVVssp6suKTpCvmiLBK5IT1vJlGpJyxHylksJ8Xuf1/h+vAwLxi426p4i6K11x50tAJ1/X+toJGIjEs4TPIS79Q53k7aJ90Qif2hZLRMuH07PSGSEw5knzgyKSDbCDdHPQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAw9vvfmpOMWp7hu7eN2h6BrajxxpCcsEwuVMpjnzhJjFRbQvl1MT0y7MlHQcHHJOJKWkXDdkybqrqlLnsG19q670dri57c21boeh6419BPbJb7ZPOflo2HiWJcZOofOCqLunblY6LGMjGSLmTmJR0ziopm8knjVqtWm0/praffTvqG5acpq9P0TrD03bHzvibxwlyLxL3kbMxq548+2NmMynwZ5WnJUF0FcYzls6buHdHrjpSITuk1Zw8ad03uvvq3DV+V3LSr2XUfWXq+wKS3GPi5JuF2MtyOkWi6qaG0tqpt1iJuK25SKRL3EMKsnzFZ1Vac9Uh1LLbLRaMi4uMg4yOhYWOYRENDsWkXExMW0bx8ZFxke3TaMI6OYNE0mrJixaIpNmjNsik3bN0k0UU00yFLj2MGDGKYMYuLZNI2MjGjdhHRzBsizYx7FmiRs0ZMmjcibdq0at000GzZBNNFBEhEkiEIUuMcsAAAAAAAAPv/D+H1/X4gKt3fl3OOOOUVJ8FuI8s6mOVexmLKCv9sqeVn8npiAtSaSbKt10sb7rpTct2ZvEEohu2Id/UYOSQmkEkrBK1pwzDTjvq7S7fyd2I26nOBRZzYE/abm0om8p+hOcuHV9uBXxW6eh6s7arJpHgIaSSMtteaVdoRR3cepW37prBQ1v+0J/+pDrC171m8c2dObkjrHvjYaEVYN97JRSwc01ZEG6hmVRrzhQhXCFEo/zjuPgG5/bPKPV5WzvG7Z5NqMmej3Qv03pcGKAnyU5Dwbd5zA2rBG8xkjhKQU0VS5r0uVKkzcn94v8AaBYUMt1dhTKBzHYYx+xkY5OwQnX9jsdAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAADrlwt9X1/VbHebvPxVVp1QhJKyWizTr1COhYGBhmir+UlpN+5ORBoxYM0FnDldU2CJppmNnP3eex/j+f+n+f0/r/iKwHJXY2wO7Tl5NcBNAWGVguunjnZol7zd31TpVJFPddti3uXkfpGhz7X5hq/iEpKPVQw4aZeR7uTj5K5PUnEZWqWS0B1KJT2d8QvyKLMy7S2696cePN0yrBRa/2lVpzmjs+tuMo/OvkzFayRKTGLZcJrlKZHFajT4jW5i7AmZdaiWl4KChKtBw1ZrUTGwFcrsVHwUBBQ7JvGxELCxDNGPiomKjmZEmjCNjWLdBmxZNkk27VsikgimRJMpR13WutqHp2g1HVur6rDUjXtDgmFZqFTgGhWcTBwkahhBozaolyY584xgyzh05UXePnai7184cPF1l1O7gAAAAAAAB+vyAQ0dxPbjrzrL07hnC5hrryi2RGPU9Q6zcL4VbxTfyqzV2ZfmzZZN20pUI8KomxZ4O1eXKabmg4pZBq0n5mDDFHdv3LVHro1o41Tqd/EWjmJsqAcZp8GbLeRYahr8gRVoXaN3ZZMdMzoucL5odYep5JYZVsaSk0Fq5GPG0noN0E9QFwh55Dsu5zRkxPb4vz1/d9L07YOHElY64ezmUfut4X9OWwo6zsWzZeuXdQYSGMu6tHO8Wd5hO0SUYlVsI9JvUZsHlRs0/ab2QJy9/kbxYC7J1BRdhJmdP9j2Jyum9jtw36Kcpkbo0iLKk2LrCkfKIRMo1bR0n9nNKTFV6NsV1UA/Wf1+Of9Pz+oAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAB9fp9+M/T+f8A/mItu1PsQacEdLw8XryKT2Hy433LJ624t6bZNjy0ta75LuWcUSyPoZufDpesVVzKMVHBMe3ibnXkHWUlm5pdZ+wDT7tW5hba3LtiudRPAmacI8oN2s2y3IXbMWo4+yOMOhJBskvY5GYlI/wDv4u1WGBfN3BstV0ZaLrkiwZRJS2q9VFy0lh4WcQNS8FeOdA426aYrErFLZHWlZ+QTb4sF5t8l6F7NebOu2ImmvN2B8X3Tpp4w1i45GOgoxNvExMe2Q1P6puvZ/wAK9TT963bMk2ZzZ5FyRthco9ySL5admJayyTlxJtKJGzblVX3a5TMvlmqi7ArVpYJ00hNFQSjjQcfFSsgAAAAAAAB/r+Xj6/0+/wD3/AP+35/T+Ah97Z+3vTfWRrL5fOInY/Ji6Ra6uq9MkkMl9tM+Vmyd62MdisV9BUCOdpK4IRM7aYt75srCV9RsROYnq+HZ+1vtZ091jaZNPTRo68b+vEe9Q0tphN/7budfEwdua4W/5Y+HsJriAdYxmUksYRdzrxLFdgD4frO30TW+6l+rndHaBviR7Rey1STt+urPYc2uhUa1tjoF3jKsVcIQrtxAnKRCD4/UxJuhG1istkUI+3EjmkW2R/Ypk9LY/V1d9Um+e1Ddzjsx7Pn8/Yda2qZQtFHoFnSWjH28CMlMHgcfYmCoJ0/jzApESZ12Cj0GhLnHtytotJCqKHlZ68pGxsfDRzCIiGDKKiYpk0jYuLjWqDGOjY5igm1ZR7Bk1TSbM2TNqkk2aNW6aaDdBNNFJMiZClwHIbt27Rug0aIItmrZJNu2bt0iIoN26JCpooIIplKmkikmUpE0iFwRMhSkIUpceB7QAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAetZZJuiq4XVTQQQSOssusciaKKSZMnUVVUOYpE0yExk5znMUhSYyYxsYx5AYU5H8iNUcUdKbA3/ALtsqNW1xriDXmpt+bCaz98t6it4uvwLA6yBpay2KTVaw1fiElU1JGVetW2FEiHOsnB31WceNq8yt6T3cvzZryKFw2NHKQvBrT8nhV0x0LoT3ZJGHtjZm6IVNKx22MfujwsrhBFZ+xmbHecJpmvUW3g8SShpHvn51mgWp3L7qZ4J30ydm9SqjWG5Z8kIhup6Y9PDdfBpeiwjd6T2lfqmlR3TpyU7R7tWO+wrQzJkzjWbSOjmjVhHsGyDJixZoJNWbJm1SIg1aNGyBE0GzZsimmiggimmkikQqaZCkLguA5H/AI8+fr9Mfhj8v/j6fQAD/H+f3+Mfzz48AAB+vqAAACAPuq7r6P11U55pvTzmFvHMm5weF4SCWwjKV/S0JKo5+SvuxGuD5SXmHKB/naTRl/C0xnCE/YEkKv8AIIWQO19yHdLrPrZozjXmvzQWx+X9yhffpuvV1jOoPXUa/SOVpsPaZGayThvGE8ZcVyoEcs5q4OCJ+hWMgSvJtvDf1O9MG3eaGzydlPaitZLdm9TLbYND1Lf0jEnNqrqEScwd02XEnI3LX9YNG5WZaPrZFlHtp6Iax3zMfHa/Sjoq05C6bOke8bTu6HY72etJ297KvE0nsfXGodn5XkpqTl3yhJBjtLd8fKFMdV4fOG7qn63fIkbRjUjN3Z49PCLKusbj/j7v98fT6efz+n5f6+PGfAels2bM27dmzboNWjRBJs1atkiIN2zdAhUkEG6CRSJIoopFKkkkmUqaaZcEIUpcYxj3AAAAfnnz933/ANPP8/1/IP1+v64/qAAH6/X/AID8/wAfH+v5fz/mAAH+f8vPn+n+wfr9fr+H3gADjuXbRkiZy8ct2jcn/O4crJoIE/8A9qqmImX+HqNjyMczO7NM1zKuLDtzWMDlEuTrYmb7VYvKJMeP3lvnpZD2i/XH7x/Tj6/eAycA1bmOcnCivGwSf5hcWoM+S5PgsxyC1NGGyQuc4MfBXtuQzkuM4z5NjHjHjPnP0yMNz3bJ1l1zGcyHO/iy5wXBs5+wdy0u058FxnOfTisSsvk/n059OCYNk+clwTBvUXyEhACISw99fUdWCLHkeZ9MdYQz6TFr1F3DbTnz9fHskq2upgy+M5x/zo4OTHnGcmxjOMjBVg+Jb6lYb3vs7c2wrZ7WM5T/AGf0hs9t8znHjwVH9qq/WvTnPnOcfMfLl/dz5NjPpxkJ8AFcXHxPvAeUXI3o2mubOzDrYNhE9F0jUX6aihcmL7RSym2IhyY3rL6M+22UwXOfGfrg2Me4nxJGiFU01EuBvZQqmoplMihNBU45D4Lkv0Icu1TFOrn1fvJ4zjx5x4Pn1fQLGgCuxj4knjM0KRSwcLOyevImXUSw7fcdqXlmmUmC+pRZU24UVMZLk3gyaKKyhPGcZxn1Y894qHxKHVrPTKcDcb7t3TMjkxU3CW0tJXZr8gufH7qEgWktruqzNk3guVlU8NU/PrUcESwZTAT3gNfuP/K3jbyqri9r457u1vuOFZ5IWTPRrRGy8jCKqYxlNvYoIixJ2uOlCmKcjSdjY5ychyKFSyQ5TZ2B/X9AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAdSvt+pOrKZZdi7ItcDRqHToh3PWq3WiTaw0BAw7EnuOpCTknqqLZsgljwXGTqYMqqdNBIp1lEyGqGcne5XmX2X7gm+FfS/SbOxrmct0LrypURd1ixo187rLCQscVLSqSDTS1AMdTJWtol0lNn2DKaSFTjK3N5JFSQTqc9O4vg/16pO4LbmxFLft0jP5pho7VqDW17FU91JQzQ9gTy9ZV+js3ByEyVe5TcM7ctlMuomPlSkMnmsrunuP7Me122SPAziDxtiOPsbyDp0zjDmZlLGvtR1qQ7MshK2SS2FIlq9XplHtdfRXhJCXa012jIoTylfgrQ7eOW7hfcA/XPwn6OONFh5mcryQXNPm9MvHLHVTDYbN9NVO0b5tCaj2Gr1AospiTczTppLkcWOy7StjSRt7aOj381X0atMvmcM8la6euCN5480K9crOUrl/ZednMx8hsjfE1PIo/aev4mRVPJ1zT0WUp1cRbevt12y1mj2R0WSUygwraCasPSa8qUIkeOnU3300rVFa0NCc5dEcO9F1Mr1KEp2i2azi0oLS753IzEq+n63rCs2ewy7507Os4mrFtmTmXJ8JFUcpkQSOXYBH4fvmRNpe/sHvH5nWWSWOVdwdpnaDdsRQ2M5VTT+1uS02dXBTZwVJb0ti4IXzhong2EyWiv1/r/p5ABWDz8PBvTOV857k+cHlUpS4z9q3DOfJfTnyrnO5/wC9x5xnJcf3fo84+ufH19yfw8e801PXjuU5y4x7PtfuTFvIp59HozjCmdyG8I5+72fR59H7nuf9Qs7AArEk+Hk3mQiJf+Mpzk/u1DHz6Je3EL+9kvnKRf7ZDe0rnxn1K5Mp6s5Ln0/u59XnHw8m88EULjuU5yYyZbCuP/vFu9Hgvn6nJ/bJ/eLfXHpVwcmMfXPoz584s64/0/w/oKyvd13nxvERvK8SuIMixuvL+zJYg7JZYlJKwRmg05ghWzZAjJErpCe3JIYcJ/s7VFEnLatGVbTVnaOVTRddmQgO7VKvJdb9pZad192185+Q/IyQSQWn9fw2zrjVoTWca8b+5Fr32zMNk2ZwtYpJQzRzF0FhEoSq8Sf7TlZSvt3UGeZ2H4V/DX8p+UVHjOVnKnlJfeN25rtPMb9UY+RqcxsrdKOC4bykLftgWiX2LT5uq3dzIJtpSOicuZGyxDduzeTEjETqisPFSOdKXRS+1RKRfObsAj17zyatjs16ousryorY3Wr5WZcZljX7Z68ud2rO7rkHK2ZFNk/UdYoTlczuQVdXsxv2TtcZ/X6/Wfz8/eArIE6MOxVp8riP+IC5oEK3NkxiP4jbkjg+Mnyfxj3+XmMZxjHguCOSuSY/6cFTx7Q9f/BX7UWZc4Yd9/JNzn3fXjEhU9lZz4x58Z91XknInLjPn6oY/us58efOS4yLOYAKxxunzt+Ryvht3q7hVKcpSky5pd1xk2MZLn7jbddfLG8Y/wCdAxjm+uDZ8GMPOOoXuJwchv8Ajn7W+iJiZ80m4Gxgxi5x6fbztD0H+ufo4N4WL/zlx6sYFnAAFY3HT32+ukyJPe9bcbcmFPVnLGm3fKmC/Tzn3k9vMFlPHjHhE6mE/wD+2POR/Zej3sneJK/anf8AcvkVlFklcYiq9tZqmT0YN6y4Ohy0ZHwU/qxgqaZEkcenydNXyUpLN4AKyKvQxzdljuMWjvi5yTbZfJTYbJLbUZpFNgxc/voueUMm1OTGPVgqabZApcmxnznwbB/H/wBPTvJc/qf9ynOt3g6OU1v/AL/binVNknp85Ott91jCXnxjKJiqZynj0e5jOfVizeNfNu8tOLegU3Bt3ci9I6nUbeMKM9gbQplVkzKZx5Ki3iZiZaSbtybGM5I2atFlz4wbJEzYLnOAgRx8NweQygraO0LnVOuUjZyZYtty3z6fPq8IYkJuaOgb1ZPnJsqK4zk3n0+fPn+cfDIaofFyjY+fvOmabZVwplDF7raJM/gbOSv4GXTyrn6eFcp58fXGSZ8+Rv8AzffF1I1+VVh3/NGiru0sqYMtCU7bNmis5TwbJvbna5r+VhFcZwXPt5SkD4Vz4wlk5jFxnfLjdyr478vqAptDjVtirbdo7aYcV9/MVlZ2RWInWrZo9Xhp6GlWkbOwEoRi/YvisJqMYOlGL1o8SSO2coqnCBxr8Kt19rKqObRujmfc3a2SHUUndpay9HvF+9YnyWlWzrKhvUcuTLu184IfOC+Dfv5yTCfDBdV8VlPL+sbvsvtk9Jize45VAqpvHj3FP2ci4A2D+fr4SMkTz/0ePoLDgAIQoH4c/qBhMoqL8Wn9gXQz6irT28uQCxTm/NZnH7PjY1bH34ymoyMlnH/MnnOC5xmiv9IPVFWcp5jeEupnPtKe4X9oVbhbcZN+79FMWqzzWFk/3cf3S3rS+uf3P3jYzKqADSis9bHXnT8ZzXODfEuOWyXBMu8cfdWO35iYzg2CGkX1XcvjE9WCmyXLjJcmKU2cZNjGRnyt6A0RTsomqWlNSVYzcmE0DV3XFOhTIEL/AMpETRsM1MmTH4YJkuMY+7H4DLYAPUigi3SIigikgkkXBE0kUyppELj7ikITBSELj8MFLjGPy/Ee7z+v9v8ALz+P0+8eAAP5/rH+Xn8vr9+PpkdLuut9ebKi1IPYtCpd+hVS5IrEXWrwdpi1CGKcpiqR84xftDlMVQ5clMjnGcHNjP0MYcbZu0tbaXpE7snbd7qmt6DWWaj6et1znI+vwMY3TIY+PmJCSXQQyut6cptGiRlHb1wYjZoiu4UIkaBXdfxAOqdkJuNLdWmt9hc4uVtpWkIeoxsPrq413VlNM3WOzVu16nLSyqz13WmGPEk2MyLH1x41IdSfutUbZK5WDV7mDxc406J7jesSj8AdeNNHcj7jtBbaXJJlpCRkKtUWvGSryTKTskZa9fQr0lTr0XsOEir7DnIxg4ePlWUdhg9RdquofBbZH5f5/wAf4/7/AIfwwIfeszrctnGywbD5c8t72lvPsE5FNsG21sjByL17XtbVVZOW+ptZpFaMkGsAwxGQyEu+ZsY9g6+woaHgY6PgIRrmQmCAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABifeW8tVcbdV3LdO67nE0HW1DiVpexWOZVyRFFJPwRuxYtkyndyszKOjJMIaFjUXMnMSLhswj2rh0ummbqfKLlJpHhvpe2b65AXRjS9f1ND0mWVyVxM2SbcJLniajUIbCibqxWydUbqoxUOz/fMVJzIPlWMRHyUizpCZd83ficeWHyqeZrQ3ATS9jKZYhMrvKzSma2C5wdwfw3jdmcirTDL/APt0jYxD0aGemMmSKh3a61uDItz2hzQ+Jj5LudRamzYOPfXJqOxsX1rlX6JlWxkklsnZT93IyXSZX3cE81TUcUnXKD9Wt0NqfD5y8IYspapq4TxL4d8a+AmlW2qNB02IoNLh232vbbPJrND2a4yjBhgkhd9kW5ZJopNS52qB1F3jv5aLh2KeI+HYw8I0bR7bu3GXjNpjiDpinaE0JTWNL13S2WEWbNDBVpOak1ip5lbRaJXJCOZ60zzknzczMvMmXcrZIikVuybtGjeI7vC5F7Ff1fS/Whxnkjo8mewmy4164fsV1yOte8f0VzF2pdJDLfJTIRktEN5SDkMmUSOtSmWxXTE5ZCJbmwGu/EqFkO43sVtnP7YbVST4N8JLXOaq4P0qWbKGhNibSjlmCtm3sZuqkRpJs0HTRhYmC6hDHJIn19EmPh5r+dQd2dPz/j+f18eMfTx+X3f6/QYB4s8cdd8RuPep+OGq2OGVJ1PUmNaj1TJYSdzcjk60hZLXKFIdRPM3cLK+l7ROHTN7R5aXeZQKmj7aZM/AAAPPj8f1+P8AsA8B+vp9fu+8epddFqgs5crJN2zdJRddwuoVJFFFEmVFVlVVMlTTSSTKZRRQ5ilIQuTGzjGBTJ7a+8e/cirwTrt6pz2W9W/YE0try6bp1ymstOW+Qd5WayFD0a/bHIo2hioEdmtu2/dZNSRjd+vWpBnX2y9vdhnnuN76nlDnZXg/1zOnGyeSlllFNf3HatGZL2nOvZ5+4xEq0TUzSMQeftbt5Z4oaMcSzFN/H0l7hVjHpSNzKpmq5D6Tuihvxccw/MXmmyRvHLufOpaKrTZx2lZY7Rz6YOo9cTszIqrPkLVul2ZwqvI2D5l4wqLtdwlBuZCaKexjP3TL0f63686rF7k3MygNjcyLFGeqRsZSlk63paPkW2SOqZrYyxMJLzJ0FTtLXf8A2SP5PyvDV80fXTvj2CwD+v8Ab6/X658fz/Px9QAAAAAAz9Px/wDAB4/X6/n9w47t20YNXL586bsmLJus7ePHaybZq0aNkzLOHTpwuZNJu3bokOqussciaSZTHUMUpc5xBr2E993EnhY9das1qdTlZycdPvsCN1DqaTbyERAWVzkjaPj9gXiPQl2UY+VkFU2GKnV2Vpu2ZD0MX0FEkXTfEhO3HqbltzIYJ727zueMP1z8W54h5mkcM6tYU6zsWzwZHa+SNm2nTuZaRPJNESKKsJu7wO4tloLEfsHVNr7A6foCfrlP3ydZXFE0pEz+/mO37xF+4VTX/HtkTakyoukTOVmatnYPWGr4l+gr6G68fP3+IfIuDmTO2xlu7y3j3bdofctztOZHry66W+jdXv10yMt/8rnp2qbuHVIUyVggIyeVolfc+VFUU1WtVj90ppkIvnGFDZWUYaccZrvx/iXyVb6KOoSQ5I2+IVTZuOcHMCKcsqBGPyKqe9Lx9gv8vEu8KFMgm4Whq1adSzJyMXCMdTnq5kvcknW69O5zlkVNHmj2dxOgdfyGTrSuoeDVRcVx+sxdeMOIBbaizKhWhAirfPsP0phzseFOUirMrZ+2eOHZw0b3vxX302auJjuH+IAjdSx7hwVxN6A47WVrUcyKblNRfDWLhIj9h3sphq2ydJFDGgLPgxTkcmcerGMu9JdZ6y60LTPOKn1idWfJjtL2E0yum935yYulwoekmEgsv4UfT5Vi0ikSjhwcxVVmV0rGtnCh1zKMX/lJ0nmzPx76GesXj64bTROPjTd15TdmkHuwORs0929NzEiZXDk0jJVyZw21ph+d37jtR5H0Ng4VcqnVVOpkqOEpSJqa1dorXMhOzsjR9Sao17CKvJKSfrwdIolNgGWcmVWXXUNGwcJGIGU8Y9WW7fCimCEx7imMGCq5VOmbsF5Ktm0Vu1xwO63dPGLhNxrPg/x0ob/bTttj99Rs/wBpLMT2OHdOCqqIry0TuSdaOXKjt0+rDlMjJPNhvg5wW0V1+aXNpTRDOxqxcpZX94uluukyew3S/XqVYRcZKWuyyny7Nn846Yw0a1SYxMdGRLRFpgzZiVyu9cuoY7V3V8sOY207hpzpp4jMt+QVHkVIS18qd1KSdb0wzeKIGUScRMc4mKKRukdFF09gc2W2oWSwJJEXaa6cMyYy99vDrmn2l0/tNo/AvnVa+NezE9haBtG352O0HCPMLaYK0bzT6slss8eDrmUZN+vXiRjmEXxYmh4y4VmVQliqu0PdCy+A9Llw3Zt13btdFq1aoquXTpwqmg3bN0CGUWXXXVMVNJFJMplFVTmKmmmUxzmKXGciO3e/bh1t8b8v2+0uYWmkJmMKb5yr0iwH2tbmzgvnBGTyr6vbW+bj3ihsFwVGTZMvQQ5F1jJNje8AkYD9fyFdF18QzWNuO14fgXwF5oczZIjhRk2sMNQ16FrNdymYxTGcXFsw2BKQ7RExS/NObFUoUjbOfSp6P+bHpzs74j/k77aNI0NxH6+6fKK+pvZNo2dPbOz4thnPpOvhjFur/ArOsE9XysdOatg1lnKePnFWTNUqoCxoNM94diXBbjbl6huzljoqiS0eZQrurOthQMveUspecK4JQq66l7otlM2PQf2IFT0qZKmbwocpcxLp9F+9uQeCPew7tP5Y8gWr5Q7qZ1dqeRbab1PhU2DYyxJXzrWevu2h8/Ry6jKTUnSrc3yiKbPCJHGdsNZ9LXUdxQr69zecatTumNQbKTk7sTkTOOthxscgxwVVWbm1dpzMjRYNszKmRU7hvDxMe1MT5jBE1MmUyGuNq+Iw4t2iZdUzhjoLlfznvWHZWccy03p6wxVXdrGzkpTu5WxMi3ONROb2zFWzrh2TCBjLrewRPyeMnnv3B9smtqclN7JgdCdY0FamKryi67evoTkNzKu7JcybdRWHpTk7+ArEa29S2VrFs2laaZtTNX6cdPvp88HDvO382e+pKZePeG3TRTqm3WasZglx5K/YFc19qrWUBHrIsp2z0RvY0YKk12rwxDkPN7p2QSIpEMgZFeFYypHsTZEIXOJnADe/YTvWxf2D3aw7w2CjYU3PJDsY2opPvdUa8nZBNHMgnoxtaitbvs3Y7FsZQ1dvc/mMtJXB4mbqNP1KhCQ22HQa98cuPHPvuS5Yw+pr/tja2xpCIcpTu39j7PstkuFc0HVFlTovln7CRf4iYOxr4RViK/r2FLGvHM7nMI4bRJIe0K1/6QHCbgxx34BaYitK8e6glCRSWUn1stsl7T677Gs2UE0Xlqu09hJJWTkXHoyVoxRI1hYJn7cXARsZGIJNS8TgtwT0H18aLhdG6Gr+WjNMyMpdrrKlQXuezLgZqk3fW23yaSSeHDxbCfsxsY2KhD1+OwjFwzNq1SzhTcsA/Wf5fh+v9wAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABgbk1yW0/xD0leuQO9bQjVNdUGMy+knWCkcSsu/WNhCHrFajDKonmbRYpA6EXBxSSqfzLxchnC7Rkk6eN88/wAxQU7Z90bl7kO1WldamgJgrPUemdjTFASfZSWcQOL5XGTkm89zW1NksYr+O12zjrBVqs2yuXKzWHekiFm0jfXDYwdTqNc5f/E282Hdoujuw6c4N6UmF0k0I/OHUFrSsvlUV0ahWlV0SRVy3/sCObtXVjsrtq4aV9jgkg6aNa3H1KpSt7Lj/wAftRcXNRUzRujKXF0LWtDiyRsFAxhDGOc+c5VfS8u/Wyo+m7DNPDKyU7OyazmTl5Jw4ePXCqymTDrvFTi9qLhtobX/AB50lXkK/R6DDoMiq+2l9rWecVIRSwXO0PEyENJ2i0yfvSsy9PjCeF18M2CLOLaMGLbve3Nzam0HRpTZe69jU3VlBhfSWStl5sEdXIZFdRNVRBkk7knDcryTeFQVLHxTLDiSkFSZRYtV1fBAGSFlkm6SrhdVNFBBM6qyyxypJJJJFydRVVU+SkTSITGTHUMbBSFKYxs4xjORW86oo/HO7n9zh7YrHhaWokRZ3XEXhuZ8mmdnH6yo6LI1tt8EUq6pEcWZBSKepPG5nBE5G67DjknpiKuW5NWO0X4kTihP8dt3cfOFs3snY+3dmVKR13C7Zj6SvWtcVphZXLWCt71m7uDmDuz+cPVHk+0qrqIpSrIk2rHyiUsmkggovpFwo5Ud5q/F7TXFnrv4GNtMa0o9dJEIbpuOuFWr+0WGWcqy9rvri77vfVfUzpSZsElKTzluzqM8s1I5bxaC78rNJNwF72Sk46GYO5WYfsoqLj0FHT+SknaDFgxao4ydVy8eO1EW7ZBIuMmVVWUImnjzkxsYxnIi73v3Z9XfHd88hrzy613O2FlnKalf1QjYNyvsOylwY7Bw91fD2qBinqeM5KsjNzEX8uqUyC5knGPaEJEH8Pr2A8yHzG2donYxcZtosYjxbVWvJecv6MfjK+V02jF3YjVnWVLdoHMZY5KxryyxuF84wg4UKX3hLfx56AurLjy1aGQ43xe57EgmRNza+Q0o62q6kcJ+MlO7qMiRlq5BT1esyh4qgRplvXlNbKiJEk0g0Rv/AMUpxrk5glO4kcV+THKa/OEjnjoVtDR9EjZLOFSolwyzFJ7MvK2MHOl7xja8TITK7chTKKqGIn+KXuP7mrHHuZyrdJOw61DoIqOzK39fZ0Us1ZpEMso4clsFLoS/tIo4yoqvlmgmVMhlDYITGc4sv6/1NqfUMWrE6s1przV8KfBTLxuv6ZW6VFmIgXPoyqzrkdGNM4RLk3pydPwTHq8enGc+KaPbt2t7j7Bd1odWnWRiUuUFcZxWjbO2LSHaiK+2pJI6qdhqdfsCKqLSG0nXGyLpxf7os5Si7UxaSGDPEqCzcuLYGjnLLur7G+1OAxwc0bo9pTZi1vLITYVY43Ss/f7ftOuVuOWeyVYTn2Tx43QoaCDGSkbJmAduGluZkYxriWVgjvoyezr1lWvlr1VQMi+Y9CnJ/bu37C1cJXTfK6mwT29WFUMVVOtUyMhuPNwZ0uqkwggu/hWD17Jzb4hnE/OSCTSIaRNmvqU6ltS9YmojNm5oy98jr/GMf7ZdwlaG8OTJ5Rd4oVBy8bovobXMK+IRVNJVJtJ2yUbpWKxJJHQhIWvS6f1+n6/H+H8/+4CsKn8Rfsuu4SxtjqJ5xa+Pj1GdETg5+R9lIv1Mokay6yohl8lxg2clUK1IX0/VTOM5yX9WM+KZ4OslkWuzdAczdWLrr+wVxP6yoTuOKfGM5WwZRLaTaVMdvj05USQhllfSbGSkNnHgWZf1+v1kcKRjI2ZZrxsvHsZWOdFym5YSLRu+ZuEzY8ZTXauk1UViZx95FCGxnGc48fUBEpqXvg6o9wtkTxHLyk0uQOQuXUPtuHt2qnUeoY2MYQXk7vAQ9ZdmxjJTGWiJ6TaFwb05c4ORUhN79f8AL7ibthdBrq7k9x62O7clTOgzou59cWx4rhQuDEwVpA2R+59Ri5xn0ZSwbHnxnGM4zjGDdq9WHXLupyrIbE4XcepOVc5MZ1NQuuoWkzzw5s5NlR9O0dGtzD5TybPhR29WUL9cFNjGfAgD7h+snpW4HcWbRu19x+n6ts6xOVqnpikUXeW0Gjq77FkGiyzPK0Rcbdbo1lTqu3TNPXF9Fw7cjSLQSjWhiTU5DIOgsH83+x7iT17U1C08kdlNoSZl2Ll7TtY1xFOw7TvpWquG6v7LVBJy2UyyI5z8stYZ15B1Vm58N3880WMRM9Ozl52x82exSuyj1zsCG6zOvGWXlmRbvLP5dXZe5Y+NM6IrB1wtdRbbM3LMyiXljI0zUMVDavhXS32XtW7oxyaE8aI3gH108uew+0NT6I1/IyDKrzjCIkNt7QxHG48aqrKOFlcRD79tIm5OdhPsnfuflKLWoyQk66i1byjyNm0Z5Z5XZ7WHS12ucWt5NuR7HW/Cns0uUIoilWi70td6fTUPERaaKUFGQlJ2RaNYarqyVaK3TPSmjKVmmtNxhNtAmj2KCDNIMc9ePAbk7slqxc9c2mJHhrqaYbuW012Wcu6tGzXLHYMM9z6HKnH7XDZdSA1XW3yaB2zMtASzIuWax05TkLIvG+G2bCfG7oO4IaYnibL3HB23mnvh25Sk57bnKmwPdjnk5jGSqOHSdEfLHpjhEy5ElWilujrnPscIkISxq5O4Ovpw67/eRnGp2WH7C+q3kPpdGPTMtM3/AFNINr3UjNEs4998xQnmFfq6bdHBVD49O2JJNRMuFCucF85GbVficuqVOloWkl+2+vOK4W9zW6WmLTi6NspJpnJhd+uZHXZsuDnMij8tfXGCqpKZcZQRykqoE/sTERUBGMYWCjI6GhotqkxjImJZNo6MjmTcmE0GjBgzSQas2qBMYIi3bpJpJlxgpCYLjwP0fy+v3/hn6fX8/H1+mP6/fjxgVkv+Pbyf5CYVbcAupTlFuBi7KUsdsbbaa1Dp7I6vn5VSSJXIaz1VZNUuMm9pTbMP6SFMoVc5CmNjWPmPyE7+6Jx/uvIvlNuri51y6Zg0GjE9Q1TE1/Yu67dMy5spwNI182fv9qoSN6l/ZWV8N9uUJu0QZScq9kYSvx8m4YBP32HdmvGXrY1q0um8553I3C0oSZNZahqhUH1+2HIxqJcr5ZNVVU2sHWmLhZqjN2+aVbxEZlyi2Q+0plzHwz6mBb+WFT7SNlOt6dt3M+J4u8TaLMKrav4T6bcT1s2XYvZeeEmrqoVOEsMlXnDpHwnJbW2pDNrLNt3Gf2Hhq3THrGViM09SvUrsntxWsfNzsq2dvTYGrnDYtM1I6ndiS7i9bPdwMw5zLuyWGwt5uQh9SVNypLwUZG140ZiUtL2a+yncUhX35ZieLkPoTpc6XtGL7wnuKWnV7KnlaM1VWrRF/wBrW3dmXxu2Ku2iKXL7ZdXeXgzFUOg4stqYmZQ9WjHPvOMZUdRcPJBHUf4ibhZw20jXNadffAXbT7TsK6XrlJmrG0Zab1jNWxbGFHyyM43Q2TZrvZneU8v5txOlZW+bcorKSDgv1flxhwh4Id9lpv25+X0JZtBcStncyVW9t2DuDb8a1uW72lIn3KM5GUujUA1b2RD68gGCGIjDeoWBlULLHN4iGjpeSbr1mDjouRHr56/d4cvd2QnaF2lV9uTYCJWK/ELiUu1O2oXHKhNFTPapLytQXwdBvY22FEJKtwUoRWSjHhE7hcMq3NWNj6fZU+/P4Yz9fp5/D/H6/Xx/X6AK4jf4fyc3kulKdh/ZBy+5dK5XSeK0WHsX9luqSqEUyriP/ZN/IbEwmwSUz6yrVhSlLquCFdFTbZydDMjOiOoPrT44fIr6y4d6dzMR5yLtLPsCDX29bGrwuMep+wsm1nlylol2ob1GyaGcxySJVFEGqTdqb2MSRAA47Rm0j2rdiwatmTJoiRBozaIpNmrZBIuCJot26JCJIoplxgpE0yFIQuMYKXGMYwOT9/j+n3ec/r/P8PuHGePGke0dP37psxYsWy7x69eLptmjNo2SMs5dOnKxiIt27dEh1Vl1TkSSTIZRQ5SFznFPbs/+INuV0uUlxF6pnjS1WlVCYZbC5Qo4isV+DYMGq5rArq6ZsjhnU4Wv1xmRw/tG+Lg5aU6uRrV5LQLlGPQbXlsE1fZF3I8SetyEdxF6nsbN30uybOq7x6okmzPcVk36eVWEpdZM6byO1zWl08kcFkp1JaYkWinzFardh9tciVKzmdzV5d9g0rX7Dzl2VZ9I6DtUhHSWmuE+j4xy+2Xs9N67wpS30Nqt7Itn0glMKOWiMZu/da6cY5w6eyulqddztXdKHXOE3Cnd/Kzb01EcToZDkluwk+kru/nbuVo+lePWh52VOs+fymuP2uSkJLaeycqFM7Y7It8HLWN0+MtI671ZFZiYvcri7Z189OvGvgu6NtKVPKcieWlhws+vnJ3bpl7DcXs3IHMtKOKUxmHkwnSUHSyipF5Ju9kLnLNznQsFslm2UmqAQTcBOhzbPIOtQMpzAqbzh3xBJKsbLFcJ6LKyCe39uSMUXBoO18m9lPs5sziRPlZdb7IlMNpGvmeTLHX1K0U1f/LK3C9Yas1vpSiVzWGo6PWNc6+qTBKMrlQqEQ0hIOKaJ/XOEGbNNMh3DhTJ3D56v7r2ReKLPX7hy8XWXP379fr9Y/r9QAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAfPs6Q7dX+OXfLyH15vp23grzdnPJzR9be2E/yZT7dcbfr9mbIkduspo4eWyIpdkioFQ5sYnHs7HR8dlw6lmSbj6CeM+M+fy+orM9zXQQ05xXBzyl4p2Cu6x5QmbNDXiAsTh9E0ncSkEyQbws2Wbi2r5zTNkMWLFrEpTGWK8FY0m0SWaUr7pm9sjsLM35fx/MVzviBeq7k72PVLR8/xtuNfdSWkiX1SW0zb7K6rMZd3NrzV/sydrMkumert7ZEoQ8lHKZtS0QzXjJH0tp5hlJw1kYI6D2191XUdIMdR81tN2na2vYZUkLDf2/xkuo/XZssewRvr7krVjycVcEMFbZIR1NPtmJoIYMg1K0KQhE5NNc/FzcVpbDUu2OK2/KIqtlMjo1DsOv8AZzVoY30Oci07JaqdOUUs/vGMVimsYmDZI2MfBUzBWT07fty9bvLXVctvfhJCzdo4Fzriw3WhwRm1XlH13vcArJUS07v2vXIzabWQdQkadO16vRz8lEMstUpaBb5j3s6nNWedefFxcR5Urcu0+MPIejrKFxhwakSWudktGyvozn91aZsWsnSyGFMYLlUrAq3p/fw3zn9zOFup7tZ4ExfMftD5Hb73nFaomuVe86u406lsmv2xo6d6To2LkwquJSWjIabqVdefY8xX2kpDv7Em6KtGJFTKuyZpuMzrSu4ekHkKQ57PsHrD2ss7x7iyF1m+MNgl8mWx595VhaVlpZFTOfrhVRumrhQufSbCpM+A1QqfxOfVLYk0jzF83DQzKF9R0rZpmzvFEM//AIK5oylzSMbH5oKrEx+BvyzTHfEN9PckkU5eX7ZmfJPWZCR0lyNZKp/vZL6DGW1FhA6mM48+lFZX9z9/z6fOcdsjusLpa3uZZemcbOIl1woXKiptSSME2SIXwY2TJk1jYmKTVPx6s/3JUifu5znzgmMlqd929A629X7bgeCPXVxEq81ykk7PBwGxL1TrTtW4u6hYpJ42Rh9O0WsvL1MVqX2LMuHKDe3O3cPIYqTZcsA2RTtq75zUg2y7tviDKruKjn4nde1+cyVQ2HC4Zbo3+3YzlKPIQU4mZsvq2k/tcwrsxEs5Fqrkl/tj1pHpGjVzVuLc5Zrz7kZd6Y989K/WfpxWbuXMzWtv5XbMjGam2b6z13uR2yqscplN411XQHy2sir/ALLwrgias/MI4SWuVgQxKvU0YthXIqI2j68PhoOJ2uNBRbrnprtrvTkHcvkZ+yRbW/32vVDU6OW6uW1DrbjXdqquLLINiOMGt1jkXEnHPphHDSslJDx5JSd35x8Pz1A4yc3/AKNoPPryXOcG21yAMXGcefGClNtgxSFz9fUUmClN/wBWM+AHud9//UIzwplbmXXD+0XBjfKat3u/znGc4x4Twx1a4MqfGc48kSwc+Mec5LjBDeOiy/xHXUBGevDXk/MTpiFybBYnQ/IEnrN4/wD0yGmNYxCeTZznxg2T4S8/epj6DKjHof6ko4/rb8LaEpn04J4fW3asoTxjHjGcpyd+dp5N4x9T5Lk5s/U2c5GSoPp16uq+ZE0fwZ49L5Qx/d4nKO2sxTePJv74tkUlir/xy4Kp9Ppn6YxgBoPNfFA9V8Xnwxse87Jjzn96F06/QxjxnOPPixTMBn6/fj6fdnHnxn6DAdp+LE4We+nGao448rdjzi58pNWUjA62qbZ6pnz6CtFI3YV1mFcm8Y/dzAEUx5+iZvqJitlcbuq7iLreb23s3jZwn0lrmpJYdSlwldDahhEEVz4N8u2aKNqeaVmZx+ZLKMZExaMhOSq+CNY5m6cehEV1N89k9g5Ss3cBxfs2tupLrvlcyUHdeZOwq1XqJvne0Q3XXSkmPGbVtWO0vU+zXSaKJ4V1+2dTLTPg1lu1GelXqD0ObIfFJcj7ts9jpTS/WJPL7Xmn7OMgKBYtl3Gz32TcyLNGRjsZosHp6sy7YzqMct5MpPml0CRipZDLv5I2HBYOZ6R7N+9vmvKxb2v1W+37S7eanC6vev4moaL0zT4i2wULPV5DMhMr4eMZewfZUfK5NPWS6XBNBZwR+/YRGFY2Yrjb289KfW1TZ3X3DrTvJrbuzbNFuY65clHevqjm+bIlFPfWxOTVhvV2q9rRjsSi2JJpUYmnV2AIokVdZiWUO4kHMffw83ZXxT68tk8kGPK7N2rT3emdSwtd2XGVRe1RFLQpkjsVW4Nrw1j3J7mxbyj21Vx77kBW7OsueCdfPtmKjVrl6E1dC4BfEh4qVfo7TnhxJ446zg41GEgdc6eo1RrDOmQqH7xI+vQmvOLUBEsEEzKqnIRjbSnMsZQxlyYOUw7sl8Ppyi3R/wC95n9vXKbamXOfbdVSkubLGV9qzzjHuNY9e4X+xwxCLGMpkxG9Cjm5c5yY7Zc5zGxZ1rljgLhXYG21WYjrFWLTCxdjrc/Du0X8ROwE2xQk4eYin7c6jd7HSce6bPWLtBQ6LhsukskcyahTZ/aAVzda/C69YdKfJyF1JyE3gr7xXDprsrbaUUxdqer1KEUzqar6ylfZVz9DYNLncePr816s5MJE/wDhAdYOaN/Z1/6G+PGK76klPmy0GPJcjKJIGQTUPsjBsbEUUKmofwqe0mNk5zqmzlU5j5yfzG7B+IvAyqoWbk1uKAozuUZrO6vR2pXFh2TcioqGb+axRIRJ7YHzLLwuGK885aM6zGOTkxMzcal6lS1vkN09qPfrZpFpxtk7BwG61CTzqty+0llss9m7Nj49RVCXwg+hX7CwXGSWLlVi/qFJnq9q+JVO6gLddLNKxxcrB2Hl31ldGPF22Sc3WeeNt699yxbpZdCJ1ByOd2m2V5Yh1DZRd67UPctutWZF84O2RazkKbCzfKLZznCSiOIBUtfc4+3TkjOcYdJ8mr1z51PxcRt181nfuRzmyayhrRS8y9XhHclPGk5N5bmUxeXhmERAp2q0tbg6hG76QRWp58TLKMmG7R+tLra6ieAVntNe17I7r5S7nestO6u2FvKeVtslFTs6xdv7zfoejR7aKoEd+zNXay7uFknNXfSMJZX9SIacXcqYVebm9J2utJ9UHVDP85+Tcs1pEjyCZxu37LJOUElbE71+RB2z0PrqqsDYauZyctsfIPbdARKC3l2+2Bn5ty2j41V20DqLnug5X9YmuNfay5ydTamjNeV6JY641lYdBbOgVdWrLVqFOWKqtdjlj3qIboZi2GXKeFNnyMyizbuXThhIr4XUxH7wN5pcKeXXNif5v9unJeqxW8KnYTx/GDjDbahsplpPQEVCSjhVg/kZ99Vz0E0/CvSpOYSOmJUxiy6Rr3ZpKWui7VnUJF+DvH/ZfbnyYL2y8+KqarcX9emeZ4L8arg7wtWGVeiH3zSW1re0ekax8hEIrxyc0vKyDNBvsK0N0JY6aWualV4uW06558j7J3l8rl+CPXjpfTU9rWoPFTbk5p3rVtOs79OKYuixz+zVO+TFalpuh0Roumswq8rVHLe/7RkfZSrrqJq/zhpQJveWHfxwH44va3T9b2qV5i7ZuaDNWsa74qng9kkUPKot14Yk1cGMrits15VJwX5WGgl7PbUs4TO5rCDddu4UzV1ndotU7FUN21x3pbYHG/dPH2ywsHsrTOzF/eskVH2hGTPX5fGXMPWpRJRV1AzUfMxElXI95BPGjQqxnCMoyWUgA5qdMnVh1f8AD+O29tnfvJmN35BN3zKiW/V2xK5Rdh7s2asiZZvXalSX1ftEZV6wxyqkeYkmKzh3U61kz2ask9JqMW8r0Prn6ve5aiaikebujOX9Y447d5FN2lgs+vuTcLm8WG162gkl1ddTOz7za6ZsdyxlZaPlJF0lGL1CNlImIWiHr58wklfsivheJHVbzeabrKnWbYWwrPB0uj0yFf2K12yyyLWIga/Bxbc7p/KSsk8USbNGjVAhlFFFVC+foQuDHMUuajlz7qu1Dg8+RiOXWr+vLf0MyMqmaZ1Hyw1Rr++zmG3jDg/2Aps+yThFDZ+qajfR8ciU2cp5QOoXJCwW9tHeJt3syTqusYOuSmgONcESIlbFrCNs6dulb1dm6ibheduM61YVdrYoasr4xilVfDNhFpvUM2WUOvMKxH7NhuL2092WwexCVt3GvizPOtOcJq24Mltfb82aWg5Ha8Rh0duR9aSNGxpuI17IKIq/srquMYu7psRyUn2zFu3SqNUguT1TdLlz50wERcrY2t+hevfMsweu3Ug3bw2+uabyvvSuSy0iq2VeNqhrPEqgVWIjo93LVOpJNm8VVHOxNhM7NuheL7g1fOAVeuFduXL6o703XV6bJpSurOGOhqaxn69LzbNdVuvbOQdyt1koZLZKymGLSRlY6ow88zsbV7GQTtzVaLDN9VxlmTZHxVND1CSKqcF107ury2YCPWptY2RbobThHFcKovEQ6sTEM6Fbzt4DCkY5jI9SKZu2GFI5wxa5xlqoRMLUGnNK6m4969r+p9Ja+qusddVZt8tCVKoRbeKi23kpffeL4RxleSlXyhcOZWaklnkxLvTqvZR87eLKrnw7t/nhwr0BLq13dPK3j9rSyoKKpL1a2bXpcZam6iJvQthxWFJjM8hhI+fQoZWOIRNT9w5in/dHz2uxXuc7NuSL5enX+5E4s67mySRMaI03Yi1SzM2KJW3iI26owm3u4UpJ+j8tk8LeSVSClvmVXzCpM45RTKPQeFXX/wBgG6GcQfUXWXTLmg4/vFdzci6lsKt1mXZOVCuMSGHO19q1jWc2i0IbGfVRaa8lV0v3DovljenIfQJju2frKlHJWrbnfxbSVNjGcGkdxU6HbY8//k8l5Ni0Ln6/XBl8Zx+OPpkbe6y3XprdcavNaa23rLbcM2whlzL6yvtVvkY3w6wplrld/VpWVapYc4SVMhlRUvu4TPknqwQ3j5bnYTo2+8XrlK6p2/s7gzJbIK5OlZNQ8TdX1d7P6udJsSqox90uzfStHaV9yqvgqDmDZ7Ls9xj1VcuZKvNWCjJZeYjqI6XeamwdC07mZxq54veIhN91KwQDpGI15Yj7AUrcBfX0S7YuHjazw6Ctel56nN7BBSEfJoZlon7IfrINDqmaohfo/X3fr9ePzwH884x/PP6z9fz+7yKzP/A17BrCZNW+d9fM18RVL0PYyqsdm1lif/mL6CYQ5OHZKl9Pp9R1YYpzm9WTF/eHrx8OvfZb2s3Ttu542ZQps5UPi2TDb1YznznCWJW92EyJs5ybOTGOtjOTefT9M+oLNQCskb4YfQ0smYlx5y877Lk6vuZ9WxqainnOfPqMZOUpE961c/THu5Pj7s5yXPnGMM/Cq8D3HzJpPkTzqkVXRS4VVW2rp7JjGwch8qH93QLj3jZyX6YXyqUvqznxk+CHKFm3/H/D8/z8f7/0D9fr8v8AH/UVj1fhSevpU2DZ3tzix4RSR+u09NH/AHUlCKYz5Px6MbGfJMeCYzhEmc+tNIhilyX0rfCidfKzjK5t784fVlT3M4NtDS6hsZ8+foqpx5Or58/9RjmP+Zs5+oCzt4/zAViFfhRev4+F/RvrnAmddbC3nOztMKFwbGTZ/fLnj4XKuf3seFDm93Hpx+/9TefWb4Wri/HFOSp8xucVeSNknhPN+144x6Ey+khT/Zut4IpzEx9EzYKTBMfTBPACzs4XQaILOnSyTZq2RUcOHLhQiLdBBEmVVllllMlTSSSTKY6qhzFImQpjGNguM5ENZO6XRt/58a24IcYKFaOUcrLSUux3RuTWUmitrTSTOMbHUVlVJRKKk2F4jop0UrS1yrGYga9CrumMZFTlls661cbaTKfC58X507dC/cw+cd1iCYIRzEvdiUIqDpAuS5M29UnrqcKi3U9OCnIVExsF8+2ch8FOWbHhtwO4t8CdeK644zaxjqUwklUXdps7xdeevt4kkSehN/b7jKGXmJX2cmWPHxJFmtehMuXScBDRSDlZE4bggAAAAAAAAAAAAAAAAAAAAAAAAAAAAA4EpFRc5Hu4iajWExEv0TN30ZKM28hHvUDZwbKDtk7TVbOUTGKXJk1kjkznGM5LnOMDTDYHWl16bR+aUvPCfi/Mvnvr+amUdKUCFsK2T5wY2TWSBgoyfwb1eTYMWSwYpjGMXOMmNk27wAKQfArpg4Lcs+RXajozcdQulVneMPMSyQes3Otr5IVmSgdK3uXup9bxCkPKt7DXXLBlF1BRxEP3ECq/V+cdoPH75sgxTa7szfwk/A9yZU1e3/y1iPV6spElrBp+eTRyb7seG2n4BU6Zc5/dwZX3MkxgplTG9RzZlUlicE/iDZ9/bD4htL9q2kapF1edVIo3hG3JLUqMNWo6sLPVS4R+0pVjEOMEalwcz2f29WiIuEvLlsJE+03sl1v1ncbJLbVlQaWfZ1sUf1fRmsVHJkVrzeE2hFjupPKCqTtpSqkk4ay90lEDpKIs1WMMyXLOz8Ii4Cit3EdZnFvq5mtfVHVPLTYezd/WYxLC41i/qFfYOqNRDEdotbbZLpXrCzWhX80/TK0q8ElXHDyXbNJmTcOYpk3YGk9zuJnw1XPHYmu9c8mleT0Txo2jsKFe3AsDIpbGa7aqzS1fP4RNZLHXX8e+YTtngXZJCcjMucyLFCaXiJ7GJNOSZJbC9GXW3snnTvuwdtHPls7vEVNXR/cNRw1xbesm19kMXuWxdiv4ZdL5VPWetlmKENr2DSTJFvJuGaINWzet05BlN3gv8/v+7x58f5/l5zj+ACman0E9xtewkandutpZnT/eJ7O6uUdawifz5/ujRcpI5L92M+opSGxnHjGPuMP0k+pD4jesp5zWu2GHm8FUxnCdj5Ncm3yxyYxnwbGZ7UtiT9ec58HSMuVLJfvUP4wUXHxxH8gwiWD2UlXrSNjI1o5kJKRfuUWTBgwZoncPHr125Om3aNGrdNRdy5XUIigimdVU5SEMbAU+CcJfim6j68w3O3W1lynjBCYPsaLnMLFLjH7xMXzRKGPPguPJ1/Qc2c5yfz5N50Z5Ec7fiFuGm1apoXY/L7V163bbyMcVvSmvqJx02zsV4nJ+hRk4lYqr6QNJ1wqzRQ0o0Nb5ODzIxKDmSjyP2LZZUk4G/O07e3N7a03ws6aoZndphEqUZufnrMN1c6Q0TGu3CaL9zR3jyOdR9wsJGZXhI2YK3kU5BdNRShV+3EIayQlfjl9pFfVnIKI6kuCjyb31zl3w9I05wczbi8yfYew5a8wyNvsWp4ifUdTr3WemYCq5Wuu7cx8pITVijiFrlxlJwsBNx0mEd+1uQvYt2Bct6pTdhP2HNbeUGdOv0fVtbZwN/wBOVOfi1EkJCZhKhrxxHaImSMzNMurZcFiWnWU9HuDuLNKTkI0blY7Xf8GburPstXa23+DMLyKsWU2Tdu023vbUlmgGacUs2NENWcJQeStRKSAh2bckRD1BcytIj4M32Q1rSTJu1RbXfutXrI0D1raZYUfW8PHz20p6NYH3But/HIEt2w51IuF1m5HZincwtHinh1SVintV8MY9vjD199oT7yUl30kf3/d/P/DGPrj8fpjGM+Px/j+QUxdUXL4kLQcIjWNM9XPDrVkEzbJtkovXWvtJ09lhMvoxk5k6vyLjUna6uSYUcrL/ADCqyuTLLZMrnJxFbyz6qe5TmHtif3Zc+t2ga62NdJF/YL9M6hu2v6yyvVhkD4We2KfgbHyOt0A0nHiuDuH7qtxtfPLvl3MlMJyEm6XeKfRY2Jsag6ipNj2RtG5VvX9Bp8arLWe4W6XYwNeg45HJSGcyMnILN2rcp1VEm6CZlPdculkGrZNVyskket5tXvq2zyZv83x86b+KFw5T3hqsaNlN/wB5hpGu6ZqOV11mKE8WLeOIDJIRXJ0nEbY9nWrWzHDtHKGa5PtlU8LBG3YefnfX1l8a9a1vZXFjiLpDSOqKbBa5oOL/AGalO5+ZiabEMYtlEQsYXli7uF9saUekg7fMq1ESkyuUziQOzw2IqdLCVh76e77ZXF/YW74PWemNW6Sj1G1YX5GROs1qkVpPSzsjBKE1hKbZ2ZL1u93XBve92BqlXu0/EsU3syrGsUI5aSZzkcW+jWf2VtXHL7t92olzO5FSmWz6I1M6Oo60DrNE6eFyV/NfM1jYW1tIxZQyaVVja7A6zZucPFFIG2KuU5oRP94l3oe3u3vibwq5NXZHQPA7TtZ15KzKiOZCBqKsRZWMnO2eZZIwDNylEKTMfBRWlq5MIRmWdKVav35FGDBWXVAQ5aT66O1rnA4rvNdnxqtPLit3awvJs9p3dtOBYx+1DQMq5i36Eqew7k1xsmTrJJJk5jSuIKWimShGSzGMkMNEFUcWVanv74oei1yDplM62+IdWqdXhmMJXa1Ar63iIKDh45sRuxj4qPZcxEGjNs0bpETQZoEKmnguCYSxnxgTe1Dsb6qtba+rFXo3NThlVaDTa7G16q1SB3pq5slA12DYpMIuIjq00sRpRBBkybot27TDD3zFJjGCHUybJtGuS3xJXW9pSPdR2p7fauVeyFPQ1g6Xp2szbWGeS7k5UmDWR2BbIyIr5GjlU5SGcVVK6ySRjEKnCuFTlSyFOLuE5adgfI/kJUdQdgtE1dqzZvG+uPTp6ppMkzY1WMQvsJB7DfSsy/Z7Uv8AHPLJaao0q6STeEtTeUeMm0JDRsbiwOUknW8b3T3dv3F1Lj3v9zxv1fYeNeqEUYjSmoZSWhdQ6Fl0K+kWNJaEtcWfaMXcbfG5bkZwTaxLSTqBkY6DUr0ZleKNYmMhi/mNwU7YuT1ke9vG0eIUbLKbLv8AX7ZIcdYyrSVgtdf1xrqAqcRRHV902XJbpL0GZrNZb12wpuVMXB5Hxz+esMNXYGbjHpZLqX8V7e6lCRFAtXWp7F3hI5nCIwVM3FMUSDTzHtUWLSPiKJI6OssvXY5qZD5dnEElJX5Jomi1SVP7PnIaydp3J3vU4x8a2GruXl20BqbVXIRnLakhqDpGJoTazP6ZCwzM9qhoh1Vo14at01lDOYirTRGk4zXWj7G0hmKC8e6kDNdTbC17GumbS8Hr+vc3tB6bsW8G9c2JnjTpGBjLvyhevbVX2ykG/wBlyUtoZo+rDCNIZCKRbTu2z4ZrupXGuoCweZZM2QezLZPad28Vyj8gpLro2Rq3SHF+Mu8nXVoamX2Xk3sffnNNcWObd5uTSGX2LGRSdJhVVntC14mwho9OZeWZZePRweL6T1Rc/OsPiDcFeQXMPS/Kne3M01gl5lvt58WibKrVUkHChspzVegrjsOny5Lut6THfXSyYtNiZvj5PAPIEirwzgJPtD/D68yOelb17yx7FecG46Zt+wNGEzX9fSFeeXHZVArKCjd5WPmbRN3eKjtcWBb205o9OgaepmuuFkFpV2lZlZaNjdyJb4X3hBFxDy4cgeYXLexwFZaOJeenbVs3VtWrMZHNS5XePpiUs+u7DiKjkS+4q8eKTLQqZM5OZ0l4MfPSr58VrqGzuf2S4hcL+RO7djSuPlK3C3I1eqeXT9QuClXRgdcO9w2OaTbKHKpiNaIxziQwXDf56MMthwlF12YVztz5E8S9gcx+yiy4456Br0pWIzTvDWsYUq7q4Xi2zmYusL2Glt30vIRTSp+4+tMtKbgmZO/rsIN3CViErqM41nosNDef2reum0bq1Jw66ite3Lcl9n7oyrtn3nM3G4WrN+tUy5JCwWvdcR0gpFVbNYj3aq01bNiJVVBF8ZtH4r06hU2M87sFsPrH+HS4v8UKeyuXLSpa+5UchptlnEy0t0A2tukdfoucNljwVNpVqj1Iy0yTZZDBXF9tsJiRWxjCdfhawgd/iVjL+HT4w8ZOLGkpXtN5gbL1prSUtStvp/Hp/sm3wlZZVmjwryQqF6ucQ0mXLRxKXG6WNhPUaDbRSD6TSg4iUZxJHityXaody7Cfip46KdT+tOvCktZ8yJ3cYryO2rDPkIdXPhMhZPWmsneWEm6J4MooxmtjFjcEXSKV1QHrUxFlA12+ItN1S6FnUtFaF4n6nxzFkPYnr1adbO7Frqmaag5VEjts2sdM11N1yn2XYFqbLklIuDexhc1yO+VsU57raXYRE3GR1ydOHPvsFjLFuPXEmw05RmMGWIrO7NzPLVDJ3SQjmzFhHwGtJCKgbBb3DBgyYtoSTuEC2bQUTBIyNVQk5FQz6rrT2dNPRRFbMimXPfstgZvaW0trzC+yaPp/ZblaSZLMrFn7XQ2RuyMflO8s9qtTh2aZjaZOrmiIyLWbObXFSMw/+yq7Pfz+7OeI/WDruEW29L+5bJaEVT1VojXjJivdLKwh0DsWWWUQmdpE06lM12xIvNknFY2FbYbrsIVKWk2mIg4VSNF0vll0ETDnY3I3qm0LvTXMU5ZEectdZTk7arxBZUMkwzMM73ZJPYTXXTN0sm1OSMW1VqFKVeK+xmRRy9SM3yjyZ76dndlN/pXELhrsSr8AdRbKZxEXtjkjyGvlaoN1a4lUW+bFAV6bjJt21q0a0WO4iI1xWpc1uubn5XKszQIV3Jkzl7VnFrm58Qbt+qcl+dbCxcbOvKkyeZPT/HeFeysPMbGSwQuMP4r7QasZN8jMtFPYse65mOZLP49dzA6oi4xi6fP4Debum4OdYnHvrm2ftSR4h6dgrTqqmQlF0S9pMW/13YjXuxSrOt0ltMz9Ff1+evEdGPZJ1Z7Eyt0nLKy0YwsDtR2nLPDSWArJXHgnoPeXZRpnq54YysteaXSLSg35O8onr5jPWTZVsiG+Z3eV5ZO22VYSBqesa8nJUah1Noqdi4vv2zmQmrI+sTSYV+kXQqJUNX0io631/AR1Vo1CrkNUahWolHKEZA1uvR7eLh4pimYxz4bsmDVBumZQ51T4Jg6yiimTnN8yfq73nvDqx2Zxk53WCnVl3xn5X2e/6EsUnJR8e/sbvX1EtlEQ2dLQEkZl9s1Z5XpaUjJuEIykkIy8P6bLQk03UbRmHLH6gnnz4/H8fP1+vnH5f+c/1x9QAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAf5jhScnGwkbITUzIsIiHiGLuUlZaUeN4+Ni41ggo7fSEi/dqItWLFk1SVdO3blZJu2bpKLLKETIY2AiU7wdM8ctqdfe2bJyGvCGpj6YbE2hp/b7ZNQ1mo244gijWjtqumzXaSsk8uku6bVFaBjXaDiR+1EHbdZpIxcdJx9Cao8nqt2F8utc7P7beUE/C6e1lSKxCyhIeo3qfnbtCUZhGNMa/pURr+AmGlXsOzpdJzZdiXSQVgWuHUtYZWNcIv81+JZyjdgPKnePf3z5pPBXh++MnxioFpeuoWwKJPkq9NpQeCxl45LbASKmg5LV4Fk/cxOuoZcpXirKSaINEm9ov6kU1ugcbeBXGTjLx61dxxqmraVZahrCPz8tJ3SoVywTVgtkhhJe0XyacSMc5wezWmSJl7IOEcEI1QTYxEeVvERUayahA3Xu3Hktzgt2s+KfS7xfntU6mr0jWIGa5W7m16zT1VrPWdQ+SavYyGo7QkjUYuMRimf2ZFMZC0OrlOMMZh65UIKcVSmIq1fj1eMeo2Mm8eDZxjOCmNjx5zjHk3jHnH3ZMbOPOPrnxnOeMzZso5o2YR7RswYM0SN2jJmgk0aNW6RcFTQbNkCJooIpkxgqaSSZCJkLgpS4xgQi81u5es622KtxH4F67c84OdUooowa65oXzEvrPWaqPksnL7Wu0O7ax5C1wx0zTtdjZqPLDG95C62mi5Imo4CSXllzI458IdVv9wckdkQ9AqyHzLaEYrm+dtV2nG7VR2nWKNWG2TSlmn3JCYzhqyRy1YImzIzTyLiEHUg3gKiKDzu75H7C2bo/b3gh1bHc5WgtNREkrE775WQpHWV2UzdHp2eE42mSaSLdwgV80UqpUVWqtXh724K3vzLZzih08Wi47VZcz+1/Y7Ll9ysOuwmKTr1cip+P/AB3STUzItq5Uah5bQNqexD05DEXcwjWqsn7cr9rETk8iS6Pp9/1+P9f55/H/AMY8Bhfj/wAd9K8WdW17S+gNd1/WWtqwQ/2bXa+3OQqzxfCeHszMyLpRxK2GwyZkk1JWwzj2QmZJUhTvXq+SJ+ikbuPdL7p0+IJ3tyd37qi/2zS+717tL1uzwsazVfSVS26zrE7J2HXzqcWjoackaFYmj2nzEHibiHabRq+ZneNknbMz2+0Mb7U07qXeVTd0Pc+s6Ftelvje45quxKnBXGBOvgh0yOixk+xftEXqJVD/ACz1FJN22Pn3G6ySmMGwEGj74nfqoaRH2i3um5pN4ZBNXMAx01YE5bChyYOZtlaSdR0H76JvCahizZmxj4zlJwon4ObU2+/FR6zurvNF4TcLuRG+trTBvk6tDW9lEwKTp4phMhHaFW1m+2tbbCkguoXH2U2TgnD3Htp5ko8y2FE5r691F9Y1YlCTEXwX42KPU1irp4mtZwVmZJqlPhQpyRVlQlosnoNjBiFKzwUmcY9GC+MeN36LrPW+ror7C1nr6ka6hM+jOYei1SBqMXn28ZKn5j4BhHtM+guTFJ5S/dwY2C+POQFVKldY/Zv21XiB212/bQe6J47wz5CwU7hzqZ01gnb02XRViNZeGj388xp7VVrlRM1lvFhv24G7Zy8g0y1Hyi9a2jtK6M0/xy13B6m0Xrqq6u1zXEzFiarUYtGMjyLK4Jh1IvTl9buWmX5kyKyk5LOX0xKuMZcyL504yZXOVvOf1/T/ADx9/wD3AA+n+H6/Xn/HwNH+ZPXFw158x8E25Q6Zir5L1Vq6ZVS5MJafqF5rjN4thyuxYWupycPKuYkznBnWIKXXkoErtVZ39mfMrKKm3gABX3i/hkeqKPfkeO9dbanG5FPXmKlN029FgoX1efaUVhFIeUwTx+75SkklfH1wpg37wky439cnBniM6LJ8eOMWq9dWBMpCJXBKEVs18RTIQ5PaQv1zd2K6IInKob3kUZ0iTg3g65FDlKbG6wAPP8f1/Hx48ePr9fGMePz/AI+Py/l9f45/MAAP1+v1/D7hgO88U+Luz5ZzP7K43aE2FOvFDLO5q8af17bJZ2sfPk6rmRnq8/eLqnz5yZRVY5jZ+/Iz4ADH1A1JqrVDJSM1brPX2to1UpSKsKDTK5TmSpCZ8kKo1rsbHIHKTP1KUxM4Ln/l8DU3sm4JVfsZ4oXPjNZLi+126mJeuWuo3tjEJ2HNVt1Vf/Nxsg8ryklDEnY12zWkoaSjvtaNWOyk1nDR82eoN1S75gApu6Y+EU19GTzGU5C8x7Zea+2WQy4qOqtYx9AeO0EDlNlua62m23/KTdwTGUFEm1ObuEE/UZu+KqchkIZ9vam4ScUu+dhqHckJG6e4Tcetk69xKRziLt16RUhqtpyCvtcc3IkUwtN2uedlbJWinNrcvW0qTEbanUfkkbToxsxjPpdCNPmJ1EcA+dl2a7O5D6PSm9mtopnBqX+p2230GxykTHeSsGlhPUpuLjbKdgh6WMfIWGNk5SPjU0Ixi+bx7du2SCLjm/8AE3cPtYa8fwvCSRfcod9WJLEVUcfsVeqtrWpyj7PsN5W0OrZCVew2pdqositHVanxzos45xiOe2Kveoy+MV9U/TZszbuzP+JX2xZmdocgby/RuOvdK7La4cp09T1FUg7bs2uukysUJSMakbp0LU/2e1r2vI5NorKxP2+hHxNTmP4tdOPXHw6tbDYOlONdaQ2NEuCPIbYF8l7Ns61V98njOEpCrO77MT7OoyaJDKJpylVYw0llJVVNR2cip8Gk4/38/jn+P4+fu/AA/wB/r/v/AD+/9ZEMne1wP3T2D8H09S6Bdxquy6Ntyp7eiKlMTbSuR+wUK9W7rVntTzNyHtRbF+dC6mmog808joVWThWqMg/ZFUSetpmwAUVOF3w8/YBt+88emXYnaIygcXONqp1arotDYFbu8utFOrEe3TtMrEHr5zM69qzK/wBiJh1se4KTq9nm0ljLHTlZTDZ9F3q/+2PH9PuD/D8MY/7/AMPxzn8/p/kAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD/P+v8AT8P8v6gApWd/3aTc+QGxUep7g59t3Ww2e2R1E3xL0VRVxJXi5u36DZjx+qzhoZMqsawkMJn2k/K5wxdPSfse+cNo2HuLeQkf79u4JHglqo3HrQVoZY5c7chVP/uEesRy80ZryQIq3cXx2UmTEaXSeJhww12zX8KslSPLg7Rw3iohpPYd+Hk6g3HGyoM+dHJiDeH5MbZhXbnW9YsqK5pXUGv7Qhk7qbl0Xxfmm+z9isnB1JZRz5ka3U3ZYJU7aUnrXHphI507dWtK60eOjGIk2UNN8ldmMIya33sFn4e4NJkIdww13VZBRJNZOkUrLhRo3OmRHNkmzSVmeJIlex0bEyb7W21rPRlAs21NwXmt6413To5aVsdutco3iYiNaIEybBcrLmwd0+dHwVtGxbJNzJyr5RCPjGbt84QbqaUdgnZ7xv68KlGqbJkX153LdifK6k48UDGJfaGx5lytllFpoxrZJ2euV15K5JHGtEu2w2Wc4WYQTOwTpEoRxF5qnri5X9nuwqvyk7jF81HVtakS2DQ/XhSpKQjKhVmrgyizOa3Yu2fZePbOsyWTaysUo7Ws8imdaPn31ShyOdeYDqk7yS51d4Fgfa54Pftvwx66Gcm+ru0eX9oj1YbbW9o5FZdnJwGmYcq7aSjYZ6gms3VzEyLZdBNT03m0wayy2uZGbvhPwF4x9f8ArBHWHHOhIQabrKbi3XucM3mtlbDlSF8GlrtbjNGzqSUwbJzMolkjG1qFwqslBQkYisqmbbSu1yvVCCiKtU4KGq9Zr8e1iYGu12LYwsFCRTJIqDKMiIiNQbR8bHs0CERas2TdFu3SIRNJIhS4xj9kAz4/D6fX+f5fy/0+n8QAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAEbXaT2Pa460uNExt+zJMLNsqxnd1jR+sFnny7m+Xozch/eelRVSeIU2qJOEJq6yjfJDto75WKZrFnJyEQcbe8iOQWquLGmL/v3ddmb1TW2t4JxO2CTVwVV24yTJUI6EhWOVE1JWxWCSVaw1fh258OZSXetGaWS5W9Zfn/0dnsPvv55bK5Xcr7M70vwC47MzTmwrDMz6ENTtP6Zh3Cz2s6hgbG6+WjsbB2EoRaQtlgQTVepqO5yeSSKVvTq2uG5PRt1wbJ7AeRNn7XOeDRe71N9fJO3a3iLc09SG4tqs5DBP2uViF8fLF1VqxdmjE1aFIl9hyM5EsIJojmvUySiZGbDmp2622T20vwX6tqK35ScypY7qHtl3YpYk9Hca0sqHYv7DfLLjOIGTmq4pn3V2bl9ipwskVvGzz2Xn8Zokjpw02/yk7cW8dxa6yoaR4U9Ves02+p7tyoTiHFVt+y6nW2iMQ519oau4Owk4uCxEpFizNGijZ6dmqRa/2Kt4fKUOYn34WcFuN3ALUjfT3G+kErcMsulI2q0Sq6cvfdhTyaR0f2hvNoy2arzEgRNVZNgzboR8DBt1lWNeh4hgfLXAaXde3UZTeLVsmuTXJa9OeXfO6/ujTNy5BbAbqyzemO3RDe9A6fjZrC6taj2aZ8xiVjwiymXEWkSNh2VQrKmKq3mQ/p/8/f8AX8f8v9cgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA/hRQiRDqqnKmmmQyiiihsEImmQuTHOc5s4KQhS4yYxjZwXGMZznOMD+8Zxn6+f6fTP+Gf8Av/QVUPiSe1F7ofXhOBPH6efpb33dBtlNtzlbW9cnQtRz+HDJOmNDNPceN7ltcnqaZRRwR9HUUz1fCJFrdX5BEIS+9btD/wCIZyQacaNR7ATgeG+irIt9q3L/AN0pXL1dYtRaKtW3pNuwOdefrFWRcvq9q2MZJrv7Gd26dQKDyWvMPGNpDeuTrY2f2Bac1LU9j1+3cZupPV03i5UDRS6ziB3RzevSpkDyO8d2zEUs1ct4y0KoJKx7to6PFV6vNouoalQUj2aeyz9u6VPh4GtVQp/K3n/WiSdgXLHWnWnFmxMSqw9dcpYVXhbbu2McmVbTNhRRcYcxGuHjX5CAyspm5EkZJdxXIW5KkkkgmmiimmkiimRJJJMhU0kk0y4IRNNMuMEIRMuMFIUuMFKXGMFxjGMYwHU6DQKTqul1nXOtqpA0ah0yHZ1+q1GsRjWHgYCGYJ4SaR8ZGs00mzZBIvnOcEJ61VTHXWMosoooft4AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAADGW5txa54/arve6duWdhTtca3rz2z2yxSJ/SgxjmeClKkilj+9eyUi7VbRkPFtSqPpaXesoxgiu9doInDVrse546167eLl637eXMW/sqDNzBaj1+8f/ACr7ZmznzVb9nayzTRyZ79loKlzMWuSapKZhqwwlJAuFHJGrZzVA6COCV859cpr/ANrHMZNa7wVf2VKWKglsrVY7bZG/cPUZE1ratF/Lb9idNly0b1xg2xmLbWlKBi4wybaiycZmPnZG0ORvxGXZxSKHDISFK1Y1cyTSl1sxyO47RHHuHkWTq632fKmoqwf3qdb4j1Zl3hX2J26P6pTGDtKGaQZG30Y9H6X13x11DrrRup4JKt661bU4mnVOJIbCiqUZEtyo/NyDrBEzyMzKOPflJyVXLl1LzD19JvDHdO1lDBlQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABx3jxpHNHUhIOmzFgxbLvHz56uk1Zs2bVIy7l07dLnTQbtm6BDrLrrKESRSIZRQ5SlznHzk+/nt6W507FU4/6EtCv/pH1HaTIpybBR2ilvrYsUk4Rf3ox0k/lnVDqmVvs+jsXTkmZL7Q/bP5VzmQj0K3PJ23cwNh8yty2Tqa4gWxlV6nAVmSu/Ytybw6VUquj9KVYppC/Ut6+YGMbB4+JTKa+MEFU3M5JvYfV+F25H95JH17uoTiPUOxrs8insRUZGN4ecWcNb40qU8tiR9nX1MnVUtP0KwuUvlWDuzbIuKyl52VhqybR9qklNpS5GDY0odMoWqfh8etxLg7xEj9nbEgEmfIzk0whr1dzPW6OZakUBVDL3XmtiLGSw6YrIxbzFpt8ef2V07VNKwsiRb9lo1VOfgP++Pr+vP+P/wAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAIYe5LsXsnDnVdR0bx2i3d65wcsXymtuPNJgCt5Gdrq0y4RgnOzHMTnJzmNGyD9vF0ps8TIymLeqRdb5mFrdlIhIly15Pa14bcdtqcktsPsNqfrCsupk7BJwg3k7ROKmIxrFMgfmM4SUn7dYHMdX4kqn9wk7fkcvDoskHK6UCvTpxkvvJPauwu7vnSzj0NmblLLP8Ai7U5l+c9b0bo1Fk9i0LXFEljkJCtXNZw5r9NeOvllcU7M7eX53b/AGGeQQCKDsbrMD06dZFX4PwU8Sx81uwBc+xOY+0MSJ5acWpsY5Rc2Out5p2mpIrVqUsbnFFg3K6+P2naMtq2N2mhIWJdBGwN8PrwTNwu4D1Ket8KaL3TyYPH7o2QRyllOSh4KSY+jVdLdYyf3EswFNdJzkhHuUG7yJtVwtMY5Kb5UmcViaAkfvL7+XVtVau7JxwpVvJaVW7tE+Yxtxo4/LsmFbYu23oWM0Y7cthokssyOr7qMltGVwk4RKkQyP0RfGPwx4/+PH8fv+n9MfgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAADz4/x/X6+/+P5ZHgaI9lPNSucAuHO3OR8v8m8sMFEYrur688yfCdq2vaCLR9JhDkTIdRRki/wrPT3t4wZGtQs05JnBkC4AQQdoNqm+17sv0H1LaofyD3QmhLC03Nzbs8Gu6TYILwxEjyNXdyDF2mRNeu1yUbU6JcEyc7XZ+zk2zxqRaoKLJZG+JB7CYbiFxTg+EGkJFlXdpcgaiSuysbXlcMFdZ8a49I9dk02zdsTBY8uwcR7jXMI3xgqZ6y0vB0TN3DCOOp7um3WUD10dbW9uzXly7eZ2nyOYS/JLZNhnEs/te6oCzh691fWCGctE1f2o2vZLG7tiBUDlRmZHYlTZPSEcRJMowh9YHHDZveR2abL5mcp2ystpfXFsi9h7BhXRnrqsyTv5pbOoOO1bUcYKQ1Uho6KSUsDbGDKq1CBXQl8pS9zbSC4WHPhyOu9Xh5w+Lu3Y0BmO3tysRg7vKISLQyMxTtTN253Gtacsk6bJvIx/JtpF5drIz8ony6nIeJlEMPKukYliEMYxjHjGMYxjGMYxj6YxjH3fTx9MY+7GMf8AgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAVC/iLZJ9yK5t9WPXmq8Vb0raO065bb40RXcJfNp7F2VCajiZVUyByqpHrNbZ7JM0Xb+lyUs4+yQ+DFJ4t6Cjv8AEsWrY/Fns14F816mwbvs1LU8KlSEZZNY8I7u2kdv3C6SzJ5gnj1JKMtp1fDtMmfWo3OTGcZL4AdK+Il5oWrk1yH1b1LcTIt1NV/XVsplet1XpqZm5bvvSTQQhqTrBii3USYK1zWUTKM03TdXJI1rcZF8nJJNV6Izdp2v+svgrUOvDiFrjjxAZYyNrbInt+3rexROli8bZsTdoa0znqUz7ho2PSZx1VreFCpLJ1WuwabpPL35pVWsd8MtwGumztsbC7RuQ8bISyziTt0Zo+XtLYp3912TcXj0+2NzJYcokUWLGJPpKow80hg7KSmrJdMJe2+raZy3b/1+v8P1gAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABhrc/HXQXI2IhoDf+ldWbrg65K/bsBEbUodZvkbDTGUDtVJGNZWaNkkGbldqc7VyogQmXTU5mznCqGckzmUAH5kLCw1biIyv12IjICBhWLaLh4SFYNIuIiY1kiRuzj4yNYooMmDFogmRFs0aopIIJEImkmQhcYx+mAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD//2QAAUQwUAAAAU2Ftc3VuZ19DYXB0dXJlX0luZm9TY3JlZW5zaG90AAChDREAAABDYXB0dXJlZF9BcHBfSW5mb2V5SmpiMjF3SWpvaVkyOXRMbk5oYlhOMWJtY3VZVzVrY205cFpDNWhjSEF1YzIxaGNuUmpZWEIwZFhKbFhDOHVjMk55WldWdWQzSnBkR1Z5TGxOamNtVmxibGR5YVhSbGNrRmpkR2wyYVhSNUluMD1TRUZIawAAAAIAAAAAAFEMrwAAACYAAAAAAKENiQAAAIkAAAAkAAAAU0VGVA==';
+
+// ═══════════════════════════════════════════════════
+// DATOS
+// ═══════════════════════════════════════════════════
+const CURSOS = [
+  {id:1, nombre:'BLOQUEO Y ETIQUETADO DE ENERGIAS (LO-TO)',                          hrs:8,  area:'6000', areaLabel:'Seguridad',
+   video:'1772573260037_original-4fa2104a-c11b-410a-b544-e3dfddbbb2ce.mp4'},
+  {id:2, nombre:'SELECCION, USO Y CONSERVACION EQUIPOS DE PROTECCION PERSONAL (EPP)',hrs:6,  area:'6000', areaLabel:'Seguridad'},
+  {id:3, nombre:'SEGURIDAD EN TRABAJOS EN ALTURAS',                                  hrs:8,  area:'6000', areaLabel:'Seguridad'},
+  {id:4, nombre:'USO DE HERRAMIENTAS MANUALES',                                      hrs:8,  area:'5000', areaLabel:'Operacion de maquinas herramienta'},
+  {id:5, nombre:'TRABAJOS DE CORTE Y SOLDADURA CON SEGURIDAD',                       hrs:8,  area:'6000', areaLabel:'Seguridad'},
+  {id:6, nombre:'TRABAJO SEGURO CON PLATAFORMAS DE ELEVACION PERSONAL',              hrs:8,  area:'6000', areaLabel:'Seguridad industrial'},
+  {id:7, nombre:'SEGURIDAD ELECTRICA',                                               hrs:12, area:'6000', areaLabel:'Seguridad'},
+  {id:8, nombre:'USO DE EXTINTORES',                                                 hrs:8,  area:'6000', areaLabel:'Seguridad'},
+  {id:9, nombre:'SEGURIDAD DE ARC FLASH (NFPA 70E)',                                 hrs:16, area:'6000', areaLabel:'Seguridad'},
+  {id:10,nombre:'SEGURIDAD EN MANIPULACION DE QUIMICOS',                             hrs:16, area:'6000', areaLabel:'Seguridad'},
+  {id:11,nombre:'SEGURIDAD INDUSTRIAL',                                              hrs:8,  area:'6000', areaLabel:'Seguridad industrial'},
+];
+const INSTRUCTORES = [
+  {name:'DE LA CRUZ CALDERON JESUS ESTEBAN', hasSig:true },
+  {name:'LUGO PEREZ GLORIA CAROLINA',        hasSig:false},
+  {name:'DE LA CRUZ CALDERON JUAN FERNANDO', hasSig:false},
+];
+const PREGUNTAS = {
+  1:[{q:'¿Objetivo principal del LO-TO?',opts:['Más velocidad','Controlar energías peligrosas','Reducir costos','Comunicar'],c:1},{q:'¿Quién coloca su candado personal?',opts:['Solo supervisor','Solo eléctrico','Cada persona en el equipo','Gerente'],c:2},{q:'¿Qué es "energía cero"?',opts:['Voltaje mínimo','Sin energía residual antes de trabajar','Costo cero','Planta apagada'],c:1}],
+  2:[{q:'¿Cuándo es obligatorio el EPP?',opts:['Si el jefe pide','Solo en alto riesgo','Cuando el análisis lo indique','Solo en alturas'],c:2},{q:'¿EPP con daño visible?',opts:['Usar con cuidado','Reportar y cambiar antes de usar','Reparar con cinta','Continuar'],c:1},{q:'¿Frecuencia de inspección de EPP?',opts:['Cada mes','Cada año','Antes de cada uso','Al dañarse'],c:2}],
+  3:[{q:'¿Desde qué altura es "trabajo en alturas"?',opts:['1 m','1.80 m','3 m','5 m'],c:1},{q:'¿Sistema más efectivo contra caídas?',opts:['Restricción','Líneas de vida','Redes','Barandales'],c:0},{q:'¿Qué debe tener un plan de rescate?',opts:['Solo tel. emergencias','Procedimiento + personal + equipo','Lista de trabajadores','Fecha inspección'],c:1}],
+  4:[{q:'¿Principal causa de accidentes con herramienta manual?',opts:['Mala calidad','Uso inadecuado o herramienta incorrecta','Sin guantes','Exceso velocidad'],c:1},{q:'¿Cómo se transportan herramientas cortantes?',opts:['En bolsillo','Punta arriba','Con protector de filo','En mano libre'],c:2},{q:'¿Herramienta defectuosa?',opts:['Usar con cuidado','Reparar en campo','Retirar y reportar','Prestar a otro'],c:2}],
+  5:[{q:'¿EPP indispensable en soldadura?',opts:['Solo guantes','Careta + guantes + delantal cuero','Solo lentes','Solo casco'],c:1},{q:'¿Gases peligrosos en corte/soldadura?',opts:['Solo vapor','Ozono + CO + humos metálicos','Solo CO2','Nitrógeno'],c:1},{q:'¿Distancia mínima de inflamables al soldar?',opts:['1 m','3 m','10 m','Sin mínimo'],c:2}],
+  6:[{q:'¿Qué verificar antes de operar plataforma elevadora?',opts:['Solo gasolina','Carga + frenos + nivelación + estado','Solo llantas','Color de plataforma'],c:1},{q:'¿Trabajar en plataforma en movimiento?',opts:['Sí siempre','Solo lento','No, detener completamente','Con supervisor'],c:2},{q:'¿Falla de plataforma elevada?',opts:['Saltar al techo','Descenso emergencia + mantenimiento','Balancearse','Ignorar si es bajo'],c:1}],
+  7:[{q:'¿Qué regula seguridad eléctrica en México?',opts:['NOM-001-SEDE','NOM-022-STPS','NOM-017-STPS','NOM-030-STPS'],c:0},{q:'¿Qué es un arco eléctrico?',opts:['Circuito cerrado','Descarga de plasma entre conductores','Tipo de transformador','Movimiento de electrón'],c:1},{q:'¿Extra alta tensión es más de...?',opts:['120V','600V','1,000V','50V'],c:2}],
+  8:[{q:'¿Extintor tipo ABC para qué fuegos?',opts:['Solo madera','Solo eléctricos','Sólidos + líquidos + eléctricos','Solo metales'],c:2},{q:'¿Técnica correcta para extintor?',opts:['LIPE','PASS (Jalar-Apuntar-Presionar-Barrer)','RACE','STOP'],c:1},{q:'¿Frecuencia revisión extintores?',opts:['Cada 5 años','Mensual visual + anual certificada','Al usarse','Cada 2 años'],c:1}],
+  9:[{q:'¿Qué norma rige Arc Flash?',opts:['NOM-001-SEDE','IEC 61508','NFPA 70E','OSHA 1910'],c:2},{q:'¿Qué determina PPE Category en Arc Flash?',opts:['Color tablero','Energía incidente calculada','Tamaño del cable','Antigüedad equipo'],c:1},{q:'¿EPP obligatorio en tableros energizados?',opts:['Solo casco','Traje AR + guantes dieléctricos + careta arco','Solo guantes','Solo botas'],c:1}],
+  10:[{q:'¿Documento a consultar antes de manipular químico?',opts:['Manual equipo','Hoja de Datos de Seguridad (HDS/SDS)','Lista precios','Catálogo proveedor'],c:1},{q:'¿Qué es el rombo NFPA 704?',opts:['Calidad del producto','Sistema de identificación de peligros','Código postal','Número de lote'],c:1},{q:'¿Qué hacer en derrame de químico peligroso?',opts:['Limpiar con agua','Evacuar + contener + notificar + procedimiento','Ignorar si es pequeño','Cubrir con papel'],c:1}],
+  11:[{q:'¿Objetivo de la Seguridad Industrial?',opts:['Aumentar producción a cualquier costo','Prevenir accidentes y enfermedades','Reducir personal','Cumplir solo auditorías'],c:1},{q:'¿Qué es el Análisis de Riesgo de Tarea (ART)?',opts:['Reporte de producción','Identificar peligros antes de iniciar tarea','Formulario de RH','Checklist inventario'],c:1},{q:'¿Condición insegura identificada?',opts:['Ignorar si no es urgente','Reportar y no operar en esa área','Continuar con cuidado','Solucionar sin notificar'],c:1}],
+};
+// ═══════════════════════════════════════════════════
+// NAVIGATION
+// ═══════════════════════════════════════════════════
+function go(id) {
+  document.querySelectorAll('.scr').forEach(s => s.classList.remove('on'));
+  document.getElementById(id).classList.add('on');
+  window.scrollTo(0, 0);
+}
+
+function toast(msg) {
+  const old = document.querySelector('.toast');
+  if (old) old.remove();
+  const t = document.createElement('div');
+  t.className = 'toast';
+  t.textContent = msg;
+  document.body.appendChild(t);
+  setTimeout(() => t && t.remove(), 2800);
+}
+
+function fmtSecs(s) { return `${Math.floor(s/60)}:${String(s%60).padStart(2,'0')}` }
+function todayISO(){ const d=new Date(); return `${d.getFullYear()}-${String(d.getMonth()+1).padStart(2,'0')}-${String(d.getDate()).padStart(2,'0')}`; }
+
+
+// ═══ CREDENCIAL MASTER ═══
+const MASTER_USER = 'ftsmaster';
+const MASTER_PASS = 'FTS#DC3!2026';
+let isMasterSession = false;
+
+// ═══ CONTROL REMOTO — GitHub (yinyo1/fts-suite) ═══
+const APP_VERSION  = '1.0';
+const BASE_RAW     = 'https://raw.githubusercontent.com/yinyo1/fts-suite/main/';
+const VERSION_URL  = BASE_RAW + 'seguridad/data/version.json';
+const VERSION_API  = 'https://api.github.com/repos/yinyo1/fts-suite/contents/seguridad/data/version.json';
+const USERS_URL    = BASE_RAW + 'seguridad/data/users.json';
+const USERS_API    = 'https://api.github.com/repos/yinyo1/fts-suite/contents/seguridad/data/users.json';
+const AUTH_URL     = USERS_URL;
+
+// Credenciales de respaldo (solo si GitHub no responde)
+const AUTH_FALLBACK = [];
+
+window.addEventListener('load', async function(){
+  // Reacción inmediata a cambios de red del sistema operativo
+  window.addEventListener('offline', () => {
+    _noConnCount++;
+    updateStatusBar('error', _noConnCount);
+    console.warn('Red perdida (offline event) — intento ' + _noConnCount + '/' + MAX_NO_CONN);
+  });
+  window.addEventListener('online', () => {
+    console.log('Red recuperada (online event)');
+    // No resetear aquí — dejar que el heartbeat o Reconectar lo confirmen con GitHub
+    const rbtn = document.getElementById('sb-reconnect');
+    if (rbtn) rbtn.style.display = 'inline-block';
+  });
+  // ── 0. Iniciar reloj del statusbar ──
+  initStatusBar();
+
+  // ── 1. Verificar versión y estado desde GitHub ──
+  const versionOk = await checkVersion();
+  if (!versionOk) return; // App bloqueada
+
+  // ── 2. Arrancar heartbeat desde el primer segundo ──
+  startHeartbeat();
+
+  // ── 2. jsPDF ──
+  if(!window.jspdf){
+    console.warn('jsPDF no disponible al cargar. Los PDFs no funcionarán hasta tener internet.');
+  } else {
+    console.log('✅ jsPDF cargado correctamente');
+  }
+  // Convertir firmas JPEG a PNG con fondo transparente
+  try {
+    // Esteban: tinta negra (pluma ejecutiva, trazo firme)
+    SIG_ESTEBAN_PNG = await makeSignatureTransparent(SIG_ESTEBAN,
+      {r:15, g:15, b:25}, {pressure:0.92, bleed:0.08});
+    // Teofilo: tinta azul oscuro (bolígrafo corporativo)
+    SIG_INSTR_PNG = await makeSignatureTransparent(SIG_INSTR,
+      {r:10, g:35, b:120}, {pressure:0.80, bleed:0.15});
+    // Francisco: tinta azul mediano (pluma fuente, más difusa)
+    SIG_EMP_PNG = await makeSignatureTransparent(SIG_EMP,
+      {r:25, g:60, b:160}, {pressure:0.75, bleed:0.20});
+    console.log('✅ Firmas convertidas a PNG transparente');
+  } catch(e) {
+    console.warn('⚠️ No se pudieron convertir firmas, se usarán JPEGs originales:', e);
+  }
+});
+function fmtDT(d) {
+// ═══════════════════════════════════════════════════
+// USER MANAGEMENT PANEL — solo sesión master
+// ═══════════════════════════════════════════════════
+let _panelUsers = [];
+
+async function loadUserPanel() {
+  document.getElementById('usr-sub').textContent = 'Cargando desde GitHub…';
+  document.getElementById('usr-list').innerHTML = '<p style="font-size:13px;color:var(--muted2);padding:8px 0">Cargando…</p>';
+  authCache = null;
+  const users = await fetchAuthUsers();
+  if (!users || users.length === 0) {
+    document.getElementById('usr-sub').textContent = '❌ No se pudieron cargar usuarios de GitHub';
+    document.getElementById('usr-list').innerHTML =
+      '<p style="font-size:13px;color:var(--red);padding:8px 0">⚠️ No se recibió respuesta válida de GitHub.<br><br>' +
+      'Abre la consola del navegador (F12) para ver el error exacto.<br><br>' +
+      'URL: ' + AUTH_URL + '</p>';
+    return;
+  }
+  _panelUsers = users.map(u => ({ ...u }));
+  renderUserPanel();
+}
+
+function renderUserPanel() {
+  const hoy  = new Date().toISOString().slice(0, 10);
+  const warn = new Date(Date.now() + 7 * 86400000).toISOString().slice(0, 10);
+  const total     = _panelUsers.length;
+  const activos   = _panelUsers.filter(u => (u.fecha_expira||'9999') >= hoy).length;
+  const expirados = total - activos;
+  document.getElementById('usr-sub').textContent =
+    `${total} usuarios · ${activos} activos · ${expirados} expirados`;
+  document.getElementById('usr-list').innerHTML = _panelUsers.map((u, i) => {
+    const exp = u.fecha_expira || '';
+    const dot = !exp || exp >= warn ? 'ok' : exp >= hoy ? 'warn' : 'exp';
+    const tag = dot==='exp' ? '⛔ Expirado' : dot==='warn' ? '⚠️ Expira pronto' : '✅ Activo';
+    return `
+    <div class="usr-row" style="flex-wrap:wrap;gap:8px;">
+      <div class="usr-dot ${dot}" style="align-self:flex-start;margin-top:4px"></div>
+      <div class="usr-info" style="flex:1;min-width:100px">
+        <strong>${u.usuario}</strong>
+        <span>${tag}</span>
+      </div>
+      <div style="flex-shrink:0;text-align:right">
+        <div style="font-size:10px;color:var(--muted2);margin-bottom:3px">Acceso</div>
+        <select onchange="_panelUsers[${i}].acceso=this.value;generateUsersJSON()"
+          style="font-size:11px;border:1px solid var(--border);border-radius:6px;padding:4px 6px;background:var(--d2);color:var(--text);font-family:'Inter',sans-serif;cursor:pointer">
+          <option value="ambos"     ${(u.acceso||'ambos')==='ambos'     ?'selected':''}>👥 Ambos</option>
+          <option value="instructor"${(u.acceso||'ambos')==='instructor'?'selected':''}>🎓 Instructor</option>
+          <option value="empleado"  ${(u.acceso||'ambos')==='empleado'  ?'selected':''}>👷 Empleado</option>
+          <option value="segurista" ${(u.acceso||'ambos')==='segurista' ?'selected':''}>⚠️ Segurista IPERC</option>
+        </select>
+      </div>
+      <div class="usr-exp">
+        <div style="font-size:10px;color:var(--muted2);margin-bottom:3px">Expira</div>
+        <input type="date" value="${exp}" max="${_maxExpira()}" onchange="
+          if(this.value > _maxExpira()){
+            toast('🔒 Máximo: hoy + 1 mes + 7 días (' + _maxExpira() + ')');
+            this.value = _panelUsers[${i}].fecha_expira;
+          } else {
+            _panelUsers[${i}].fecha_expira = this.value;
+            renderUserPanel();
+          }">
+        <button onclick="addOneMonth(${i})" title="+1 mes" style="margin-top:4px;width:100%;background:var(--d3);border:1px solid var(--border);border-radius:6px;padding:3px 0;font-size:11px;font-weight:600;cursor:pointer;color:var(--muted2)">+1 mes</button>
+      </div>
+      <div style="display:flex;flex-direction:column;gap:4px;align-items:center;flex-shrink:0">
+        <button class="usr-del" onclick="togglePassEdit(${i})" title="Cambiar contraseña" style="font-size:15px">🔑</button>
+        <button class="usr-del" onclick="removeUser(${i})" title="Eliminar">🗑</button>
+      </div>
+      <div id="pass-edit-${i}" style="display:none;width:100%;padding-top:4px;border-top:1px solid var(--border)">
+        <div style="font-size:10px;color:var(--muted2);margin-bottom:4px">Nueva contraseña para <strong>${u.usuario}</strong></div>
+        <div style="display:flex;gap:6px;align-items:center">
+          <input type="text" id="pass-input-${i}" placeholder="Nueva contraseña" value="${u.contraseña}"
+            style="flex:1;font-size:12px;border:1px solid var(--border);border-radius:6px;padding:6px 8px;background:var(--d2);color:var(--text);font-family:'Inter',sans-serif">
+          <button onclick="savePass(${i})" style="background:var(--o);color:#fff;border:none;border-radius:6px;padding:6px 12px;font-size:12px;font-weight:700;cursor:pointer">Guardar</button>
+        </div>
+      </div>
+    </div>`;
+  }).join('');
+  generateUsersJSON();
+}
+
+function removeUser(i) {
+  if (!confirm('¿Eliminar usuario "' + _panelUsers[i].usuario + '"?\n\nSe aplica cuando copies el JSON a GitHub.')) return;
+  _panelUsers.splice(i, 1);
+  renderUserPanel();
+  toast('🗑 Usuario eliminado del JSON');
+}
+
+function addUserToPanel() {
+  const user = document.getElementById('nu-user').value.trim().toLowerCase();
+  const pass = document.getElementById('nu-pass').value.trim();
+  
+  const exp  = document.getElementById('nu-exp').value;
+  if (!user) { toast('⚠️ Ingresa un nombre de usuario'); return; }
+  if (!pass) { toast('⚠️ Ingresa una contraseña'); return; }
+  if (!exp)  { toast('⚠️ Ingresa la fecha de expiración'); return; }
+  if (exp > _maxExpira()) { toast('🔒 Máximo permitido: hoy + 1 mes + 7 días (' + _maxExpira() + ')'); return; }
+  if (_panelUsers.find(u => u.usuario === user)) { toast('⚠️ Ese usuario ya existe'); return; }
+  _panelUsers.push({ usuario:user, contraseña:pass, fecha_expira:exp, acceso: document.getElementById('nu-acceso').value });
+  document.getElementById('nu-user').value = '';
+  document.getElementById('nu-pass').value = '';
+  document.getElementById('nu-exp').value  = '';
+  renderUserPanel();
+  toast('✅ Usuario agregado — copia el JSON a GitHub');
+}
+
+function togglePassEdit(i) {
+  const el = document.getElementById('pass-edit-' + i);
+  if (!el) return;
+  const visible = el.style.display !== 'none';
+  // Cerrar todos los demás
+  document.querySelectorAll('[id^="pass-edit-"]').forEach(e => e.style.display = 'none');
+  if (!visible) {
+    el.style.display = 'block';
+    const inp = document.getElementById('pass-input-' + i);
+    if (inp) { inp.focus(); inp.select(); }
+  }
+}
+
+function savePass(i) {
+  const inp = document.getElementById('pass-input-' + i);
+  const newPass = inp ? inp.value.trim() : '';
+  if (!newPass) { toast('⚠️ La contraseña no puede estar vacía'); return; }
+  _panelUsers[i].contraseña = newPass;
+  generateUsersJSON();
+  document.getElementById('pass-edit-' + i).style.display = 'none';
+  toast('🔑 Contraseña de "' + _panelUsers[i].usuario + '" actualizada — copia el JSON a GitHub');
+}
+
+function _maxExpira() {
+  // Límite siempre: hoy + 1 mes + 7 días
+  const d = new Date();
+  d.setMonth(d.getMonth() + 1);
+  d.setDate(d.getDate() + 7);
+  return d.toISOString().slice(0, 10);
+}
+
+function addOneMonth(i) {
+  const current  = _panelUsers[i].fecha_expira;
+  const base     = current ? new Date(current + 'T00:00:00') : new Date();
+  base.setMonth(base.getMonth() + 1);
+  const proposed = base.toISOString().slice(0, 10);
+  const max      = _maxExpira();
+  if (proposed > max) {
+    _panelUsers[i].fecha_expira = max;
+    toast('📅 ' + _panelUsers[i].usuario + ' → ' + max + ' (límite máximo)');
+  } else {
+    _panelUsers[i].fecha_expira = proposed;
+    toast('📅 ' + _panelUsers[i].usuario + ' → ' + proposed);
+  }
+  renderUserPanel();
+}
+
+function generateUsersJSON() {
+  const out = { users: _panelUsers.map(u => ({
+    user: u.usuario, pass: u.contraseña, expira: u.fecha_expira, acceso: u.acceso||'ambos'
+  }))};
+  const el = document.getElementById('usr-json');
+  if (el) el.value = JSON.stringify(out, null, 2);
+}
+
+function copyUsersJSON() {
+  const ta = document.getElementById('usr-json');
+  navigator.clipboard.writeText(ta.value).then(() => {
+    const msg = document.getElementById('usr-copy-msg');
+    if (msg) { msg.textContent = '✅ JSON copiado — pégalo en GitHub › users.json'; setTimeout(()=>{msg.textContent='';},4000); }
+    toast('📋 JSON copiado al portapapeles');
+  }).catch(() => { ta.select(); document.execCommand('copy'); toast('📋 JSON copiado'); });
+}
+
+// ═══════════════════════════════════════════════════
+// INSTRUCTOR MODE
+// ═══════════════════════════════════════════════════
+const inst = {
+  workers: [],         // [{name, curp}]
+  selWorkers: new Set, // índices seleccionados
+  selCourses: new Set, // ids seleccionados
+  instructor: 0,
+};
+
+// Pre-select all courses
+CURSOS.forEach(c => inst.selCourses.add(c.id));
+
+function goInstPin() { document.getElementById('auth-user').value=''; document.getElementById('auth-pass').value=''; document.getElementById('pin-err').textContent=''; go('s-pin'); }
+
+// ═══════════════════════════════════════════════════════
+// STATUS BAR — reloj en vivo + última validación
+// ═══════════════════════════════════════════════════════
+let _clockTimer = null;
+
+function initStatusBar() {
+  // Zona horaria del dispositivo
+  const tz = Intl.DateTimeFormat().resolvedOptions().timeZone;
+  const sbTz = document.getElementById('sb-tz');
+  if (sbTz) sbTz.textContent = tz;
+
+  // Reloj en vivo — actualiza cada segundo
+  function tickClock() {
+    const now  = new Date();
+    const h    = String(now.getHours()).padStart(2,'0');
+    const m    = String(now.getMinutes()).padStart(2,'0');
+    const s    = String(now.getSeconds()).padStart(2,'0');
+    const el   = document.getElementById('sb-clock');
+    if (el) el.textContent = h + ':' + m + ':' + s;
+  }
+  tickClock();
+  if (_clockTimer) clearInterval(_clockTimer);
+  _clockTimer = setInterval(tickClock, 1000);
+}
+
+function updateStatusBar(status, noConnCount) {
+  const dot  = document.getElementById('sb-dot');
+  const lbl  = document.getElementById('sb-status');
+  const last = document.getElementById('sb-lastval');
+  const rbtn = document.getElementById('sb-reconnect');
+  if (!dot || !lbl) return;
+
+  const now = new Date();
+  const ts  = String(now.getHours()).padStart(2,'0') + ':' +
+              String(now.getMinutes()).padStart(2,'0') + ':' +
+              String(now.getSeconds()).padStart(2,'0');
+
+  dot.className = '';
+  if (status === 'ok') {
+    hideBlockScreen();
+    dot.classList.add('ok');
+    lbl.textContent = 'FTS · Conectado';
+    if (last) last.textContent = 'Última validación: ' + ts;
+    if (rbtn) rbtn.style.display = 'none';
+  } else if (status === 'offline') {
+    dot.classList.add('error');
+    lbl.textContent = 'Sistema desactivado';
+    if (last) last.textContent = 'Bloqueado: ' + ts;
+    if (rbtn) rbtn.style.display = 'none';
+  } else if (status === 'error') {
+    dot.classList.add('warn');
+    if (noConnCount !== undefined && noConnCount > 0) {
+      const restantes = MAX_NO_CONN - noConnCount;
+      const minutos   = Math.round((restantes * HEARTBEAT_MS) / 60000);
+      lbl.textContent = 'Sin conexión';
+      if (last) last.textContent = 'Intento ' + noConnCount + '/' + MAX_NO_CONN + ' · Cierra en ~' + minutos + ' min';
+    } else {
+      lbl.textContent = 'Sin conexión';
+      if (last) last.textContent = 'Error: ' + ts;
+    }
+    if (rbtn) rbtn.style.display = 'inline-block';
+  } else {
+    dot.className = '';
+    lbl.textContent = 'Verificando…';
+    if (last) last.textContent = '';
+    if (rbtn) rbtn.style.display = 'none';
+  }
+}
+// ═══════════════════════════════════════════════════════
+
+// ═══════════════════════════════════════════════════════
+let _heartbeatTimer   = null;
+let _loggedUser       = null;
+let _noConnCount      = 0;        // contador de fallos de red consecutivos
+const HEARTBEAT_MS    = 15000;       // cada 5 segundos
+const MAX_NO_CONN     = 8;                // 8 × 15s = ~2 minutos
+
+// Inicia el heartbeat — corre mientras el sistema esté online
+function startHeartbeat() {
+  stopHeartbeat();
+  _noConnCount = 0; // resetear contador al (re)arrancar
+  _heartbeatTimer = setInterval(async () => {
+    let data = null;
+
+    // raw.githubusercontent + Pragma — detecta pérdida de red correctamente
+    try {
+      const bust = Date.now() + '_' + Math.random().toString(36).slice(2, 10);
+      const res = await fetch(VERSION_URL + '?nocache=' + bust, {
+        cache: 'no-store',
+        headers: { 'Pragma': 'no-cache' }
+      });
+      if (res.ok) data = JSON.parse(await res.text());
+    } catch(e) { /* sin red */ }
+
+    // Fallback: GitHub API
+    if (!data) {
+      try {
+        const res = await fetch(VERSION_API + '?t=' + Date.now(), { cache: 'no-store' });
+        if (res.ok) {
+          const wrapper = await res.json();
+          data = JSON.parse(atob(wrapper.content.replace(/\n/g, '')));
+        }
+      } catch(e) { /* sin red */ }
+    }
+
+    // ── Sin respuesta de GitHub ──
+    if (!data) {
+      _noConnCount++;
+      const restantes = MAX_NO_CONN - _noConnCount;
+      console.warn('Heartbeat sin conexión — intento ' + _noConnCount + '/' + MAX_NO_CONN);
+
+      if (_noConnCount >= MAX_NO_CONN) {
+        updateStatusBar('error', _noConnCount);
+        stopHeartbeat();
+        showBlockScreen('📡 Sin conexión a internet',
+          'No se pudo verificar con el servidor FTS después de ' + MAX_NO_CONN + ' intentos (' + Math.round((MAX_NO_CONN * HEARTBEAT_MS) / 60000) + ' min).\n\nConéctate a internet y presiona Sincronizar para continuar.');
+      } else {
+        updateStatusBar('error', _noConnCount);
+      }
+      return;
+    }
+
+    // ── Conexión recuperada — resetear contador ──
+    if (_noConnCount > 0) {
+      console.log('Conexión recuperada después de ' + _noConnCount + ' intentos fallidos.');
+      _noConnCount = 0;
+    }
+
+    // ── GitHub responde offline ── sacar inmediatamente sin importar el contador
+    if (data.status !== 'online') {
+      updateStatusBar('offline');
+      stopHeartbeat();
+      showBlockScreen('🔒 Sistema desactivado',
+        'GitHub reporta: status = "' + data.status + '"\n\n' + (data.mensaje || 'Contacta al administrador para reactivar el acceso.'));
+      return;
+    }
+
+    if (data.force_update && data.version !== APP_VERSION) {
+      updateStatusBar('offline');
+      stopHeartbeat();
+      showBlockScreen('⬆️ Actualización requerida',
+        (data.mensaje || 'Esta versión ya no está disponible.') +
+        '\n\nVersión requerida: ' + data.version + ' · Tu versión: ' + APP_VERSION);
+      return;
+    }
+
+    // ── Todo OK ──
+    updateStatusBar('ok');
+
+    // Limpiar caché y re-validar usuario activo contra GitHub
+    authCache = null;
+
+    // Si el panel de usuarios está abierto, refrescarlo también
+    const panelVisible = document.getElementById('s-users') &&
+                         document.getElementById('s-users').classList.contains('on');
+    if (panelVisible) {
+      const freshUsers = await fetchAuthUsers();
+      if (freshUsers && freshUsers.length > 0) {
+        _panelUsers = freshUsers.map(u => ({ ...u }));
+        renderUserPanel();
+      }
+      authCache = null; // volver a limpiar para el siguiente ciclo
+    }
+
+    // Si hay usuario activo, re-validar su vigencia contra GitHub actualizado
+    if (_loggedUser) {
+      const freshUsers = await fetchAuthUsers();
+      const fresh = freshUsers.find(u => u.usuario === _loggedUser.usuario);
+      if (!fresh) {
+        stopHeartbeat();
+        showBlockScreen('🚫 Acceso revocado', 'Tu usuario fue eliminado del sistema.\nContacta al administrador.');
+        return;
+      }
+      _loggedUser = fresh;
+      checkUserExpiry(_loggedUser);
+    }
+
+    authCache = null; // siempre limpiar al final para el siguiente tick
+
+  }, HEARTBEAT_MS);
+}
+
+function stopHeartbeat() {
+  if (_heartbeatTimer) { clearInterval(_heartbeatTimer); _heartbeatTimer = null; }
+}
+
+async function reconnectNow() {
+  const rbtn = document.getElementById('sb-reconnect');
+  if (rbtn) { rbtn.disabled = true; rbtn.textContent = '⏳ Verificando…'; }
+  updateStatusBar('checking');
+
+  // Intentar leer version.json — ruta relativa mismo dominio
+  let data = null;
+  try {
+    const bust = Date.now() + '_' + Math.random().toString(36).slice(2, 10);
+    const res  = await fetch(VERSION_URL + '?nocache=' + bust, { cache: 'no-store', headers: { 'Pragma': 'no-cache' } });
+    if (res.ok) data = JSON.parse(await res.text());
+  } catch(e) {}
+  if (!data) {
+    try {
+      const res = await fetch(VERSION_API + '?t=' + Date.now(), { cache: 'no-store' });
+      if (res.ok) {
+        const w = await res.json();
+        data = JSON.parse(atob(w.content.replace(/\n/g, '')));
+      }
+    } catch(e) {}
+  }
+
+  if (rbtn) { rbtn.disabled = false; rbtn.textContent = '🔄 Reconectar'; }
+
+  if (!data) {
+    // Sigue sin red — resetear contador y seguir intentando
+    _noConnCount = 0;
+    updateStatusBar('error', 0);
+    toast('⚠️ Sigue sin conexión — reintentando');
+    startHeartbeat();
+    return;
+  }
+
+  if (data.status !== 'online') {
+    updateStatusBar('offline');
+    stopHeartbeat();
+    showBlockScreen('🔒 Sistema desactivado',
+      'GitHub reporta: status = "' + data.status + '"\n\n' + (data.mensaje || 'Contacta al administrador.'));
+    return;
+  }
+
+  // ✅ Conexión recuperada
+  _noConnCount = 0;
+  authCache = null;
+  updateStatusBar('ok');
+  toast('✅ Conexión recuperada');
+  startHeartbeat();
+}
+
+// Verifica si el usuario activo sigue vigente
+function checkUserExpiry(userData) {
+  if (!userData || !userData.fecha_expira) return;
+  const hoy     = new Date();
+  const hoyStr  = hoy.toISOString().slice(0, 10);
+  const expDate = new Date(userData.fecha_expira + 'T00:00:00');
+  const diffMs  = expDate - hoy;
+  const diffDias = Math.ceil(diffMs / 86400000);
+
+  // Expirado — sacar
+  if (userData.fecha_expira < hoyStr) {
+    stopHeartbeat();
+    showBlockScreen('⏰ Sesión expirada', 'Tu acceso expiró el ' + userData.fecha_expira + '.\nSolicita renovación al administrador.');
+    return;
+  }
+
+  // Por vencer en ≤7 días — mostrar banner
+  const bannerId = 'expiry-warning-banner';
+  const existing = document.getElementById(bannerId);
+  if (diffDias <= 7) {
+    if (!existing) {
+      const banner = document.createElement('div');
+      banner.id = bannerId;
+      banner.style.cssText = [
+        'position:fixed', 'bottom:28px', 'left:50%', 'transform:translateX(-50%)',
+        'width:100%', 'max-width:520px', 'z-index:9995',
+        'background:#f59e0b', 'color:#000',
+        'padding:8px 16px', 'font-size:12px', 'font-weight:600',
+        'text-align:center', 'line-height:1.4', 'box-shadow:0 -2px 8px rgba(0,0,0,.2)'
+      ].join(';');
+      banner.innerHTML = '⚠️ Tu acceso vence en <strong>' + diffDias + (diffDias === 1 ? ' día' : ' días') + '</strong> (' + userData.fecha_expira + '). Contacta a tu administrador para renovarlo.';
+      document.body.appendChild(banner);
+    } else {
+      // Actualizar días si ya existe
+      existing.innerHTML = '⚠️ Tu acceso vence en <strong>' + diffDias + (diffDias === 1 ? ' día' : ' días') + '</strong> (' + userData.fecha_expira + '). Contacta a tu administrador para renovarlo.';
+    }
+  } else {
+    // Más de 7 días — quitar banner si existía
+    if (existing) existing.remove();
+  }
+}
+
+// ═══ SYNC SERVER — re-valida contra GitHub ═══
+async function syncServer() {
+  let btn = document.getElementById('btn-sync');
+  let lbl = document.getElementById('sync-lbl');
+  if (btn) { btn.disabled = true; btn.style.opacity = '0.6'; }
+  if (lbl) { lbl.textContent = 'Conectando…'; lbl.style.color = 'var(--muted2)'; }
+
+  authCache = null;
+
+  let data = null;
+
+  // Ruta relativa — mismo dominio GitHub Pages
+  try {
+    const bust = Date.now() + '_' + Math.random().toString(36).slice(2, 10);
+    const res  = await fetch(VERSION_URL + '?nocache=' + bust, { cache: 'no-store', headers: { 'Pragma': 'no-cache' } });
+    if (res.ok) data = JSON.parse(await res.text());
+  } catch(e) {
+    console.warn('Sync relativo falló:', e.message);
+  }
+
+  // Fallback: GitHub API
+  if (!data) {
+    try {
+      const res = await fetch(VERSION_API + '?t=' + Date.now(), { cache: 'no-store' });
+      if (res.ok) {
+        const wrapper = await res.json();
+        data = JSON.parse(atob(wrapper.content.replace(/\n/g, '')));
+      }
+    } catch(e) {
+      console.warn('Sync API falló:', e.message);
+    }
+  }
+
+  // Re-tomar referencias (showBlockScreen pudo regenerar el DOM)
+  btn = document.getElementById('btn-sync');
+  lbl = document.getElementById('sync-lbl');
+
+  if (!data) {
+    if (lbl) { lbl.textContent = '⚠️ Sin conexión a internet'; lbl.style.color = 'var(--red)'; }
+    if (btn) { btn.disabled = false; btn.style.opacity = '1'; }
+    toast('⚠️ Sin conexión — reintenta en unos segundos');
+    return;
+  }
+
+  if (data.status !== 'online') {
+    showBlockScreen('🔒 Sistema desactivado',
+      'GitHub reporta: status = "' + data.status + '"\n\n' + (data.mensaje || 'Contacta al administrador.'));
+    return;
+  }
+
+  if (data.force_update && data.version !== APP_VERSION) {
+    showBlockScreen('⬆️ Actualización requerida',
+      (data.mensaje || 'Esta versión ya no está disponible.') +
+      '\n\nGitHub requiere: v' + data.version + ' · Esta copia: v' + APP_VERSION);
+    return;
+  }
+
+  // ✅ Todo OK
+  updateStatusBar('ok');
+  _noConnCount = 0; // resetear contador de fallos
+  if (lbl) { lbl.textContent = '✅ Conectado'; lbl.style.color = 'var(--green)'; }
+  toast('✅ Conexión verificada con GitHub');
+  setTimeout(() => {
+    hideBlockScreen();
+    go('s-home');
+    startHeartbeat();
+  }, 800);
+}
+
+// ═══ VERSION CHECK — GitHub API (tiempo real) + fallback CDN ═══
+async function checkVersion() {
+  updateStatusBar('checking');
+  let data = null;
+
+  // raw.githubusercontent + Pragma — detecta red real, sin caché CDN
+  try {
+    const bust = Date.now() + '_' + Math.random().toString(36).slice(2);
+    const res  = await fetch(VERSION_URL + '?nocache=' + bust, {
+      cache: 'no-store',
+      headers: { 'Pragma': 'no-cache' }
+    });
+    if (res.ok) data = await res.json();
+  } catch(e) {
+    console.warn('raw GitHub falló, intentando API:', e.message);
+  }
+
+  // Fallback: GitHub API
+  if (!data) {
+    try {
+      const res = await fetch(VERSION_API + '?t=' + Date.now(), { cache: 'no-store' });
+      if (res.ok) {
+        const wrapper = await res.json();
+        data = JSON.parse(atob(wrapper.content.replace(/\n/g, '')));
+      }
+    } catch(e) {
+      console.warn('GitHub API también falló:', e.message);
+    }
+  }
+
+  if (!data) {
+    updateStatusBar('error', 0);
+    showBlockScreen('📡 Sin conexión al servidor',
+      'No se pudo obtener version.json de GitHub.\n\nVerifica tu conexión a internet y presiona Sincronizar.\n\n🔎 ' + VERSION_API);
+    return false;
+  }
+
+  if (data.status !== 'online') {
+    updateStatusBar('offline');
+    showBlockScreen('🔒 Sistema desactivado',
+      'GitHub reporta: status = "' + data.status + '"\n\n' + (data.mensaje || 'Contacta al administrador para reactivar el acceso.'));
+    return false;
+  }
+
+  if (data.force_update && data.version !== APP_VERSION) {
+    updateStatusBar('offline');
+    showBlockScreen('⬆️ Actualización requerida',
+      (data.mensaje || 'Esta versión ya no está disponible.') +
+      '\n\nGitHub requiere: v' + data.version + '\nEsta copia: v' + APP_VERSION);
+    return false;
+  }
+
+  updateStatusBar('ok');
+  return true;
+}
+
+function showBlockScreen(titulo, mensaje) {
+  document.querySelectorAll('.scr').forEach(s => s.classList.remove('on'));
+  let bl = document.getElementById('s-blocked');
+  if (!bl) {
+    bl = document.createElement('div');
+    bl.id = 's-blocked';
+    bl.className = 'scr on';
+    bl.style.cssText = 'display:flex!important;flex-direction:column;align-items:center;justify-content:center;text-align:center;padding:40px 24px;background:#fff;min-height:100vh';
+    document.body.appendChild(bl);
+  }
+  bl.classList.add('on');
+  bl.innerHTML = `
+    <div style="font-size:56px;margin-bottom:20px">🚫</div>
+    <h2 style="font-size:20px;font-weight:800;color:#D83B01;margin-bottom:12px">${titulo}</h2>
+    <p style="font-size:14px;color:#666;line-height:1.6;max-width:300px;white-space:pre-line">${mensaje}</p>
+    <button id="btn-sync" onclick="syncServer()" style="margin-top:28px;background:#fff;border:1px solid #e0e0e0;border-radius:10px;padding:13px 22px;font-size:13px;font-family:'Inter',sans-serif;color:#666;cursor:pointer;display:inline-flex;align-items:center;gap:8px;box-shadow:0 1px 4px rgba(0,0,0,.06)">
+      <span style="font-size:16px">🔄</span>
+      <span id="sync-lbl">Sincronizar con servidor FTS</span>
+    </button>
+    <p style="margin-top:20px;font-size:11px;color:#aaa">SERVICIOS FTS SA DE CV · v${APP_VERSION}</p>`;
+}
+
+function hideBlockScreen() {
+  const bl = document.getElementById('s-blocked');
+  if (bl) bl.remove(); // eliminar del DOM completamente, no solo ocultar
+}
+
+// ═══ AUTH: fetch JSON desde GitHub raw ═══
+let authCache = null;
+async function fetchAuthUsers() {
+  if (authCache) return authCache;
+  let arr = null;
+
+  // raw.githubusercontent + Pragma — bypasa CDN de GitHub, tiempo real garantizado
+  try {
+    const bust = Date.now() + '_' + Math.random().toString(36).slice(2);
+    const res  = await fetch(USERS_URL + '?t=' + bust, {
+      cache: 'no-store',
+      headers: { 'Pragma': 'no-cache' }
+    });
+    if (res.ok) {
+      const parsed = await res.json();
+      arr = parsed.users || parsed;
+    }
+  } catch(e) {
+    console.warn('users raw falló, intentando API:', e.message);
+  }
+
+  // Fallback: GitHub API
+  if (!arr) {
+    try {
+      const res = await fetch(USERS_API + '?t=' + Date.now(), { cache: 'no-store' });
+      if (res.ok) {
+        const wrapper = await res.json();
+        const decoded = JSON.parse(atob(wrapper.content.replace(/\n/g, '')));
+        arr = decoded.users || decoded;
+      }
+    } catch(e) {
+      console.warn('API users falló:', e.message);
+    }
+  }
+
+  if (!arr || arr.length === 0) {
+    console.error('❌ No se pudo obtener users.json');
+    authCache = [];
+    return authCache;
+  }
+
+  authCache = arr.map(u => ({
+    usuario:      (u.usuario || u.user     || '').toLowerCase(),
+    contraseña:   (u.contraseña || u.pass  || u.password || ''),
+    fecha_expira: (u.fecha_expira || u.expira || ''),
+    
+    acceso:       (u.acceso || u.tipo || 'ambos'),
+  }));
+  return authCache;
+}
+
+async function authLogin() {
+  const user = document.getElementById('auth-user').value.trim().toLowerCase();
+  const pass = document.getElementById('auth-pass').value.trim();
+  const err  = document.getElementById('pin-err');
+  if (!user||!pass) { err.textContent='Ingresa usuario y contraseña'; return; }
+  // Master bypass — sin CSV, sin expiración
+  if (user===MASTER_USER && pass===MASTER_PASS) {
+    err.textContent=''; isMasterSession=true; _loggedUser=null;
+    loadInstDashboard(); go('s-inst');
+    startHeartbeat();
+    toast('🔑 Sesión Master activa'); updateSettingsBtn(); return;
+  }
+  isMasterSession=false;
+  err.textContent='Verificando...'; err.style.color='var(--muted2)';
+  const users = await fetchAuthUsers();
+
+  // ── Diagnóstico detallado ──
+  const byUser = users.find(u => u.usuario.toLowerCase() === user);
+  if (!byUser) {
+    err.style.color='var(--red)';
+    err.textContent = '❌ Usuario "' + user + '" no encontrado. (' + users.length + ' usuarios cargados)';
+    return;
+  }
+  if (byUser.contraseña !== pass) {
+    err.style.color='var(--red)';
+    err.textContent = '❌ Contraseña incorrecta para "' + user + '"';
+    return;
+  }
+  const hoy = new Date().toISOString().slice(0,10);
+  if (byUser.fecha_expira && byUser.fecha_expira < hoy) {
+    err.style.color='var(--red)';
+    err.textContent = '⏰ Acceso expirado el ' + byUser.fecha_expira + '. Solicita renovación.'; return;
+  }
+  const acceso = (byUser.acceso||'ambos').toLowerCase();
+  if (acceso !== 'ambos' && acceso !== 'instructor') {
+    err.style.color='var(--red)';
+    err.textContent = '🚫 Tu acceso es "' + acceso + '" — usa el modo Empleado.'; return;
+  }
+  err.textContent=''; _loggedUser = byUser; isMasterSession=false;
+  loadInstDashboard(); go('s-inst'); updateSettingsBtn();
+  startHeartbeat();
+  toast('✅ Bienvenido, '+byUser.usuario);
+}
+function updateSettingsBtn(){
+  // Solo master ve el botón de settings
+  const b = document.getElementById('btn-settings');
+  if (b) b.style.display = isMasterSession ? 'inline-block' : 'none';
+}
+function toggleSettings(){
+  const p = document.getElementById('settings-panel');
+  p.style.display = p.style.display === 'none' ? 'block' : 'none';
+}
+
+function loadInstDashboard() {
+  renderWorkerList();
+  renderInstSelector();
+  renderCourseSelector();
+  renderGenSummary();
+  // Set today's date
+  document.getElementById('inst-fecha').value = todayISO();
+}
+
+function instTab(tab) {
+  document.querySelectorAll('.tab').forEach(t => t.classList.remove('on'));
+  document.querySelectorAll('.tab-pane').forEach(p => p.classList.remove('on'));
+  const map = {workers:'tp-workers', courses:'tp-courses', generate:'tp-generate'};
+  document.getElementById(map[tab]).classList.add('on');
+  event.target.classList.add('on');
+  if (tab === 'generate') renderGenSummary();
+}
+
+function addWorker() {
+  const ap = document.getElementById('new-ap').value.trim().toUpperCase();
+  const am = document.getElementById('new-am').value.trim().toUpperCase();
+  const nom = document.getElementById('new-nom').value.trim().toUpperCase();
+  const curp = document.getElementById('new-curp').value.trim().toUpperCase();
+  if (!ap) { toast('⚠️ Ingresa el apellido paterno'); return; }
+  if (!nom) { toast('⚠️ Ingresa el nombre'); return; }
+  if (curp.length !== 18) { toast('⚠️ CURP debe tener 18 caracteres'); return; }
+  const name = (ap + ' ' + am + ' ' + nom).replace(/\s+/g,' ').trim();
+  inst.workers.push({name, curp});
+  inst.selWorkers.add(inst.workers.length - 1);
+  document.getElementById('new-ap').value = '';
+  document.getElementById('new-am').value = '';
+  document.getElementById('new-nom').value = '';
+  document.getElementById('new-curp').value = '';
+  renderWorkerList();
+  toast('✅ Trabajador agregado');
+}
+
+function renderWorkerList() {
+  const el = document.getElementById('worker-list');
+  if (!inst.workers.length) {
+    el.innerHTML = '<p style="font-size:13px;color:var(--muted2);text-align:center;padding:16px">No hay trabajadores. Agrégalos arriba.</p>';
+    return;
+  }
+  el.innerHTML = inst.workers.map((w,i) => `
+    <div class="worker-row ${inst.selWorkers.has(i)?'sel':''}" onclick="toggleWorker(${i})">
+      <div class="wr-chk">${inst.selWorkers.has(i)?'✓':''}</div>
+      <div class="wr-info"><strong>${w.name}</strong><span>${w.curp}</span></div>
+    </div>`).join('');
+}
+
+function toggleWorker(i) {
+  if (inst.selWorkers.has(i)) inst.selWorkers.delete(i);
+  else inst.selWorkers.add(i);
+  renderWorkerList();
+}
+
+function renderInstSelector() {
+  document.getElementById('inst-selector').innerHTML = INSTRUCTORES.map((n,i) => `
+    <div class="inst-radio ${inst.instructor===i?'sel':''}" onclick="selInst(${i})">
+      <div class="ir-dot"></div>
+      <span style="font-size:13px;font-weight:500">${n.name}</span>
+      ${n.hasSig?'<span style="font-size:10px;color:var(--green);margin-left:6px">✓ firma</span>':''}
+    </div>`).join('');
+}
+
+function selInst(i) { inst.instructor = i; renderInstSelector(); }
+
+function renderCourseSelector() {
+  document.getElementById('course-selector').innerHTML = CURSOS.map(c => `
+    <div class="course-chk ${inst.selCourses.has(c.id)?'sel':''}" onclick="toggleCourse(${c.id})">
+      <div class="cc-box">${inst.selCourses.has(c.id)?'✓':''}</div>
+      <div class="cc-info"><strong>${c.nombre}</strong><span>${c.hrs} hrs · ${c.area}</span></div>
+    </div>`).join('');
+}
+
+function toggleCourse(id) {
+  if (inst.selCourses.has(id)) inst.selCourses.delete(id);
+  else inst.selCourses.add(id);
+  renderCourseSelector();
+}
+
+function selectAllCourses(val) {
+  if (val) CURSOS.forEach(c => inst.selCourses.add(c.id));
+  else inst.selCourses.clear();
+  renderCourseSelector();
+}
+
+function renderGenSummary() {
+  const wCount = inst.selWorkers.size;
+  const cCount = inst.selCourses.size;
+  const total  = wCount * cCount;
+  document.getElementById('gen-sub').textContent = `${wCount} trabajador(es) · ${cCount} curso(s)`;
+  document.getElementById('gen-body').innerHTML = total
+    ? `<div class="stat-row">
+        <div class="stat o"><strong>${wCount}</strong><span>Trabajadores</span></div>
+        <div class="stat g"><strong>${cCount}</strong><span>Cursos</span></div>
+        <div class="stat"><strong>${total}</strong><span>DC-3 a generar</span></div>
+       </div>
+       <p style="font-size:12px;color:var(--muted2);margin-top:12px">Instructor: <strong style="color:var(--text)">${INSTRUCTORES[inst.instructor].name}</strong></p>`
+    : '<p style="font-size:13px;color:var(--muted2)">Selecciona al menos un trabajador y un curso.</p>';
+}
+
+// ══════════════════════════════════════════════════════
+// PDF ENGINE
+// ══════════════════════════════════════════════════════
+const DC3_CFG = {
+  empName:'SERVICIOS FTS SA DE CV', rfc:'SFT170905L43',
+  imss:'D4247032 10-2', actividad:'Tecnico Electromecanico',
+  ocupacion:'04.6 PROCESOS INDUSTRIALES',
+  repEmpresa:'TEOFILOTAURINO LUGOVALEZ',
+  repTrab:'FRANCISCOMONTALVORAMIREZ',
+};
+
+function _dateParts(s){
+  if(!s) return {y:'    ',m:'  ',d:'  ',ye:'    ',me:'  ',de:'  '};
+  const [y,m,d]=s.split('-');
+  return {y,m,d,ye:String(parseInt(y)+1),me:m,de:d};
+}
+
+function buildPage(doc,worker,course,instrName,instrIdx){
+  const W=215.9,H=279.4,ml=12,mr=W-12,pw=mr-ml;
+  // Logo FTS — JPEG directo con fondo blanco
+  doc.setFillColor(255,255,255);doc.rect(ml,5.5,16,4.6,'F');
+  doc.addImage(LOGO_B64,'JPEG',ml,5.5,16,4.6);
+  doc.setTextColor(70,70,70);doc.setFont('helvetica','normal');doc.setFontSize(5.2);
+  doc.text('SERVICIOS FTS S.A. DE C.V.',ml+18,8);
+  doc.text('RFC: SFT170905L43',ml+18,11.5);
+  doc.setTextColor(0);doc.setFont('helvetica','bold');doc.setFontSize(11);
+  doc.text('FORMATO DC-3',W/2,10,{align:'center'});
+  doc.setFontSize(8);doc.text('CONSTANCIA DE COMPETENCIAS O DE HABILIDADES LABORALES',W/2,15.5,{align:'center'});
+  doc.setDrawColor(40);doc.setLineWidth(0.4);doc.line(ml,17,mr,17);
+  let y=20;
+  const SEC=(t,yy)=>{doc.setFillColor(22,22,22);doc.rect(ml,yy,pw,6,'F');doc.setTextColor(255,255,255);doc.setFont('helvetica','bold');doc.setFontSize(7);doc.text(t,W/2,yy+4.2,{align:'center'});doc.setTextColor(0);return yy+6;};
+  const BOX=(x,yy,w,h)=>{doc.setDrawColor(155);doc.setLineWidth(0.25);doc.rect(x,yy,w,h);};
+  const CEL=(x,yy,w,h)=>{doc.setDrawColor(120);doc.setLineWidth(0.2);doc.rect(x,yy,w,h);};
+  const LBL=(t,x,yy)=>{doc.setFont('helvetica','normal');doc.setFontSize(5.5);doc.setTextColor(90,90,90);doc.text(t,x,yy);doc.setTextColor(0);};
+  const LINE=(y2)=>{doc.setDrawColor(215);doc.setLineWidth(0.18);doc.line(ml,y2,mr,y2);};
+  // TRABAJADOR
+  y=SEC('DATOS DEL TRABAJADOR',y);
+  BOX(ml,y,pw,22);
+  LBL('Nombre (Anotar apellido paterno, apellido materno y nombre (s))',ml+2,y+4.5);
+  doc.setFont('helvetica','bold');doc.setFontSize(9);doc.text(worker.name,ml+2,y+9.5);
+  LINE(y+11);
+  LBL('Clave Unica de Registro de Poblacion (CURP)',ml+2,y+14);
+  const CW=4.6,CH=5.2,CY=y+15.2;
+  worker.curp.split('').forEach((c,i)=>{const bx=ml+2+i*CW;CEL(bx,CY,CW,CH);doc.setFont('helvetica','bold');doc.setFontSize(6);doc.text(c,bx+CW/2,CY+3.9,{align:'center'});});
+  const OX=ml+pw*0.56;
+  LBL('Ocupacion especifica (Catalogo Nacional de Ocupaciones) 1/',OX,y+4.5);
+  doc.setFont('helvetica','normal');doc.setFontSize(7);doc.text(DC3_CFG.ocupacion,OX,y+9.5);
+  y+=25;
+  // EMPRESA
+  y=SEC('DATOS DE LA EMPRESA',y);
+  BOX(ml,y,pw,28);
+  LBL('Nombre o razon social',ml+2,y+4.5);
+  doc.setFont('helvetica','normal');doc.setFontSize(8.5);doc.text(DC3_CFG.empName,ml+2,y+9.5);
+  LINE(y+11);
+  LBL('Registro Federal de Contribuyentes con homoclave (SHCP)',ml+2,y+14);
+  let rx=ml+2;
+  DC3_CFG.rfc.replace(/-/g,'').split('').forEach((c,i)=>{CEL(rx,y+15.2,3.7,4.5);doc.setFont('helvetica','bold');doc.setFontSize(5.8);doc.text(c,rx+1.85,y+18.7,{align:'center'});rx+=3.7;if(i===2||i===8)rx+=1.2;});
+  const IX=ml+pw*0.56;
+  LBL('Registro patronal ante el I.M.S.S.',IX,y+14);
+  doc.setFont('helvetica','normal');doc.setFontSize(8);doc.text(DC3_CFG.imss,IX,y+20);
+  LINE(y+22);
+  LBL('Actividad o giro principal',ml+2,y+24.5);
+  doc.setFont('helvetica','normal');doc.setFontSize(7.5);doc.text(DC3_CFG.actividad,ml+2,y+27.5);
+  y+=31;
+  // PROGRAMA
+  y=SEC('DATOS DEL PROGRAMA DE CAPACITACION, ADIESTRAMIENTO Y PRODUCTIVIDAD',y);
+  BOX(ml,y,pw,52);
+  LBL('Nombre del curso',ml+2,y+5);
+  doc.setFont('helvetica','bold');doc.setFontSize(9);
+  doc.text(doc.splitTextToSize(course.nombre,pw-4),ml+2,y+10);
+  LINE(y+16);
+  const DY=y+17;
+  LBL('Duracion en horas',ml+2,DY+2);LBL('Periodo de ejecucion:',ml+22,DY+2);
+  BOX(ml+2,DY+4,15,8.5);
+  doc.setFont('helvetica','bold');doc.setFontSize(11);doc.text(String(course.hrs),ml+9.5,DY+11.2,{align:'center'});
+  const dp=_dateParts(course._fecha||'');
+  const DX1=ml+33,DX2=DX1+43;
+  doc.setFont('helvetica','normal');doc.setFontSize(5);doc.setTextColor(110,110,110);
+  doc.text('Anno',DX1,DY+5.5);doc.text('Mes',DX1+15,DY+5.5);doc.text('Dia',DX1+24,DY+5.5);
+  doc.text('Anno',DX2,DY+5.5);doc.text('Mes',DX2+15,DY+5.5);doc.text('Dia',DX2+24,DY+5.5);
+  doc.setTextColor(0);
+  doc.setFont('helvetica','normal');doc.setFontSize(6.5);doc.text('De',ml+23,DY+11.5);
+  (dp.y+dp.m+dp.d).split('').forEach((c,i)=>{CEL(DX1+i*3.5,DY+7,3.5,5.5);doc.setFont('helvetica','normal');doc.setFontSize(6);doc.text(c.trim(),DX1+i*3.5+1.75,DY+11.5,{align:'center'});});
+  doc.setFont('helvetica','normal');doc.setFontSize(7);doc.text('a',DX2-5,DY+11.5);
+  (dp.ye+dp.me+dp.de).split('').forEach((c,i)=>{CEL(DX2+i*3.5,DY+7,3.5,5.5);doc.setFont('helvetica','normal');doc.setFontSize(6);doc.text(c.trim(),DX2+i*3.5+1.75,DY+11.5,{align:'center'});});
+  LINE(y+31);
+  LBL('Area tematica del curso 2/',ml+2,y+33);
+  doc.setFont('helvetica','normal');doc.setFontSize(7.5);doc.text(course.area+' - '+course.areaLabel,ml+2,y+37.5);
+  LINE(y+39);
+  // Agente capacitador — label + texto dentro del box (box = 52mm, texto max y+50)
+  LBL('Agente capacitador (nombre del agente capacitador externo o interno):',ml+2,y+41.5);
+  doc.setFont('helvetica','normal');doc.setFontSize(6.2);
+  doc.text(doc.splitTextToSize('SERVICIOS FTS SA DE CV  |  RFC: SFT170905L43  |  INSTRUCTOR: '+instrName, pw-4), ml+2, y+46);
+  y+=55;
+  // FIRMAS — box ampliado a 56mm para que todo el contenido quepa
+  BOX(ml,y,pw,56);
+  doc.setFont('helvetica','bold');doc.setFontSize(6);
+  doc.text('Los datos se asientan en esta constancia bajo protesta de decir verdad, apercibidos de la responsabilidad en que incurre todo',W/2,y+5.5,{align:'center'});
+  doc.text('aquel que no se conduce con verdad.',W/2,y+9.5,{align:'center'});
+  const f1=ml+pw*0.175,f2=ml+pw*0.50,f3=ml+pw*0.835;
+  LINE(y+11);
+  doc.setDrawColor(215);doc.setLineWidth(0.2);
+  doc.line(ml+pw*0.33,y+11,ml+pw*0.33,y+56);
+  doc.line(ml+pw*0.67,y+11,ml+pw*0.67,y+56);
+  doc.setFont('helvetica','normal');doc.setFontSize(6);doc.setTextColor(80,80,80);
+  doc.text('Instructor o tutor',f1,y+15,{align:'center'});
+  doc.text('Patron o representante legal 4/',f2,y+15,{align:'center'});
+  doc.text('Representante de los trabajadores 5/',f3,y+15,{align:'center'});
+  doc.setTextColor(0);
+  // Firmas con fondo transparente — posicionadas cruzando la línea de firma
+  const sigW=32, sigH=14;
+  const SLY=y+37;
+  // Primero dibujar las líneas de firma
+  [f1,f2,f3].forEach(x=>{doc.setDrawColor(70);doc.setLineWidth(0.3);doc.line(x-18,SLY,x+18,SLY);});
+  // Posicionar firmas para que crucen sobre la línea (efecto pluma digital)
+  // La firma empieza arriba de la línea y su parte inferior cruza ~3mm debajo
+  const sigY = SLY - sigH + 3; // 3mm debajo de la línea
+  // Col 1: Capacitador — usa SIG_ESTEBAN si instrIdx===0
+  const _sc = (instrIdx===0) ? (SIG_ESTEBAN_PNG || SIG_ESTEBAN) : null;
+  const _scFmt = SIG_ESTEBAN_PNG ? 'PNG' : 'JPEG';
+  if (_sc) {
+    if(!SIG_ESTEBAN_PNG){doc.setFillColor(255,255,255);doc.rect(f1-sigW/2, sigY, sigW, sigH,'F');}
+    doc.addImage(_sc, _scFmt, f1-sigW/2, sigY, sigW, sigH);
+  }
+  // Col 2: Rep. Empresa (Teofilo)
+  const _si = SIG_INSTR_PNG || SIG_INSTR;
+  const _siFmt = SIG_INSTR_PNG ? 'PNG' : 'JPEG';
+  if(!SIG_INSTR_PNG){doc.setFillColor(255,255,255);doc.rect(f2-sigW/2, sigY, sigW, sigH,'F');}
+  doc.addImage(_si, _siFmt, f2-sigW/2, sigY, sigW, sigH);
+  // Col 3: Rep. Trabajadores (Francisco)
+  const _se = SIG_EMP_PNG || SIG_EMP;
+  const _seFmt = SIG_EMP_PNG ? 'PNG' : 'JPEG';
+  if(!SIG_EMP_PNG){doc.setFillColor(255,255,255);doc.rect(f3-sigW/2, sigY, sigW, sigH,'F');}
+  doc.addImage(_se, _seFmt, f3-sigW/2, sigY, sigW, sigH);
+  doc.setFont('helvetica','bold');doc.setFontSize(5.5);doc.setTextColor(0);
+  // Nombre del capacitador: splitTextToSize por si es muy largo
+  const colW = pw*0.33 - 4;
+  const nLines = doc.splitTextToSize(instrName, colW);
+  doc.text(nLines, f1, SLY+4, {align:'center'});
+  doc.text(DC3_CFG.repEmpresa,f2,SLY+4,{align:'center'});
+  doc.text(DC3_CFG.repTrab,f3,SLY+4,{align:'center'});
+  doc.setFont('helvetica','normal');doc.setFontSize(5.5);doc.setTextColor(100,100,100);
+  const nameH = nLines.length * 3.5;
+  doc.text('Nombre y firma',f1,SLY+4+nameH+2,{align:'center'});
+  doc.text('Nombre y firma',f2,SLY+8,{align:'center'});
+  doc.text('Nombre y firma',f3,SLY+8,{align:'center'});
+  doc.setTextColor(0);y+=59;
+  // INSTRUCCIONES
+  doc.setFont('helvetica','bold');doc.setFontSize(6);doc.text('INSTRUCCIONES',ml,y);
+  doc.setFont('helvetica','normal');doc.setFontSize(5);doc.setTextColor(70,70,70);
+  ['- Llenar a maquina o con letra de molde.',
+   '- Debera entregarse al trabajador dentro de los veinte dias habiles siguientes al termino del curso de capacitacion aprobado.',
+   '1/ Las areas y subareas ocupacionales del Catalogo Nacional de Ocupaciones se encuentran disponibles en el reverso de este formato y en la pagina www.stps.gob.mx',
+   '2/ Las areas tematicas de los cursos se encuentran disponibles en el reverso de este formato y en la pagina www.stps.gob.mx',
+   '3/ Cursos impartidos por el area competente de la Secretaria del Trabajo y Prevision Social.',
+   '4/ Para empresas con menos de 51 trabajadores. Para empresas con mas de 50 trabajadores firmaria el representante del patron ante la Comision mixta de capacitacion,',
+   '     adiestramiento y productividad.',
+   '5/ Solo para empresas con mas de 50 trabajadores.',
+   '* Dato no obligatorio.',
+  ].forEach((ln,i)=>doc.text(ln,ml,y+4+i*3));
+  doc.setTextColor(0);
+  doc.setFont('helvetica','normal');doc.setFontSize(7);doc.setTextColor(120,120,120);
+  doc.text('DC-3  ANVERSO',mr,H-5,{align:'right'});doc.setTextColor(0);
+}
+
+async function _makeDC3(worker, courses, instrIdx){
+  // Garantizar JPEG listo aunque el usuario genere el PDF antes de que cargue el load async
+  // Imágenes ya en JPEG — no se necesita conversión
+
+  try {
+    if(!window.jspdf){
+      toast('❌ ERROR: jsPDF no cargó. Revisa conexión a internet y recarga la página.', 'red');
+      console.error('window.jspdf is undefined - CDN script failed to load');
+      return;
+    }
+    const {jsPDF}=window.jspdf;
+    const doc=new jsPDF({orientation:'portrait',unit:'mm',format:'letter'});
+    const instrName=INSTRUCTORES[instrIdx].name;
+    courses.forEach((c,i)=>{if(i>0)doc.addPage('letter','portrait');buildPage(doc,worker,c,instrName,instrIdx);});
+    doc.save('DC3_'+worker.name.replace(/\s+/g,'_')+'.pdf');
+  } catch(err) {
+    toast('❌ Error al generar PDF: '+err.message, 'red');
+    console.error('PDF generation error:', err);
+    alert('Error al generar DC-3:\n'+err.message+'\n\nAbre la consola del navegador (F12) para más detalles.');
+  }
+}
+
+function generateDC3() {
+  const wCount = inst.selWorkers.size;
+  const cCount = inst.selCourses.size;
+  if (!wCount) { toast('⚠️ Selecciona al menos un trabajador'); return; }
+  if (!cCount) { toast('⚠️ Selecciona al menos un curso'); return; }
+  const fecha = document.getElementById('inst-fecha').value;
+  if (!fecha) { toast('⚠️ Ingresa la fecha de impartición'); return; }
+  const courses = CURSOS.filter(c=>inst.selCourses.has(c.id)).map(c=>({...c,_fecha:fecha}));
+  const selArr  = [...inst.selWorkers];
+  toast(`⏳ Generando ${selArr.length} PDF(s)…`);
+  selArr.forEach((wi,i)=>setTimeout(()=>{
+    _makeDC3(inst.workers[wi], courses, inst.instructor);
+    if(i===selArr.length-1) toast(`✅ ${selArr.length} DC-3 descargado(s)`);
+  }, i*700));
+}
+
+// ═══════════════════════════════════════════════════
+const emp = {
+  nombre: '', curp: '',
+  foto: '', fotoTs: '',
+  // completed: Map de id -> {score, fecha}
+  completed: new Map(),
+  currentId: null,
+  vidTimer: null, vidRunning: false,
+  quizQ: [], quizIdx: 0, quizAnswers: [], quizStart: null,
+  lastScore: 0,
+};
+
+function goEmpAccess() { document.getElementById('emp-user').value=''; document.getElementById('emp-pass').value=''; document.getElementById('emp-auth-err').textContent=''; go('s-emp'); }
+
+// ═══ IPERC ACCESS LOGIN ═══
+async function ipercAccessLogin(){
+  const user=document.getElementById('iperc-login-user').value.trim().toLowerCase();
+  const pass=document.getElementById('iperc-login-pass').value.trim();
+  const err=document.getElementById('iperc-login-err');
+  err.textContent='Verificando...';
+  try{
+    // ftsmaster con contraseña maestra — acceso directo sin consultar server
+    if(user===MASTER_USER && pass===MASTER_PASS){
+      const session={user:MASTER_USER,acceso:'master',esMaster:true};
+      sessionStorage.setItem('fts_iperc_session',JSON.stringify(session));
+      window.location.href='iperc.html';return;
+    }
+    const users=await fetchAuthUsers();
+    if(!users||!users.length){err.textContent='No se pudo conectar al servidor.';return;}
+    const found=users.find(u=>(u.user||'').toLowerCase()===user);
+    if(!found){err.textContent='Usuario no encontrado.';return;}
+    if(found.pass!==pass){err.textContent='Contraseña incorrecta.';return;}
+    if(found.expira){
+      const hoy=new Date().toISOString().split('T')[0];
+      if(found.expira<hoy){err.textContent='Tu acceso ha expirado.';return;}
+    }
+    const acceso=(found.acceso||'ambos').toLowerCase();
+    if(acceso==='empleado'){err.textContent='Tu perfil es solo "Empleado". Solicita acceso segurista al administrador.';return;}
+    const session={user:found.user,acceso,esMaster:false,nombre:found.nombre||found.user};
+    sessionStorage.setItem('fts_iperc_session',JSON.stringify(session));
+    window.location.href='iperc.html';
+  }catch(e){err.textContent='Error de conexión. Verifica tu internet.';}
+}
+
+// Paso 1: autenticación
+async function empAuthStep() {
+  const user = document.getElementById('emp-user').value.trim().toLowerCase();
+  const pass = document.getElementById('emp-pass').value.trim();
+  const err  = document.getElementById('emp-auth-err');
+  if (!user||!pass) { err.textContent='Ingresa usuario y contraseña'; return; }
+  if (user===MASTER_USER && pass===MASTER_PASS) {
+    err.textContent=''; _loggedUser=null; startHeartbeat(); go('s-emp-info'); toast('🔑 Sesión Master'); return;
+  }
+  err.textContent='Verificando...'; err.style.color='var(--muted2)';
+  const users = await fetchAuthUsers();
+  const byUser = users.find(u => u.usuario.toLowerCase() === user);
+  if (!byUser) {
+    err.style.color='var(--red)';
+    err.textContent = '❌ Usuario "' + user + '" no encontrado'; return;
+  }
+  if (byUser.contraseña !== pass) {
+    err.style.color='var(--red)';
+    err.textContent = '❌ Contraseña incorrecta'; return;
+  }
+  const hoy = new Date().toISOString().slice(0,10);
+  if (byUser.fecha_expira && byUser.fecha_expira < hoy) {
+    err.style.color='var(--red)';
+    err.textContent = '⏰ Acceso expirado el ' + byUser.fecha_expira + '. Solicita renovación.'; return;
+  }
+  const acceso = (byUser.acceso||'ambos').toLowerCase();
+  if (acceso !== 'ambos' && acceso !== 'empleado') {
+    err.style.color='var(--red)';
+    err.textContent = '🚫 Tu acceso es "' + acceso + '" — usa el modo Instructor.'; return;
+  }
+  err.textContent=''; _loggedUser = byUser; startHeartbeat(); go('s-emp-info');
+}
+
+// Paso 2: datos personales → cámara
+function empInfoStep() {
+  const ap   = document.getElementById('emp-ap').value.trim().toUpperCase();
+  const am   = document.getElementById('emp-am').value.trim().toUpperCase();
+  const nom  = document.getElementById('emp-nom').value.trim().toUpperCase();
+  const curp = document.getElementById('emp-curp').value.trim().toUpperCase();
+  if (!ap)  { toast('⚠️ Ingresa tu apellido paterno'); return; }
+  if (!nom) { toast('⚠️ Ingresa tu nombre'); return; }
+  if (curp.length !== 18) { toast('⚠️ CURP de 18 caracteres'); return; }
+  emp.nombre = (ap+' '+am+' '+nom).replace(/\s+/g,' ').trim();
+  emp.curp = curp;
+  go('s-cam'); startCam();
+}
+
+// ── Camera ──
+let camStream = null;
+
+async function startCam() {
+  const dot = document.getElementById('cam-dot');
+  const txt = document.getElementById('cam-txt');
+  const btn = document.getElementById('btn-cap');
+  try {
+    camStream = await navigator.mediaDevices.getUserMedia({video:{facingMode:'user',width:{ideal:640},height:{ideal:640}}});
+    document.getElementById('cam-vid').srcObject = camStream;
+    dot.className = 'blink ok';
+    txt.textContent = 'Cámara lista';
+    btn.disabled = false;
+  } catch(e) {
+    txt.textContent = 'Sin cámara · modo prueba';
+    btn.disabled = false;
+    btn.textContent = '📷 Continuar (sin foto)';
+  }
+}
+
+function stopCam() {
+  if (camStream) { camStream.getTracks().forEach(t => t.stop()); camStream = null; }
+}
+
+function capturePhoto() {
+  if (!camStream) {
+    emp.foto = '';
+    emp.fotoTs = fmtDT(new Date());
+    proceedAfterPhoto();
+    return;
+  }
+  const vid = document.getElementById('cam-vid');
+  const cvs = document.getElementById('cam-cvs');
+  cvs.width = vid.videoWidth || 320;
+  cvs.height = vid.videoHeight || 320;
+  cvs.getContext('2d').drawImage(vid, 0, 0);
+  emp.foto   = cvs.toDataURL('image/jpeg', 0.85);
+  emp.fotoTs = fmtDT(new Date());
+  // Show preview
+  document.getElementById('cam-prev-img').src = emp.foto;
+  document.getElementById('cam-ts').textContent = emp.fotoTs;
+  document.getElementById('cam-vid').style.display = 'none';
+  document.querySelector('.cam-ov').style.display = 'none';
+  document.querySelector('.cam-bot').style.display = 'none';
+  document.querySelector('.cam-top').style.display = 'none';
+  document.getElementById('cam-prev-wrap').style.display = 'flex';
+  document.getElementById('cam-act1').style.display = 'none';
+  document.getElementById('cam-act2').style.display = 'flex';
+}
+
+function retakePhoto() {
+  document.getElementById('cam-vid').style.display = 'block';
+  document.querySelector('.cam-ov').style.display = 'flex';
+  document.querySelector('.cam-bot').style.display = 'block';
+  document.querySelector('.cam-top').style.display = 'block';
+  document.getElementById('cam-prev-wrap').style.display = 'none';
+  document.getElementById('cam-act1').style.display = 'flex';
+  document.getElementById('cam-act2').style.display = 'none';
+}
+
+function confirmPhoto() { stopCam(); proceedAfterPhoto(); }
+
+function proceedAfterPhoto() {
+  loadEmpDash();
+  go('s-edash');
+  toast('✅ Identidad verificada');
+}
+
+// ── Employee Dashboard ──
+function loadEmpDash() {
+  document.getElementById('tb-nombre').textContent = emp.nombre.split(' ').slice(0,3).join(' ');
+  document.getElementById('tb-curp').textContent   = emp.curp;
+  document.getElementById('foto-ts').textContent   = emp.fotoTs || 'Sin foto · modo prueba';
+  renderEmpDash();
+}
+
+function renderEmpDash() {
+  const done  = emp.completed.size;
+  const total = CURSOS.length;
+  const pct   = Math.round(done / total * 100);
+  const scores = [...emp.completed.values()].map(v => v.score);
+  const avg   = scores.length ? Math.round(scores.reduce((a,b)=>a+b,0)/scores.length) : null;
+
+  document.getElementById('tb-prog').textContent   = `${done}/${total}`;
+  document.getElementById('pct-fill').style.width  = pct + '%';
+  document.getElementById('pct-label').textContent = pct + '%';
+  document.getElementById('stat-pend').textContent = total - done;
+  document.getElementById('stat-done').textContent = done;
+  document.getElementById('stat-avg').textContent  = avg ? avg + '%' : '—';
+
+  // Render course list
+  const completedIds = new Set(emp.completed.keys());
+
+  // Find the FIRST incomplete course index
+  let firstIncompleteIdx = -1;
+  for (let i = 0; i < CURSOS.length; i++) {
+    if (!completedIds.has(CURSOS[i].id)) {
+      firstIncompleteIdx = i;
+      break;
+    }
+  }
+
+  document.getElementById('emp-course-list').innerHTML = CURSOS.map((c, i) => {
+    const isDone   = completedIds.has(c.id);
+    const isNext   = (i === firstIncompleteIdx);
+    const isLocked = !isDone && !isNext;
+
+    let cls   = isDone ? 'done' : isNext ? 'active' : 'locked';
+    let badge = isDone
+      ? `<span class="ci-badge done">${emp.completed.get(c.id).score}%</span>`
+      : isNext
+        ? '<span class="ci-badge next">▶ Siguiente</span>'
+        : '<span class="ci-badge lock">🔒</span>';
+
+    const numLabel = isDone ? '✓' : (i + 1);
+
+    return `<div class="ci ${cls}" data-id="${c.id}">
+      <div class="ci-num">${numLabel}</div>
+      <div class="ci-txt"><strong>${c.nombre.length>36?c.nombre.substring(0,36)+'…':c.nombre}</strong><span>${c.hrs} hrs · ${c.area}</span></div>
+      ${badge}
+    </div>`;
+  }).join('');
+
+  // Attach click listeners only to non-locked courses
+  document.querySelectorAll('#emp-course-list .ci:not(.locked)').forEach(el => {
+    el.addEventListener('click', function() {
+      openCourse(parseInt(this.dataset.id));
+    });
+  });
+}
+
+// ── Course ──
+function openCourse(id) {
+  const c = CURSOS.find(x => x.id === id);
+  if (!c) return;
+  emp.currentId  = id;
+  emp.vidRunning = false;
+  clearInterval(emp.vidTimer);
+
+  document.getElementById('course-tb-title').textContent = `Curso ${id} de ${CURSOS.length}`;
+  document.getElementById('course-tb-sub').textContent   = c.nombre.substring(0, 32) + (c.nombre.length > 32 ? '…' : '');
+  document.getElementById('vid-label').textContent       = `${c.hrs} hrs · ${c.area}`;
+  document.getElementById('vid-dur').textContent         = `Duración del curso: ${c.hrs} horas`;
+
+  document.getElementById('vid-progress').style.display = 'none';
+  document.getElementById('quiz-card').style.display    = 'none';
+  document.getElementById('result-card').style.display  = 'none';
+  document.getElementById('vid-fill').style.width       = '0%';
+
+  const vidArea = document.getElementById('vid-area');
+  vidArea.style.display = 'flex';
+
+  if (c.video) {
+    // ── Video real HTML5 ──
+    vidArea.style.cssText = 'background:#000;border-radius:10px;overflow:hidden;width:100%;padding:0;display:block';
+    vidArea.innerHTML = `
+      <video id="course-video"
+        src="${c.video}"
+        controls
+        playsinline
+        preload="metadata"
+        style="width:100%;max-height:320px;display:block;border-radius:10px"
+        onended="onVideoEnd()"
+        onerror="vidError(this)">
+        Tu navegador no soporta video HTML5.
+      </video>
+      <p id="vid-hint" style="font-size:11px;color:#aaa;text-align:center;padding:6px 0;background:#111;margin:0">
+        Mira el video completo para desbloquear el examen
+      </p>`;
+
+    // Escuchar cuando termine para disparar quiz
+    const vEl = document.getElementById('course-video');
+    vEl.addEventListener('ended', onVideoEnd, { once: true });
+
+    // Barra de progreso nativa está desactivada — usamos el control del video
+    // Si quieres la barra custom también:
+    vEl.addEventListener('timeupdate', () => {
+      if (!vEl.duration) return;
+      const pct = (vEl.currentTime / vEl.duration) * 100;
+      document.getElementById('vid-fill').style.width = pct + '%';
+    });
+    document.getElementById('vid-progress').style.display = 'block';
+
+  } else {
+    // ── Sin video — modo demo ──
+    vidArea.style.cssText = '';
+    vidArea.innerHTML = `
+      <div style="font-size:40px">🎥</div>
+      <p style="font-size:12px;color:#555;text-align:center;padding:0 16px">Video próximamente</p>
+      <div class="play-btn" id="play-btn" onclick="startVideo()">
+        <svg width="22" height="22" viewBox="0 0 24 24" fill="white"><path d="M8 5v14l11-7z"/></svg>
+      </div>`;
+  }
+
+  go('s-course');
+}
+
+function vidError(el) {
+  el.closest('#vid-area').innerHTML = `
+    <div style="font-size:36px;padding:20px 0">⚠️</div>
+    <p style="font-size:12px;color:var(--red);text-align:center;padding:0 16px">
+      No se pudo cargar el video.<br>Verifica que el archivo esté en la misma carpeta que el HTML.
+    </p>
+    <button onclick="onVideoEnd()" style="margin:12px auto;background:var(--o);color:#fff;border:none;border-radius:8px;padding:8px 20px;font-size:13px;cursor:pointer">
+      Continuar al examen →
+    </button>`;
+}
+
+function startVideo() {
+  // Solo para modo demo (sin URL de video)
+  if (emp.vidRunning) return;
+  emp.vidRunning = true;
+  document.getElementById('play-btn').style.display     = 'none';
+  document.getElementById('vid-progress').style.display = 'block';
+
+  const total = 3;
+  let elapsed = 0;
+  document.getElementById('vid-tot').textContent = fmtSecs(total);
+
+  emp.vidTimer = setInterval(() => {
+    elapsed++;
+    document.getElementById('vid-fill').style.width = (elapsed / total * 100) + '%';
+    document.getElementById('vid-cur').textContent  = fmtSecs(elapsed);
+    if (elapsed >= total) {
+      clearInterval(emp.vidTimer);
+      emp.vidRunning = false;
+      onVideoEnd();
+    }
+  }, 1000);
+}
+
+function onVideoEnd() {
+  document.getElementById('vid-area').innerHTML =
+    '<div style="font-size:36px">✅</div><p style="font-size:12px;color:var(--green);font-weight:600">Material revisado</p>';
+  toast('✅ Video completado');
+  setTimeout(startQuiz, 600);
+}
+
+// ── Quiz (Demo mode: pre-answered) ──
+function startQuiz() {
+  emp.quizQ       = PREGUNTAS[emp.currentId] || PREGUNTAS[1];
+  emp.quizIdx     = 0;
+  emp.quizAnswers = [];
+  emp.quizStart   = new Date();
+  document.getElementById('quiz-card').style.display = 'block';
+  renderQuestion();
+  document.getElementById('quiz-card').scrollIntoView({behavior:'smooth'});
+}
+
+function renderQuestion() {
+  const q   = emp.quizQ[emp.quizIdx];
+  const idx = emp.quizIdx;
+  const tot = emp.quizQ.length;
+  const L   = ['A','B','C','D'];
+
+  // DEMO: pre-mark correct answer, just click Siguiente
+  emp.quizAnswers[idx] = true; // register as correct
+
+  document.getElementById('quiz-sub').textContent = `Pregunta ${idx+1} de ${tot}`;
+  document.getElementById('quiz-body').innerHTML = `
+    <span class="demo-pill">🔧 MODO DEMO — Respuesta correcta pre-marcada</span>
+    <p class="quiz-q">${q.q}</p>
+    <div class="quiz-opts">
+      ${q.opts.map((o,i) => `
+        <div class="qopt ${i===q.c?'right':''}" style="pointer-events:none">
+          <div class="ql" style="${i===q.c?'background:var(--green);color:#fff':''}">${L[i]}</div>
+          <span>${o}</span>
+        </div>`).join('')}
+    </div>
+    <div class="qfb on ok">✓ ${L[q.c]}. ${q.opts[q.c]}</div>
+    <button class="btn btn-g mt" onclick="nextQ()">${idx+1 < tot ? 'Siguiente →' : 'Ver resultado →'}</button>`;
+}
+
+function nextQ() {
+  emp.quizIdx++;
+  if (emp.quizIdx < emp.quizQ.length) {
+    renderQuestion();
+    document.getElementById('quiz-card').scrollIntoView({behavior:'smooth'});
+  } else {
+    showResult();
+  }
+}
+
+function showResult() {
+  const correctas = emp.quizAnswers.filter(Boolean).length;
+  const total     = emp.quizQ.length;
+  const score     = Math.round(correctas / total * 100);
+  const secs      = Math.round((new Date() - emp.quizStart) / 1000);
+  emp.lastScore   = score;
+
+  document.getElementById('quiz-card').style.display  = 'none';
+  document.getElementById('result-card').style.display = 'block';
+  document.getElementById('result-sub').textContent    = score >= 70 ? '✅ Aprobado' : '❌ No aprobado';
+  document.getElementById('r-score').textContent       = score + '%';
+  document.getElementById('r-correct').textContent     = `${correctas}/${total}`;
+  document.getElementById('r-time').textContent        = fmtSecs(secs);
+
+  const btn = document.getElementById('btn-complete');
+  if (score >= 70) {
+    btn.textContent = '✓ Registrar y continuar';
+    btn.className   = 'btn btn-g';
+    btn.onclick     = completeCourse;
+  } else {
+    btn.textContent = '🔄 Repetir examen';
+    btn.className   = 'btn btn-s';
+    btn.onclick     = () => { document.getElementById('result-card').style.display = 'none'; startQuiz(); };
+  }
+  document.getElementById('result-card').scrollIntoView({behavior:'smooth'});
+}
+
+function completeCourse() {
+  // Store with explicit number key
+  emp.completed.set(emp.currentId, {
+    score: emp.lastScore,
+    fecha: fmtDT(new Date()),
+    fechaISO: todayISO(),
+  });
+
+  const allDone = emp.completed.size === CURSOS.length;
+  if (allDone) {
+    go('s-edash');
+    renderEmpDash();
+    setTimeout(showDone, 400);
+  } else {
+    go('s-edash');
+    renderEmpDash();
+    toast(`✅ Curso completado · ${emp.lastScore}%`);
+  }
+}
+
+function showDone() {
+  const scores = [...emp.completed.values()].map(v => v.score);
+  const avg    = Math.round(scores.reduce((a,b)=>a+b,0)/scores.length);
+  document.getElementById('dc-nombre').textContent = emp.nombre;
+  document.getElementById('dc-curp').textContent   = emp.curp;
+  document.getElementById('dc-cursos').textContent = `${CURSOS.length}/${CURSOS.length}`;
+  document.getElementById('dc-avg').textContent    = avg + '%';
+  document.getElementById('dc-fecha').textContent  = fmtDT(new Date());
+  go('s-emp-done');
+}
+
+function generateEmpDC3(){
+  if(!emp.completed.size){ toast('⚠️ No hay cursos completados'); return; }
+  const worker = {name:emp.nombre, curp:emp.curp};
+  const fecha = todayISO();
+  const courses = CURSOS
+    .filter(c=>emp.completed.has(c.id))
+    .map(c=>({...c, _fecha: emp.completed.get(c.id).fechaISO || fecha}));
+  toast('⏳ Generando DC-3…');
+  setTimeout(()=>{ _makeDC3(worker, courses, 0); }, 300);
+}
+</script>
+</script>
+
+<script>
+(function(){
+  'use strict';
+  function makeFTSIcon(size){
+    const cv=document.createElement('canvas');cv.width=cv.height=size;
+    const ctx=cv.getContext('2d');
+    ctx.fillStyle='#0a0a0a';ctx.fillRect(0,0,size,size);
+    const cx=size/2,cy=size/2,r=size*0.42;
+    ctx.beginPath();
+    for(let i=0;i<6;i++){const a=Math.PI/180*(60*i-30);i===0?ctx.moveTo(cx+r*Math.cos(a),cy+r*Math.sin(a)):ctx.lineTo(cx+r*Math.cos(a),cy+r*Math.sin(a));}
+    ctx.closePath();ctx.fillStyle='#D83B01';ctx.fill();
+    ctx.fillStyle='#ffffff';ctx.font=`800 ${size*0.28}px Arial,sans-serif`;
+    ctx.textAlign='center';ctx.textBaseline='middle';
+    ctx.fillText('FTS',cx,cy+size*0.02);
+    return cv.toDataURL('image/png');
+  }
+  const icon192=makeFTSIcon(192),icon512=makeFTSIcon(512);
+  const manifest={name:'FTS Capacitación',short_name:'FTS Cap.',description:'Sistema de capacitación y constancias DC-3',start_url:'./',scope:'./',display:'standalone',orientation:'portrait-primary',background_color:'#0a0a0a',theme_color:'#D83B01',lang:'es-MX',icons:[{src:icon192,sizes:'192x192',type:'image/png',purpose:'any maskable'},{src:icon512,sizes:'512x512',type:'image/png',purpose:'any maskable'}]};
+  const mBlob=new Blob([JSON.stringify(manifest)],{type:'application/json'});
+  const mLink=document.getElementById('pwa-manifest');
+  if(mLink) mLink.href=URL.createObjectURL(mBlob);
+  const iLink=document.getElementById('pwa-icon');
+  if(iLink) iLink.href=icon192;
+  const swCode=`
+const CACHE='fts-cap-v7';
+self.addEventListener('install',e=>e.waitUntil(caches.open(CACHE).then(c=>fetch('https://cdnjs.cloudflare.com/ajax/libs/jspdf/2.5.1/jspdf.umd.min.js').then(r=>c.put('https://cdnjs.cloudflare.com/ajax/libs/jspdf/2.5.1/jspdf.umd.min.js',r)).catch(()=>{})).then(()=>self.skipWaiting())));
+self.addEventListener('activate',e=>e.waitUntil(caches.keys().then(ks=>Promise.all(ks.filter(k=>k!==CACHE).map(k=>caches.delete(k)))).then(()=>self.clients.claim())));
+self.addEventListener('fetch',e=>{
+  const u=e.request.url;
+  // Nunca cachear archivos de control — deben ir siempre a la red o fallar
+  if(u.includes('version.json')||u.includes('users.json')||u.includes('raw.githubusercontent')){
+    e.respondWith(fetch(e.request));
+    return;
+  }
+  if(u.includes('cdnjs')||u.includes('fonts.g')){
+    e.respondWith(caches.match(e.request).then(c=>c||(fetch(e.request).then(r=>{const cl=r.clone();caches.open(CACHE).then(ca=>ca.put(e.request,cl));return r;}))));
+    return;
+  }
+  if(e.request.mode==='navigate'){
+    e.respondWith(fetch(e.request).catch(()=>caches.match(e.request)));
+    return;
+  }
+  e.respondWith(fetch(e.request).catch(()=>caches.match(e.request)));
+});
+`;
+  if('serviceWorker' in navigator){
+    const swBlob=new Blob([swCode],{type:'application/javascript'});
+    navigator.serviceWorker.register(URL.createObjectURL(swBlob),{scope:'./'})
+      .then(r=>console.log('✅ SW registrado'))
+      .catch(e=>console.warn('SW no disponible:',e));
+  }
+  let _dp=null;
+  window.addEventListener('beforeinstallprompt',e=>{e.preventDefault();_dp=e;showBar();});
+  window.addEventListener('appinstalled',()=>{hideBar();_dp=null;});
+  function showBar(){
+    if(document.getElementById('pwa-bar'))return;
+    const b=document.createElement('div');b.id='pwa-bar';
+    b.innerHTML=`<div style="display:flex;align-items:center;gap:10px;flex:1;min-width:0"><div style="width:36px;height:36px;background:#D83B01;border-radius:8px;display:flex;align-items:center;justify-content:center;font-weight:800;font-size:11px;color:#fff;flex-shrink:0">FTS</div><div style="min-width:0"><div style="font-weight:600;font-size:13px">Instalar FTS Capacitación</div><div style="font-size:11px;color:#666">Acceso directo desde tu pantalla de inicio</div></div></div><div style="display:flex;gap:8px;flex-shrink:0"><button id="pwa-ok" style="background:#D83B01;color:#fff;border:none;padding:8px 16px;border-radius:8px;font-weight:700;font-size:13px;cursor:pointer">Instalar</button><button id="pwa-x" style="background:#f0f0f0;color:#666;border:none;padding:8px 12px;border-radius:8px;font-size:13px;cursor:pointer">✕</button></div>`;
+    b.style.cssText='position:fixed;bottom:0;left:0;right:0;background:#1c1c1c;border-top:1px solid #2c2c2c;padding:12px 16px;display:flex;align-items:center;gap:12px;z-index:9999;box-shadow:0 -4px 20px rgba(0,0,0,.5)';
+    document.body.appendChild(b);
+    document.getElementById('pwa-ok').onclick=async()=>{if(!_dp)return;_dp.prompt();const{outcome}=await _dp.userChoice;if(outcome==='accepted')hideBar();_dp=null;};
+    document.getElementById('pwa-x').onclick=()=>hideBar();
+  }
+  function hideBar(){const b=document.getElementById('pwa-bar');if(b)b.remove();}
+})();
+
+// ── Curso personalizado temporal ──
+let _customCursoIdSeed = 9001;
+
+function toggleAddCursoForm(){
+  const form = document.getElementById('add-curso-form');
+  if(!form) return;
+  const visible = form.style.display !== 'none';
+  form.style.display = visible ? 'none' : 'block';
+  if(!visible) setTimeout(()=>{ const el=document.getElementById('nc-nombre'); if(el) el.focus(); },50);
+}
+
+function addCursoPersonalizado(){
+  const nombre = (document.getElementById('nc-nombre')?.value||'').trim();
+  const hrs    = parseInt(document.getElementById('nc-hrs')?.value)||8;
+  const areaLabel = (document.getElementById('nc-area-label')?.value||'Seguridad').trim();
+  const area   = (document.getElementById('nc-area-code')?.value||'6000').trim();
+
+  if(!nombre){ alert('Escribe el nombre del curso'); return; }
+
+  const newId = _customCursoIdSeed++;
+  CURSOS.push({ id:newId, nombre, hrs, area, areaLabel, _custom:true });
+  inst.selCourses.add(newId);
+
+  // Limpiar form y cerrar
+  document.getElementById('nc-nombre').value = '';
+  document.getElementById('nc-hrs').value = '8';
+  document.getElementById('nc-area-label').value = '';
+  document.getElementById('nc-area-code').value = '6000';
+  toggleAddCursoForm();
+
+  renderCourseSelector();
+  renderGenSummary();
+}
+
+</script>
+
+<!-- ════════════ USER MANAGEMENT (solo master) ════════════ -->
+<div id="s-users" class="scr">
+  <div class="topbar">
+    <button class="tb-back" onclick="go('s-inst')">‹</button>
+    <div class="tb-info"><strong>Gestión de Usuarios</strong><span>Control de acceso · FTS Master</span></div>
+    <button onclick="loadUserPanel()" style="background:none;border:none;cursor:pointer;font-size:18px;padding:4px 8px" title="Recargar desde GitHub">🔄</button>
+  </div>
+  <div class="content">
+
+    <!-- Estado general -->
+    <div id="usr-summary" class="card">
+      <div class="card-hd"><div class="card-icon" style="font-size:16px">👥</div><div><div class="card-title">Usuarios registrados</div><div class="card-sub" id="usr-sub">Cargando…</div></div></div>
+    </div>
+
+    <!-- Lista de usuarios -->
+    <div id="usr-list"></div>
+
+    <!-- Agregar usuario -->
+    <div class="card">
+      <div class="card-hd"><div class="card-icon g" style="font-size:16px">➕</div><div><div class="card-title">Agregar usuario</div><div class="card-sub">Se agrega al JSON generado</div></div></div>
+      <div class="card-body">
+        <div style="display:flex;gap:8px;margin-bottom:8px">
+          <div class="field" style="flex:1;margin-bottom:0"><label>Usuario</label><input id="nu-user" type="text" placeholder="ej: juan.garcia" style="text-transform:lowercase"></div>
+          <div class="field" style="flex:1;margin-bottom:0"><label>Contraseña</label><input id="nu-pass" type="text" placeholder="ej: FTS2025"></div>
+        </div>
+        <div style="display:flex;gap:8px;margin-bottom:8px">
+          <div class="field" style="flex:1;margin-bottom:0"><label>Acceso</label>
+            <select id="nu-acceso"><option value="ambos">👥 Ambos</option><option value="instructor">🎓 Instructor</option><option value="empleado">👷 Empleado</option><option value="segurista">⚠️ Segurista IPERC</option></select>
+          </div>
+          <div class="field" style="flex:1;margin-bottom:0"><label>Expira</label><input id="nu-exp" type="date" onchange="if(this.value>_maxExpira()){toast('🔒 Máximo: hoy + 1 mes ('+_maxExpira()+')');this.value=_maxExpira();}"></div>
+        </div>
+        <button class="btn btn-p" onclick="addUserToPanel()" style="margin-top:4px">+ Agregar usuario</button>
+      </div>
+    </div>
+
+    <!-- JSON generado -->
+    <div class="card">
+      <div class="card-hd"><div class="card-icon b" style="font-size:16px">📋</div><div><div class="card-title">JSON para GitHub</div><div class="card-sub">Copia y pega en tu users.json</div></div></div>
+      <div class="card-body">
+        <textarea id="usr-json" class="json-out" rows="10" readonly></textarea>
+        <button class="btn btn-s mt" onclick="copyUsersJSON()" style="margin-top:8px">📋 Copiar JSON</button>
+        <div id="usr-copy-msg" style="font-size:11px;color:var(--green);margin-top:6px;min-height:14px;text-align:center"></div>
+      </div>
+    </div>
+
+  </div>
+</div>
+
+<!-- ════════════ STATUS BAR (todas las pantallas) ════════════ -->
+<div id="fts-statusbar">
+  <div class="sb-left">
+    <div id="sb-dot"></div>
+    <span id="sb-status">Verificando…</span>
+    <span id="sb-lastval"></span>
+    <button id="sb-reconnect" onclick="reconnectNow()" style="display:none;margin-left:6px;background:#f59e0b;color:#000;border:none;border-radius:5px;padding:2px 8px;font-size:11px;font-weight:700;cursor:pointer;font-family:'Inter',sans-serif">🔄 Reconectar</button>
+  </div>
+  <div class="sb-right">
+    <span id="sb-clock">--:--:--</span>
+    <span style="opacity:.3">·</span>
+    <span id="sb-tz" style="color:rgba(255,255,255,.3)"></span>
+  </div>
+</div>
+
+<!-- videos.js se conectará en instrucción #3 -->
+</body>
+</html>

--- a/seguridad/js/videos.js
+++ b/seguridad/js/videos.js
@@ -1,0 +1,1040 @@
+/* ================================================================
+   FTS VIDEO TRAINING MODULE — v3.1
+   Insertar justo antes de </body> en index.html
+   Archivos externos requeridos (raíz del repo):
+     · videos.json       → catálogo de cursos y paquetes
+     · asignaciones.json → asignaciones instructor → empleado
+   ================================================================ */
+(function () {
+'use strict';
+
+/* ── Config ──────────────────────────────────────────────────── */
+const BASE     = 'https://raw.githubusercontent.com/yinyo1/fts-suite/main';
+const VID_URL  = BASE + '/videos.json';
+const ASIG_URL = BASE + '/asignaciones.json';
+const MIN_PASS = 70;
+
+/* ── Estado global ───────────────────────────────────────────── */
+const S = {
+  cursos:      [],   // del videos.json
+  paquetes:    [],   // del videos.json
+  asignaciones:[],   // del asignaciones.json  [{curp,nombre,cursos:[ids]}]
+  seleccion:   [],   // checkboxes del empleado
+  cola:        [],   // cursos en ejecución
+  indice:      0,
+  empleado:    null,
+  resultados:  {},   // {id: {aprobado,score,foto,hash,ts}}
+  camStream:   null,
+};
+
+/* ════════════════════════════════════════════════════════════
+   1. CARGA DE DATOS
+═══════════════════════════════════════════════════════════════*/
+async function cargarTodo() {
+  const [vRes, aRes] = await Promise.allSettled([
+    fetch(VID_URL  + '?_=' + Date.now()),
+    fetch(ASIG_URL + '?_=' + Date.now()),
+  ]);
+
+  if (vRes.status === 'fulfilled' && vRes.value.ok) {
+    const d = await vRes.value.json();
+    S.cursos   = (d.cursos   || []).filter(c => c.activo !== false);
+    S.paquetes = d.paquetes  || [];
+  }
+
+  if (aRes.status === 'fulfilled' && aRes.value.ok) {
+    const d = await aRes.value.json();
+    S.asignaciones = d.asignaciones || [];
+  }
+
+  // Mezclar con sessionStorage (asignaciones hechas en esta sesión)
+  try {
+    const local = JSON.parse(sessionStorage.getItem('fts3_asig') || '[]');
+    local.forEach(la => {
+      const idx = S.asignaciones.findIndex(a =>
+        (a.curp && a.curp === la.curp) || a.nombre === la.nombre);
+      if (idx >= 0) S.asignaciones[idx] = { ...S.asignaciones[idx], ...la };
+      else S.asignaciones.push(la);
+    });
+  } catch(e) {}
+
+  console.log('[FTS3.1] cursos:', S.cursos.length,
+    '| paquetes:', S.paquetes.length,
+    '| asignaciones:', S.asignaciones.length);
+}
+
+/* Helper: buscar asignación de un empleado */
+function _getAsig(emp) {
+  if (!emp) return null;
+  return S.asignaciones.find(a =>
+    (emp.curp && a.curp && a.curp.trim().toUpperCase() === emp.curp.trim().toUpperCase()) ||
+    (a.nombre && emp.nombre && a.nombre.trim().toUpperCase().includes(emp.nombre.trim().toUpperCase()))
+  ) || null;
+}
+
+/* ════════════════════════════════════════════════════════════
+   2. CSS
+═══════════════════════════════════════════════════════════════*/
+function inyectarCSS() {
+  if (document.getElementById('fts3-css')) return;
+  const s = document.createElement('style');
+  s.id = 'fts3-css';
+  s.textContent = `
+  .fts3-ov{position:fixed;inset:0;background:rgba(0,0,0,.82);z-index:9000;
+    display:none;align-items:flex-start;justify-content:center;
+    overflow-y:auto;padding:14px 10px 40px;box-sizing:border-box}
+  .fts3-ov.on{display:flex}
+  .fts3-box{background:#fff;border-radius:14px;width:100%;max-width:580px;
+    padding:18px;position:relative;box-sizing:border-box}
+  .fts3-close{position:absolute;top:10px;right:10px;background:#f0f0f0;
+    border:none;border-radius:50%;width:28px;height:28px;cursor:pointer;font-size:15px}
+  .fc-card{background:#f5f5f5;border:1px solid #e0e0e0;border-radius:10px;
+    padding:12px;margin-bottom:8px}
+  .fc-title{font-weight:700;font-size:13px}
+  .fc-url{font-size:10px;color:#0078D4;word-break:break-all;
+    background:#f0f6ff;padding:2px 6px;border-radius:3px;margin:4px 0}
+  .fc-meta{font-size:11px;color:#999;margin-top:2px}
+  .fc-btns{display:flex;gap:5px;margin-top:7px;flex-wrap:wrap}
+  .fb{font-size:11px;padding:4px 9px;border-radius:5px;border:none;
+    cursor:pointer;font-family:Inter,sans-serif;font-weight:600}
+  .fb-e{background:#e8e8e8;color:#333}
+  .fb-d{background:#ffeaea;color:#c00}
+  .fb-t{background:#e8f5e9;color:#107C10}
+  .fts3-form label{font-size:11px;color:#666;display:block;margin-bottom:2px}
+  .fts3-form input,.fts3-form textarea,.fts3-form select{
+    width:100%;box-sizing:border-box;margin-bottom:8px;padding:9px 11px;
+    border:1px solid #ccc;border-radius:7px;font-family:Inter,sans-serif;font-size:13px}
+  .fts3-json{background:#111;color:#00ff88;font-family:monospace;font-size:10px;
+    padding:10px;border-radius:8px;white-space:pre;max-height:220px;
+    overflow-y:auto;overflow-x:auto;word-break:break-all}
+  .fts3-q-item{background:#f9f9f9;border:1px solid #e0e0e0;border-radius:8px;
+    padding:10px;margin-bottom:8px}
+  /* Asignación en instructor */
+  .fa-worker{display:flex;align-items:center;gap:8px;padding:9px 10px;
+    background:#fff;border:1px solid #e0e0e0;border-radius:8px;margin-bottom:6px;
+    cursor:pointer;transition:border-color .15s}
+  .fa-worker.sel{border-color:#D83B01;background:rgba(216,59,1,.04)}
+  .fa-chk{width:20px;height:20px;border-radius:5px;border:2px solid #ccc;
+    flex-shrink:0;display:flex;align-items:center;justify-content:center;font-size:11px;transition:all .2s}
+  .fa-worker.sel .fa-chk{background:#D83B01;border-color:#D83B01;color:#fff}
+  /* Dashboard empleado */
+  #fts3-dash{display:none}
+  #fts3-dash.on{display:block}
+  .fv-chk-card{background:#fff;border:1.5px solid #e0e0e0;border-radius:10px;
+    padding:12px 13px;margin-bottom:8px;display:flex;align-items:center;gap:10px;
+    cursor:pointer;transition:all .15s}
+  .fv-chk-card.sel{border-color:#D83B01;background:rgba(216,59,1,.04)}
+  .fv-chk-card.done{border-color:#107C10;background:rgba(16,124,16,.04);
+    opacity:.75;cursor:default}
+  .fv-cb{width:22px;height:22px;border-radius:6px;border:2px solid #ccc;flex-shrink:0;
+    display:flex;align-items:center;justify-content:center;font-size:13px;transition:all .2s}
+  .fv-chk-card.sel  .fv-cb{background:#D83B01;border-color:#D83B01;color:#fff}
+  .fv-chk-card.done .fv-cb{background:#107C10;border-color:#107C10;color:#fff}
+  .fv-info strong{font-size:13px;font-weight:600;display:block}
+  .fv-info span{font-size:11px;color:#666}
+  .fv-badge{font-size:10px;font-weight:700;padding:2px 7px;border-radius:4px;
+    margin-left:auto;flex-shrink:0}
+  .fv-badge.pend{background:#f0f0f0;color:#999}
+  .fv-badge.ok{background:rgba(16,124,16,.12);color:#107C10}
+  /* Player y examen */
+  #fts3-player{display:none;background:#fff;border:1px solid #e0e0e0;
+    border-radius:14px;overflow:hidden;margin-bottom:12px}
+  #fts3-player.on{display:block}
+  #fts3-player iframe,#fts3-player video{width:100%;height:210px;border:none;display:block}
+  .f3-prog{height:4px;background:#e0e0e0}
+  .f3-prog-fill{height:100%;background:#D83B01;transition:width .4s;width:0}
+  #fts3-exam{display:none;padding:14px}
+  #fts3-exam.on{display:block}
+  .fq-opt{background:#f5f5f5;border:1.5px solid #e0e0e0;border-radius:9px;
+    padding:11px 13px;margin-bottom:7px;cursor:pointer;font-size:13px;
+    display:flex;align-items:center;gap:8px;transition:all .15s}
+  .fq-opt:active{transform:scale(.98)}
+  .fq-opt.ok{border-color:#107C10;background:rgba(16,124,16,.08);color:#107C10}
+  .fq-opt.err{border-color:#D13438;background:rgba(209,52,56,.08);color:#D13438}
+  .fq-l{width:24px;height:24px;border-radius:50%;background:#e0e0e0;
+    display:flex;align-items:center;justify-content:center;font-size:11px;
+    font-weight:700;flex-shrink:0;transition:all .2s}
+  .fq-opt.ok  .fq-l{background:#107C10;color:#fff}
+  .fq-opt.err .fq-l{background:#D13438;color:#fff}
+  /* Modal cámara */
+  #fts3-cam{position:fixed;inset:0;background:rgba(0,0,0,.88);z-index:9100;
+    display:none;align-items:center;justify-content:center}
+  #fts3-cam.on{display:flex}
+  .f3cam-box{background:#fff;border-radius:14px;padding:18px;
+    max-width:330px;width:92%;text-align:center}
+  #f3cam-vid{width:100%;border-radius:8px;transform:scaleX(-1)}
+  #f3cam-cvs{display:none}
+  #f3cam-prev{width:100%;border-radius:8px;display:none;margin-bottom:8px}
+  .f3cam-btns{display:flex;gap:8px;margin-top:10px}
+  .f3cam-btns button{flex:1;padding:10px;border-radius:8px;border:none;
+    font-family:Inter,sans-serif;font-weight:700;font-size:13px;cursor:pointer}
+  .f3cam-cap{background:#D83B01;color:#fff}
+  .f3cam-ret{background:#f0f0f0;color:#333}
+  .f3cam-ok{background:#107C10;color:#fff}
+  .fts3-hash{background:#0a0a1a;color:#00ff88;font-family:monospace;font-size:9px;
+    padding:6px 9px;border-radius:5px;word-break:break-all;margin:6px 0}
+  `;
+  document.head.appendChild(s);
+}
+
+/* ════════════════════════════════════════════════════════════
+   3. MODAL CÁMARA
+═══════════════════════════════════════════════════════════════*/
+function inyectarCam() {
+  if (document.getElementById('fts3-cam')) return;
+  document.body.insertAdjacentHTML('beforeend', `
+    <div id="fts3-cam">
+      <div class="f3cam-box">
+        <h3 style="margin:0 0 6px;font-size:16px">📸 Foto de verificación</h3>
+        <p style="margin:0 0 12px;font-size:12px;color:#666">Mira a la cámara — evidencia de tu participación</p>
+        <video id="f3cam-vid" autoplay playsinline></video>
+        <canvas id="f3cam-cvs"></canvas>
+        <img id="f3cam-prev" alt="">
+        <div class="f3cam-btns" id="f3cam-btns-area">
+          <button class="f3cam-cap" onclick="FTS3._tomarFoto()">📷 Tomar foto</button>
+        </div>
+        <button onclick="FTS3._saltarFoto()" style="margin-top:8px;width:100%;background:#f0f0f0;color:#666;border:none;border-radius:8px;padding:8px;font-size:12px;cursor:pointer;font-family:Inter,sans-serif">× Continuar sin foto</button>
+      </div>
+    </div>`);
+}
+
+/* ════════════════════════════════════════════════════════════
+   4. PANEL FTSMASTER — CURSOS + EXÁMENES + PAQUETES
+═══════════════════════════════════════════════════════════════*/
+function inyectarBotonMaster() {
+  const panel = document.getElementById('settings-panel');
+  if (!panel || document.getElementById('fts3-btn-master')) return;
+  panel.insertAdjacentHTML('beforeend', `
+    <button id="fts3-btn-master" class="btn btn-s"
+      style="padding:11px;margin-top:8px;border-color:#D83B01;color:#D83B01"
+      onclick="FTS3.abrirAdmin()">
+      🎬 Gestionar Cursos / Exámenes / Paquetes
+    </button>`);
+}
+
+function abrirAdmin() {
+  let ov = document.getElementById('fts3-admin-ov');
+  if (!ov) {
+    document.body.insertAdjacentHTML('beforeend', `
+      <div id="fts3-admin-ov" class="fts3-ov">
+        <div class="fts3-box">
+          <button class="fts3-close"
+            onclick="document.getElementById('fts3-admin-ov').classList.remove('on')">✕</button>
+          <div id="fts3-admin-inner"></div>
+        </div>
+      </div>`);
+    ov = document.getElementById('fts3-admin-ov');
+  }
+  ov.classList.add('on');
+  renderAdmin('cursos');
+}
+
+function renderAdmin(tab) {
+  const el = document.getElementById('fts3-admin-inner');
+  if (!el) return;
+
+  const tabBtn = (t, lbl) => `<button onclick="FTS3._adminTab('${t}')" style="flex:1;padding:9px;border:none;
+    background:${tab===t?'#D83B01':'#f5f5f5'};color:${tab===t?'#fff':'#666'};
+    cursor:pointer;font-family:Inter,sans-serif;font-weight:600;font-size:11px">${lbl}</button>`;
+
+  let h = `<h3 style="margin:0 0 10px;font-size:16px">🎬 Configuración de Cursos</h3>
+    <div style="display:flex;gap:0;border-bottom:2px solid #e0e0e0;margin-bottom:12px;border-radius:6px 6px 0 0;overflow:hidden">
+      ${tabBtn('cursos','📚 Cursos')}
+      ${tabBtn('paquetes','📦 Paquetes')}
+      ${tabBtn('json','📋 Exportar JSON')}
+    </div>`;
+
+  /* ── TAB CURSOS ── */
+  if (tab === 'cursos') {
+    h += `<button onclick="FTS3._formCurso(null)" style="width:100%;background:#D83B01;color:#fff;border:none;border-radius:8px;padding:10px;font-size:13px;font-weight:700;cursor:pointer;font-family:Inter,sans-serif;margin-bottom:10px">➕ Agregar Curso</button>
+      <div id="fts3-fc-form"></div>`;
+    if (!S.cursos.length) {
+      h += `<p style="color:#999;text-align:center;padding:16px">Sin cursos. Agrega el primero.</p>`;
+    } else {
+      S.cursos.forEach(c => {
+        h += `<div class="fc-card">
+          <div class="fc-title">${c.activo===false?'🔴':'🎬'} ${c.titulo}</div>
+          <div class="fc-url">${c.url||'(sin URL)'}</div>
+          <div class="fc-meta">⏱ ${c.duracion_min} min · ${c.examen?.length||0} preguntas · Orden ${c.orden_sugerido}</div>
+          <div class="fc-btns">
+            <button class="fb fb-e" onclick="FTS3._formCurso('${c.id}')">✏️ Editar</button>
+            <button class="fb fb-t" onclick="FTS3._toggleCurso('${c.id}')">${c.activo===false?'▶️ Activar':'⏸ Pausar'}</button>
+            <button class="fb fb-d" onclick="FTS3._delCurso('${c.id}')">🗑 Borrar</button>
+          </div>
+        </div>`;
+      });
+    }
+  }
+
+  /* ── TAB PAQUETES ── */
+  if (tab === 'paquetes') {
+    h += `<button onclick="FTS3._formPaquete(null)" style="width:100%;background:#D83B01;color:#fff;border:none;border-radius:8px;padding:10px;font-size:13px;font-weight:700;cursor:pointer;font-family:Inter,sans-serif;margin-bottom:10px">➕ Agregar Paquete</button>
+      <div id="fts3-fp-form"></div>`;
+    S.paquetes.forEach(p => {
+      const nombres = (p.cursos||[]).map(id => S.cursos.find(c=>c.id===id)?.titulo||id).join(', ');
+      h += `<div class="fc-card">
+        <div class="fc-title">📦 ${p.nombre}</div>
+        <div class="fc-meta">${p.descripcion||''}</div>
+        <div class="fc-meta" style="margin-top:2px">Cursos: ${nombres||'ninguno'}</div>
+        <div class="fc-btns">
+          <button class="fb fb-e" onclick="FTS3._formPaquete('${p.id}')">✏️ Editar</button>
+          <button class="fb fb-d" onclick="FTS3._delPaquete('${p.id}')">🗑 Borrar</button>
+        </div>
+      </div>`;
+    });
+  }
+
+  /* ── TAB JSON ── */
+  if (tab === 'json') {
+    const exportVid = { cursos: S.cursos, paquetes: S.paquetes };
+    const exportAsig = { asignaciones: S.asignaciones };
+    h += `
+      <div style="background:#e8f5e9;border:1px solid #a5d6a7;border-radius:8px;padding:12px;margin-bottom:12px;font-size:12px">
+        <strong>ℹ️ Cómo actualizar:</strong><br>
+        1. Copia cada JSON<br>
+        2. Abre el archivo en GitHub y pega<br>
+        3. Guarda el commit — los cambios aplican inmediatamente
+      </div>
+      <h4 style="font-size:12px;margin:0 0 4px">📁 videos.json</h4>
+      <div class="fts3-json">${JSON.stringify(exportVid,null,2)}</div>
+      <button onclick="FTS3._copiar('videos')" style="margin:6px 0 14px;width:100%;background:#f0f0f0;border:none;border-radius:7px;padding:8px;font-size:12px;font-weight:600;cursor:pointer;font-family:Inter,sans-serif">📋 Copiar videos.json</button>
+      <h4 style="font-size:12px;margin:0 0 4px">📁 asignaciones.json</h4>
+      <div class="fts3-json">${JSON.stringify(exportAsig,null,2)}</div>
+      <button onclick="FTS3._copiar('asig')" style="margin-top:6px;width:100%;background:#f0f0f0;border:none;border-radius:7px;padding:8px;font-size:12px;font-weight:600;cursor:pointer;font-family:Inter,sans-serif">📋 Copiar asignaciones.json</button>`;
+  }
+
+  el.innerHTML = h;
+}
+
+/* ── CRUD Cursos ── */
+function _formCurso(id) {
+  const c = id ? S.cursos.find(x=>x.id===id) : null;
+  const wrap = document.getElementById('fts3-fc-form');
+  if (!wrap) return;
+  const pregs = (c?.examen||[]).map((q,qi)=>_htmlPregunta(q,qi)).join('');
+  wrap.innerHTML = `<div class="fts3-form" style="background:#f8f8f8;border:2px dashed #D83B01;border-radius:10px;padding:14px;margin-bottom:12px">
+    <h4 style="margin:0 0 10px;font-size:13px">${c?'✏️ Editar':'➕ Nuevo'} Curso</h4>
+    <label>ID único</label>
+    <input id="fc-id" value="${c?.id||'v'+String(S.cursos.length+1).padStart(3,'0')}" ${c?'readonly style="background:#f0f0f0"':''}>
+    <label>Título</label><input id="fc-titulo" value="${c?.titulo||''}" placeholder="Seguridad en Alturas">
+    <label>Descripción</label><input id="fc-desc" value="${c?.descripcion||''}" placeholder="NOM · Breve descripción">
+    <label>URL del video (SharePoint embed o MP4)</label>
+    <input id="fc-url" value="${c?.url||''}" placeholder="https://...sharepoint.com/...">
+    <label>Duración (min)</label><input id="fc-dur" type="number" value="${c?.duracion_min||30}" min="1">
+    <label>Orden sugerido</label><input id="fc-orden" type="number" value="${c?.orden_sugerido||S.cursos.length+1}" min="1">
+    <label style="display:flex;align-items:center;gap:7px;cursor:pointer;margin-bottom:10px">
+      <input type="checkbox" id="fc-oblig" ${c?.obligatorio!==false?'checked':''}> Obligatorio
+    </label>
+    <hr style="border-color:#e0e0e0;margin-bottom:10px">
+    <h5 style="margin:0 0 8px;font-size:12px;color:#D83B01">📝 PREGUNTAS DEL EXAMEN (mín. 1)</h5>
+    <div id="fc-pregs-wrap">${pregs}</div>
+    <button onclick="FTS3._addPregunta()" style="width:100%;background:#f0f0f0;border:1px dashed #ccc;border-radius:7px;padding:8px;font-size:12px;font-weight:600;cursor:pointer;font-family:Inter,sans-serif;margin-bottom:10px">+ Agregar pregunta</button>
+    <div style="display:flex;gap:8px">
+      <button onclick="FTS3._guardarCurso('${id||''}')" style="flex:1;background:#D83B01;color:#fff;border:none;border-radius:8px;padding:10px;font-size:13px;font-weight:700;cursor:pointer;font-family:Inter,sans-serif">💾 Guardar</button>
+      <button onclick="document.getElementById('fts3-fc-form').innerHTML=''" style="flex:1;background:#f0f0f0;color:#333;border:none;border-radius:8px;padding:10px;font-size:13px;cursor:pointer;font-family:Inter,sans-serif">Cancelar</button>
+    </div>
+    <p style="font-size:10px;color:#aaa;margin-top:8px">💡 SharePoint: abre el video → Compartir → Insertar → copia el src del iframe</p>
+  </div>`;
+}
+
+function _htmlPregunta(q, i) {
+  const opts = (q.opciones||['','','','']).map((o,oi)=>`
+    <div style="display:flex;gap:6px;align-items:center;margin-bottom:5px">
+      <input type="radio" name="fc-c-${i}" value="${oi}" ${q.correcta===oi?'checked':''}>
+      <input type="text" placeholder="Opción ${String.fromCharCode(65+oi)}" value="${o||''}"
+        style="flex:1;padding:6px 9px;border:1px solid #ccc;border-radius:5px;font-size:12px;font-family:Inter,sans-serif"
+        data-preg="${i}" data-opt="${oi}">
+    </div>`).join('');
+  return `<div class="fts3-q-item" data-qi="${i}">
+    <div style="display:flex;justify-content:space-between;align-items:center;margin-bottom:6px">
+      <strong style="font-size:12px">Pregunta ${i+1}</strong>
+      <button onclick="this.closest('.fts3-q-item').remove()" style="background:#ffeaea;border:none;border-radius:4px;padding:2px 7px;cursor:pointer;font-size:11px;color:#c00">✕</button>
+    </div>
+    <input type="text" placeholder="Texto de la pregunta" value="${q.pregunta||''}"
+      style="width:100%;box-sizing:border-box;padding:7px 9px;border:1px solid #ccc;border-radius:5px;font-size:12px;font-family:Inter,sans-serif;margin-bottom:6px"
+      data-preg="${i}" data-field="p">
+    <p style="font-size:10px;color:#999;margin:0 0 5px">☑ Marca la respuesta correcta:</p>
+    ${opts}
+  </div>`;
+}
+
+function _addPregunta() {
+  const wrap = document.getElementById('fc-pregs-wrap');
+  if (!wrap) return;
+  const n = wrap.querySelectorAll('.fts3-q-item').length;
+  const tmp = document.createElement('div');
+  tmp.innerHTML = _htmlPregunta({},n);
+  wrap.appendChild(tmp.firstElementChild);
+}
+
+function _leerPreguntas() {
+  return Array.from(document.querySelectorAll('#fc-pregs-wrap .fts3-q-item')).map((item,i) => {
+    const pInput = item.querySelector(`[data-preg="${i}"][data-field="p"]`)
+      || item.querySelector('input[type="text"]');
+    const optInputs = item.querySelectorAll(`[data-opt]`);
+    const correctaEl = item.querySelector(`input[type="radio"]:checked`);
+    return {
+      pregunta: pInput?.value?.trim()||'',
+      opciones: Array.from(optInputs).map(o=>o.value?.trim()||''),
+      correcta: correctaEl ? parseInt(correctaEl.value) : 0
+    };
+  }).filter(q=>q.pregunta);
+}
+
+function _guardarCurso(id) {
+  const g = s => document.getElementById(s)?.value?.trim();
+  const curso = {
+    id: g('fc-id'), titulo: g('fc-titulo'), descripcion: g('fc-desc'),
+    url: g('fc-url'), duracion_min: parseInt(g('fc-dur'))||30,
+    obligatorio: document.getElementById('fc-oblig')?.checked,
+    activo: true, orden_sugerido: parseInt(g('fc-orden'))||1,
+    examen: _leerPreguntas()
+  };
+  if (!curso.id||!curso.titulo||!curso.url) { alert('Completa ID, Título y URL'); return; }
+  if (id) {
+    const i=S.cursos.findIndex(x=>x.id===id);
+    if(i>=0) S.cursos[i]=curso; else S.cursos.push(curso);
+  } else {
+    if(S.cursos.find(x=>x.id===curso.id)){alert('ID ya existe');return;}
+    S.cursos.push(curso);
+  }
+  S.cursos.sort((a,b)=>(a.orden_sugerido||99)-(b.orden_sugerido||99));
+  renderAdmin('cursos');
+}
+
+function _toggleCurso(id){const c=S.cursos.find(x=>x.id===id);if(c){c.activo=!c.activo;renderAdmin('cursos');}}
+function _delCurso(id){if(!confirm('¿Eliminar curso?'))return;S.cursos=S.cursos.filter(x=>x.id!==id);renderAdmin('cursos');}
+
+/* ── CRUD Paquetes ── */
+function _formPaquete(id) {
+  const p = id ? S.paquetes.find(x=>x.id===id) : null;
+  const wrap = document.getElementById('fts3-fp-form');
+  if (!wrap) return;
+  const checks = S.cursos.map(c=>`
+    <label style="display:flex;align-items:center;gap:7px;margin-bottom:6px;cursor:pointer;font-size:12px">
+      <input type="checkbox" name="fp-c" value="${c.id}" ${(p?.cursos||[]).includes(c.id)?'checked':''}> ${c.titulo}
+    </label>`).join('');
+  wrap.innerHTML = `<div class="fts3-form" style="background:#f8f8f8;border:2px dashed #D83B01;border-radius:10px;padding:14px;margin-bottom:12px">
+    <h4 style="margin:0 0 10px;font-size:13px">${p?'✏️ Editar':'➕ Nuevo'} Paquete</h4>
+    <label>ID único</label>
+    <input id="fp-id" value="${p?.id||'pkg'+String(S.paquetes.length+1).padStart(2,'0')}" ${p?'readonly style="background:#f0f0f0"':''}>
+    <label>Nombre del paquete</label><input id="fp-nombre" value="${p?.nombre||''}" placeholder="Onboarding General">
+    <label>Descripción</label><input id="fp-desc" value="${p?.descripcion||''}" placeholder="Cursos para nuevos trabajadores">
+    <label>Cursos incluidos:</label>
+    <div style="background:#fff;border:1px solid #e0e0e0;border-radius:7px;padding:10px;margin-bottom:10px">${checks||'<p style="font-size:12px;color:#999">No hay cursos cargados.</p>'}</div>
+    <div style="display:flex;gap:8px">
+      <button onclick="FTS3._guardarPaquete('${id||''}')" style="flex:1;background:#D83B01;color:#fff;border:none;border-radius:8px;padding:10px;font-size:13px;font-weight:700;cursor:pointer;font-family:Inter,sans-serif">💾 Guardar</button>
+      <button onclick="document.getElementById('fts3-fp-form').innerHTML=''" style="flex:1;background:#f0f0f0;color:#333;border:none;border-radius:8px;padding:10px;font-size:13px;cursor:pointer;font-family:Inter,sans-serif">Cancelar</button>
+    </div>
+  </div>`;
+}
+
+function _guardarPaquete(id) {
+  const g = s=>document.getElementById(s)?.value?.trim();
+  const cursosSel = Array.from(document.querySelectorAll('input[name="fp-c"]:checked')).map(e=>e.value);
+  const p = {id:g('fp-id'),nombre:g('fp-nombre'),descripcion:g('fp-desc'),cursos:cursosSel};
+  if(!p.id||!p.nombre){alert('Completa ID y Nombre');return;}
+  if(id){const i=S.paquetes.findIndex(x=>x.id===id);if(i>=0)S.paquetes[i]=p;else S.paquetes.push(p);}
+  else{if(S.paquetes.find(x=>x.id===p.id)){alert('ID ya existe');return;}S.paquetes.push(p);}
+  renderAdmin('paquetes');
+}
+
+function _delPaquete(id){if(!confirm('¿Eliminar paquete?'))return;S.paquetes=S.paquetes.filter(x=>x.id!==id);renderAdmin('paquetes');}
+function _adminTab(t){renderAdmin(t);}
+function _copiar(tipo) {
+  const txt = tipo==='asig'
+    ? JSON.stringify({asignaciones:S.asignaciones},null,2)
+    : JSON.stringify({cursos:S.cursos,paquetes:S.paquetes},null,2);
+  const archivo = tipo==='asig' ? 'asignaciones.json' : 'videos.json';
+  navigator.clipboard.writeText(txt)
+    .then(()=>alert(`✅ Copiado. Pégalo en ${archivo} en GitHub.`))
+    .catch(()=>alert('Selecciona el texto manualmente.'));
+}
+
+/* ════════════════════════════════════════════════════════════
+   5. PANEL INSTRUCTOR — ASIGNAR CURSOS
+═══════════════════════════════════════════════════════════════*/
+function inyectarAsignacion() {
+  const tpW = document.getElementById('tp-workers');
+  if (!tpW || document.getElementById('fts3-asig-section')) return;
+
+  tpW.insertAdjacentHTML('beforeend', `
+    <div id="fts3-asig-section">
+      <div style="height:1px;background:#e0e0e0;margin:12px 0"></div>
+      <div style="font-size:12px;font-weight:700;color:#D83B01;margin-bottom:8px;letter-spacing:.3px">
+        📚 ASIGNAR CURSOS A TRABAJADORES
+      </div>
+
+      <!-- Lista de trabajadores del panel original -->
+      <p style="font-size:11px;color:#666;margin:0 0 6px">Selecciona trabajadores:</p>
+      <div id="fts3-wk-list" style="margin-bottom:10px"></div>
+
+      <!-- Paquete completo -->
+      <label style="font-size:11px;font-weight:700;color:#666;text-transform:uppercase;letter-spacing:.5px">Asignar paquete completo</label>
+      <select id="fts3-pkg-sel" style="width:100%;padding:9px 11px;border:1px solid #e0e0e0;border-radius:7px;font-family:Inter,sans-serif;font-size:13px;margin-bottom:8px;background:#fff;color:#1a1a1a;-webkit-appearance:none">
+        <option value="">— Elegir paquete —</option>
+      </select>
+
+      <!-- Cursos individuales -->
+      <label style="font-size:11px;font-weight:700;color:#666;text-transform:uppercase;letter-spacing:.5px">O cursos individuales</label>
+      <div id="fts3-curso-chks" style="background:#fff;border:1px solid #e0e0e0;border-radius:7px;padding:10px;margin-bottom:10px"></div>
+
+      <button onclick="FTS3.asignar()" style="width:100%;background:#D83B01;color:#fff;border:none;border-radius:8px;padding:11px;font-size:13px;font-weight:700;cursor:pointer;font-family:Inter,sans-serif;margin-bottom:8px">✅ Asignar cursos</button>
+
+      <!-- Exportar asignaciones.json -->
+      <button onclick="FTS3.verAsignaciones()" style="width:100%;background:#f0f0f0;color:#333;border:1px solid #e0e0e0;border-radius:8px;padding:9px;font-size:12px;font-weight:600;cursor:pointer;font-family:Inter,sans-serif">📋 Ver / Exportar asignaciones.json</button>
+
+      <!-- Asignaciones actuales -->
+      <div id="fts3-asig-actual" style="margin-top:10px"></div>
+    </div>`);
+
+  _refrescarAsigPanel();
+}
+
+function _refrescarAsigPanel() {
+  // Trabajadores del panel original
+  const wkList = document.getElementById('fts3-wk-list');
+  const pkgSel = document.getElementById('fts3-pkg-sel');
+  const cursoChks = document.getElementById('fts3-curso-chks');
+
+  const workers = Array.from(document.querySelectorAll('#worker-list .worker-row'))
+    .map(el => ({
+      nombre: el.querySelector('.wr-info strong')?.textContent?.trim()||'',
+      curp:   el.querySelector('.wr-info span')?.textContent?.trim()||''
+    })).filter(w=>w.nombre);
+
+  if (wkList) {
+    wkList.innerHTML = workers.length
+      ? workers.map(w=>`
+          <div class="fa-worker" data-curp="${w.curp}" data-nombre="${w.nombre}"
+            onclick="this.classList.toggle('sel');this.querySelector('.fa-chk').textContent=this.classList.contains('sel')?'✓':''">
+            <div class="fa-chk"></div>
+            <div>
+              <strong style="font-size:13px;display:block">${w.nombre}</strong>
+              <span style="font-size:11px;color:#666">${w.curp||'Sin CURP'}</span>
+            </div>
+          </div>`).join('')
+      : `<p style="font-size:12px;color:#999;padding:6px 0">Agrega trabajadores arriba primero.</p>`;
+  }
+
+  if (pkgSel) {
+    pkgSel.innerHTML = `<option value="">— Elegir paquete —</option>` +
+      S.paquetes.map(p=>`<option value="${p.id}">${p.nombre} (${p.cursos?.length||0} cursos)</option>`).join('');
+  }
+
+  if (cursoChks) {
+    cursoChks.innerHTML = S.cursos.map(c=>`
+      <label style="display:flex;align-items:center;gap:7px;margin-bottom:6px;cursor:pointer;font-size:12px">
+        <input type="checkbox" name="fts3-ind" value="${c.id}"> ${c.titulo}
+      </label>`).join('') || '<p style="font-size:12px;color:#999">Sin cursos cargados.</p>';
+  }
+}
+
+function asignar() {
+  const sels = Array.from(document.querySelectorAll('.fa-worker.sel'));
+  if (!sels.length) { alert('Selecciona al menos un trabajador'); return; }
+
+  const pkgId = document.getElementById('fts3-pkg-sel')?.value;
+  let ids = [];
+  if (pkgId) {
+    ids = S.paquetes.find(p=>p.id===pkgId)?.cursos || [];
+  } else {
+    ids = Array.from(document.querySelectorAll('input[name="fts3-ind"]:checked')).map(e=>e.value);
+  }
+  if (!ids.length) { alert('Elige un paquete o cursos individuales'); return; }
+
+  sels.forEach(el => {
+    const curp   = el.dataset.curp   || '';
+    const nombre = el.dataset.nombre || '';
+    const existIdx = S.asignaciones.findIndex(a =>
+      (curp && a.curp === curp) || a.nombre === nombre);
+    if (existIdx >= 0) {
+      S.asignaciones[existIdx].cursos = ids;
+    } else {
+      S.asignaciones.push({ curp, nombre, cursos: ids });
+    }
+  });
+
+  // Guardar en sessionStorage como respaldo
+  sessionStorage.setItem('fts3_asig', JSON.stringify(S.asignaciones));
+
+  alert(`✅ ${ids.length} curso(s) asignados a ${sels.length} trabajador(es).\n\nRecuerda exportar asignaciones.json y subirlo a GitHub para que persista entre dispositivos.`);
+
+  // Limpiar selección
+  sels.forEach(el=>{ el.classList.remove('sel'); const c=el.querySelector('.fa-chk');if(c)c.textContent=''; });
+  _mostrarAsignActuales();
+}
+
+function verAsignaciones() {
+  // Abre el panel admin en la pestaña de JSON (asig)
+  abrirAdmin();
+  setTimeout(()=>renderAdmin('json'), 50);
+}
+
+function _mostrarAsignActuales() {
+  const el = document.getElementById('fts3-asig-actual');
+  if (!el || !S.asignaciones.length) return;
+  let h = `<p style="font-size:11px;font-weight:700;color:#666;margin:8px 0 4px">Asignaciones en esta sesión:</p>`;
+  S.asignaciones.filter(a=>a.cursos?.length).forEach(a=>{
+    const nombres = (a.cursos||[]).map(id=>S.cursos.find(c=>c.id===id)?.titulo||id).join(', ');
+    h += `<div style="background:#f5f5f5;border-radius:6px;padding:7px 9px;margin-bottom:5px;font-size:11px">
+      <strong>${a.nombre||a.curp}</strong><br><span style="color:#666">${nombres}</span>
+    </div>`;
+  });
+  el.innerHTML = h;
+}
+
+/* ════════════════════════════════════════════════════════════
+   6. DASHBOARD EMPLEADO — CHECKBOXES
+═══════════════════════════════════════════════════════════════*/
+function hookEdash() {
+  const obs = new MutationObserver(() => {
+    const edash = document.getElementById('s-edash');
+    if (!edash?.classList.contains('on')) return;
+    if (document.getElementById('fts3-dash')) return;
+
+    const content = edash.querySelector('.content');
+    if (!content) return;
+
+    S.empleado = {
+      nombre:   document.getElementById('emp-nom')?.value?.trim()  || '',
+      apaterno: document.getElementById('emp-ap')?.value?.trim()   || '',
+      amaterno: document.getElementById('emp-am')?.value?.trim()   || '',
+      curp:     document.getElementById('emp-curp')?.value?.trim() || '',
+    };
+
+    // Buscar asignación del empleado
+    const asig = _getAsig(S.empleado);
+    const ids  = asig?.cursos || S.cursos.map(c=>c.id); // sin asignación → todos
+    const cursos = ids.map(id=>S.cursos.find(c=>c.id===id)).filter(Boolean);
+
+    if (!cursos.length) return;
+
+    // Inyectar dashboard
+    const dashDiv = document.createElement('div');
+    dashDiv.id = 'fts3-dash';
+    dashDiv.className = 'on';
+    dashDiv.innerHTML = _renderDash(cursos);
+    content.insertBefore(dashDiv, content.firstChild);
+
+    // Inyectar player y examen (ocultos)
+    ['fts3-player','fts3-exam'].forEach((id,i) => {
+      const d = document.createElement('div');
+      d.id = id;
+      content.insertBefore(d, content.children[i+1]||null);
+    });
+  });
+  obs.observe(document.body, { attributes:true, subtree:true, attributeFilter:['class'] });
+}
+
+function _renderDash(cursos) {
+  let h = `<div style="background:#fff;border:1px solid #e0e0e0;border-radius:14px;padding:14px;margin-bottom:12px">
+    <h4 style="margin:0 0 4px;font-size:14px;font-weight:700">📚 Tus cursos asignados</h4>
+    <p style="font-size:12px;color:#666;margin-bottom:10px">Selecciona los que quieres realizar hoy</p>`;
+
+  cursos.forEach(c => {
+    const done = S.resultados[c.id]?.aprobado;
+    h += `<div class="fv-chk-card ${done?'done':''}" id="fts3-cv-${c.id}" ${done?'':'onclick="FTS3._toggleCV(\''+c.id+'\')"'}>
+      <div class="fv-cb">${done?'✓':''}</div>
+      <div class="fv-info">
+        <strong>${c.titulo}</strong>
+        <span>⏱ ${c.duracion_min} min · ${c.examen?.length||0} preguntas</span>
+      </div>
+      <span class="fv-badge ${done?'ok':'pend'}">${done?'✅ Aprobado':'Pendiente'}</span>
+    </div>`;
+  });
+
+  h += `<button onclick="FTS3.iniciarSel()" style="width:100%;background:#D83B01;color:#fff;border:none;border-radius:10px;padding:13px;font-size:14px;font-weight:800;cursor:pointer;font-family:Inter,sans-serif;margin-top:6px">🚀 Iniciar cursos seleccionados</button>
+  </div>`;
+  return h;
+}
+
+function _toggleCV(id) {
+  const el = document.getElementById('fts3-cv-'+id);
+  if (!el||el.classList.contains('done')) return;
+  el.classList.toggle('sel');
+  const cb=el.querySelector('.fv-cb');
+  if(cb)cb.textContent=el.classList.contains('sel')?'✓':'';
+}
+
+function iniciarSel() {
+  const sels = Array.from(document.querySelectorAll('.fv-chk-card.sel'))
+    .map(el=>el.id.replace('fts3-cv-',''));
+  if (!sels.length) { alert('Selecciona al menos un curso'); return; }
+  S.cola=[...sels]; S.indice=0;
+  _sigCurso();
+}
+
+/* ════════════════════════════════════════════════════════════
+   7. FLUJO: VIDEO → EXAMEN → FOTO → HASH → PDF
+═══════════════════════════════════════════════════════════════*/
+function _sigCurso() {
+  while(S.indice<S.cola.length && S.resultados[S.cola[S.indice]]?.aprobado) S.indice++;
+  if(S.indice>=S.cola.length){_finTodo();return;}
+  _mostrarVideo(S.cursos.find(c=>c.id===S.cola[S.indice]));
+}
+
+function _mostrarVideo(c) {
+  _ocultar(['fts3-dash','fts3-exam']);
+  const p=document.getElementById('fts3-player');if(!p)return;
+  p.classList.add('on');
+  const esIframe=c.url.includes('sharepoint')||c.tipo==='sharepoint';
+  const media=esIframe
+    ?`<iframe src="${c.url}" allowfullscreen allow="autoplay"></iframe>`
+    :`<video id="fts3-vid-tag" controls controlslist="nodownload" preload="metadata"><source src="${c.url}"></video>`;
+  p.innerHTML=`<div style="padding:14px">
+    <p style="font-size:11px;color:#999;margin:0 0 2px">Curso ${S.indice+1} de ${S.cola.length}</p>
+    <h3 style="margin:0 0 10px;font-size:15px">${c.titulo}</h3>
+    ${media}
+    <div class="f3-prog"><div class="f3-prog-fill" id="f3vfill"></div></div>
+    <p style="font-size:12px;color:#666;margin:6px 0 4px">${c.descripcion||''}</p>
+    <p style="font-size:11px;color:#999;margin-bottom:12px">⏱ ${c.duracion_min} min estimados</p>
+    <button onclick="FTS3._iniciarExamen('${c.id}')" style="width:100%;background:#107C10;color:#fff;border:none;border-radius:10px;padding:13px;font-size:14px;font-weight:800;cursor:pointer;font-family:Inter,sans-serif">✅ Terminé el video — Presentar examen →</button>
+  </div>`;
+  const tag=document.getElementById('fts3-vid-tag');
+  if(tag)tag.addEventListener('timeupdate',()=>{
+    const pct=tag.duration?(tag.currentTime/tag.duration*100).toFixed(1):0;
+    const f=document.getElementById('f3vfill');if(f)f.style.width=pct+'%';
+  });
+}
+
+/* ── Examen ── */
+let _EX={id:'',pregs:[],resp:[],idx:0};
+
+function _iniciarExamen(id) {
+  const c=S.cursos.find(x=>x.id===id);
+  if(!c?.examen?.length){_pedirFoto(id,100);return;}
+  _ocultar(['fts3-player']);
+  const examDiv=document.getElementById('fts3-exam');if(!examDiv)return;
+  examDiv.classList.add('on');
+  const pregs=[...c.examen].sort(()=>Math.random()-.5).slice(0,Math.min(5,c.examen.length));
+  _EX={id,pregs,resp:new Array(pregs.length).fill(-1),idx:0};
+  _renderQ();
+}
+
+function _renderQ(){
+  const {pregs,resp,idx}=_EX;
+  const q=pregs[idx];
+  const examDiv=document.getElementById('fts3-exam');if(!examDiv)return;
+  examDiv.innerHTML=`<div style="padding:14px">
+    <p style="font-size:11px;color:#999;margin:0 0 4px">Pregunta ${idx+1} de ${pregs.length}</p>
+    <h4 style="font-size:14px;font-weight:700;line-height:1.4;margin-bottom:14px">${q.pregunta}</h4>
+    <div id="f3opts">
+      ${q.opciones.map((o,oi)=>`<div class="fq-opt" onclick="FTS3._selOpt(${oi})" id="f3o${oi}">
+        <div class="fq-l">${String.fromCharCode(65+oi)}</div>${o}
+      </div>`).join('')}
+    </div>
+    <div id="f3fb" style="display:none;margin-top:10px;padding:10px;border-radius:8px;font-size:13px;font-weight:500"></div>
+    <button id="f3next" onclick="FTS3._sigQ()" style="display:none;width:100%;background:#D83B01;color:#fff;border:none;border-radius:10px;padding:12px;font-size:14px;font-weight:800;cursor:pointer;font-family:Inter,sans-serif;margin-top:10px">
+      ${idx<pregs.length-1?'Siguiente →':'Ver resultado'}
+    </button>
+  </div>`;
+}
+
+function _selOpt(oi){
+  const{pregs,resp,idx}=_EX;
+  if(resp[idx]!==-1)return;
+  resp[idx]=oi;
+  const cor=pregs[idx].correcta;
+  document.querySelectorAll('.fq-opt').forEach((el,i)=>{
+    if(i===cor)el.classList.add('ok');
+    else if(i===oi&&oi!==cor)el.classList.add('err');
+  });
+  const fb=document.getElementById('f3fb'),next=document.getElementById('f3next');
+  if(fb){
+    fb.style.display='block';
+    if(oi===cor){fb.style.cssText='display:block;margin-top:10px;padding:10px;border-radius:8px;font-size:13px;font-weight:500;background:rgba(16,124,16,.08);border:1px solid rgba(16,124,16,.25);color:#107C10';fb.textContent='✅ ¡Correcto!';}
+    else{fb.style.cssText='display:block;margin-top:10px;padding:10px;border-radius:8px;font-size:13px;font-weight:500;background:rgba(209,52,56,.08);border:1px solid rgba(209,52,56,.25);color:#D13438';fb.textContent=`❌ Incorrecto. Correcta: ${pregs[idx].opciones[cor]}`;}
+  }
+  if(next)next.style.display='block';
+}
+
+function _sigQ(){
+  const{pregs,resp,idx,id}=_EX;
+  if(idx<pregs.length-1){_EX.idx++;_renderQ();}
+  else{
+    const correctas=resp.filter((r,i)=>r===pregs[i].correcta).length;
+    const score=Math.round(correctas/pregs.length*100);
+    _resultadoExamen(id,score,correctas,pregs.length);
+  }
+}
+
+function _resultadoExamen(id,score,correctas,total){
+  const examDiv=document.getElementById('fts3-exam');if(!examDiv)return;
+  const ok=score>=MIN_PASS;
+  examDiv.innerHTML=`<div style="padding:16px;text-align:center">
+    <div style="font-size:42px;margin-bottom:8px">${ok?'🎓':'📖'}</div>
+    <h3 style="color:${ok?'#107C10':'#D13438'};margin:0 0 4px">${ok?'¡Aprobado!':'No aprobado'}</h3>
+    <p style="font-size:28px;font-weight:800;margin:6px 0">${score}%</p>
+    <p style="font-size:13px;color:#666">${correctas} de ${total} correctas · Mínimo ${MIN_PASS}%</p>
+    ${ok
+      ?`<button onclick="FTS3._pedirFoto('${id}',${score})" style="width:100%;background:#107C10;color:#fff;border:none;border-radius:10px;padding:13px;font-size:14px;font-weight:800;cursor:pointer;font-family:Inter,sans-serif;margin-top:14px">📷 Tomar foto y generar constancia →</button>`
+      :`<button onclick="FTS3._iniciarExamen('${id}')" style="width:100%;background:#D83B01;color:#fff;border:none;border-radius:10px;padding:13px;font-size:14px;font-weight:800;cursor:pointer;font-family:Inter,sans-serif;margin-top:14px">🔄 Repetir examen</button>`
+    }
+  </div>`;
+}
+
+/* ── Foto ── */
+function _pedirFoto(id,score){
+  const m=document.getElementById('fts3-cam');
+  if(!m){_completar(id,score,null);return;}
+  m._id=id;m._score=score;
+  m.classList.add('on');
+  navigator.mediaDevices.getUserMedia({video:{facingMode:'user'},audio:false})
+    .then(st=>{S.camStream=st;const v=document.getElementById('f3cam-vid');if(v){v.srcObject=st;v.play();}})
+    .catch(()=>{_cerrarCam();_completar(id,score,null);});
+}
+function _tomarFoto(){
+  const vid=document.getElementById('f3cam-vid'),cvs=document.getElementById('f3cam-cvs'),prev=document.getElementById('f3cam-prev');
+  if(!vid||!cvs)return;
+  cvs.width=vid.videoWidth||320;cvs.height=vid.videoHeight||240;
+  cvs.getContext('2d').drawImage(vid,0,0);
+  const d=cvs.toDataURL('image/jpeg',.75);window._f3foto=d;
+  if(prev){prev.src=d;prev.style.display='block';}vid.style.display='none';
+  const b=document.getElementById('f3cam-btns-area');
+  if(b)b.innerHTML=`<button class="f3cam-ret" onclick="FTS3._retakeFoto()">🔄 Repetir</button><button class="f3cam-ok" onclick="FTS3._confirmarFoto()">✅ Confirmar</button>`;
+}
+function _retakeFoto(){window._f3foto=null;const v=document.getElementById('f3cam-vid'),p=document.getElementById('f3cam-prev');if(v)v.style.display='block';if(p)p.style.display='none';const b=document.getElementById('f3cam-btns-area');if(b)b.innerHTML=`<button class="f3cam-cap" onclick="FTS3._tomarFoto()">📷 Tomar foto</button>`;}
+function _confirmarFoto(){const m=document.getElementById('fts3-cam');_cerrarCam();_completar(m?._id||'',m?._score||0,window._f3foto||null);window._f3foto=null;}
+function _saltarFoto(){const m=document.getElementById('fts3-cam');_cerrarCam();_completar(m?._id||'',m?._score||0,null);}
+function _cerrarCam(){
+  const m=document.getElementById('fts3-cam');if(m)m.classList.remove('on');
+  if(S.camStream){S.camStream.getTracks().forEach(t=>t.stop());S.camStream=null;}
+  const v=document.getElementById('f3cam-vid'),p=document.getElementById('f3cam-prev');
+  if(v)v.style.display='block';if(p){p.style.display='none';p.src='';}
+  const b=document.getElementById('f3cam-btns-area');
+  if(b)b.innerHTML=`<button class="f3cam-cap" onclick="FTS3._tomarFoto()">📷 Tomar foto</button>`;
+}
+
+/* ── Completar y PDF ── */
+async function _completar(id,score,foto){
+  const ts=new Date().toISOString(),emp=S.empleado||{};
+  const c=S.cursos.find(x=>x.id===id)||{titulo:id,duracion_min:0};
+  const seed=[emp.curp||'SIN-CURP',id,ts,score,navigator.userAgent.slice(0,30),'3.1'].join('|');
+  const hash=await _hash(seed);
+  S.resultados[id]={videoId:id,titulo:c.titulo,aprobado:true,score,foto,hash,ts,empleado:emp};
+
+  const card=document.getElementById('fts3-cv-'+id);
+  if(card){card.classList.remove('sel');card.classList.add('done');const cb=card.querySelector('.fv-cb');if(cb)cb.textContent='✓';const b=card.querySelector('.fv-badge');if(b){b.textContent='✅ Aprobado';b.className='fv-badge ok';}}
+
+  await _generarPDF(id);
+
+  const examDiv=document.getElementById('fts3-exam');
+  if(examDiv){examDiv.innerHTML=`<div style="padding:16px;text-align:center">
+    <div style="font-size:36px;margin-bottom:6px">🎓</div>
+    <h3 style="color:#107C10;margin:0 0 4px">¡Constancia descargada!</h3>
+    <p style="font-size:13px;color:#333;margin:0 0 8px">${c.titulo}</p>
+    ${foto?`<img src="${foto}" style="width:64px;height:64px;object-fit:cover;border-radius:50%;border:3px solid #107C10;display:block;margin:0 auto 8px">`:``}
+    <p style="font-size:11px;color:#666;margin:0 0 4px">🔐 Sello SHA-256:</p>
+    <div class="fts3-hash">${hash}</div>
+    <button onclick="FTS3._avanzar()" style="width:100%;background:#D83B01;color:#fff;border:none;border-radius:10px;padding:12px;font-size:14px;font-weight:800;cursor:pointer;font-family:Inter,sans-serif;margin-top:10px">
+      ${S.indice+1<S.cola.length?'▶️ Siguiente curso →':'🏠 Volver al inicio'}
+    </button>
+  </div>`;}
+  S.indice++;
+}
+
+function _avanzar(){
+  _ocultar(['fts3-player','fts3-exam']);
+  if(S.indice<S.cola.length){_sigCurso();}
+  else{
+    const dash=document.getElementById('fts3-dash');
+    if(dash){
+      const asig=_getAsig(S.empleado);
+      const ids=asig?.cursos||S.cursos.map(c=>c.id);
+      const cursos=ids.map(id=>S.cursos.find(c=>c.id===id)).filter(Boolean);
+      dash.innerHTML=_renderDash(cursos);dash.classList.add('on');
+    }
+  }
+}
+
+function _finTodo(){
+  const examDiv=document.getElementById('fts3-exam');
+  if(examDiv){examDiv.classList.add('on');examDiv.innerHTML=`<div style="padding:16px;text-align:center">
+    <div style="font-size:40px;margin-bottom:8px">🏆</div>
+    <h2 style="color:#107C10;margin:0 0 4px">¡Todos los cursos completados!</h2>
+    <p style="font-size:13px;color:#666">Tus constancias fueron generadas y descargadas</p>
+  </div>`;}
+}
+
+/* ════════════════════════════════════════════════════════════
+   8. PDF: DC-3 (hoja 1) + CERTIFICADO (hoja 2)
+═══════════════════════════════════════════════════════════════*/
+async function _generarPDF(id) {
+  const r=S.resultados[id];if(!r)return;
+  const c=S.cursos.find(x=>x.id===id)||{titulo:id,duracion_min:0};
+  const emp=r.empleado||{};
+  const {jsPDF}=window.jspdf;
+  const doc=new jsPDF({unit:'mm',format:'letter',orientation:'portrait'});
+  const W=215.9,H=279.4;
+  const az=[0,71,171],ro=[216,59,1],ve=[16,124,16],ne=[10,10,10],gr=[100,100,100];
+  const fechaStr=new Date(r.ts).toLocaleDateString('es-MX',{day:'2-digit',month:'long',year:'numeric'});
+
+  /* HOJA 1 — DC-3 */
+  doc.setFillColor(...az);doc.rect(0,0,W,22,'F');
+  doc.setTextColor(255,255,255);doc.setFont('helvetica','bold');doc.setFontSize(11);
+  doc.text('CONSTANCIA DE HABILIDADES LABORALES — DC-3',W/2,8,{align:'center'});
+  doc.setFontSize(8);doc.setFont('helvetica','normal');
+  doc.text('NOM-STPS · SERVICIOS FTS SA DE CV · Monterrey, NL',W/2,15,{align:'center'});
+  doc.text('RFC: FTS000000XXX',W/2,20,{align:'center'});
+
+  doc.setFillColor(248,248,248);doc.rect(0,22,W,H-38,'F');
+  doc.setFillColor(255,255,255);doc.roundedRect(8,26,W-16,14,2,2,'F');
+  doc.setTextColor(...ro);doc.setFont('helvetica','bold');doc.setFontSize(13);
+  doc.text('CONSTANCIA DE COMPETENCIAS O HABILIDADES LABORALES',W/2,35,{align:'center'});
+
+  const caja=(lbl,val,xL,xV,yy)=>{
+    doc.setFont('helvetica','bold');doc.setFontSize(8);doc.setTextColor(...gr);doc.text(lbl,xL,yy);
+    doc.setFont('helvetica','normal');doc.setFontSize(10);doc.setTextColor(...ne);doc.text(val||'—',xV,yy);
+  };
+
+  let y=46;
+  doc.setFillColor(255,255,255);doc.roundedRect(8,y,W-16,38,2,2,'F');
+  doc.setFont('helvetica','bold');doc.setFontSize(9);doc.setTextColor(...ro);doc.text('I. DATOS DEL TRABAJADOR',12,y+7);
+  caja('Nombre:',`${emp.apaterno||''} ${emp.amaterno||''} ${emp.nombre||''}`.trim(),12,42,y+15);
+  caja('CURP:',emp.curp||'',12,42,y+23);
+  caja('Empresa:','SERVICIOS FTS SA DE CV',12,42,y+31);
+  y+=44;
+
+  doc.setFillColor(255,255,255);doc.roundedRect(8,y,W-16,40,2,2,'F');
+  doc.setFont('helvetica','bold');doc.setFontSize(9);doc.setTextColor(...ro);doc.text('II. DATOS DEL CURSO',12,y+7);
+  caja('Curso:',c.titulo,12,42,y+15);
+  caja('Duración:',`${c.duracion_min} horas`,12,42,y+23);
+  caja('Fecha:',fechaStr,12,42,y+31);
+  caja('Modalidad:','Video en línea',115,150,y+23);
+  caja('Calificación:',`${r.score}%`,115,150,y+31);
+  y+=46;
+
+  doc.setFillColor(255,255,255);doc.roundedRect(8,y,W-16,20,2,2,'F');
+  doc.setFont('helvetica','bold');doc.setFontSize(9);doc.setTextColor(...ro);doc.text('III. OBJETIVO',12,y+7);
+  doc.setFont('helvetica','normal');doc.setFontSize(8.5);doc.setTextColor(...ne);
+  doc.text(c.descripcion||'Capacitación en seguridad industrial.',14,y+14,{maxWidth:W-24});
+  y+=26;
+
+  doc.setFillColor(...ve);doc.roundedRect(8,y,W-16,16,2,2,'F');
+  doc.setTextColor(255,255,255);doc.setFont('helvetica','bold');doc.setFontSize(11);
+  doc.text(`✅ APROBADO — Calificación: ${r.score}%`,W/2,y+11,{align:'center'});
+  y+=22;
+
+  doc.setFillColor(255,255,255);doc.roundedRect(8,y,W-16,34,2,2,'F');
+  doc.setFont('helvetica','bold');doc.setFontSize(9);doc.setTextColor(...ro);doc.text('IV. FIRMAS',12,y+7);
+  doc.setDrawColor(180,180,180);doc.setLineWidth(.3);
+  doc.line(20,y+26,90,y+26);doc.line(120,y+26,190,y+26);
+  doc.setFont('helvetica','normal');doc.setFontSize(8);doc.setTextColor(...gr);
+  doc.text('Firma del Trabajador',55,y+31,{align:'center'});
+  doc.text('Instructor / Supervisor',155,y+31,{align:'center'});
+  y+=40;
+
+  doc.setFillColor(10,10,26);doc.roundedRect(8,y,W-16,22,2,2,'F');
+  doc.setTextColor(0,255,136);doc.setFont('courier','bold');doc.setFontSize(7);
+  doc.text('🔐 VERIFICACIÓN DIGITAL SHA-256',12,y+7);
+  doc.setFont('courier','normal');doc.setFontSize(6);
+  doc.text(r.hash.slice(0,42),12,y+13);doc.text(r.hash.slice(42),12,y+19);
+  try{const q=await _qr(r.hash.slice(0,32));if(q)doc.addImage(q,'PNG',W-28,y+2,18,18);}catch(e){}
+
+  doc.setFillColor(...az);doc.rect(0,H-14,W,14,'F');
+  doc.setTextColor(255,255,255);doc.setFontSize(8);doc.setFont('helvetica','normal');
+  doc.text('SERVICIOS FTS SA DE CV · Sistema de Capacitación Digital · STPS',W/2,H-6,{align:'center'});
+
+  /* HOJA 2 — CERTIFICADO */
+  doc.addPage();
+  doc.setFillColor(...az);doc.rect(0,0,W,16,'F');
+  doc.setTextColor(255,255,255);doc.setFont('helvetica','bold');doc.setFontSize(12);
+  doc.text('CERTIFICADO INDIVIDUAL DE CAPACITACIÓN',W/2,10,{align:'center'});
+  doc.setFillColor(245,245,245);doc.rect(0,16,W,H-32,'F');
+
+  if(r.foto){try{doc.addImage(r.foto,'JPEG',12,24,36,36);}catch(e){}}
+  doc.setDrawColor(...ve);doc.setLineWidth(.8);doc.roundedRect(12,24,36,36,3,3,'S');
+
+  const nomCompleto=[emp.nombre,emp.apaterno,emp.amaterno].filter(Boolean).join(' ');
+  doc.setFont('helvetica','bold');doc.setFontSize(14);doc.setTextColor(...ne);
+  doc.text(nomCompleto||'Trabajador',54,34);
+  doc.setFont('helvetica','normal');doc.setFontSize(9);doc.setTextColor(...gr);
+  if(emp.curp)doc.text('CURP: '+emp.curp,54,41);
+  doc.text('SERVICIOS FTS SA DE CV',54,48);
+
+  doc.setFillColor(...ve);doc.roundedRect(8,68,W-16,38,3,3,'F');
+  doc.setTextColor(255,255,255);doc.setFont('helvetica','bold');doc.setFontSize(12);
+  doc.text(c.titulo,W/2,80,{align:'center'});
+  doc.setFont('helvetica','normal');doc.setFontSize(9);
+  doc.text(`Duración: ${c.duracion_min} min · Calificación: ${r.score}%`,W/2,89,{align:'center'});
+  const tsStr=new Date(r.ts).toLocaleString('es-MX',{weekday:'long',year:'numeric',month:'long',day:'numeric',hour:'2-digit',minute:'2-digit',timeZoneName:'short'});
+  doc.setFontSize(8);doc.text(tsStr,W/2,97,{align:'center'});
+
+  doc.setFillColor(10,10,26);doc.roundedRect(8,114,W-16,26,3,3,'F');
+  doc.setTextColor(0,255,136);doc.setFont('courier','bold');doc.setFontSize(7);
+  doc.text('🔐 SELLO DE VERIFICACIÓN SHA-256',12,121);
+  doc.setFont('courier','normal');doc.setFontSize(6.5);
+  doc.text(r.hash.slice(0,32),12,127);doc.text(r.hash.slice(32),12,133);
+  doc.setTextColor(120,120,120);doc.setFontSize(5.5);
+  doc.text('Algoritmo: SHA-256 · FTS Training v3.1 · Hash único e irrepetible',12,138);
+  try{const q=await _qr(r.hash.slice(0,32));if(q)doc.addImage(q,'PNG',W-28,116,18,18);}catch(e){}
+
+  doc.setFillColor(255,250,240);doc.roundedRect(8,148,W-16,16,2,2,'F');
+  doc.setDrawColor(...ro);doc.setLineWidth(.4);doc.roundedRect(8,148,W-16,16,2,2,'S');
+  doc.setFont('helvetica','italic');doc.setFontSize(7);doc.setTextColor(...ro);
+  doc.text('Este certificado fue generado digitalmente. La foto y el sello SHA-256 son evidencia de participación y aprobación del trabajador.',W/2,155,{align:'center',maxWidth:W-20});
+  doc.text('Válido junto con el DC-3 correspondiente emitido en la hoja anterior.',W/2,161,{align:'center'});
+
+  doc.setDrawColor(200,200,200);doc.setLineWidth(.3);
+  doc.line(20,195,90,195);doc.line(125,195,190,195);
+  doc.setFont('helvetica','normal');doc.setFontSize(8);doc.setTextColor(...gr);
+  doc.text('Trabajador',55,200,{align:'center'});doc.text('Instructor / Supervisor',157,200,{align:'center'});
+
+  doc.setFillColor(...az);doc.rect(0,H-14,W,14,'F');
+  doc.setTextColor(255,255,255);doc.setFontSize(8);
+  doc.text('SERVICIOS FTS SA DE CV · Sistema de Capacitación Digital · STPS',W/2,H-6,{align:'center'});
+
+  const ap=(emp.apaterno||'trabajador').replace(/\s/g,'_');
+  doc.save(`FTS_DC3_${ap}_${c.id}_${Date.now()}.pdf`);
+}
+
+/* ════════════════════════════════════════════════════════════
+   9. HELPERS
+═══════════════════════════════════════════════════════════════*/
+async function _hash(t){
+  const buf=await crypto.subtle.digest('SHA-256',new TextEncoder().encode(t));
+  return Array.from(new Uint8Array(buf)).map(b=>b.toString(16).padStart(2,'0')).join('');
+}
+async function _qr(data){
+  return new Promise(res=>{
+    const img=new Image();img.crossOrigin='anonymous';
+    img.onload=()=>{const c=document.createElement('canvas');c.width=img.width;c.height=img.height;c.getContext('2d').drawImage(img,0,0);res(c.toDataURL('image/png'));};
+    img.onerror=()=>res(null);
+    img.src=`https://api.qrserver.com/v1/create-qr-code/?size=80x80&data=${encodeURIComponent(data)}`;
+  });
+}
+function _ocultar(ids){ids.forEach(id=>{const el=document.getElementById(id);if(el)el.classList.remove('on');});}
+
+/* ════════════════════════════════════════════════════════════
+   10. INIT
+═══════════════════════════════════════════════════════════════*/
+async function init() {
+  inyectarCSS();
+  inyectarCam();
+  await cargarTodo();
+
+  // Botón master
+  const tM=setInterval(()=>{if(document.getElementById('settings-panel')){inyectarBotonMaster();clearInterval(tM);}},400);
+  // Panel asignación instructor
+  const tI=setInterval(()=>{if(document.getElementById('tp-workers')&&S.cursos.length){inyectarAsignacion();clearInterval(tI);}},600);
+
+  hookEdash();
+}
+
+/* ── API pública ── */
+window.FTS3 = {
+  abrirAdmin, _adminTab: renderAdmin,
+  _formCurso, _guardarCurso, _toggleCurso, _delCurso, _addPregunta,
+  _formPaquete, _guardarPaquete, _delPaquete,
+  _copiar,
+  asignar, verAsignaciones,
+  _toggleCV, iniciarSel,
+  _iniciarExamen, _selOpt, _sigQ,
+  _pedirFoto, _tomarFoto, _retakeFoto, _confirmarFoto, _saltarFoto,
+  _avanzar,
+  estado: ()=>S,
+};
+
+if(document.readyState==='loading'){document.addEventListener('DOMContentLoaded',init);}else{init();}
+})();


### PR DESCRIPTION
## Summary

- **Launcher principal** (`index.html`): grid 2x2 de módulos, solo Seguridad activo, statusbar con heartbeat
- **Design system compartido** (`shared/fts-styles.css`): variables CSS, componentes base extraídos de FTS_DC3
- **Autenticación** (`shared/auth.js`): login/logout, validación de sesión y roles, master bypass
- **Módulo Seguridad completo** (`seguridad/index.html`): migración fiel de FTS_DC3 con 11 pantallas (Instructor DC-3, Empleado, IPERC, Usuarios)
- **Videos v3.1** (`seguridad/js/videos.js`): copia exacta de fts_videos_patch.js con BASE_RAW actualizado a fts-suite
- **JSONs de producción**: users.json, videos.json, asignaciones.json migrados desde FTS_DC3
- **Estructura de carpetas**: seguridad/, shared/, rh/, comercial/, odoo/ con .gitkeep

### Cambios respecto a FTS_DC3
- URLs apuntan a `yinyo1/fts-suite/main/` (no FTS_DC3)
- CSS compartido en `shared/fts-styles.css` (no inline)
- Auth compartido en `shared/auth.js` (no inline)
- JSONs en `seguridad/data/` (no raíz)
- Botón "← Suite" en topbar para volver al launcher

### Archivos (16 nuevos, 4,220 líneas)
| Archivo | Líneas |
|---------|--------|
| `seguridad/index.html` | 2,358 |
| `seguridad/js/videos.js` | 1,040 |
| `seguridad/data/videos.json` | 342 |
| `shared/auth.js` | 195 |
| `index.html` (launcher) | 131 |
| `shared/fts-styles.css` | 92 |
| `seguridad/data/users.json` | 46 |

## Test plan
- [ ] Verificar que el launcher carga y muestra los 4 módulos
- [ ] Verificar heartbeat del launcher (dot verde en statusbar)
- [ ] Acceder a Seguridad y validar login instructor (master: ftsmaster)
- [ ] Verificar generación de PDF DC-3
- [ ] Verificar flujo empleado (login → datos → foto → cursos)
- [ ] Verificar que videos.js carga cursos desde videos.json
- [ ] Confirmar que los módulos RH, Comercial, Odoo muestran "Próximamente"

https://claude.ai/code/session_01Szg8ib9eP22U5LUrDGmMEk