### PR TITLE
feat(kiosk): hardening de manejo de errores

### DIFF
--- a/operaciones/kiosk/js/kiosk.js
+++ b/operaciones/kiosk/js/kiosk.js
@@ -675,13 +675,26 @@ async function registrarAsistencia(){
       var result = await window.OdooKiosk.registrarCheckin(payload);
       // Verificar candados del backend
       var r = Array.isArray(result) ? result[0] : result;
-      if(r && r.accion_valida === false){
-        var errMsg = r.error_msg || 'Error desconocido';
-        mostrarErrorCandado(errMsg);
+      console.log('[KIOSK] n8n response:', r);
+
+      // Detectar éxito explícito (v4.0 usa accion_valida:true; v3.4 algunos endpoints usaban success:true)
+      if(r && (r.accion_valida === true || r.success === true)){
+        // éxito real, continuar al reset
+      } else if(r && r.accion_valida === false){
+        mostrarErrorCandado(r.error_msg || r.mensaje || 'Error desconocido');
+        return;
+      } else {
+        // Respuesta ambigua o vacía — el workflow debe responder con shape explícito
+        mostrarErrorCandado('Respuesta inválida del servidor. Intenta de nuevo.');
         return;
       }
     } catch(e){
-      console.warn('Error enviando a n8n:', e);
+      console.error('[KIOSK] Error fetch n8n:', e);
+      mostrarErrorCandado(
+        'No se pudo conectar al servidor. Verifica tu internet e intenta de nuevo. ' +
+        'Si el problema persiste, avisa a Esteban.'
+      );
+      return; // NO seguir al reset que limpia estado
     }
   } else {
     console.log('[DEMO] Payload kiosk:', payload);
@@ -1392,6 +1405,7 @@ async function confirmarOlvideCheckout(){
       motivo:             motivoInput.value.trim(),
       es_estimado:        true
     });
+    console.log('[KIOSK] cerrar-registro response:', resCheckout);
     var r = Array.isArray(resCheckout) ? resCheckout[0] : resCheckout;
     // cerrar-registro devuelve respuesta GitHub (content + commit) si OK,
     // o un objeto con error / accion_valida:false si falla.
@@ -1535,17 +1549,28 @@ async function confirmarOlvideEntrada(){
     });
 
     var r = Array.isArray(res) ? res[0] : res;
-    if(r && r.accion_valida === false){
-      mostrarErrorCandado(r.error_msg || 'Error al registrar entrada');
+    console.log('[KIOSK] n8n response:', r);
+
+    // Detectar éxito explícito (v4.0 usa accion_valida:true; v3.4 algunos endpoints usaban success:true)
+    if(r && (r.accion_valida === true || r.success === true)){
+      // éxito real, refrescar estado
+      mostrarEstadoEmpleado(empleado);
+    } else if(r && r.accion_valida === false){
+      mostrarErrorCandado(r.error_msg || r.mensaje || 'Error al registrar entrada');
+      return;
+    } else {
+      // Respuesta ambigua o vacía
+      mostrarErrorCandado('Respuesta inválida del servidor. Intenta de nuevo.');
       return;
     }
 
-    // Refrescar estado
-    mostrarEstadoEmpleado(empleado);
-
   } catch(e){
-    alert('Error al procesar: ' + e.message);
-    mostrarEstadoEmpleado(empleado);
+    console.error('[KIOSK] Error fetch n8n:', e);
+    mostrarErrorCandado(
+      'No se pudo conectar al servidor. Verifica tu internet e intenta de nuevo. ' +
+      'Si el problema persiste, avisa a Esteban.'
+    );
+    return; // NO seguir al reset que limpia estado
   }
 }
 window.confirmarOlvideEntrada = confirmarOlvideEntrada;


### PR DESCRIPTION
## Contexto

El backend `kiosk/checkin v4.0` ya devuelve respuestas explícitas con `accion_valida:true/false`. Este PR arregla 3 anti-patrones de UX del frontend que aparentaban éxito cuando el servidor fallaba silenciosamente.

**NO cambia endpoints, payloads ni lógica de negocio — solo manejo de respuesta y errores.**

## Cambios en `operaciones/kiosk/js/kiosk.js`

### 1. `registrarAsistencia()` (flujo normal: entrada/salida/comida/regreso)

**Antes**:
```js
if(r && r.accion_valida === false){
  mostrarErrorCandado(r.error_msg || 'Error desconocido');
  return;
}
// implícito: cualquier otra cosa = éxito
```

**Después**:
```js
console.log('[KIOSK] n8n response:', r);
if(r && (r.accion_valida === true || r.success === true)){
  // éxito real
} else if(r && r.accion_valida === false){
  mostrarErrorCandado(r.error_msg || r.mensaje || 'Error desconocido');
  return;
} else {
  mostrarErrorCandado('Respuesta inválida del servidor. Intenta de nuevo.');
  return;
}
```

**Catch con mensaje visible**:
```js
} catch(e){
  console.error('[KIOSK] Error fetch n8n:', e);
  mostrarErrorCandado(
    'No se pudo conectar al servidor. Verifica tu internet e intenta de nuevo. ' +
    'Si el problema persiste, avisa a Esteban.'
  );
  return; // NO seguir al reset que limpia estado
}
```

Antes: `console.warn` silencioso → usuario veía confirmación falsa.

### 2. `confirmarOlvideEntrada()` (flujo "olvidé checar entrada")

Mismo patch de 3 branches + catch visible. Antes tenía `alert('Error al procesar: '...)` que no era consistente con el resto del UI.

### 3. `confirmarOlvideCheckout()` (flujo "olvidé checar salida")

Solo añade `console.log('[KIOSK] cerrar-registro response:', resCheckout)` para debugging. El detector triple ya existente (`commit`/`content`/`ok:true` OR `accion_valida:false`/`error`/`status:error`) se preserva intacto.

## Compatibilidad

- **v4.0** (`{accion_valida:true, ...}`) → ✅ detectado como éxito
- **v3.4 legacy** (`{success:true, ...}` donde aplicaba) → ✅ sigue funcionando por `r.success === true`
- **Response vacía** `{}` o `200 OK` sin body estructurado → ⚠️ ahora falla con "Respuesta inválida del servidor" (antes aparentaba éxito silencioso)
- **Network timeout** → ⚠️ ahora muestra mensaje visible (antes `console.warn` silencioso)

⚠️ **Cambio de comportamiento** intencional: si el workflow de producción está devolviendo `200 OK` sin `accion_valida:true`, ahora se verá un error en el kiosk. Esto es deseable — obliga a que el backend responda con shape explícito.

## Archivos modificados

- `operaciones/kiosk/js/kiosk.js` — **+36 / −11 líneas**

## Validación

- ✅ `node --check kiosk.js` pasa sin errores
- ✅ Ningún otro archivo tocado
- ✅ Endpoints NO cambian (`/webhook/kiosk/checkin` y `/webhook/kiosk/cerrar-registro`)
- ✅ Payloads de request NO cambian
- ✅ Compatibilidad v3.4 preservada vía `success:true` como alternativa

## Test plan

- [ ] Smoke test en demo: verificar que el flujo normal sigue mostrando confirm screen tras POST exitoso
- [ ] Simular timeout (bloquear red): verificar que se muestra el mensaje "No se pudo conectar al servidor" y el reset no avanza
- [ ] Simular `accion_valida:false` con `error_msg:"ZONA_GRIS:3h"`: verificar que `mostrarErrorCandado` renderiza el prefijo correctamente
- [ ] Simular response vacía `{}`: verificar que muestra "Respuesta inválida del servidor"
- [ ] Verificar en DevTools console que aparece `[KIOSK] n8n response: ...` en todas las operaciones
- [ ] Verificar en DevTools console que aparece `[KIOSK] cerrar-registro response: ...` al resolver zona_gris/error_critico

## NO mergear

Dejar en review. Rollback fácil: revertir 1 commit (`2d29670`).

https://claude.ai/code/session_019xG4Q27EDoJHoMLSmTk9p1