### PR TITLE
fix(kiosk): corregir timezone en construcción de timestamp olvidé-entrada/salida

### DIFF
--- a/operaciones/kiosk/js/kiosk.js
+++ b/operaciones/kiosk/js/kiosk.js
@@ -35,6 +35,16 @@ function loadKioskConfig(){
   };
 }
 
+// Helper: fecha local en formato YYYY-MM-DD (NO usa UTC)
+// Fix bug: new Date().toISOString().split('T')[0] retorna UTC,
+// tras 18:00 CST queda 1 día adelantado
+function fechaLocalISO(fecha){
+  var d = fecha || new Date();
+  return d.getFullYear() + '-' +
+    String(d.getMonth() + 1).padStart(2, '0') + '-' +
+    String(d.getDate()).padStart(2, '0');
+}
+
 // ═══ Geo: radio fallback + distancia + validación ═══
 function getRadioPermitido(){
   return 100; // fallback — cada sitio define su propio radio en ops_kiosk_geolocations
@@ -1363,7 +1373,7 @@ async function confirmarOlvideCheckout(){
 
   // Fecha del check_in original para construir el checkout estimado
   var regAbierto = estado && estado.registro_abierto;
-  var fechaCheckIn = (regAbierto && regAbierto.check_in) ? regAbierto.check_in.substring(0, 10) : new Date().toISOString().split('T')[0];
+  var fechaCheckIn = (regAbierto && regAbierto.check_in) ? regAbierto.check_in.substring(0, 10) : fechaLocalISO();
   var checkoutEstimado = fechaCheckIn + 'T' + horaInput.value + ':00';
 
   // Cerrar modal
@@ -1505,7 +1515,7 @@ async function confirmarOlvideEntrada(){
   var empleado = window._empleadoActual;
   if(!empleado) return;
 
-  var hoyISO = new Date().toISOString().split('T')[0];
+  var hoyISO = fechaLocalISO();
   var checkinEstimado = hoyISO + 'T' + horaInput.value + ':00';
   var motivo = motivoInput.value.trim();
 


### PR DESCRIPTION
## Resumen del bug

El frontend del kiosk construye el campo `timestamp`/`checkout_estimado` con la **fecha UTC** en lugar de la **fecha local** del browser en los flujos "Olvidé checar entrada/salida". Como Monterrey es UTC-6, **cualquier invocación después de las 18:00 CST** genera un timestamp con día adelantado en 1.

### Ejemplo reproducido

- Hora local CST: **20 abril 18:25**
- Usuario ingresa `"08:00"` en el modal de hora estimada
- Frontend envía: `{"timestamp": "2026-04-21T08:00:00"}` ← **día 21, debería ser 20**
- Consecuencia: attendance queda con `check_in` en el **futuro** en Odoo

### Causa raíz

```js
// Antes (buggy):
new Date().toISOString().split('T')[0]
// Retorna fecha UTC. Cuando CST es 18:00, UTC ya cruzó a 00:00 del día siguiente.
```

## Por qué el fix resuelve el problema

Se crea un helper `fechaLocalISO()` que extrae la fecha usando los getters locales del objeto `Date` (`.getFullYear()`, `.getMonth()`, `.getDate()`) en lugar de la serialización UTC via `.toISOString()`. Esto retorna la fecha del **calendario local del navegador** sin afectación de timezone.

```js
function fechaLocalISO(fecha){
  var d = fecha || new Date();
  return d.getFullYear() + '-' +
    String(d.getMonth() + 1).padStart(2, '0') + '-' +
    String(d.getDate()).padStart(2, '0');
}
```

Resultado esperado tras el fix con el mismo escenario:
- Hora local CST: 20 abril 18:25
- Usuario ingresa `"08:00"`
- Frontend envía: `{"timestamp": "2026-04-20T08:00:00"}` ✅ **día 20 correcto**

## Archivos modificados

**`operaciones/kiosk/js/kiosk.js`** — +12 / −2 líneas:

| Línea (post-fix) | Cambio |
|---|---|
| 38-46 | **NUEVO** helper `fechaLocalISO(fecha)` |
| 1376 | Fallback de `confirmarOlvideCheckout()`: `new Date().toISOString().split('T')[0]` → `fechaLocalISO()` |
| 1518 | `confirmarOlvideEntrada()`: `new Date().toISOString().split('T')[0]` → `fechaLocalISO()` |

## Qué NO se tocó (y por qué)

| Línea | Código | Razón para NO tocar |
|---|---|---|
| **635** | `timestamp: now.toISOString()` en `registrarAsistencia()` (flujo checkin normal) | Envía ISO UTC **completo con `Z` explícito**. El backend puede parsearlo correctamente sin asumir timezone. Este flujo NO está reportado como buggy. Requiere validación con el workflow v4.0 antes de tocar. |
| **940-941** | Date pickers de rango en historial (`hist-desde`/`hist-hasta`) | Display de UI que el usuario puede editar manualmente antes de enviar. Bug menor, no crítico. |
| **123, 1043** | `ts` en geoErrorCode (diagnóstico) y `ops_geo_sync_timestamp` en localStorage | Son timestamps completos (no fecha-pura) que se usan como metadato, no como `check_in`/`check_out` de Odoo. |

## Otros archivos con el mismo antipatrón (fuera de scope)

El análisis previo identificó **13 archivos del repo** con `new Date().toISOString().split('T')[0]`. Este PR SOLO arregla las 2 ocurrencias críticas del kiosk. Los demás (dashboard, incidencias, auth-suite, seguridad, iperc, etc.) quedan para un PR posterior con un helper compartido en `shared/date-utils.js`.

**Bugs relacionados conocidos** (no incluidos en este PR):
- `operaciones/dashboard/js/dashboard.js:144` — dashboard muestra "sin técnicos" tras 18:00 CST
- `operaciones/incidencias/empleado/index.html:233,357` — validación de fechas en creación de incidencias
- `shared/auth.js:97,138` + `shared/auth-suite.js:84` — verificación de vigencia de usuarios

## Validación

- ✅ `node --check kiosk.js` OK
- ✅ Solo 1 commit en la rama (historia limpia)
- ✅ 2 call sites de `fechaLocalISO()` confirmadas (grep)
- ✅ 4 líneas `toISOString()` no-críticas preservadas intactas
- ✅ Diff mínimo: +12 / −2

## Test plan

- [ ] Simular CST 18:30 y usar "Olvidé checar entrada" → verificar en DevTools Network que `timestamp` incluye la fecha del día correcto
- [ ] Simular CST 18:30 sin `registro_abierto` en el estado → probar fallback de `confirmarOlvideCheckout()` y verificar `checkout_estimado`
- [ ] Verificar en Odoo que el attendance queda con check_in/check_out del día correcto
- [ ] Confirmar que el flujo normal de checkin (línea 635) sigue funcionando igual que antes (no se tocó)

## NO mergear

Dejar en review. Rollback trivial: revertir commit `04692c2`.

https://claude.ai/code/session_019xG4Q27EDoJHoMLSmTk9p1