### PR TITLE
fix(kiosk): SOs con dashes + ocultar botones comida (placeholder Fase 3)

### DIFF
--- a/operaciones/kiosk/css/kiosk.css
+++ b/operaciones/kiosk/css/kiosk.css
@@ -90,6 +90,7 @@ html,body{height:100%;overflow:hidden;font-family:'Inter',-apple-system,sans-ser
 .kiosk-so-card:hover,.kiosk-so-card:active{border-color:#107C10;background:#f0faf0}
 .kiosk-so-num{font-size:13px;color:#107C10;font-weight:700;letter-spacing:1px}
 .kiosk-so-name{font-size:18px;font-weight:700;margin-top:4px;color:#1a1a1a}
+.kiosk-so-cliente{font-size:13px;color:#666;margin-top:4px}
 
 .kiosk-pin-pad{
   display:grid;grid-template-columns:repeat(3,1fr);

--- a/operaciones/kiosk/index.html
+++ b/operaciones/kiosk/index.html
@@ -97,8 +97,10 @@
   <p style="color:#666;font-size:14px;margin:0 0 24px;text-align:center">¿Qué deseas registrar?</p>
   <div style="display:flex;flex-direction:column;gap:12px;width:100%;max-width:400px">
     <button onclick="selectTipo('entrada')" class="kiosk-tipo-btn tipo-entrada">🟢 Entrada — Inicio del día</button>
+    <!-- FASE 3 PENDIENTE: botones de comida
     <button onclick="selectTipo('salida_comida')" class="kiosk-tipo-btn tipo-comida">🍽️ Salida a comer</button>
     <button onclick="selectTipo('regreso_comida')" class="kiosk-tipo-btn tipo-regreso">🔄 Regreso de comida</button>
+    -->
     <button onclick="selectTipo('salida')" class="kiosk-tipo-btn tipo-salida">🔴 Salida — Fin del día</button>
   </div>
   <p id="ks-tipo-sugerencia" style="color:#0078D4;font-size:13px;margin-top:20px;text-align:center;font-style:italic"></p>

--- a/operaciones/kiosk/js/kiosk.js
+++ b/operaciones/kiosk/js/kiosk.js
@@ -282,10 +282,10 @@ const DEMO_EMPLEADOS = [
   { id:5, nombre:'Carlos Hernández',  puesto:'Ayudante',   foto:'', pin:'2222' },
 ];
 const DEMO_SOS = [
-  { id:101, num:'SO-2026-001', nombre:'Topo Chico — Radium' },
-  { id:102, num:'SO-2026-002', nombre:'Arca Continental — Mezzanine' },
-  { id:103, num:'SO-2026-003', nombre:'Sigma — Polipasto 2T' },
-  { id:104, num:'SO-2026-004', nombre:'HEB — Tanque 5000L' },
+  { id:101, name:'🛠️ SO-2026-001 - Topo Chico Radium',        cliente:'Ecolab Nalco',        nombre:'Topo Chico — Radium',       num:'SO-2026-001' },
+  { id:102, name:'🛠️ SO-2026-002 - Arca Mezzanine',           cliente:'Arca Continental',    nombre:'Arca Continental — Mezzanine', num:'SO-2026-002' },
+  { id:103, name:'🛠️ SO-2026-003 - Sigma Polipasto 2T',       cliente:'Sigma Alimentos',     nombre:'Sigma — Polipasto 2T',      num:'SO-2026-003' },
+  { id:104, name:'🛠️ SO-2026-004 - HEB Tanque 5000L',         cliente:'HEB México',          nombre:'HEB — Tanque 5000L',        num:'SO-2026-004' },
 ];
 
 async function loadEmpleados(){
@@ -572,7 +572,11 @@ async function afterVerifyContinue(){
 // ═══ SOs ═══
 function searchSOs(q){
   const nq = normalize(q);
-  const filtered = !nq ? K.sos : K.sos.filter(s => normalize(s.nombre).includes(nq) || normalize(s.num).includes(nq));
+  const filtered = !nq ? K.sos : K.sos.filter(s =>
+    normalize(s.name || s.nombre || '').includes(nq) ||
+    normalize(s.cliente || '').includes(nq) ||
+    normalize(s.num || '').includes(nq)
+  );
   renderSOs(filtered);
 }
 
@@ -583,12 +587,14 @@ function renderSOs(list){
     el.innerHTML = '<div style="text-align:center;color:#666;padding:24px">Sin resultados</div>';
     return;
   }
-  el.innerHTML = list.map(s =>
-    '<div class="kiosk-so-card" onclick="selectSO('+s.id+')">'+
-      '<div class="kiosk-so-num">'+(s.num||'')+'</div>'+
-      '<div class="kiosk-so-name">'+(s.nombre||'—')+'</div>'+
-    '</div>'
-  ).join('');
+  el.innerHTML = list.map(s => {
+    var nombre  = s.name || s.nombre || '—';
+    var cliente = s.cliente || '';
+    return '<div class="kiosk-so-card" onclick="selectSO('+s.id+')">'+
+      '<div class="kiosk-so-name">'+nombre+'</div>'+
+      (cliente ? '<div class="kiosk-so-cliente">'+cliente+'</div>' : '')+
+    '</div>';
+  }).join('');
 }
 
 function selectSO(id){

--- a/operaciones/kiosk/js/kiosk.js
+++ b/operaciones/kiosk/js/kiosk.js
@@ -1272,8 +1272,9 @@ function renderEstadoBotones(estado){
       html = '<button onclick="olvideChecarEntrada()" style="background:#f0f4ff;color:#0078D4;border:1px solid #0078D4;padding:14px;border-radius:12px;font-size:14px;font-weight:500;cursor:pointer;font-family:inherit">⏰ Llegué pero olvidé checar entrada</button>';
       break;
     case 'activo':
-      // Principal (Checar Salida) ya en #ksAccionRapida → sólo "Salida a Comer"
-      html = '<button onclick="iniciarCheckin(\'salida_comida\')" style="background:#0078D4;color:#fff;border:none;padding:14px;border-radius:12px;font-size:15px;font-weight:600;cursor:pointer;font-family:inherit">🍽️ Salida a Comer</button>';
+      // FASE 3 PENDIENTE: botón Salida a Comer desactivado temporalmente
+      // html = '<button onclick="iniciarCheckin(\'salida_comida\')" style="background:#0078D4;color:#fff;border:none;padding:14px;border-radius:12px;font-size:15px;font-weight:600;cursor:pointer;font-family:inherit">🍽️ Salida a Comer</button>';
+      html = '';  // sin botón secundario mientras no exista Fase 3
       break;
     case 'zona_gris':
       // Principal (Seguí en turno) ya en #ksAccionRapida → sólo el alternativo


### PR DESCRIPTION
## Contexto

Dos bugs críticos identificados tras pruebas en producción del kiosk, ambos en la misma área del código. Se corrigen juntos en este PR (PR A — crítico). El PR B (mejoras UX: keypad, spinner geo, botón "Terminado") va después.

---

## Bug 1 — Selector de SOs muestra solo "—" (dashes)

### Síntoma

Al llegar a la pantalla "¿En qué proyecto trabajas hoy?", la lista de SOs aparece con cada item mostrando `—` en vez del nombre del proyecto. El buscador no filtra nada. Sin embargo, al seleccionar un item y llegar a la pantalla de confirmación, sí aparece el texto correcto.

### Root cause

El workflow `kiosk/sos v3.4` migrado devuelve objetos con schema Odoo nativo:
```js
{ id: 160, name: '🛠️ SO10300 - Techo de Magnekon', cliente: 'MAGNEKON S.A. DE C.V.', ... }
```

Pero `renderSOs()` (líneas 579-592) y `searchSOs()` (líneas 573-577) seguían leyendo el schema legacy:
- `s.nombre` → undefined → muestra `—` (fallback)
- `s.num` → undefined → muestra vacío

La confirmación accidentalmente funcionaba porque `registrarAsistencia()` ya usaba cadena fallback `s.name || s.nombre`.

### Fix aplicado (commit `4bbc496`)

**`operaciones/kiosk/js/kiosk.js`**:

1. **`renderSOs()`** (l.579-596): ahora usa `s.name || s.nombre || '—'` y muestra `cliente` debajo en texto gris si está presente.
2. **`searchSOs()`** (l.573-581): filtra sobre `name`, `cliente`, y `num` — permite buscar por código SO, nombre del proyecto O nombre del cliente.
3. **`DEMO_SOS`** (l.284-289): agregados campos `name` + `cliente` (además de `nombre` + `num` legacy) para defensive fallback.

**`operaciones/kiosk/css/kiosk.css`**:

4. Agregado estilo `.kiosk-so-cliente`:
   ```css
   .kiosk-so-cliente{font-size:13px;color:#666;margin-top:4px}
   ```

### Estructura del item resultante

```html
<div class="kiosk-so-card" onclick="selectSO(160)">
  <div class="kiosk-so-name">🛠️ SO10300 - Techo de Magnekon</div>
  <div class="kiosk-so-cliente">MAGNEKON S.A. DE C.V.</div>
</div>
```

---

## Bug 2 — Ocultar botones de comida (placeholder Fase 3)

### Síntoma

Botones "🍽️ Salida a Comer" y "🔄 Regreso de comida" son placeholders — la funcionalidad de comida no está implementada en Odoo aún. Confunden al usuario final del kiosk.

### Fix aplicado (commit `660791d`)

**`operaciones/kiosk/js/kiosk.js:1276`** — dentro de `renderEstadoBotones` case `'activo'`:
```js
case 'activo':
  // FASE 3 PENDIENTE: botón Salida a Comer desactivado temporalmente
  // html = '<button onclick="iniciarCheckin(\'salida_comida\')" ...>🍽️ Salida a Comer</button>';
  html = '';  // sin botón secundario mientras no exista Fase 3
  break;
```

**`operaciones/kiosk/index.html:99-103`** — pantalla `ks-tipo` (obsoleta):
```html
<button onclick="selectTipo('entrada')" class="kiosk-tipo-btn tipo-entrada">🟢 Entrada — Inicio del día</button>
<!-- FASE 3 PENDIENTE: botones de comida
<button onclick="selectTipo('salida_comida')" class="kiosk-tipo-btn tipo-comida">🍽️ Salida a comer</button>
<button onclick="selectTipo('regreso_comida')" class="kiosk-tipo-btn tipo-regreso">🔄 Regreso de comida</button>
-->
<button onclick="selectTipo('salida')" class="kiosk-tipo-btn tipo-salida">🔴 Salida — Fin del día</button>
```

### Lo que NO se tocó

- **Labels de comida** en código que procesa datos del backend (`kiosk.js:389, 400, 652, 800-801, 984`): mantienen soporte para históricos que puedan traer `salida_comida`/`regreso_comida` desde Odoo.
- **Tipos** `salida_comida`/`regreso_comida` como strings: siguen existiendo en el código pero sin botón clickable.
- Clases CSS `.tipo-comida`/`.tipo-regreso`: dejadas intactas para reactivación rápida.

---

## Archivos modificados

| Archivo | Commit 1 | Commit 2 | Total |
|---|---|---|---|
| `operaciones/kiosk/js/kiosk.js` | +17 / −11 | +3 / −2 | +20 / −13 |
| `operaciones/kiosk/css/kiosk.css` | +1 / −0 | — | +1 / −0 |
| `operaciones/kiosk/index.html` | — | +2 / −0 | +2 / −0 |

## Validación

- ✅ `node --check kiosk.js` JS OK en ambos commits
- ✅ 2 commits separados en la misma rama (historia limpia)
- ✅ No se tocó lógica de `registrarAsistencia()` (payload intacto)
- ✅ No se tocó backend ni workflows n8n
- ✅ `DEMO_SOS` preserva ambos schemas (name+cliente nuevo + nombre+num legacy)

## Test plan

### Bug 1 (SOs render)
- [ ] Usuario entra → busca empleado → mete PIN → ingresa Salida
- [ ] En pantalla "¿En qué proyecto trabajas hoy?" verificar que cada SO muestra:
  - Línea 1 **bold**: `🛠️ SO10300 - Techo de Magnekon`
  - Línea 2 gris: `MAGNEKON S.A. DE C.V.`
- [ ] Buscar "magnekon" (lowercase, sin acentos) → filtra
- [ ] Buscar "10300" → filtra por código de SO
- [ ] Seleccionar un SO → pantalla confirmación sigue mostrando el nombre correcto

### Bug 2 (botones comida ocultos)
- [ ] Empleado con estado `activo` entra → pantalla `ks-estado` muestra solo botón principal de Salida (no aparece "🍽️ Salida a Comer")
- [ ] Empleado con estado `sin_registro` sigue mostrando alternativo "⏰ Llegué pero olvidé checar entrada" (NO afectado)
- [ ] Navegación normal no llega a `ks-tipo` (flujo actual la evita)

### Rollback

Si hace falta, ambos commits se revierten independientemente:
- `git revert 660791d` → reactiva botones comida
- `git revert 4bbc496` → revierte fix de SOs (volvería a mostrar dashes)

## NO mergear

Dejar en review. Ambos bugs son críticos pero no bloqueantes (el usuario sigue pudiendo checar salida, solo con UX confusa).

https://claude.ai/code/session_019xG4Q27EDoJHoMLSmTk9p1