### PR TITLE
feat(kiosk): mejoras UX keypad + spinner + pantalla éxito

### DIFF
--- a/operaciones/kiosk/css/kiosk.css
+++ b/operaciones/kiosk/css/kiosk.css
@@ -143,6 +143,21 @@ html,body{height:100%;overflow:hidden;font-family:'Inter',-apple-system,sans-ser
   vertical-align:middle;
 }
 @keyframes mini-spin{to{transform:rotate(360deg)}}
+
+/* Botón "Terminado" en pantalla confirmación — skip al home sin esperar countdown */
+.kiosk-terminar-btn{
+  display:block;width:100%;max-width:420px;
+  margin:20px auto 0;padding:18px;
+  border:none;border-radius:12px;
+  background:#107C10;color:#fff;
+  font-size:20px;font-weight:700;
+  font-family:inherit;cursor:pointer;
+  transition:transform 0.05s;
+}
+.kiosk-terminar-btn:active{
+  transform:scale(0.97);
+  background:#0d6b0d;
+}
 .kiosk-pin-dots{
   display:flex;gap:16px;margin:20px 0;
   justify-content:center;

--- a/operaciones/kiosk/css/kiosk.css
+++ b/operaciones/kiosk/css/kiosk.css
@@ -123,6 +123,26 @@ html,body{height:100%;overflow:hidden;font-family:'Inter',-apple-system,sans-ser
 }
 .kiosk-pin-ok-btn.enabled{background:#107C10;cursor:pointer}
 .kiosk-pin-ok-btn.enabled:active{transform:scale(0.97)}
+
+/* Keypad bloqueado durante validación geo (post-PIN) */
+.ks-verify-busy .kiosk-pin-pad,
+.ks-verify-busy .kiosk-pin-ok-btn{
+  pointer-events:none;
+  opacity:0.4;
+}
+
+/* Spinner inline pequeño (para estados de "procesando") */
+.mini-spinner{
+  display:inline-block;
+  width:14px;height:14px;
+  margin-right:6px;
+  border:2px solid #e0e0e0;
+  border-top-color:#0078D4;
+  border-radius:50%;
+  animation:mini-spin 0.8s linear infinite;
+  vertical-align:middle;
+}
+@keyframes mini-spin{to{transform:rotate(360deg)}}
 .kiosk-pin-dots{
   display:flex;gap:16px;margin:20px 0;
   justify-content:center;

--- a/operaciones/kiosk/css/kiosk.css
+++ b/operaciones/kiosk/css/kiosk.css
@@ -109,6 +109,20 @@ html,body{height:100%;overflow:hidden;font-family:'Inter',-apple-system,sans-ser
 .kiosk-pin-btn:hover{border-color:#0078D4;background:#f0f7ff}
 .kiosk-pin-btn:active{background:#d0e8ff;transform:scale(0.94)}
 .kiosk-pin-btn.del{color:#D83B01}
+.kiosk-pin-btn.clear-btn{color:#D83B01}
+.kiosk-pin-btn.back-btn{color:#666;background:#f5f5f5}
+
+.kiosk-pin-ok-btn{
+  display:block;width:100%;max-width:300px;
+  margin:12px auto 0;padding:18px;
+  border:none;border-radius:12px;
+  background:#ccc;color:#fff;
+  font-size:20px;font-weight:700;
+  font-family:inherit;cursor:not-allowed;
+  transition:background 0.15s;
+}
+.kiosk-pin-ok-btn.enabled{background:#107C10;cursor:pointer}
+.kiosk-pin-ok-btn.enabled:active{transform:scale(0.97)}
 .kiosk-pin-dots{
   display:flex;gap:16px;margin:20px 0;
   justify-content:center;

--- a/operaciones/kiosk/css/kiosk.css
+++ b/operaciones/kiosk/css/kiosk.css
@@ -101,13 +101,13 @@ html,body{height:100%;overflow:hidden;font-family:'Inter',-apple-system,sans-ser
   border-radius:12px;cursor:pointer;
   border:2px solid #e0e0e0;
   font-family:inherit;min-height:80px;
-  transition:transform 0.08s,background 0.08s;
+  transition:transform 0.04s ease-out,background 0.04s ease-out;
   box-shadow:0 1px 3px rgba(0,0,0,0.04);
   -webkit-tap-highlight-color:transparent;
   user-select:none;-webkit-user-select:none;
 }
 .kiosk-pin-btn:hover{border-color:#0078D4;background:#f0f7ff}
-.kiosk-pin-btn:active{background:#d0e8ff;transform:scale(0.94)}
+.kiosk-pin-btn:active{background:#d0e8ff;transform:scale(0.92);transition:none}
 .kiosk-pin-btn.del{color:#D83B01}
 .kiosk-pin-btn.clear-btn{color:#D83B01}
 .kiosk-pin-btn.back-btn{color:#666;background:#f5f5f5}
@@ -262,3 +262,26 @@ html,body{height:100%;overflow:hidden;font-family:'Inter',-apple-system,sans-ser
 .tipo-comida:hover{border-color:#f39c12;background:#fffbf0}
 .tipo-regreso:hover{border-color:#0078D4;background:#f0f7ff}
 .tipo-salida:hover{border-color:#D83B01;background:#fff5f0}
+
+/* ── Responsive: keypad/foto más chicos en pantallas bajas ── */
+@media (max-height: 750px), (max-width: 480px) {
+  .kiosk-pin-btn{
+    padding:14px;
+    min-height:56px;
+    font-size:22px;
+  }
+  .kiosk-pin-pad{
+    gap:8px;
+    max-width:260px;
+  }
+  .kiosk-pin-ok-btn{
+    max-width:260px;
+    padding:14px;
+    font-size:18px;
+    margin-top:10px;
+  }
+  .kiosk-verify-photo,.kiosk-camera-preview{
+    width:140px;
+    height:140px;
+  }
+}

--- a/operaciones/kiosk/index.html
+++ b/operaciones/kiosk/index.html
@@ -167,6 +167,9 @@
     <div class="kiosk-confirm-row"><span class="lbl">Ubicación</span><span class="val" id="confirm-geo"><span class="kiosk-geo-dot warn"></span>Registrando…</span></div>
   </div>
   <div style="font-size:13px;color:#666;margin-top:32px" id="ksReturnCounter">Regresando en 4…</div>
+  <button class="kiosk-terminar-btn" onclick="terminarYHome()">
+    ✓ Terminado
+  </button>
 </div>
 
 <!-- ═══════ PANTALLA 6 — MI HISTORIAL ═══════ -->

--- a/operaciones/kiosk/index.html
+++ b/operaciones/kiosk/index.html
@@ -114,7 +114,7 @@
     </div>
     <div style="text-align:center">
       <video id="ksCamera" class="kiosk-camera-preview" autoplay playsinline muted></video>
-      <div style="font-size:13px;color:#999;margin-top:8px" id="ksFaceStatus">Esperando PIN…</div>
+      <div style="font-size:15px;color:#555;margin-top:10px;font-weight:500" id="ksFaceStatus">Esperando PIN…</div>
     </div>
   </div>
   <span id="ks-verify-tipo" style="color:#666;font-size:14px;display:block;text-align:center;margin-bottom:8px;font-weight:600"></span>

--- a/operaciones/kiosk/index.html
+++ b/operaciones/kiosk/index.html
@@ -137,10 +137,13 @@
     <button class="kiosk-pin-btn" onclick="addPin('7')">7</button>
     <button class="kiosk-pin-btn" onclick="addPin('8')">8</button>
     <button class="kiosk-pin-btn" onclick="addPin('9')">9</button>
-    <button class="kiosk-pin-btn del" onclick="clearPin()">C</button>
+    <button class="kiosk-pin-btn clear-btn" onclick="clearPin()">C</button>
     <button class="kiosk-pin-btn" onclick="addPin('0')">0</button>
-    <button class="kiosk-pin-btn del" onclick="backPin()">←</button>
+    <button class="kiosk-pin-btn back-btn" onclick="backPin()">←</button>
   </div>
+  <button id="ksPinOkBtn" class="kiosk-pin-ok-btn" onclick="verifyPin()" disabled>
+    ✓ Confirmar
+  </button>
 </div>
 
 <!-- ═══════ PANTALLA 4 — SELECCIONAR SO ═══════ -->

--- a/operaciones/kiosk/js/kiosk.js
+++ b/operaciones/kiosk/js/kiosk.js
@@ -423,12 +423,22 @@ function addPin(n){
   if(K.pin.length >= 4) return;
   K.pin += n;
   updatePinDots();
+  updateOkButton();
+}
+function clearPin(){ K.pin = ''; updatePinDots(); updateOkButton(); }
+function backPin(){ K.pin = K.pin.slice(0,-1); updatePinDots(); updateOkButton(); }
+
+function updateOkButton(){
+  const btn = document.getElementById('ksPinOkBtn');
+  if(!btn) return;
   if(K.pin.length === 4){
-    setTimeout(verifyPin, 50);
+    btn.classList.add('enabled');
+    btn.disabled = false;
+  } else {
+    btn.classList.remove('enabled');
+    btn.disabled = true;
   }
 }
-function clearPin(){ K.pin = ''; updatePinDots(); }
-function backPin(){ K.pin = K.pin.slice(0,-1); updatePinDots(); }
 
 function updatePinDots(){
   const dots = document.querySelectorAll('#ksPinDots .kiosk-pin-dot');

--- a/operaciones/kiosk/js/kiosk.js
+++ b/operaciones/kiosk/js/kiosk.js
@@ -273,6 +273,34 @@ function goHome(){
   showScreen('ks-home');
 }
 
+function terminarYHome(){
+  // Cancelar countdown de auto-return si está en curso
+  if(K.autoReturnTimer){ clearTimeout(K.autoReturnTimer); K.autoReturnTimer = null; }
+  if(K.autoReturnInterval){ clearInterval(K.autoReturnInterval); K.autoReturnInterval = null; }
+
+  // Limpieza completa del estado del kiosk
+  K.seleccionado = null;
+  K.soSeleccionada = null;
+  K.tipo = null;
+  K.geo = null;
+  K.geoAutorizada = null;
+  K.geoMotivo = null;
+  K.geoSitio = null;
+  K.geoDistancia = 0;
+  K.pin = '';
+  updatePinDots();
+  if(typeof updateOkButton === 'function') updateOkButton();
+
+  // Cerrar stream de cámara
+  if(K.stream){
+    K.stream.getTracks().forEach(t => t.stop());
+    K.stream = null;
+  }
+
+  showScreen('ks-home');
+}
+window.terminarYHome = terminarYHome;
+
 // ═══ Carga de empleados/SOs ═══
 const DEMO_EMPLEADOS = [
   { id:1, nombre:'Mateo Salazar',     puesto:'Ingeniero',  foto:'', pin:'1234' },
@@ -720,24 +748,8 @@ async function registrarAsistencia(){
     console.log('[DEMO] Payload kiosk:', payload);
   }
 
-  // Reset estado y volver a home
-  setTimeout(() => {
-    K.seleccionado = null;
-    K.soSeleccionada = null;
-    K.tipo = null;
-    K.geo = null;
-    K.geoAutorizada = null;
-    K.geoMotivo = null;
-    K.geoSitio = null;
-    K.geoDistancia = 0;
-    K.pin = '';
-    updatePinDots();
-    if(K.stream){
-      K.stream.getTracks().forEach(t => t.stop());
-      K.stream = null;
-    }
-    showScreen('ks-home');
-  }, 4000);
+  // Contador visible + reset al terminar (o al click en "Terminado")
+  autoReturn();
 }
 
 // ═══════ HISTORIAL ═══════
@@ -1026,13 +1038,13 @@ function autoReturn(){
   let remaining = 4;
   const el = document.getElementById('ksReturnCounter');
   if(el) el.textContent = 'Regresando en '+remaining+'…';
-  K.returnTimer = setInterval(() => {
+  K.autoReturnInterval = setInterval(() => {
     remaining--;
     if(el) el.textContent = 'Regresando en '+remaining+'…';
     if(remaining <= 0){
-      clearInterval(K.returnTimer);
-      K.returnTimer = null;
-      goHome();
+      clearInterval(K.autoReturnInterval);
+      K.autoReturnInterval = null;
+      terminarYHome();
     }
   }, 1000);
 }

--- a/operaciones/kiosk/js/kiosk.js
+++ b/operaciones/kiosk/js/kiosk.js
@@ -503,9 +503,14 @@ function shakeVerify(){
   setTimeout(() => el.classList.remove('kiosk-shake'), 400);
 }
 
-function setFaceStatus(text){
+function setFaceStatus(text, spinner){
   const el = document.getElementById('ksFaceStatus');
-  if(el) el.textContent = text;
+  if(!el) return;
+  if(spinner){
+    el.innerHTML = '<span class="mini-spinner"></span>' + text;
+  } else {
+    el.textContent = text;
+  }
 }
 
 // ═══ Cámara ═══
@@ -537,7 +542,7 @@ async function doFaceVerify(){
     return;
   }
   try{
-    setFaceStatus('🔍 Analizando rostro…');
+    setFaceStatus('🔍 Analizando rostro…', true);
     const result = await window.FaceVerify.compareFaces(K.seleccionado.foto, video);
     if(result.match){
       setFaceStatus('✅ Rostro verificado ('+result.similarity+'%)');
@@ -556,7 +561,11 @@ async function doFaceVerify(){
 
 // ═══ Continuación tras PIN+facial OK: captura geo y valida zona ═══
 async function afterVerifyContinue(){
-  setFaceStatus('📍 Obteniendo ubicación…');
+  // Bloquear keypad visual/funcionalmente durante la validación geo
+  var verifyEl = document.getElementById('ks-verify');
+  if(verifyEl) verifyEl.classList.add('ks-verify-busy');
+
+  setFaceStatus('📍 Obteniendo ubicación…', true);
   K.geoMotivo = null;
   const geo = await window.getGeolocacion();
   K.geo = geo;
@@ -567,6 +576,10 @@ async function afterVerifyContinue(){
   K.geoAutorizada = geoResult.autorizado;
   K.geoSitio = geoResult.sitio || geoResult.sitioMasCercano;
   K.geoDistancia = geoResult.distancia || 0;
+
+  // Liberar bloqueo antes de avanzar a siguiente pantalla
+  if(verifyEl) verifyEl.classList.remove('ks-verify-busy');
+
   if(!geoResult.autorizado){
     mostrarModalGeo(geoResult);
   } else if(K.tipo === 'salida'){


### PR DESCRIPTION
## Contexto

PR B de mejoras UX del kiosk, post-feedback de pruebas reales en producción. Construido sobre `main` (el PR A `fix/kiosk-sos-render-y-ocultar-comida` #5 está aún en review — NO hay dependencia directa, los cambios no se solapan en las mismas líneas).

## Resumen de los 4 commits

### Commit `0d1aa83` — `feat(kiosk): botón OK + diferenciar C/← en keypad`

**Problema**: el PIN se auto-enviaba al completar 4 dígitos. Un usuario confundió "←" (backspace rojo) con "OK" y perdió un dígito.

**Cambios**:
- **JS `addPin`** (`kiosk.js:412`): quitado `setTimeout(verifyPin, 50)` cuando pin.length === 4. Reemplazado por `updateOkButton()` que habilita el botón verde.
- **JS `clearPin`/`backPin`**: ahora llaman a `updateOkButton()` para refrescar el estado del botón.
- **JS nueva función `updateOkButton()`**: habilita/deshabilita botón OK según si hay 4 dígitos.
- **HTML `index.html:143+`**: agregado `<button id="ksPinOkBtn" class="kiosk-pin-ok-btn" onclick="verifyPin()" disabled>✓ Confirmar</button>` debajo del pad.
- **HTML**: clase `del` → `clear-btn` (C) y `back-btn` (←) para diferenciar colores.
- **CSS**: `.kiosk-pin-btn.clear-btn` rojo (destructivo), `.kiosk-pin-btn.back-btn` gris claro (NO destructivo), `.kiosk-pin-ok-btn` verde cuando enabled / gris cuando disabled.

### Commit `57f13cf` — `feat(kiosk): keypad responsive + feedback visual más ágil`

**Problema**: el keypad empujaba la foto de verificación fuera del viewport en móvil. Además el feedback de presión era perceptible como lento.

**Cambios (solo CSS)**:
- Transition reducida de `0.08s` → `0.04s ease-out` para respuesta más ágil.
- `:active` ahora usa `transition: none` + `scale(0.92)` (más perceptible, instantáneo).
- Media query `@media (max-height: 750px), (max-width: 480px)`:
  - Botones keypad: `padding:14px`, `min-height:56px`, `font-size:22px`
  - `.kiosk-pin-pad`: `gap:8px`, `max-width:260px`
  - `.kiosk-pin-ok-btn`: `max-width:260px`, `padding:14px`, `font-size:18px`
  - Foto/cámara: `140×140` en vez de `220×220`

### Commit `5a68fc5` — `feat(kiosk): spinner + bloqueo durante validación geo`

**Problema**: tras validar el PIN, el mensaje "📍 Obteniendo ubicación…" era texto chiquito (13px, gris #999) sin spinner visible. El usuario podía seguir tecleando en el keypad aunque el PIN ya pasó.

**Cambios**:
- **JS `setFaceStatus(text, spinner)`**: ahora acepta 2do argumento booleano. Si `true` inyecta `<span class="mini-spinner"></span>` antes del texto.
- **JS `afterVerifyContinue()`**: agrega clase `.ks-verify-busy` al `#ks-verify` al iniciar, la quita antes de avanzar a siguiente pantalla.
- **Call sites actualizados** a `true`: `🔍 Analizando rostro…` y `📍 Obteniendo ubicación…` (los estados "en curso"). Los resultados finales ("✅ Rostro verificado", "❌ PIN incorrecto") NO usan spinner.
- **HTML**: `#ksFaceStatus` estilo actualizado a `font-size:15px; color:#555; font-weight:500` (antes 13px/#999 débil).
- **CSS**: `.mini-spinner` (14×14, border azul, animación 0.8s), `.ks-verify-busy .kiosk-pin-pad, .ks-verify-busy .kiosk-pin-ok-btn { pointer-events:none; opacity:0.4 }`.

### Commit `e154aa4` — `feat(kiosk): botón Terminado + contador dinámico`

**Problema**:
1. El texto "Regresando en 4…" era ESTÁTICO — `autoReturn()` existía pero nunca se invocaba. `registrarAsistencia` usaba un `setTimeout(…, 4000)` suelto sin actualizar el UI.
2. No había botón de acción — el usuario tenía que esperar los 4 segundos sí o sí.

**Cambios**:
- **JS nueva función `terminarYHome()`**: cancela `K.autoReturnTimer` y `K.autoReturnInterval`, limpia estado completo (K.*, stream de cámara), `showScreen('ks-home')`.
- **JS `autoReturn()` refactorizado**: usa `K.autoReturnInterval` (no `K.returnTimer`), al llegar a 0 llama a `terminarYHome()` en lugar de `goHome()`.
- **JS `registrarAsistencia()`**: el `setTimeout(…, 4000)` largo (15 líneas de limpieza) fue reemplazado por una sola línea `autoReturn()`. Toda la lógica de limpieza vive ahora en `terminarYHome()`.
- **HTML `#ks-confirm`**: agregado `<button class="kiosk-terminar-btn" onclick="terminarYHome()">✓ Terminado</button>` debajo del contador.
- **CSS `.kiosk-terminar-btn`**: botón verde `#107C10`, full-width (max 420px), padding generoso, transition 0.05s.

## Archivos modificados

| Archivo | Cambios |
|---|---|
| `operaciones/kiosk/js/kiosk.js` | +69 / −21 líneas |
| `operaciones/kiosk/css/kiosk.css` | +63 / −2 líneas |
| `operaciones/kiosk/index.html` | +5 / −2 líneas |

**Total**: ~+137 / −25 líneas en 3 archivos.

## Validación

- ✅ `node --check kiosk.js` OK tras cada commit
- ✅ 4 commits separados, historia limpia, cada uno independiente
- ✅ Endpoints NO tocados
- ✅ Lógica de negocio NO tocada (PIN validation, face compare, geo check, registrarAsistencia payload)
- ✅ Compatible con workflow v4.0 y con v3.x anteriores

## Test plan

### Flujo completo end-to-end
- [ ] Home → tocar → Search → Seleccionar empleado → Estado → click "Checar Salida"
- [ ] **Keypad**: teclear 3 dígitos → OK en gris disabled
- [ ] **Keypad**: teclear el 4to → OK cambia a verde enabled
- [ ] **Keypad**: presionar `←` (gris) → borra último dígito → OK vuelve a disabled
- [ ] **Keypad**: presionar `C` (rojo) → limpia todo
- [ ] **Keypad**: teclear 4 dígitos → presionar ✓ Confirmar → dispara `verifyPin`
- [ ] **Face**: durante análisis aparece spinner inline girando antes del texto
- [ ] **Geo**: tras PIN OK, el keypad se pone opaco (opacity 0.4) y no responde clicks
- [ ] **Geo**: texto "📍 Obteniendo ubicación…" tiene spinner inline girando
- [ ] **Geo OK**: avanza a SO (si salida) o confirm (si entrada) — keypad ya no bloqueado
- [ ] **Confirm**: el contador "Regresando en 4… 3… 2… 1…" BAJA visualmente
- [ ] **Confirm**: click "✓ Terminado" → va al home inmediatamente (sin esperar)
- [ ] **Confirm**: sin click → al llegar a 0 va al home automáticamente
- [ ] **Post-home**: estado limpio (K.seleccionado, K.pin, K.stream, K.geo, etc.)

### Mobile específico
- [ ] Viewport < 750px alto → keypad + foto/cámara más chicos
- [ ] Viewport < 480px ancho → idem
- [ ] Foto del técnico visible completa (no solo ojos+frente)
- [ ] Presión del botón del keypad se siente instantánea

### Edge cases
- [ ] Usuario escribe 4 dígitos, presiona ← antes de click OK → OK vuelve a disabled
- [ ] Usuario escribe 4 dígitos, presiona C → dots vacíos, OK disabled
- [ ] Usuario click "Terminado" mientras el contador sigue corriendo → countdown se cancela, no hay race condition

## Rollback

Cada commit es independiente. Rollback por commit individual:
- `git revert e154aa4` — quita botón Terminado + restaura `setTimeout` original
- `git revert 5a68fc5` — quita spinner + bloqueo
- `git revert 57f13cf` — quita responsive CSS
- `git revert 0d1aa83` — restaura auto-submit del PIN (volverá el bug del ←)

## NO mergear

Dejar en review. Recomendación de orden:
1. Mergear PR #5 (`fix/kiosk-sos-render-y-ocultar-comida`) primero — fixes críticos
2. Luego mergear este PR — mejoras UX

Si se mergea este primero, no hay conflicto con #5 (archivos tocados son mayormente disjuntos salvo por líneas cercanas en kiosk.js que resolverán limpio).

https://claude.ai/code/session_019xG4Q27EDoJHoMLSmTk9p1