### PR TITLE
fix(kiosk): pulir alineación + puntitos + nombre en grid

### DIFF
--- a/operaciones/kiosk/css/kiosk.css
+++ b/operaciones/kiosk/css/kiosk.css
@@ -164,19 +164,23 @@ html,body{height:100%;overflow:hidden;font-family:'Inter',-apple-system,sans-ser
   justify-content:center;
 }
 .kiosk-pin-dot{
-  width:18px;height:18px;border-radius:50%;
-  background:#e0e0e0;transition:background 0.2s;
-  border:2px solid #ccc;
+  width:24px;height:24px;border-radius:50%;
+  background:#e0e0e0;border:2px solid #ccc;
+  transition:background 0.1s, border-color 0.1s, transform 0.1s, box-shadow 0.1s;
 }
-.kiosk-pin-dot.filled{background:#107C10;border-color:#107C10}
+.kiosk-pin-dot.filled{
+  background:#107C10;border-color:#107C10;
+  transform:scale(1.05);
+  box-shadow:0 2px 6px rgba(16,124,16,0.3);
+}
 .kiosk-pin-dot.error{background:#D83B01;border-color:#D83B01}
 
 .kiosk-verify-grid{
   display:grid;
-  grid-template-columns:1fr 1.2fr;
-  gap:20px;align-items:center;
-  width:100%;max-width:560px;
-  margin:0 auto 16px;
+  grid-template-columns:auto 1fr;
+  gap:14px;align-items:center;
+  width:100%;max-width:420px;
+  margin:48px auto 16px;
 }
 .kiosk-verify-cam{display:flex;justify-content:center;align-items:center}
 .kiosk-verify-info{
@@ -184,7 +188,7 @@ html,body{height:100%;overflow:hidden;font-family:'Inter',-apple-system,sans-ser
   gap:8px;text-align:center;
 }
 .kiosk-camera-preview{
-  width:180px;height:180px;border-radius:50%;
+  width:120px;height:120px;border-radius:50%;
   object-fit:cover;border:4px solid #107C10;
   background:#f5f5f5;
   box-shadow:0 4px 16px rgba(16,124,16,0.15);
@@ -249,6 +253,7 @@ html,body{height:100%;overflow:hidden;font-family:'Inter',-apple-system,sans-ser
   border-radius:10px;cursor:pointer;
   font-family:inherit;
   box-shadow:0 1px 3px rgba(0,0,0,0.04);
+  margin-bottom:16px;align-self:flex-start;
 }
 .kiosk-back:hover{border-color:#107C10;background:#f0faf0}
 
@@ -329,7 +334,7 @@ html,body{height:100%;overflow:hidden;font-family:'Inter',-apple-system,sans-ser
 .tipo-regreso:hover{border-color:#0078D4;background:#f0f7ff}
 .tipo-salida:hover{border-color:#D83B01;background:#fff5f0}
 
-/* ── Responsive: keypad/cámara más chicos en pantallas bajas ── */
+/* ── Responsive: keypad más chico en pantallas bajas ── */
 @media (max-height: 750px), (max-width: 480px) {
   .kiosk-pin-btn{
     padding:14px;
@@ -346,32 +351,29 @@ html,body{height:100%;overflow:hidden;font-family:'Inter',-apple-system,sans-ser
     font-size:18px;
     margin-top:10px;
   }
-  .kiosk-camera-preview{
-    width:140px;
-    height:140px;
-  }
 }
 
 /* ── Viewport angosto: reducir cámara e info ── */
 @media (max-width: 400px) {
   .kiosk-verify-grid{
-    grid-template-columns:1fr 1.2fr;
+    grid-template-columns:auto 1fr;
     gap:12px;
   }
   .kiosk-camera-preview{
-    width:110px;height:110px;
+    width:100px;height:100px;
     border-width:3px;
   }
+  .kiosk-pin-dot{width:20px;height:20px}
   .kiosk-pin-nombre{font-size:13px;padding:6px 10px}
   .kiosk-verify-subtitle{font-size:13px}
 }
 
 /* ── Viewport bajo: compactar info + pin-pad ── */
 @media (max-height: 600px) {
-  .kiosk-verify-grid{margin-bottom:8px;gap:12px}
-  .kiosk-camera-preview{width:120px;height:120px}
-  .kiosk-pin-dots{margin:8px 0}
-  .kiosk-pin-dot{width:14px;height:14px}
+  .kiosk-verify-grid{margin-top:32px;margin-bottom:8px;gap:12px}
+  .kiosk-camera-preview{width:90px;height:90px}
+  .kiosk-pin-dots{margin:8px 0;gap:12px}
+  .kiosk-pin-dot{width:18px;height:18px}
   .kiosk-pin-nombre{padding:6px 10px;font-size:13px}
   .kiosk-pin-btn{min-height:48px;padding:10px;font-size:20px}
   .kiosk-pin-ok-btn{padding:12px;font-size:16px;margin-top:6px}


### PR DESCRIPTION
## Resumen

Pulido visual de la pantalla PIN (ks-verify) tras feedback de producción en Android portrait (~400×850). Sólo toca `operaciones/kiosk/css/kiosk.css`. **Sin cambios en HTML ni en JS.**

## Fixes aplicados

| # | Problema observado | Solución |
|---|--------------------|----------|
| 1 | Cámara desalineada respecto al info | **Ya resuelto en PR #7** (`align-items: center`). Sin cambio. |
| 2 | Dots muy chicos y opacos al llenar | 18 → **24 px**, estado `.filled` con `scale(1.05)` + `box-shadow` verde |
| 3 | Nombre fuera del grid | **Ya resuelto en PR #7** (`#ksPinNombre` ya estaba anidado dentro de `.kiosk-verify-info`). Sin cambio. |
| 4 | `1fr 1.2fr` cortaba el texto largo | Cambio a `auto 1fr` + `max-width 420` + `gap 14`. Cámara 180 → **120 px**. |
| 5 | Botón "← Volver" pegado al contenido | Grid gana `margin-top: 48px` (32 en `<600h`) + `.kiosk-back` recibe `margin-bottom: 16px` + `align-self: flex-start` para contextos no-absolute. |

### Extra
- Removido override obsoleto de `.kiosk-camera-preview` en la media query `max-height: 750 | max-width: 480` que apuntaba a 140×140 (más grande que la nueva base de 120). Ahora la progresión responsive es **monótona descendente**: 120 → 100 (<400 w) → 90 (<600 h).
- Dots también escalan: 24 → 20 (<400 w) → 18 (<600 h).

## Diff
1 archivo, +22 / −20 líneas.

## Test plan
- [ ] Abrir kiosk en móvil portrait ~400×850 → ks-verify sin scroll, Confirmar visible.
- [ ] "Obteniendo ubicación..." cabe en **una sola línea**.
- [ ] Banner `👷 Nombre` dentro del cuadrante derecho, pegado al PIN.
- [ ] Teclear 1–2 dígitos → dots verdes grandes con sombra.
- [ ] Visible separación entre "← Volver" y la cámara.
- [ ] Probar `max-height: 600px` → layout compacto, todo cabe.

https://claude.ai/code/session_019xG4Q27EDoJHoMLSmTk9p1