### PR TITLE
feat(website): flag icons in lang switcher + mobile hamburger nav

### DIFF
--- a/website/index.html
+++ b/website/index.html
@@ -52,9 +52,10 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
   .logo-img { height: 44px; width: auto; display: block; }
   .nav-right { display: flex; align-items: center; gap: 1.25rem; }
   .lang-switcher { display: flex; gap: 0.3rem; }
-  .lang-btn { background: none; border: none; cursor: pointer; padding: 0.3rem 0.4rem; font-family: 'JetBrains Mono', monospace; font-size: 0.75rem; font-weight: 500; color: var(--text-muted); transition: color 0.15s; line-height: 1; }
+  .lang-btn { background: none; border: none; cursor: pointer; padding: 0.3rem 0.5rem; font-family: 'JetBrains Mono', monospace; font-size: 0.75rem; font-weight: 500; color: var(--text-muted); transition: color 0.15s; line-height: 1; display: inline-flex; align-items: center; gap: 0.3em; font-variant-emoji: text; }
   .lang-btn:hover { color: var(--text); }
   .lang-btn.active { color: var(--brand-red); font-weight: 700; }
+  .lang-btn-mob { display: inline-flex; align-items: center; justify-content: center; gap: 0.3em; font-variant-emoji: text; }
   .nav-links { display: flex; align-items: center; gap: 1.5rem; }
   .nav-links a { font-family: 'JetBrains Mono', monospace; font-size: 0.78rem; letter-spacing: 0.1em; text-transform: uppercase; color: var(--text); text-decoration: none; transition: color 0.15s; }
   .nav-links a:hover { color: var(--brand-red); }
@@ -219,6 +220,34 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
   .footer-bottom .brand-bar { margin: 0 0 1.5rem; height: 4px; }
   .whatsapp-float { position: fixed; bottom: 24px; right: 24px; width: 56px; height: 56px; border-radius: 50%; background: #25D366; color: #FFF; display: flex; align-items: center; justify-content: center; box-shadow: 0 8px 24px rgba(37,211,102,0.4); z-index: 999; transition: transform 0.2s, box-shadow 0.2s; text-decoration: none; }
   .whatsapp-float:hover { transform: scale(1.08); box-shadow: 0 12px 32px rgba(37,211,102,0.5); }
+  .nav-hamburger { display: none; flex-direction: column; justify-content: center; gap: 5px; background: none; border: none; cursor: pointer; padding: 0.5rem; border-radius: 6px; transition: background 0.15s; z-index: 1001; color: var(--text); }
+  .nav-hamburger:hover { background: rgba(0,0,0,0.06); }
+  .ham-bar { display: block; width: 22px; height: 2px; background: currentColor; border-radius: 2px; transition: transform 0.25s ease, opacity 0.2s ease; }
+  .nav-hamburger[aria-expanded="true"] { color: #FFF; position: fixed; top: 14px; right: 14px; }
+  .nav-hamburger[aria-expanded="true"]:hover { background: rgba(255,255,255,0.1); }
+  .nav-hamburger[aria-expanded="true"] .ham-bar:nth-child(1) { transform: translateY(7px) rotate(45deg); }
+  .nav-hamburger[aria-expanded="true"] .ham-bar:nth-child(2) { opacity: 0; transform: scaleX(0); }
+  .nav-hamburger[aria-expanded="true"] .ham-bar:nth-child(3) { transform: translateY(-7px) rotate(-45deg); }
+  .mobile-drawer { position: fixed; top: 0; right: 0; height: 100%; width: min(320px, 88vw); background: var(--bg-dark); color: #FFF; z-index: 1000; padding: 5rem 1.75rem 2rem; display: flex; flex-direction: column; gap: 2rem; transform: translateX(100%); transition: transform 0.28s cubic-bezier(0.4, 0, 0.2, 1); box-shadow: -8px 0 40px rgba(0,0,0,0.35); }
+  .mobile-drawer.is-open { transform: translateX(0); }
+  .mobile-nav-links { display: flex; flex-direction: column; gap: 0; }
+  .mob-link { display: block; padding: 1rem 0; font-size: 1.15rem; font-weight: 600; color: rgba(255,255,255,0.85); text-decoration: none; border-bottom: 1px solid rgba(255,255,255,0.08); transition: color 0.15s, padding-left 0.15s; font-family: 'Manrope', sans-serif; }
+  .mob-link:hover { color: #FFF; padding-left: 0.5rem; }
+  .mobile-drawer-footer { margin-top: auto; display: flex; flex-direction: column; gap: 1rem; }
+  .mobile-lang-switcher { display: flex; gap: 0.5rem; }
+  .lang-btn-mob { flex: 1; background: rgba(255,255,255,0.07); border: 1px solid rgba(255,255,255,0.12); color: rgba(255,255,255,0.75); border-radius: 6px; padding: 0.55rem 0; font-size: 0.78rem; cursor: pointer; transition: background 0.15s, color 0.15s; font-family: 'JetBrains Mono', monospace; }
+  .lang-btn-mob:hover { background: rgba(255,255,255,0.14); color: #FFF; }
+  .lang-btn-mob.active { background: rgba(220,85,68,0.18); border-color: var(--brand-red); color: #FFF; }
+  .mob-cta { display: block; text-align: center; width: 100%; box-sizing: border-box; }
+  .drawer-backdrop { position: fixed; inset: 0; background: rgba(0,0,0,0.55); z-index: 999; opacity: 0; pointer-events: none; transition: opacity 0.28s ease; backdrop-filter: blur(2px); -webkit-backdrop-filter: blur(2px); }
+  .drawer-backdrop.is-visible { opacity: 1; pointer-events: all; }
+  @media (max-width: 768px) {
+    .nav-hamburger { display: flex; }
+    .nav-links, .nav-right { display: none !important; }
+  }
+  @media (min-width: 769px) {
+    .mobile-drawer, .drawer-backdrop, .nav-hamburger { display: none !important; }
+  }
   @media (max-width: 700px) {
     nav { padding: 0.8rem 1rem; }
     .logo-img { height: 34px; }
@@ -280,13 +309,35 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
   </div>
   <div class="nav-right">
     <div class="lang-switcher" role="group" aria-label="Language selector">
-      <button type="button" class="lang-btn active" data-lang="es">ES</button>
-      <button type="button" class="lang-btn" data-lang="en">EN</button>
-      <button type="button" class="lang-btn" data-lang="pt">PT</button>
+      <button type="button" class="lang-btn active" data-lang="es">🇲🇽&nbsp;ES</button>
+      <button type="button" class="lang-btn" data-lang="en">🇺🇸&nbsp;EN</button>
+      <button type="button" class="lang-btn" data-lang="pt">🇧🇷&nbsp;PT</button>
     </div>
     <a href="#contact" class="nav-cta" data-i18n="cta_nav">Cotizar</a>
   </div>
+  <button class="nav-hamburger" id="navHamburger" aria-label="Abrir menú" aria-expanded="false" aria-controls="mobileDrawer">
+    <span class="ham-bar"></span>
+    <span class="ham-bar"></span>
+    <span class="ham-bar"></span>
+  </button>
 </nav>
+<div class="mobile-drawer" id="mobileDrawer" aria-hidden="true">
+  <nav class="mobile-nav-links" aria-label="Navegación mobile">
+    <a href="#caps"      class="mob-link" data-i18n="nav_services">Servicios</a>
+    <a href="#nosotros"  class="mob-link" data-i18n="nav_about">Nosotros</a>
+    <a href="#proyectos" class="mob-link" data-i18n="nav_projects">Proyectos</a>
+    <a href="#contact"   class="mob-link" data-i18n="nav_contact">Contacto</a>
+  </nav>
+  <div class="mobile-drawer-footer">
+    <div class="mobile-lang-switcher" role="group" aria-label="Language selector">
+      <button type="button" class="lang-btn-mob active" data-lang="es" onclick="setLang('es')">🇲🇽&nbsp;ES</button>
+      <button type="button" class="lang-btn-mob" data-lang="en" onclick="setLang('en')">🇺🇸&nbsp;EN</button>
+      <button type="button" class="lang-btn-mob" data-lang="pt" onclick="setLang('pt')">🇧🇷&nbsp;PT</button>
+    </div>
+    <a href="#contact" class="btn-primary mob-cta" data-i18n="cta_nav">Cotizar →</a>
+  </div>
+</div>
+<div class="drawer-backdrop" id="drawerBackdrop"></div>
 <section class="hero">
   <div class="hero-inner">
     <div class="hero-eyebrow" data-i18n="hero_eyebrow">— Servicios EPC industriales · Desde 2014</div>
@@ -1127,11 +1178,12 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
       const txt = TRANSLATIONS[lang][key];
       if (txt != null) el.innerText = txt;
     });
-    document.querySelectorAll('.lang-btn').forEach(b => {
+    document.querySelectorAll('.lang-btn, .lang-btn-mob').forEach(b => {
       b.classList.toggle('active', b.getAttribute('data-lang') === lang);
     });
     try { localStorage.setItem('fts_lang', lang); } catch (e) {}
   }
+  window.setLang = applyLang;
   document.querySelectorAll('.lang-btn').forEach(b => {
     b.addEventListener('click', () => applyLang(b.getAttribute('data-lang')));
   });
@@ -1180,6 +1232,38 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
       }
     });
   }
+</script>
+<script>
+  /* Mobile nav drawer */
+  (function() {
+    const hamburger = document.getElementById('navHamburger');
+    const drawer    = document.getElementById('mobileDrawer');
+    const backdrop  = document.getElementById('drawerBackdrop');
+    const mobLinks  = document.querySelectorAll('.mob-link, .mob-cta, .lang-btn-mob');
+    if (!hamburger || !drawer || !backdrop) return;
+    function openDrawer() {
+      drawer.classList.add('is-open');
+      backdrop.classList.add('is-visible');
+      hamburger.setAttribute('aria-expanded', 'true');
+      hamburger.setAttribute('aria-label', 'Cerrar menú');
+      drawer.setAttribute('aria-hidden', 'false');
+      document.body.style.overflow = 'hidden';
+    }
+    function closeDrawer() {
+      drawer.classList.remove('is-open');
+      backdrop.classList.remove('is-visible');
+      hamburger.setAttribute('aria-expanded', 'false');
+      hamburger.setAttribute('aria-label', 'Abrir menú');
+      drawer.setAttribute('aria-hidden', 'true');
+      document.body.style.overflow = '';
+    }
+    hamburger.addEventListener('click', function() {
+      drawer.classList.contains('is-open') ? closeDrawer() : openDrawer();
+    });
+    backdrop.addEventListener('click', closeDrawer);
+    mobLinks.forEach(function(link) { link.addEventListener('click', closeDrawer); });
+    document.addEventListener('keydown', function(e) { if (e.key === 'Escape') closeDrawer(); });
+  })();
 </script>
 </body>
 </html>


### PR DESCRIPTION
Two independent changes bundled in a single commit.

## A — Flag icons in the language switcher

Desktop `.lang-btn` buttons now read `🇲🇽 ES` / `🇺🇸 EN` / `🇧🇷 PT` (flag + non-breaking space + code). `.lang-btn` gets `display: inline-flex; align-items: center; font-variant-emoji: text;` so the emoji baseline lines up with the JetBrains Mono code on every OS. Same treatment applied to the new `.lang-btn-mob` class used inside the drawer. `applyLang` already only touches `data-i18n` text and toggles `.active`, so the new content stays put on language change.

## B — Mobile hamburger + slide-in drawer

**HTML** — added `<button id="navHamburger">` with three `.ham-bar` spans inside the existing `<nav>` (after `.nav-right`), then `<div id="mobileDrawer">` and `<div id="drawerBackdrop">` as siblings of `<nav>` so they stack independently of the sticky nav. Drawer contains 4 mob-links (`#caps`, `#nosotros`, `#proyectos`, `#contact`) using the existing i18n keys (`nav_services`, `nav_about`, `nav_projects`, `nav_contact`), a 3-button mobile lang switcher with flags, and a primary CTA reusing `cta_nav`.

**CSS** — full hamburger animation (3 bars → X via `aria-expanded="true"` rotations), drawer slides from the right (`width: min(320px, 88vw)` on `--bg-dark`), backdrop with `backdrop-filter: blur(2px)` and `rgba(0,0,0,0.55)`. When open the hamburger jumps to `position: fixed; top:14px; right:14px;` and switches to white so the close-X stays tappable on top of the dark drawer. New media queries:
- `max-width: 768px` → show `.nav-hamburger`, hide `.nav-links` and `.nav-right` (which contains the desktop switcher + Cotizar)
- `min-width: 769px` → hide drawer + backdrop + hamburger

**JS** — IIFE at end of body wires `click` (toggle), backdrop `click`, all `.mob-link / .mob-cta / .lang-btn-mob` `click`, and `Escape` keydown to `closeDrawer()`. `openDrawer()` locks body scroll via `overflow: hidden`. `aria-expanded` and `aria-hidden` flip with state. Inside the existing language script, `window.setLang = applyLang` exposes the function globally so the inline `onclick="setLang('es')"` handlers in the drawer's lang buttons resolve. `applyLang` selector widened to `.lang-btn, .lang-btn-mob` so the active state reflects in both switchers.

## Adjustments vs. spec

- i18n keys use the project's underscore convention: `nav_services` (not `nav.caps`), `nav_about`, `nav_projects`, `nav_contact`, `cta_nav` (not `nav.cta`).
- `setLang` is aliased to existing `applyLang` instead of being a new function (the rest of the page uses `applyLang`).
- `.lang-btn-mob` added to the close-on-click selector so changing language in the drawer also closes it (cleaner UX; one extra tap saved).
- The hamburger CSS color flips to white when `aria-expanded="true"` and pins `position: fixed` on the top-right so the close X stays visible on top of the dark drawer (without this it would either be invisible or scroll out with the original nav).

---
_Generated by [Claude Code](https://claude.ai/code/session_011LxJUE5JCy4kM6CLuN4gCQ)_