### PR TITLE
feat(website): SVG technical illustrations for capability and project cards

### DIFF
--- a/website/index.html
+++ b/website/index.html
@@ -113,6 +113,13 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
   .cap-chip { font-size: 0.72rem; color: var(--brand-red); background: rgba(220,85,68,0.06); border: 1px solid rgba(220,85,68,0.2); border-radius: 100px; padding: 0.25rem 0.7rem; text-decoration: none; transition: background 0.2s, border-color 0.2s; line-height: 1.3; }
   .cap-chip:hover { background: rgba(220,85,68,0.14); border-color: rgba(220,85,68,0.35); }
   @media (max-width: 900px) { .caps-grid { grid-template-columns: 1fr; } }
+  .cap-visual { margin: -2rem -1.75rem 0; height: 180px; overflow: hidden; border-radius: 12px 12px 0 0; display: block; }
+  .cap-visual svg { width: 100%; height: 100%; display: block; }
+  .proj-visual { margin: -1.8rem -1.8rem 1rem; height: 160px; overflow: hidden; display: block; }
+  .proj-visual svg { width: 100%; height: 100%; display: block; }
+  .blueprint-aut { background: #080d18; }
+  .blueprint-eng { background: #0a1628; }
+  .blueprint-em  { background: #110806; }
   .trust-strip { background: var(--bg-warm); padding: 3rem 2rem; border-top: 1px solid var(--border); border-bottom: 1px solid var(--border); }
   .trust-inner { max-width: 1400px; margin: 0 auto; }
   .trust-label { font-family: 'JetBrains Mono', monospace; font-size: 0.75rem; letter-spacing: 0.18em; color: var(--brand-red); text-transform: uppercase; text-align: center; margin-bottom: 1.5rem; font-weight: 500; }
@@ -450,6 +457,25 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
     </article>
     <div class="projects-grid">
       <article class="project-card">
+        <div class="proj-visual blueprint-aut" aria-hidden="true">
+          <svg width="100%" height="100%" viewBox="0 0 320 200" xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="xMidYMid slice">
+            <defs>
+              <linearGradient id="pf-gruma" x1="0" y1="0" x2="0" y2="1"><stop offset="50%" stop-color="transparent"/><stop offset="100%" stop-color="#080d18"/></linearGradient>
+            </defs>
+            <circle cx="80"  cy="100" r="18" fill="none" stroke="rgba(220,85,68,0.4)" stroke-width="1.2"/>
+            <circle cx="160" cy="100" r="18" fill="none" stroke="rgba(220,85,68,0.4)" stroke-width="1.2"/>
+            <circle cx="240" cy="100" r="18" fill="none" stroke="rgba(220,85,68,0.4)" stroke-width="1.2"/>
+            <path d="M 98 100 L 142 100 M 178 100 L 222 100" stroke="rgba(220,85,68,0.35)" stroke-width="1.2" stroke-dasharray="4,3"/>
+            <text x="80"  y="104" fill="rgba(220,85,68,0.55)" font-size="7" text-anchor="middle" font-family="monospace">CA</text>
+            <text x="160" y="104" fill="rgba(220,85,68,0.55)" font-size="7" text-anchor="middle" font-family="monospace">TX</text>
+            <text x="240" y="104" fill="rgba(220,85,68,0.55)" font-size="7" text-anchor="middle" font-family="monospace">TX</text>
+            <text x="80"  y="130" fill="rgba(220,85,68,0.3)" font-size="6" text-anchor="middle" font-family="monospace">Hayward</text>
+            <text x="160" y="130" fill="rgba(220,85,68,0.3)" font-size="6" text-anchor="middle" font-family="monospace">Houston</text>
+            <text x="240" y="130" fill="rgba(220,85,68,0.3)" font-size="6" text-anchor="middle" font-family="monospace">San Antonio</text>
+            <text x="160" y="168" fill="rgba(220,85,68,0.35)" font-size="7" text-anchor="middle" font-family="monospace">GRUMA / AZTECA MILLING · VFD MIGRATION</text>
+            <rect width="320" height="200" fill="url(#pf-gruma)"/>
+          </svg>
+        </div>
         <div class="project-tag" data-i18n="proj1_tag">Automatización · Migración</div>
         <div class="project-client" data-i18n="proj1_client">Planta alimenticia US líder</div>
         <div class="project-location">Hayward, CA</div>
@@ -506,6 +532,32 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
     </div>
     <div class="caps-grid">
       <div class="cap-card" id="ingenieria">
+        <div class="cap-visual cap-visual-eng" aria-hidden="true">
+          <svg width="100%" height="100%" viewBox="0 0 320 200" xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="xMidYMid slice">
+            <defs>
+              <pattern id="grid-eng" width="40" height="40" patternUnits="userSpaceOnUse"><path d="M 40 0 L 0 0 0 40" fill="none" stroke="rgba(59,130,246,0.12)" stroke-width="0.5"/></pattern>
+              <linearGradient id="fade-eng" x1="0" y1="0" x2="0" y2="1"><stop offset="40%" stop-color="transparent"/><stop offset="100%" stop-color="#0D1117"/></linearGradient>
+            </defs>
+            <rect width="320" height="200" fill="#0D1117"/>
+            <rect width="320" height="200" fill="url(#grid-eng)"/>
+            <path d="M 20 170 L 160 40 L 300 170" stroke="rgba(59,130,246,0.6)" stroke-width="1.5" fill="none"/>
+            <path d="M 20 170 L 300 170" stroke="rgba(59,130,246,0.4)" stroke-width="1"/>
+            <path d="M 90 170 L 125 105 M 160 170 L 160 40 M 230 170 L 195 105" stroke="rgba(59,130,246,0.3)" stroke-width="0.8"/>
+            <circle cx="20"  cy="170" r="4" fill="rgba(59,130,246,0.7)"/>
+            <circle cx="160" cy="40"  r="4" fill="rgba(59,130,246,0.7)"/>
+            <circle cx="300" cy="170" r="4" fill="rgba(59,130,246,0.7)"/>
+            <circle cx="90"  cy="170" r="3" fill="rgba(59,130,246,0.5)"/>
+            <circle cx="160" cy="170" r="3" fill="rgba(59,130,246,0.5)"/>
+            <circle cx="230" cy="170" r="3" fill="rgba(59,130,246,0.5)"/>
+            <path d="M 20 185 L 300 185" stroke="rgba(59,130,246,0.2)" stroke-width="0.5" stroke-dasharray="4,4"/>
+            <path d="M 20 180 L 20 190 M 300 180 L 300 190" stroke="rgba(59,130,246,0.3)" stroke-width="0.5"/>
+            <text x="160" y="196" fill="rgba(59,130,246,0.4)" font-size="8" text-anchor="middle" font-family="monospace">L = 14.00 m</text>
+            <text x="168" y="34"  fill="rgba(59,130,246,0.5)" font-size="7" font-family="monospace">H = 8.30 m</text>
+            <rect x="240" y="12" width="68" height="16" rx="2" fill="rgba(59,130,246,0.08)" stroke="rgba(59,130,246,0.2)" stroke-width="0.5"/>
+            <text x="244" y="23" fill="rgba(59,130,246,0.5)" font-size="7" font-family="monospace">LRFD / AISC</text>
+            <rect width="320" height="200" fill="url(#fade-eng)"/>
+          </svg>
+        </div>
         <div class="cap-number">01</div>
         <div class="cap-icon"><svg width="32" height="32" viewBox="0 0 32 32" fill="none" aria-hidden="true"><path d="M4 28L16 4L28 28" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/><path d="M8 20H24" stroke="currentColor" stroke-width="2" stroke-linecap="round"/></svg></div>
         <h3 class="cap-title" data-i18n="caps_eng_title">Ingeniería</h3>
@@ -527,6 +579,31 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
         </div>
       </div>
       <div class="cap-card" id="automatizacion">
+        <div class="cap-visual cap-visual-aut" aria-hidden="true">
+          <svg width="100%" height="100%" viewBox="0 0 220 200" xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="xMidYMid slice">
+            <defs>
+              <pattern id="grid-aut" width="22" height="22" patternUnits="userSpaceOnUse"><path d="M 22 0 L 0 0 0 22" fill="none" stroke="rgba(220,85,68,0.07)" stroke-width="0.5"/></pattern>
+              <linearGradient id="fade-aut" x1="0" y1="0" x2="0" y2="1"><stop offset="40%" stop-color="transparent"/><stop offset="100%" stop-color="#080F1A"/></linearGradient>
+            </defs>
+            <rect width="220" height="200" fill="#080F1A"/>
+            <rect width="220" height="200" fill="url(#grid-aut)"/>
+            <path d="M 20 60 L 80 60 L 80 100 L 140 100 L 140 60 L 200 60" stroke="rgba(220,85,68,0.5)" stroke-width="1.2" fill="none"/>
+            <path d="M 60 20 L 60 60 M 120 60 L 120 20 M 160 20 L 160 60" stroke="rgba(220,85,68,0.3)" stroke-width="1" fill="none"/>
+            <path d="M 40 140 L 180 140 M 40 160 L 180 160" stroke="rgba(220,85,68,0.25)" stroke-width="1" fill="none" stroke-dasharray="6,4"/>
+            <path d="M 40 100 L 40 140 M 180 100 L 180 140" stroke="rgba(220,85,68,0.2)" stroke-width="0.8" fill="none"/>
+            <rect x="85" y="72" width="50" height="30" rx="3" fill="rgba(220,85,68,0.1)" stroke="rgba(220,85,68,0.45)" stroke-width="1"/>
+            <text x="110" y="91" fill="rgba(220,85,68,0.6)" font-size="7" text-anchor="middle" font-family="monospace" font-weight="500">PLC</text>
+            <path d="M 85 78 L 75 78 M 85 84 L 75 84 M 85 90 L 75 90 M 85 96 L 75 96" stroke="rgba(220,85,68,0.35)" stroke-width="0.8"/>
+            <path d="M 135 78 L 145 78 M 135 84 L 145 84 M 135 90 L 145 90 M 135 96 L 145 96" stroke="rgba(220,85,68,0.35)" stroke-width="0.8"/>
+            <circle cx="80"  cy="60"  r="3" fill="rgba(220,85,68,0.7)"/>
+            <circle cx="140" cy="60"  r="3" fill="rgba(220,85,68,0.7)"/>
+            <circle cx="40"  cy="140" r="2.5" fill="rgba(220,85,68,0.5)"/>
+            <circle cx="180" cy="140" r="2.5" fill="rgba(220,85,68,0.5)"/>
+            <rect x="150" y="155" width="58" height="16" rx="2" fill="rgba(220,85,68,0.07)" stroke="rgba(220,85,68,0.2)" stroke-width="0.5"/>
+            <text x="154" y="166" fill="rgba(220,85,68,0.45)" font-size="7" font-family="monospace">VFD / SCADA</text>
+            <rect width="220" height="200" fill="url(#fade-aut)"/>
+          </svg>
+        </div>
         <div class="cap-number">02</div>
         <div class="cap-icon"><svg width="32" height="32" viewBox="0 0 32 32" fill="none" aria-hidden="true"><rect x="4" y="10" width="24" height="16" rx="2" stroke="currentColor" stroke-width="2"/><circle cx="11" cy="18" r="2.5" stroke="currentColor" stroke-width="2"/><circle cx="21" cy="18" r="2.5" stroke="currentColor" stroke-width="2"/><path d="M11 10V6M21 10V6M16 6V4" stroke="currentColor" stroke-width="2" stroke-linecap="round"/></svg></div>
         <h3 class="cap-title" data-i18n="caps_aut_title">Automatización</h3>
@@ -548,6 +625,33 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
         </div>
       </div>
       <div class="cap-card" id="electromecanica">
+        <div class="cap-visual cap-visual-em" aria-hidden="true">
+          <svg width="100%" height="100%" viewBox="0 0 220 200" xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="xMidYMid slice">
+            <defs>
+              <pattern id="grid-em" width="20" height="20" patternUnits="userSpaceOnUse"><path d="M 20 0 L 0 0 0 20" fill="none" stroke="rgba(240,140,40,0.07)" stroke-width="0.5"/></pattern>
+              <linearGradient id="fade-em" x1="0" y1="0" x2="0" y2="1"><stop offset="40%" stop-color="transparent"/><stop offset="100%" stop-color="#110806"/></linearGradient>
+            </defs>
+            <rect width="220" height="200" fill="#110806"/>
+            <rect width="220" height="200" fill="url(#grid-em)"/>
+            <path d="M 20 50 L 200 50" stroke="rgba(240,140,40,0.6)" stroke-width="2" fill="none"/>
+            <path d="M 50 50 L 50 120 M 110 50 L 110 120 M 170 50 L 170 120" stroke="rgba(240,140,40,0.45)" stroke-width="1.2"/>
+            <rect x="44"  y="72" width="12" height="8" rx="1" fill="none" stroke="rgba(240,140,40,0.5)" stroke-width="1"/>
+            <rect x="104" y="72" width="12" height="8" rx="1" fill="none" stroke="rgba(240,140,40,0.5)" stroke-width="1"/>
+            <rect x="164" y="72" width="12" height="8" rx="1" fill="none" stroke="rgba(240,140,40,0.5)" stroke-width="1"/>
+            <circle cx="50"  cy="138" r="12" fill="none" stroke="rgba(240,140,40,0.4)" stroke-width="1.2"/>
+            <text x="50"  y="142" fill="rgba(240,140,40,0.5)" font-size="7" text-anchor="middle" font-family="monospace">M</text>
+            <circle cx="110" cy="138" r="12" fill="none" stroke="rgba(240,140,40,0.4)" stroke-width="1.2"/>
+            <text x="110" y="142" fill="rgba(240,140,40,0.5)" font-size="7" text-anchor="middle" font-family="monospace">M</text>
+            <circle cx="170" cy="138" r="12" fill="none" stroke="rgba(240,140,40,0.4)" stroke-width="1.2"/>
+            <text x="170" y="142" fill="rgba(240,140,40,0.5)" font-size="7" text-anchor="middle" font-family="monospace">Ω</text>
+            <circle cx="110" cy="30" r="10" fill="none" stroke="rgba(240,140,40,0.35)" stroke-width="1"/>
+            <path d="M 110 20 L 110 50" stroke="rgba(240,140,40,0.3)" stroke-width="0.8"/>
+            <text x="14"  y="46"  fill="rgba(240,140,40,0.4)" font-size="7" font-family="monospace">13.8 kV</text>
+            <rect x="148" y="155" width="56" height="16" rx="2" fill="rgba(240,140,40,0.07)" stroke="rgba(240,140,40,0.2)" stroke-width="0.5"/>
+            <text x="152" y="166" fill="rgba(240,140,40,0.4)" font-size="7" font-family="monospace">MT / BT SLD</text>
+            <rect width="220" height="200" fill="url(#fade-em)"/>
+          </svg>
+        </div>
         <div class="cap-number">03</div>
         <div class="cap-icon"><svg width="32" height="32" viewBox="0 0 32 32" fill="none" aria-hidden="true"><path d="M16 4V28M4 16H28" stroke="currentColor" stroke-width="2" stroke-linecap="round"/><path d="M8 8L24 24M24 8L8 24" stroke="currentColor" stroke-width="1.2" stroke-linecap="round" opacity="0.4"/><circle cx="16" cy="16" r="5" stroke="currentColor" stroke-width="2"/></svg></div>
         <h3 class="cap-title" data-i18n="caps_em_title">Infraestructura Electromecánica</h3>


### PR DESCRIPTION
Adds technical SVG header illustrations to the three capability cards and one project card. Purely additive — no existing HTML, CSS, JS or i18n was modified.

## What changed

### Capability cards (3 of 3)
- **Ingeniería** — gets `.cap-visual.cap-visual-eng`: blueprint truss with annotated dimensions (L=14m, H=8.3m), LRFD/AISC tag, blue palette on `#0D1117`.
- **Automatización** — gets `.cap-visual.cap-visual-aut`: PLC block with bus lines + inputs/outputs + ladder dashes, VFD/SCADA tag, coral palette on `#080F1A`.
- **Infraestructura Electromecánica** — gets `.cap-visual.cap-visual-em`: single-line diagram (13.8kV bus, three feeders, breakers, M/M/Ω consumers), MT/BT SLD tag, orange palette on `#110806`.

Each visual is inserted as the first child of its `.cap-card`, before `.cap-number`. New CSS rule uses negative margins (`-2rem -1.75rem 0`) to pull the visual flush with the card edges past the card's `padding: 2rem 1.75rem 1.75rem`, plus `border-radius: 12px 12px 0 0` so the visual matches the card's rounded top corners and butts flat against the text content below.

### Project cards (1 of 6)
Only one of the six grid project cards has a clean client/topic match to the three blueprints the spec provided. Specifically:

- **`proj1`** (Migración 45 VFDs, "Planta alimenticia US líder", Hayward CA) is **GRUMA** per `CLAUDE.md` context (real GRUMA Hayward CA client). Gets `.proj-visual.blueprint-aut` — the spec's GRUMA / Azteca Milling VFD migration SVG with CA / TX / TX site markers and Hayward / Houston / San Antonio annotations.

The other 5 project cards are skipped:
- **Featured-case Multipanel/Topo Chico** (Nalco) already has its own `.featured-case-visual` placeholder with `"▸ MULTIPANEL · TOPOCHICO"` label. Per spec ("Si las project cards ya tienen imagen de cabecera, NO las modifiques") — left untouched.
- **`proj2`** (Subestación 34.5kV, **"Confidencial · Industria pesada"**) topologically matches `blueprint-em` (substation SLD), but that SVG bakes in the label `"ARCA CONTINENTAL · TOPO CHICO SLD"`. Putting an explicit client name on a card explicitly labeled "Confidencial" would be a false attribution, so skipped.
- **`proj3`–`proj6`** have no Nalco/GRUMA/Arca match — skipped.

If you want the EM blueprint anyway on `proj2` with the "ARCA CONTINENTAL" label removed, or the Nalco blueprint on the featured-case (replacing the current generic placeholder), I can do it in a follow-up.

### CSS additions (5 new rules, no edits to existing)
```
.cap-visual { margin: -2rem -1.75rem 0; height: 180px; overflow: hidden; border-radius: 12px 12px 0 0; display: block; }
.cap-visual svg { width: 100%; height: 100%; display: block; }
.proj-visual { margin: -1.8rem -1.8rem 1rem; height: 160px; overflow: hidden; display: block; }
.proj-visual svg { width: 100%; height: 100%; display: block; }
.blueprint-aut { background: #080d18; } .blueprint-eng { background: #0a1628; } .blueprint-em { background: #110806; }
```

The `blueprint-eng` and `blueprint-em` background variants are pre-registered for future use even though only `blueprint-aut` is rendered today.

## Validation

- 3 `.cap-visual cap-visual-{eng,aut,em}` markers (one per cap card).
- 7 unique SVG IDs (`grid-eng`, `fade-eng`, `grid-aut`, `fade-aut`, `grid-em`, `fade-em`, `pf-gruma`) — `grep` for existing `<pattern id|linearGradient id` returned 0 prior matches, so zero collision risk.
- Diff is `+104 / -0` — pure addition, no existing rule, markup or translation touched.
- Negative margins on `.cap-visual` align to the exact card padding (`2rem 1.75rem 1.75rem`); on mobile the card padding stays the same so the visual remains flush.

---
_Generated by [Claude Code](https://claude.ai/code/session_011LxJUE5JCy4kM6CLuN4gCQ)_