### PR TITLE
feat(website): cap-card photos + 10-brand carousel via bridge URLs (assets/ migration pending)

### DIFF
--- a/website/index.html
+++ b/website/index.html
@@ -395,32 +395,33 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
     </div>
   </div>
 </section>
+<!-- TODO: migrar a assets/ locales — ver issue assets-migration -->
 <section class="clients-section" id="clientes">
   <div class="clients-eyebrow-wrap">
     <p class="clients-eyebrow" data-i18n="trust_label">Empresas que confían en FTS</p>
   </div>
   <div class="clients-track-wrap">
     <div class="clients-track">
-      <div class="client-logo-card"><img src="assets/logos/gruma.svg" alt="GRUMA" loading="lazy" onerror="this.style.display='none';this.nextElementSibling.style.display='flex'"><span class="logo-fallback" style="display:none">GRUMA</span></div>
-      <div class="client-logo-card"><img src="assets/logos/nalco-water.svg" alt="Nalco Water" loading="lazy" onerror="this.style.display='none';this.nextElementSibling.style.display='flex'"><span class="logo-fallback" style="display:none">Nalco · Ecolab</span></div>
-      <div class="client-logo-card"><img src="assets/logos/mondelez.svg" alt="Mondelez" loading="lazy" onerror="this.style.display='none';this.nextElementSibling.style.display='flex'"><span class="logo-fallback" style="display:none">Mondelez</span></div>
-      <div class="client-logo-card"><img src="assets/logos/arca-continental.webp" alt="Arca Continental" loading="lazy" onerror="this.style.display='none';this.nextElementSibling.style.display='flex'"><span class="logo-fallback" style="display:none">Arca Continental</span></div>
-      <div class="client-logo-card"><img src="assets/logos/mercado-libre.png" alt="Mercado Libre" loading="lazy" onerror="this.style.display='none';this.nextElementSibling.style.display='flex'"><span class="logo-fallback" style="display:none">Mercado Libre</span></div>
-      <div class="client-logo-card"><img src="assets/logos/mattel.png" alt="Mattel" loading="lazy" onerror="this.style.display='none';this.nextElementSibling.style.display='flex'"><span class="logo-fallback" style="display:none">Mattel</span></div>
-      <div class="client-logo-card"><img src="assets/logos/clarios.jpg" alt="Clarios" loading="lazy" onerror="this.style.display='none';this.nextElementSibling.style.display='flex'"><span class="logo-fallback" style="display:none">Clarios</span></div>
-      <div class="client-logo-card"><img src="assets/logos/vertiv.svg" alt="Vertiv" loading="lazy" onerror="this.style.display='none';this.nextElementSibling.style.display='flex'"><span class="logo-fallback" style="display:none">Vertiv</span></div>
-      <div class="client-logo-card"><img src="assets/logos/budenheim.png" alt="Budenheim" loading="lazy" onerror="this.style.display='none';this.nextElementSibling.style.display='flex'"><span class="logo-fallback" style="display:none">Budenheim</span></div>
-      <div class="client-logo-card"><img src="assets/logos/gepp.jpg" alt="GEPP" loading="lazy" onerror="this.style.display='none';this.nextElementSibling.style.display='flex'"><span class="logo-fallback" style="display:none">GEPP</span></div>
-      <div class="client-logo-card" aria-hidden="true"><img src="assets/logos/gruma.svg" alt="" loading="lazy" onerror="this.style.display='none';this.nextElementSibling.style.display='flex'"><span class="logo-fallback" style="display:none">GRUMA</span></div>
-      <div class="client-logo-card" aria-hidden="true"><img src="assets/logos/nalco-water.svg" alt="" loading="lazy" onerror="this.style.display='none';this.nextElementSibling.style.display='flex'"><span class="logo-fallback" style="display:none">Nalco · Ecolab</span></div>
-      <div class="client-logo-card" aria-hidden="true"><img src="assets/logos/mondelez.svg" alt="" loading="lazy" onerror="this.style.display='none';this.nextElementSibling.style.display='flex'"><span class="logo-fallback" style="display:none">Mondelez</span></div>
-      <div class="client-logo-card" aria-hidden="true"><img src="assets/logos/arca-continental.webp" alt="" loading="lazy" onerror="this.style.display='none';this.nextElementSibling.style.display='flex'"><span class="logo-fallback" style="display:none">Arca Continental</span></div>
-      <div class="client-logo-card" aria-hidden="true"><img src="assets/logos/mercado-libre.png" alt="" loading="lazy" onerror="this.style.display='none';this.nextElementSibling.style.display='flex'"><span class="logo-fallback" style="display:none">Mercado Libre</span></div>
-      <div class="client-logo-card" aria-hidden="true"><img src="assets/logos/mattel.png" alt="" loading="lazy" onerror="this.style.display='none';this.nextElementSibling.style.display='flex'"><span class="logo-fallback" style="display:none">Mattel</span></div>
-      <div class="client-logo-card" aria-hidden="true"><img src="assets/logos/clarios.jpg" alt="" loading="lazy" onerror="this.style.display='none';this.nextElementSibling.style.display='flex'"><span class="logo-fallback" style="display:none">Clarios</span></div>
-      <div class="client-logo-card" aria-hidden="true"><img src="assets/logos/vertiv.svg" alt="" loading="lazy" onerror="this.style.display='none';this.nextElementSibling.style.display='flex'"><span class="logo-fallback" style="display:none">Vertiv</span></div>
-      <div class="client-logo-card" aria-hidden="true"><img src="assets/logos/budenheim.png" alt="" loading="lazy" onerror="this.style.display='none';this.nextElementSibling.style.display='flex'"><span class="logo-fallback" style="display:none">Budenheim</span></div>
-      <div class="client-logo-card" aria-hidden="true"><img src="assets/logos/gepp.jpg" alt="" loading="lazy" onerror="this.style.display='none';this.nextElementSibling.style.display='flex'"><span class="logo-fallback" style="display:none">GEPP</span></div>
+      <div class="client-logo-card"><img src="https://commons.wikimedia.org/wiki/Special:FilePath/Gruma_logo-en.svg" alt="GRUMA" loading="lazy" onerror="this.style.display='none';this.nextElementSibling.style.display='flex'"><span class="logo-fallback" style="display:none">GRUMA</span></div>
+      <div class="client-logo-card"><img src="https://commons.wikimedia.org/wiki/Special:FilePath/Nalco_Water_logo.svg" alt="Nalco Water" loading="lazy" onerror="this.style.display='none';this.nextElementSibling.style.display='flex'"><span class="logo-fallback" style="display:none">Nalco · Ecolab</span></div>
+      <div class="client-logo-card"><img src="https://commons.wikimedia.org/wiki/Special:FilePath/Mondelez_International.svg" alt="Mondelez" loading="lazy" onerror="this.style.display='none';this.nextElementSibling.style.display='flex'"><span class="logo-fallback" style="display:none">Mondelez</span></div>
+      <div class="client-logo-card"><img src="https://fulltechnologysystems.com/wp-content/uploads/2024/12/cropped-PRIMARY500px.webp" alt="Arca Continental" loading="lazy" onerror="this.style.display='none';this.nextElementSibling.style.display='flex'"><span class="logo-fallback" style="display:none">Arca Continental</span></div>
+      <div class="client-logo-card"><img src="https://fulltechnologysystems.com/wp-content/uploads/2024/12/mercado-libre-logo-0233EC77C6-seeklogo.com_-1.png" alt="Mercado Libre" loading="lazy" onerror="this.style.display='none';this.nextElementSibling.style.display='flex'"><span class="logo-fallback" style="display:none">Mercado Libre</span></div>
+      <div class="client-logo-card"><img src="https://fulltechnologysystems.com/wp-content/uploads/2024/12/Mattel_logo.svg_-1021x1024.png" alt="Mattel" loading="lazy" onerror="this.style.display='none';this.nextElementSibling.style.display='flex'"><span class="logo-fallback" style="display:none">Mattel</span></div>
+      <div class="client-logo-card"><img src="https://fulltechnologysystems.com/wp-content/uploads/2024/12/Clarios_Logo-1024x188.jpg" alt="Clarios" loading="lazy" onerror="this.style.display='none';this.nextElementSibling.style.display='flex'"><span class="logo-fallback" style="display:none">Clarios</span></div>
+      <div class="client-logo-card"><img src="https://commons.wikimedia.org/wiki/Special:FilePath/Vertiv_logo.svg" alt="Vertiv" loading="lazy" onerror="this.style.display='none';this.nextElementSibling.style.display='flex'"><span class="logo-fallback" style="display:none">Vertiv</span></div>
+      <div class="client-logo-card"><img src="https://fulltechnologysystems.com/wp-content/uploads/2024/12/Chemische_Fabrik_Budenheim_logo.svg_-1-1024x255.png" alt="Budenheim" loading="lazy" onerror="this.style.display='none';this.nextElementSibling.style.display='flex'"><span class="logo-fallback" style="display:none">Budenheim</span></div>
+      <div class="client-logo-card"><img src="https://fulltechnologysystems.com/wp-content/uploads/2024/12/logo-gepp.jpg" alt="GEPP" loading="lazy" onerror="this.style.display='none';this.nextElementSibling.style.display='flex'"><span class="logo-fallback" style="display:none">GEPP</span></div>
+      <div class="client-logo-card" aria-hidden="true"><img src="https://commons.wikimedia.org/wiki/Special:FilePath/Gruma_logo-en.svg" alt="" loading="lazy" onerror="this.style.display='none';this.nextElementSibling.style.display='flex'"><span class="logo-fallback" style="display:none">GRUMA</span></div>
+      <div class="client-logo-card" aria-hidden="true"><img src="https://commons.wikimedia.org/wiki/Special:FilePath/Nalco_Water_logo.svg" alt="" loading="lazy" onerror="this.style.display='none';this.nextElementSibling.style.display='flex'"><span class="logo-fallback" style="display:none">Nalco · Ecolab</span></div>
+      <div class="client-logo-card" aria-hidden="true"><img src="https://commons.wikimedia.org/wiki/Special:FilePath/Mondelez_International.svg" alt="" loading="lazy" onerror="this.style.display='none';this.nextElementSibling.style.display='flex'"><span class="logo-fallback" style="display:none">Mondelez</span></div>
+      <div class="client-logo-card" aria-hidden="true"><img src="https://fulltechnologysystems.com/wp-content/uploads/2024/12/cropped-PRIMARY500px.webp" alt="" loading="lazy" onerror="this.style.display='none';this.nextElementSibling.style.display='flex'"><span class="logo-fallback" style="display:none">Arca Continental</span></div>
+      <div class="client-logo-card" aria-hidden="true"><img src="https://fulltechnologysystems.com/wp-content/uploads/2024/12/mercado-libre-logo-0233EC77C6-seeklogo.com_-1.png" alt="" loading="lazy" onerror="this.style.display='none';this.nextElementSibling.style.display='flex'"><span class="logo-fallback" style="display:none">Mercado Libre</span></div>
+      <div class="client-logo-card" aria-hidden="true"><img src="https://fulltechnologysystems.com/wp-content/uploads/2024/12/Mattel_logo.svg_-1021x1024.png" alt="" loading="lazy" onerror="this.style.display='none';this.nextElementSibling.style.display='flex'"><span class="logo-fallback" style="display:none">Mattel</span></div>
+      <div class="client-logo-card" aria-hidden="true"><img src="https://fulltechnologysystems.com/wp-content/uploads/2024/12/Clarios_Logo-1024x188.jpg" alt="" loading="lazy" onerror="this.style.display='none';this.nextElementSibling.style.display='flex'"><span class="logo-fallback" style="display:none">Clarios</span></div>
+      <div class="client-logo-card" aria-hidden="true"><img src="https://commons.wikimedia.org/wiki/Special:FilePath/Vertiv_logo.svg" alt="" loading="lazy" onerror="this.style.display='none';this.nextElementSibling.style.display='flex'"><span class="logo-fallback" style="display:none">Vertiv</span></div>
+      <div class="client-logo-card" aria-hidden="true"><img src="https://fulltechnologysystems.com/wp-content/uploads/2024/12/Chemische_Fabrik_Budenheim_logo.svg_-1-1024x255.png" alt="" loading="lazy" onerror="this.style.display='none';this.nextElementSibling.style.display='flex'"><span class="logo-fallback" style="display:none">Budenheim</span></div>
+      <div class="client-logo-card" aria-hidden="true"><img src="https://fulltechnologysystems.com/wp-content/uploads/2024/12/logo-gepp.jpg" alt="" loading="lazy" onerror="this.style.display='none';this.nextElementSibling.style.display='flex'"><span class="logo-fallback" style="display:none">GEPP</span></div>
     </div>
   </div>
 </section>
@@ -567,9 +568,10 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
       <p class="lead" data-i18n="caps_lead">Ejecutamos toda la cadena de un proyecto CAPEX dentro de tu planta en operación — desde el cálculo estructural hasta la puesta en marcha.</p>
     </div>
     <div class="caps-grid">
+      <!-- TODO: migrar a assets/ locales — ver issue assets-migration -->
       <div class="cap-card" id="ingenieria">
         <div class="cap-visual">
-          <img src="assets/photos/obra-campo.jpg" alt="Ingeniería industrial — FTS" loading="lazy" class="cap-photo">
+          <img src="https://fulltechnologysystems.com/wp-content/uploads/2024/12/WhatsApp-Image-2024-10-03-at-11.44.17-768x1024.jpeg" alt="Ingeniería industrial — FTS" loading="lazy" class="cap-photo">
         </div>
         <div class="cap-number">01</div>
         <div class="cap-icon"><svg width="32" height="32" viewBox="0 0 32 32" fill="none" aria-hidden="true"><path d="M4 28L16 4L28 28" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/><path d="M8 20H24" stroke="currentColor" stroke-width="2" stroke-linecap="round"/></svg></div>
@@ -593,7 +595,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
       </div>
       <div class="cap-card" id="automatizacion">
         <div class="cap-visual">
-          <img src="assets/photos/cap-automatizacion.jpg" alt="Automatización industrial — FTS" loading="lazy" class="cap-photo">
+          <img src="https://fulltechnologysystems.com/wp-content/uploads/2024/12/Automatizacion-768x1024.jpeg" alt="Automatización industrial — FTS" loading="lazy" class="cap-photo">
         </div>
         <div class="cap-number">02</div>
         <div class="cap-icon"><svg width="32" height="32" viewBox="0 0 32 32" fill="none" aria-hidden="true"><rect x="4" y="10" width="24" height="16" rx="2" stroke="currentColor" stroke-width="2"/><circle cx="11" cy="18" r="2.5" stroke="currentColor" stroke-width="2"/><circle cx="21" cy="18" r="2.5" stroke="currentColor" stroke-width="2"/><path d="M11 10V6M21 10V6M16 6V4" stroke="currentColor" stroke-width="2" stroke-linecap="round"/></svg></div>
@@ -617,7 +619,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
       </div>
       <div class="cap-card" id="electromecanica">
         <div class="cap-visual">
-          <img src="assets/photos/cap-electromecanica.jpg" alt="Infraestructura electromecánica — FTS" loading="lazy" class="cap-photo">
+          <img src="https://fulltechnologysystems.com/wp-content/uploads/2024/12/image.jpeg" alt="Infraestructura electromecánica — FTS" loading="lazy" class="cap-photo">
         </div>
         <div class="cap-number">03</div>
         <div class="cap-icon"><svg width="32" height="32" viewBox="0 0 32 32" fill="none" aria-hidden="true"><path d="M16 4V28M4 16H28" stroke="currentColor" stroke-width="2" stroke-linecap="round"/><path d="M8 8L24 24M24 8L8 24" stroke="currentColor" stroke-width="1.2" stroke-linecap="round" opacity="0.4"/><circle cx="16" cy="16" r="5" stroke="currentColor" stroke-width="2"/></svg></div>

--- a/website/index.html
+++ b/website/index.html
@@ -116,8 +116,10 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
   .cap-chip { font-size: 0.72rem; color: var(--brand-red); background: rgba(220,85,68,0.06); border: 1px solid rgba(220,85,68,0.2); border-radius: 100px; padding: 0.25rem 0.7rem; text-decoration: none; transition: background 0.2s, border-color 0.2s; line-height: 1.3; }
   .cap-chip:hover { background: rgba(220,85,68,0.14); border-color: rgba(220,85,68,0.35); }
   @media (max-width: 900px) { .caps-grid { grid-template-columns: 1fr; } }
-  .cap-visual { margin: -2rem -1.75rem 0; height: 180px; overflow: hidden; border-radius: 12px 12px 0 0; display: block; }
+  .cap-visual { margin: -2rem -1.75rem 0; height: 200px; overflow: hidden; border-radius: 12px 12px 0 0; display: block; }
   .cap-visual svg { width: 100%; height: 100%; display: block; }
+  .cap-photo { width: 100%; height: 100%; object-fit: cover; object-position: center; display: block; transition: transform 0.4s ease; }
+  .cap-card:hover .cap-photo { transform: scale(1.04); }
   .proj-visual { margin: -1.8rem -1.8rem 1rem; height: 160px; overflow: hidden; display: block; }
   .proj-visual svg { width: 100%; height: 100%; display: block; }
   .blueprint-aut { background: #080d18; }
@@ -399,24 +401,26 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
   </div>
   <div class="clients-track-wrap">
     <div class="clients-track">
-      <div class="client-logo-card"><img src="https://commons.wikimedia.org/wiki/Special:FilePath/Gruma_logo-en.svg" alt="GRUMA" loading="lazy" onerror="this.style.display='none';this.nextElementSibling.style.display='flex'"><span class="logo-fallback" style="display:none">GRUMA</span></div>
-      <div class="client-logo-card"><img src="https://commons.wikimedia.org/wiki/Special:FilePath/Nalco_Water_logo.svg" alt="Nalco Water" loading="lazy" onerror="this.style.display='none';this.nextElementSibling.style.display='flex'"><span class="logo-fallback" style="display:none">Nalco · Ecolab</span></div>
-      <div class="client-logo-card"><img src="https://commons.wikimedia.org/wiki/Special:FilePath/Mondelez_International.svg" alt="Mondelez International" loading="lazy" onerror="this.style.display='none';this.nextElementSibling.style.display='flex'"><span class="logo-fallback" style="display:none">Mondelez</span></div>
-      <div class="client-logo-card"><img src="https://commons.wikimedia.org/wiki/Special:FilePath/Arca_Continental_logo.svg" alt="Arca Continental" loading="lazy" onerror="this.style.display='none';this.nextElementSibling.style.display='flex'"><span class="logo-fallback" style="display:none">Arca Continental</span></div>
-      <div class="client-logo-card"><img src="https://commons.wikimedia.org/wiki/Special:FilePath/Mercado_Libre_wordmark_(Spanish_version).svg" alt="Mercado Libre" loading="lazy" onerror="this.style.display='none';this.nextElementSibling.style.display='flex'"><span class="logo-fallback" style="display:none">Mercado Libre</span></div>
-      <div class="client-logo-card"><img src="https://commons.wikimedia.org/wiki/Special:FilePath/Mattel_(2019).svg" alt="Mattel" loading="lazy" onerror="this.style.display='none';this.nextElementSibling.style.display='flex'"><span class="logo-fallback" style="display:none">Mattel</span></div>
-      <div class="client-logo-card"><img src="https://commons.wikimedia.org/wiki/Special:FilePath/Clarios_logo.svg" alt="Clarios" loading="lazy" onerror="this.style.display='none';this.nextElementSibling.style.display='flex'"><span class="logo-fallback" style="display:none">Clarios</span></div>
-      <div class="client-logo-card"><img src="https://commons.wikimedia.org/wiki/Special:FilePath/Vertiv_logo.svg" alt="Vertiv" loading="lazy" onerror="this.style.display='none';this.nextElementSibling.style.display='flex'"><span class="logo-fallback" style="display:none">Vertiv</span></div>
-      <div class="client-logo-card"><img src="https://commons.wikimedia.org/wiki/Special:FilePath/Chemische_Fabrik_Budenheim_logo.svg" alt="Budenheim" loading="lazy" onerror="this.style.display='none';this.nextElementSibling.style.display='flex'"><span class="logo-fallback" style="display:none">Budenheim</span></div>
-      <div class="client-logo-card" aria-hidden="true"><img src="https://commons.wikimedia.org/wiki/Special:FilePath/Gruma_logo-en.svg" alt="" loading="lazy" onerror="this.style.display='none';this.nextElementSibling.style.display='flex'"><span class="logo-fallback" style="display:none">GRUMA</span></div>
-      <div class="client-logo-card" aria-hidden="true"><img src="https://commons.wikimedia.org/wiki/Special:FilePath/Nalco_Water_logo.svg" alt="" loading="lazy" onerror="this.style.display='none';this.nextElementSibling.style.display='flex'"><span class="logo-fallback" style="display:none">Nalco · Ecolab</span></div>
-      <div class="client-logo-card" aria-hidden="true"><img src="https://commons.wikimedia.org/wiki/Special:FilePath/Mondelez_International.svg" alt="" loading="lazy" onerror="this.style.display='none';this.nextElementSibling.style.display='flex'"><span class="logo-fallback" style="display:none">Mondelez</span></div>
-      <div class="client-logo-card" aria-hidden="true"><img src="https://commons.wikimedia.org/wiki/Special:FilePath/Arca_Continental_logo.svg" alt="" loading="lazy" onerror="this.style.display='none';this.nextElementSibling.style.display='flex'"><span class="logo-fallback" style="display:none">Arca Continental</span></div>
-      <div class="client-logo-card" aria-hidden="true"><img src="https://commons.wikimedia.org/wiki/Special:FilePath/Mercado_Libre_wordmark_(Spanish_version).svg" alt="" loading="lazy" onerror="this.style.display='none';this.nextElementSibling.style.display='flex'"><span class="logo-fallback" style="display:none">Mercado Libre</span></div>
-      <div class="client-logo-card" aria-hidden="true"><img src="https://commons.wikimedia.org/wiki/Special:FilePath/Mattel_(2019).svg" alt="" loading="lazy" onerror="this.style.display='none';this.nextElementSibling.style.display='flex'"><span class="logo-fallback" style="display:none">Mattel</span></div>
-      <div class="client-logo-card" aria-hidden="true"><img src="https://commons.wikimedia.org/wiki/Special:FilePath/Clarios_logo.svg" alt="" loading="lazy" onerror="this.style.display='none';this.nextElementSibling.style.display='flex'"><span class="logo-fallback" style="display:none">Clarios</span></div>
-      <div class="client-logo-card" aria-hidden="true"><img src="https://commons.wikimedia.org/wiki/Special:FilePath/Vertiv_logo.svg" alt="" loading="lazy" onerror="this.style.display='none';this.nextElementSibling.style.display='flex'"><span class="logo-fallback" style="display:none">Vertiv</span></div>
-      <div class="client-logo-card" aria-hidden="true"><img src="https://commons.wikimedia.org/wiki/Special:FilePath/Chemische_Fabrik_Budenheim_logo.svg" alt="" loading="lazy" onerror="this.style.display='none';this.nextElementSibling.style.display='flex'"><span class="logo-fallback" style="display:none">Budenheim</span></div>
+      <div class="client-logo-card"><img src="assets/logos/gruma.svg" alt="GRUMA" loading="lazy" onerror="this.style.display='none';this.nextElementSibling.style.display='flex'"><span class="logo-fallback" style="display:none">GRUMA</span></div>
+      <div class="client-logo-card"><img src="assets/logos/nalco-water.svg" alt="Nalco Water" loading="lazy" onerror="this.style.display='none';this.nextElementSibling.style.display='flex'"><span class="logo-fallback" style="display:none">Nalco · Ecolab</span></div>
+      <div class="client-logo-card"><img src="assets/logos/mondelez.svg" alt="Mondelez" loading="lazy" onerror="this.style.display='none';this.nextElementSibling.style.display='flex'"><span class="logo-fallback" style="display:none">Mondelez</span></div>
+      <div class="client-logo-card"><img src="assets/logos/arca-continental.webp" alt="Arca Continental" loading="lazy" onerror="this.style.display='none';this.nextElementSibling.style.display='flex'"><span class="logo-fallback" style="display:none">Arca Continental</span></div>
+      <div class="client-logo-card"><img src="assets/logos/mercado-libre.png" alt="Mercado Libre" loading="lazy" onerror="this.style.display='none';this.nextElementSibling.style.display='flex'"><span class="logo-fallback" style="display:none">Mercado Libre</span></div>
+      <div class="client-logo-card"><img src="assets/logos/mattel.png" alt="Mattel" loading="lazy" onerror="this.style.display='none';this.nextElementSibling.style.display='flex'"><span class="logo-fallback" style="display:none">Mattel</span></div>
+      <div class="client-logo-card"><img src="assets/logos/clarios.jpg" alt="Clarios" loading="lazy" onerror="this.style.display='none';this.nextElementSibling.style.display='flex'"><span class="logo-fallback" style="display:none">Clarios</span></div>
+      <div class="client-logo-card"><img src="assets/logos/vertiv.svg" alt="Vertiv" loading="lazy" onerror="this.style.display='none';this.nextElementSibling.style.display='flex'"><span class="logo-fallback" style="display:none">Vertiv</span></div>
+      <div class="client-logo-card"><img src="assets/logos/budenheim.png" alt="Budenheim" loading="lazy" onerror="this.style.display='none';this.nextElementSibling.style.display='flex'"><span class="logo-fallback" style="display:none">Budenheim</span></div>
+      <div class="client-logo-card"><img src="assets/logos/gepp.jpg" alt="GEPP" loading="lazy" onerror="this.style.display='none';this.nextElementSibling.style.display='flex'"><span class="logo-fallback" style="display:none">GEPP</span></div>
+      <div class="client-logo-card" aria-hidden="true"><img src="assets/logos/gruma.svg" alt="" loading="lazy" onerror="this.style.display='none';this.nextElementSibling.style.display='flex'"><span class="logo-fallback" style="display:none">GRUMA</span></div>
+      <div class="client-logo-card" aria-hidden="true"><img src="assets/logos/nalco-water.svg" alt="" loading="lazy" onerror="this.style.display='none';this.nextElementSibling.style.display='flex'"><span class="logo-fallback" style="display:none">Nalco · Ecolab</span></div>
+      <div class="client-logo-card" aria-hidden="true"><img src="assets/logos/mondelez.svg" alt="" loading="lazy" onerror="this.style.display='none';this.nextElementSibling.style.display='flex'"><span class="logo-fallback" style="display:none">Mondelez</span></div>
+      <div class="client-logo-card" aria-hidden="true"><img src="assets/logos/arca-continental.webp" alt="" loading="lazy" onerror="this.style.display='none';this.nextElementSibling.style.display='flex'"><span class="logo-fallback" style="display:none">Arca Continental</span></div>
+      <div class="client-logo-card" aria-hidden="true"><img src="assets/logos/mercado-libre.png" alt="" loading="lazy" onerror="this.style.display='none';this.nextElementSibling.style.display='flex'"><span class="logo-fallback" style="display:none">Mercado Libre</span></div>
+      <div class="client-logo-card" aria-hidden="true"><img src="assets/logos/mattel.png" alt="" loading="lazy" onerror="this.style.display='none';this.nextElementSibling.style.display='flex'"><span class="logo-fallback" style="display:none">Mattel</span></div>
+      <div class="client-logo-card" aria-hidden="true"><img src="assets/logos/clarios.jpg" alt="" loading="lazy" onerror="this.style.display='none';this.nextElementSibling.style.display='flex'"><span class="logo-fallback" style="display:none">Clarios</span></div>
+      <div class="client-logo-card" aria-hidden="true"><img src="assets/logos/vertiv.svg" alt="" loading="lazy" onerror="this.style.display='none';this.nextElementSibling.style.display='flex'"><span class="logo-fallback" style="display:none">Vertiv</span></div>
+      <div class="client-logo-card" aria-hidden="true"><img src="assets/logos/budenheim.png" alt="" loading="lazy" onerror="this.style.display='none';this.nextElementSibling.style.display='flex'"><span class="logo-fallback" style="display:none">Budenheim</span></div>
+      <div class="client-logo-card" aria-hidden="true"><img src="assets/logos/gepp.jpg" alt="" loading="lazy" onerror="this.style.display='none';this.nextElementSibling.style.display='flex'"><span class="logo-fallback" style="display:none">GEPP</span></div>
     </div>
   </div>
 </section>
@@ -564,31 +568,8 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
     </div>
     <div class="caps-grid">
       <div class="cap-card" id="ingenieria">
-        <div class="cap-visual cap-visual-eng" aria-hidden="true">
-          <svg width="100%" height="100%" viewBox="0 0 320 200" xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="xMidYMid slice">
-            <defs>
-              <pattern id="grid-eng" width="40" height="40" patternUnits="userSpaceOnUse"><path d="M 40 0 L 0 0 0 40" fill="none" stroke="rgba(59,130,246,0.12)" stroke-width="0.5"/></pattern>
-              <linearGradient id="fade-eng" x1="0" y1="0" x2="0" y2="1"><stop offset="40%" stop-color="transparent"/><stop offset="100%" stop-color="#0D1117"/></linearGradient>
-            </defs>
-            <rect width="320" height="200" fill="#0D1117"/>
-            <rect width="320" height="200" fill="url(#grid-eng)"/>
-            <path d="M 20 170 L 160 40 L 300 170" stroke="rgba(59,130,246,0.6)" stroke-width="1.5" fill="none"/>
-            <path d="M 20 170 L 300 170" stroke="rgba(59,130,246,0.4)" stroke-width="1"/>
-            <path d="M 90 170 L 125 105 M 160 170 L 160 40 M 230 170 L 195 105" stroke="rgba(59,130,246,0.3)" stroke-width="0.8"/>
-            <circle cx="20"  cy="170" r="4" fill="rgba(59,130,246,0.7)"/>
-            <circle cx="160" cy="40"  r="4" fill="rgba(59,130,246,0.7)"/>
-            <circle cx="300" cy="170" r="4" fill="rgba(59,130,246,0.7)"/>
-            <circle cx="90"  cy="170" r="3" fill="rgba(59,130,246,0.5)"/>
-            <circle cx="160" cy="170" r="3" fill="rgba(59,130,246,0.5)"/>
-            <circle cx="230" cy="170" r="3" fill="rgba(59,130,246,0.5)"/>
-            <path d="M 20 185 L 300 185" stroke="rgba(59,130,246,0.2)" stroke-width="0.5" stroke-dasharray="4,4"/>
-            <path d="M 20 180 L 20 190 M 300 180 L 300 190" stroke="rgba(59,130,246,0.3)" stroke-width="0.5"/>
-            <text x="160" y="196" fill="rgba(59,130,246,0.4)" font-size="8" text-anchor="middle" font-family="monospace">L = 14.00 m</text>
-            <text x="168" y="34"  fill="rgba(59,130,246,0.5)" font-size="7" font-family="monospace">H = 8.30 m</text>
-            <rect x="240" y="12" width="68" height="16" rx="2" fill="rgba(59,130,246,0.08)" stroke="rgba(59,130,246,0.2)" stroke-width="0.5"/>
-            <text x="244" y="23" fill="rgba(59,130,246,0.5)" font-size="7" font-family="monospace">LRFD / AISC</text>
-            <rect width="320" height="200" fill="url(#fade-eng)"/>
-          </svg>
+        <div class="cap-visual">
+          <img src="assets/photos/obra-campo.jpg" alt="Ingeniería industrial — FTS" loading="lazy" class="cap-photo">
         </div>
         <div class="cap-number">01</div>
         <div class="cap-icon"><svg width="32" height="32" viewBox="0 0 32 32" fill="none" aria-hidden="true"><path d="M4 28L16 4L28 28" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/><path d="M8 20H24" stroke="currentColor" stroke-width="2" stroke-linecap="round"/></svg></div>
@@ -611,30 +592,8 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
         </div>
       </div>
       <div class="cap-card" id="automatizacion">
-        <div class="cap-visual cap-visual-aut" aria-hidden="true">
-          <svg width="100%" height="100%" viewBox="0 0 220 200" xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="xMidYMid slice">
-            <defs>
-              <pattern id="grid-aut" width="22" height="22" patternUnits="userSpaceOnUse"><path d="M 22 0 L 0 0 0 22" fill="none" stroke="rgba(220,85,68,0.07)" stroke-width="0.5"/></pattern>
-              <linearGradient id="fade-aut" x1="0" y1="0" x2="0" y2="1"><stop offset="40%" stop-color="transparent"/><stop offset="100%" stop-color="#080F1A"/></linearGradient>
-            </defs>
-            <rect width="220" height="200" fill="#080F1A"/>
-            <rect width="220" height="200" fill="url(#grid-aut)"/>
-            <path d="M 20 60 L 80 60 L 80 100 L 140 100 L 140 60 L 200 60" stroke="rgba(220,85,68,0.5)" stroke-width="1.2" fill="none"/>
-            <path d="M 60 20 L 60 60 M 120 60 L 120 20 M 160 20 L 160 60" stroke="rgba(220,85,68,0.3)" stroke-width="1" fill="none"/>
-            <path d="M 40 140 L 180 140 M 40 160 L 180 160" stroke="rgba(220,85,68,0.25)" stroke-width="1" fill="none" stroke-dasharray="6,4"/>
-            <path d="M 40 100 L 40 140 M 180 100 L 180 140" stroke="rgba(220,85,68,0.2)" stroke-width="0.8" fill="none"/>
-            <rect x="85" y="72" width="50" height="30" rx="3" fill="rgba(220,85,68,0.1)" stroke="rgba(220,85,68,0.45)" stroke-width="1"/>
-            <text x="110" y="91" fill="rgba(220,85,68,0.6)" font-size="7" text-anchor="middle" font-family="monospace" font-weight="500">PLC</text>
-            <path d="M 85 78 L 75 78 M 85 84 L 75 84 M 85 90 L 75 90 M 85 96 L 75 96" stroke="rgba(220,85,68,0.35)" stroke-width="0.8"/>
-            <path d="M 135 78 L 145 78 M 135 84 L 145 84 M 135 90 L 145 90 M 135 96 L 145 96" stroke="rgba(220,85,68,0.35)" stroke-width="0.8"/>
-            <circle cx="80"  cy="60"  r="3" fill="rgba(220,85,68,0.7)"/>
-            <circle cx="140" cy="60"  r="3" fill="rgba(220,85,68,0.7)"/>
-            <circle cx="40"  cy="140" r="2.5" fill="rgba(220,85,68,0.5)"/>
-            <circle cx="180" cy="140" r="2.5" fill="rgba(220,85,68,0.5)"/>
-            <rect x="150" y="155" width="58" height="16" rx="2" fill="rgba(220,85,68,0.07)" stroke="rgba(220,85,68,0.2)" stroke-width="0.5"/>
-            <text x="154" y="166" fill="rgba(220,85,68,0.45)" font-size="7" font-family="monospace">VFD / SCADA</text>
-            <rect width="220" height="200" fill="url(#fade-aut)"/>
-          </svg>
+        <div class="cap-visual">
+          <img src="assets/photos/cap-automatizacion.jpg" alt="Automatización industrial — FTS" loading="lazy" class="cap-photo">
         </div>
         <div class="cap-number">02</div>
         <div class="cap-icon"><svg width="32" height="32" viewBox="0 0 32 32" fill="none" aria-hidden="true"><rect x="4" y="10" width="24" height="16" rx="2" stroke="currentColor" stroke-width="2"/><circle cx="11" cy="18" r="2.5" stroke="currentColor" stroke-width="2"/><circle cx="21" cy="18" r="2.5" stroke="currentColor" stroke-width="2"/><path d="M11 10V6M21 10V6M16 6V4" stroke="currentColor" stroke-width="2" stroke-linecap="round"/></svg></div>
@@ -657,32 +616,8 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
         </div>
       </div>
       <div class="cap-card" id="electromecanica">
-        <div class="cap-visual cap-visual-em" aria-hidden="true">
-          <svg width="100%" height="100%" viewBox="0 0 220 200" xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="xMidYMid slice">
-            <defs>
-              <pattern id="grid-em" width="20" height="20" patternUnits="userSpaceOnUse"><path d="M 20 0 L 0 0 0 20" fill="none" stroke="rgba(240,140,40,0.07)" stroke-width="0.5"/></pattern>
-              <linearGradient id="fade-em" x1="0" y1="0" x2="0" y2="1"><stop offset="40%" stop-color="transparent"/><stop offset="100%" stop-color="#110806"/></linearGradient>
-            </defs>
-            <rect width="220" height="200" fill="#110806"/>
-            <rect width="220" height="200" fill="url(#grid-em)"/>
-            <path d="M 20 50 L 200 50" stroke="rgba(240,140,40,0.6)" stroke-width="2" fill="none"/>
-            <path d="M 50 50 L 50 120 M 110 50 L 110 120 M 170 50 L 170 120" stroke="rgba(240,140,40,0.45)" stroke-width="1.2"/>
-            <rect x="44"  y="72" width="12" height="8" rx="1" fill="none" stroke="rgba(240,140,40,0.5)" stroke-width="1"/>
-            <rect x="104" y="72" width="12" height="8" rx="1" fill="none" stroke="rgba(240,140,40,0.5)" stroke-width="1"/>
-            <rect x="164" y="72" width="12" height="8" rx="1" fill="none" stroke="rgba(240,140,40,0.5)" stroke-width="1"/>
-            <circle cx="50"  cy="138" r="12" fill="none" stroke="rgba(240,140,40,0.4)" stroke-width="1.2"/>
-            <text x="50"  y="142" fill="rgba(240,140,40,0.5)" font-size="7" text-anchor="middle" font-family="monospace">M</text>
-            <circle cx="110" cy="138" r="12" fill="none" stroke="rgba(240,140,40,0.4)" stroke-width="1.2"/>
-            <text x="110" y="142" fill="rgba(240,140,40,0.5)" font-size="7" text-anchor="middle" font-family="monospace">M</text>
-            <circle cx="170" cy="138" r="12" fill="none" stroke="rgba(240,140,40,0.4)" stroke-width="1.2"/>
-            <text x="170" y="142" fill="rgba(240,140,40,0.5)" font-size="7" text-anchor="middle" font-family="monospace">Ω</text>
-            <circle cx="110" cy="30" r="10" fill="none" stroke="rgba(240,140,40,0.35)" stroke-width="1"/>
-            <path d="M 110 20 L 110 50" stroke="rgba(240,140,40,0.3)" stroke-width="0.8"/>
-            <text x="14"  y="46"  fill="rgba(240,140,40,0.4)" font-size="7" font-family="monospace">13.8 kV</text>
-            <rect x="148" y="155" width="56" height="16" rx="2" fill="rgba(240,140,40,0.07)" stroke="rgba(240,140,40,0.2)" stroke-width="0.5"/>
-            <text x="152" y="166" fill="rgba(240,140,40,0.4)" font-size="7" font-family="monospace">MT / BT SLD</text>
-            <rect width="220" height="200" fill="url(#fade-em)"/>
-          </svg>
+        <div class="cap-visual">
+          <img src="assets/photos/cap-electromecanica.jpg" alt="Infraestructura electromecánica — FTS" loading="lazy" class="cap-photo">
         </div>
         <div class="cap-number">03</div>
         <div class="cap-icon"><svg width="32" height="32" viewBox="0 0 32 32" fill="none" aria-hidden="true"><path d="M16 4V28M4 16H28" stroke="currentColor" stroke-width="2" stroke-linecap="round"/><path d="M8 8L24 24M24 8L8 24" stroke="currentColor" stroke-width="1.2" stroke-linecap="round" opacity="0.4"/><circle cx="16" cy="16" r="5" stroke="currentColor" stroke-width="2"/></svg></div>


### PR DESCRIPTION
Bridge solution while the local `website/assets/` migration is pending.

## What this PR does

Two commits on the same branch:

1. **`7c9780d`** — Switched cap-cards and the carousel from external URLs to local paths (`assets/photos/*`, `assets/logos/*`). Replaced the 3 technical SVG visuals in the capability cards with `<img class="cap-photo">` and added `object-fit: cover` / `transform: scale(1.04)` hover. Carousel grew from 9 to 10 brands (added GEPP).

2. **`8e943a9`** (this commit) — Since the assets haven't been vendored into the repo yet, swapped every local path to a direct URL on either `fulltechnologysystems.com` (WordPress, FTS-owned) or `commons.wikimedia.org`. Page renders today; nothing visually broken.

Two `<!-- TODO: migrar a assets/ locales — ver issue assets-migration -->` markers added above the cap-cards block and above the carousel, so it's grep-able once the local migration commit lands.

## URLs in use right now

**Cap photos (3 — WordPress):**
- Ingeniería → `…/2024/12/WhatsApp-Image-2024-10-03-at-11.44.17-768x1024.jpeg`
- Automatización → `…/2024/12/Automatizacion-768x1024.jpeg`
- Infraestructura Electromecánica → `…/2024/12/image.jpeg`

**Carousel logos (10 brands × 2 copies = 20 refs):**
- WordPress (6): `arca-continental`, `mercado-libre`, `mattel`, `clarios`, `budenheim`, `gepp`
- Wikimedia (4): `gruma`, `nalco-water`, `mondelez`, `vertiv`

## Counts after this commit

- `src="assets/(photos|logos|videos)/..."` → **0**
- `fulltechnologysystems.com/wp-content/...` → **15** (3 cap photos + 6 brands × 2 copies)
- `commons.wikimedia.org/wiki/Special:FilePath/...` → **8** (4 brands × 2 copies)
- `onerror` fallback to text on every carousel `<img>` so any 404 / rename swaps cleanly to the brand name.

## Next step (separate PR later)

When you're ready to vendor the assets locally: run the curl script I provided earlier on your Mac targeting `assets/photos/` and `assets/logos/`, then a follow-up PR that flips the 23 image `src` attributes back to local paths and removes the two TODO comments. The structural work (CSS, `.cap-photo`, hover scale, GEPP card) is already done — that follow-up is pure URL swap.

---
_Generated by [Claude Code](https://claude.ai/code/session_011LxJUE5JCy4kM6CLuN4gCQ)_