### PR TITLE
copy: update hero eyebrow — EPC industrial + CAPEX active plants + 3 countries

### DIFF
--- a/website/index.html
+++ b/website/index.html
@@ -373,7 +373,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
 <div class="drawer-backdrop" id="drawerBackdrop"></div>
 <section class="hero">
   <div class="hero-inner">
-    <div class="hero-eyebrow" data-i18n="hero_eyebrow">— Servicios EPC industriales · Desde 2014</div>
+    <div class="hero-eyebrow" data-i18n="hero_eyebrow">EPC industrial · Proyectos CAPEX en planta activa · México · USA · Brasil</div>
     <h1><span data-i18n="hero_h1_a">Construimos plantas que </span><span class="gradient-text" data-i18n="hero_h1_b">no pueden parar.</span></h1>
     <p data-i18n="hero_p">Ejecutamos proyectos CAPEX completos dentro de plantas en operación. Un equipo, un contrato: ingeniería certificada, automatización e infraestructura electromecánica — sin detener tu producción, sin dividir la responsabilidad.</p>
     <div class="hero-actions">
@@ -806,7 +806,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
   const TRANSLATIONS = {
     es: {
       cta_nav: "Cotizar",
-      hero_eyebrow: "— Servicios EPC industriales · Desde 2014",
+      hero_eyebrow: "EPC industrial · Proyectos CAPEX en planta activa · México · USA · Brasil",
       hero_h1_a: "Construimos plantas que ",
       hero_h1_b: "no pueden parar.",
       hero_p: "Ejecutamos proyectos CAPEX completos dentro de plantas en operación. Un equipo, un contrato: ingeniería certificada, automatización e infraestructura electromecánica — sin detener tu producción, sin dividir la responsabilidad.",
@@ -961,7 +961,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
     },
     en: {
       cta_nav: "Get a quote",
-      hero_eyebrow: "— Industrial EPC services · Since 2014",
+      hero_eyebrow: "Industrial EPC · CAPEX projects in active plants · Mexico · USA · Brazil",
       hero_h1_a: "We build plants that ",
       hero_h1_b: "cannot stop.",
       hero_p: "We execute complete CAPEX projects inside operating plants. One team, one contract: certified engineering, automation and electromechanical infrastructure — without stopping your production, without splitting accountability.",
@@ -1116,7 +1116,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
     },
     pt: {
       cta_nav: "Cotação",
-      hero_eyebrow: "— Serviços EPC industriais · Desde 2014",
+      hero_eyebrow: "EPC industrial · Projetos CAPEX em planta ativa · México · EUA · Brasil",
       hero_h1_a: "Construímos plantas que ",
       hero_h1_b: "não podem parar.",
       hero_p: "Executamos projetos CAPEX completos dentro de plantas em operação. Uma equipe, um contrato: engenharia certificada, automação e infraestrutura eletromecânica — sem parar sua produção, sem dividir a responsabilidade.",


### PR DESCRIPTION
Hero eyebrow refresh in three languages. Title tag intact (kept for SEO).

Old (3 langs):
- ES: `— Servicios EPC industriales · Desde 2014`
- EN: `— Industrial EPC services · Since 2014`
- PT: `— Serviços EPC industriais · Desde 2014`

New:
- ES: `EPC industrial · Proyectos CAPEX en planta activa · México · USA · Brasil`
- EN: `Industrial EPC · CAPEX projects in active plants · Mexico · USA · Brazil`
- PT: `EPC industrial · Projetos CAPEX em planta ativa · México · EUA · Brasil`

Updated 4 strings: 1 HTML default on `.hero-eyebrow` + 1 value per `TRANSLATIONS.es / en / pt`. Leading em-dash dropped — the `·` separators between phrases provide their own rhythm. `<title>FTS · Full Technology Systems — Servicios EPC industriales en México, USA y Brasil</title>` left untouched per spec.

---
_Generated by [Claude Code](https://claude.ai/code/session_011LxJUE5JCy4kM6CLuN4gCQ)_