### PR TITLE
copy: trim hero eyebrow — remove redundant active plant reference

### DIFF
--- a/website/index.html
+++ b/website/index.html
@@ -373,7 +373,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
 <div class="drawer-backdrop" id="drawerBackdrop"></div>
 <section class="hero">
   <div class="hero-inner">
-    <div class="hero-eyebrow" data-i18n="hero_eyebrow">EPC industrial · Proyectos CAPEX en planta activa · México · USA · Brasil</div>
+    <div class="hero-eyebrow" data-i18n="hero_eyebrow">EPC industrial · Proyectos CAPEX · México · USA · Brasil</div>
     <h1><span data-i18n="hero_h1_a">Construimos plantas que </span><span class="gradient-text" data-i18n="hero_h1_b">no pueden parar.</span></h1>
     <p data-i18n="hero_p">Ejecutamos proyectos CAPEX completos dentro de plantas en operación. Un equipo, un contrato: ingeniería certificada, automatización e infraestructura electromecánica — sin detener tu producción, sin dividir la responsabilidad.</p>
     <div class="hero-actions">
@@ -806,7 +806,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
   const TRANSLATIONS = {
     es: {
       cta_nav: "Cotizar",
-      hero_eyebrow: "EPC industrial · Proyectos CAPEX en planta activa · México · USA · Brasil",
+      hero_eyebrow: "EPC industrial · Proyectos CAPEX · México · USA · Brasil",
       hero_h1_a: "Construimos plantas que ",
       hero_h1_b: "no pueden parar.",
       hero_p: "Ejecutamos proyectos CAPEX completos dentro de plantas en operación. Un equipo, un contrato: ingeniería certificada, automatización e infraestructura electromecánica — sin detener tu producción, sin dividir la responsabilidad.",
@@ -961,7 +961,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
     },
     en: {
       cta_nav: "Get a quote",
-      hero_eyebrow: "Industrial EPC · CAPEX projects in active plants · Mexico · USA · Brazil",
+      hero_eyebrow: "Industrial EPC · CAPEX Projects · Mexico · USA · Brazil",
       hero_h1_a: "We build plants that ",
       hero_h1_b: "cannot stop.",
       hero_p: "We execute complete CAPEX projects inside operating plants. One team, one contract: certified engineering, automation and electromechanical infrastructure — without stopping your production, without splitting accountability.",
@@ -1116,7 +1116,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
     },
     pt: {
       cta_nav: "Cotação",
-      hero_eyebrow: "EPC industrial · Projetos CAPEX em planta ativa · México · EUA · Brasil",
+      hero_eyebrow: "EPC industrial · Projetos CAPEX · México · EUA · Brasil",
       hero_h1_a: "Construímos plantas que ",
       hero_h1_b: "não podem parar.",
       hero_p: "Executamos projetos CAPEX completos dentro de plantas em operação. Uma equipe, um contrato: engenharia certificada, automação e infraestrutura eletromecânica — sem parar sua produção, sem dividir a responsabilidade.",


### PR DESCRIPTION
Trims "en planta activa" / "in active plants" / "em planta ativa" from the hero eyebrow since the hero subtitle already says it. 4 string updates (1 HTML default + 3 i18n values).

- ES: `EPC industrial · Proyectos CAPEX · México · USA · Brasil`
- EN: `Industrial EPC · CAPEX Projects · Mexico · USA · Brazil`
- PT: `EPC industrial · Projetos CAPEX · México · EUA · Brasil`

---
_Generated by [Claude Code](https://claude.ai/code/session_011LxJUE5JCy4kM6CLuN4gCQ)_