### PR TITLE
Sprint 1 Fase 3 fix — kiosk/empleados expone campos custom + refactor SIN_CHECK_DIARIO

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -29,7 +29,7 @@ Idiomas del repo: español para UI/textos, inglés para variables/funciones de c
 | 2 | `incidencias/resolver` (v2.1 F1.1) | `Oc2ceMHX2O0L0y2X` | `0L0y2X` | 20 nodos. TAG management + 4 acciones (sup/rh/dir) + branch tipo (entrada/checkout). Fixes D1-D4 F1.1: respeta `tag_disputa_activo` previo, calcula `aplicaHora` antes de conversión, discrimina `baseUtcStr` por tipo, night-shift fix solo para checkout. Helper `esEstadoTerminal`. |
 | 3 | `asistencias/admin` | `Bqnfsx8gx2TpzfwM` | `TpzfwM` | Consultas admin |
 | 4 | `accesos-incidencias/guardar (v2.2 auth-fix)` | `HwPq9dqxjy2KETi7` | `2KETi7` | Auth + persistencia |
-| 5 | `kiosk/empleados (v3.1)` | `2UGWLjNwYRGtXq5y` | `GtXq5y` | Lookup empleados pre-checkin |
+| 5 | `kiosk/empleados (v3.1)` | `2UGWLjNwYRGtXq5y` | `GtXq5y` | Lookup empleados pre-checkin. **Fix Sprint 1 Fase 3 (2026-05-11):** response ahora incluye `x_studio_hora_entrada`, `x_categoria_nomina`, `x_aplica_ppa` para soportar refactor autoprogresivo de planeación. 8 consumers verificados sin breaking change. |
 | 6 | `kiosk/checkin (v4.2 fix respuesta · build 20abr · 00c76071)` | `a7mEjjdwIzzvomXs` | `zvomXs` | **Núcleo del kiosk**. 26 nodos (3 nuevos F1.5: `IF - Auto-rescate?` + `Odoo - UPDATE Auto-rescate Close` + `Code - Continue Auto-rescate`). Auto-rescate huérfana >16h en rama entrada. |
 | 7 | `kiosk/cerrar-registro (v2.0 · build 20abr · f020af31)` | `WkgYjDeL2kQInz3H` | `QInz3H` | Cierre manual humano |
 | 8 | `kiosk/estado-empleado (v3 Fase 1)` | `U13fngg2dTKgDQ8Y` | `KgDQ8Y` | Estado actual empleado |

--- a/operaciones/planeacion/js/empleados.js
+++ b/operaciones/planeacion/js/empleados.js
@@ -1,16 +1,21 @@
-// Build: 20260428-planeacion-f2-empleados-v2
+// Build: 20260512-planeacion-fase3-empleados-categoria
 // V1 confirmado caso A: /webhook/kiosk/empleados retorna empleados activos
 // de todos los deptos (consumido también por kiosk, mi-perfil, config-master).
+// F1 Sprint 1 Fase 3 (2026-05-11): _normalizar preserva x_categoria_nomina +
+// x_aplica_ppa + x_studio_hora_entrada del workflow. SIN_CHECK_DIARIO array
+// hardcoded → esSinCheckDiario() autoprogresiva por categoría.
 'use strict';
 
 window.PLANEACION_EMPLEADOS = {
   todos: [],
   byDept: {},
 
-  // IDs Odoo de empleados de Operaciones que NO requieren confirmación
-  // diaria (oficina con horario fijo). TODO F4: cargar desde
-  // shared/planeacion-config.json. Por ahora hardcoded basado en mockup v3.
-  SIN_CHECK_DIARIO: [89, 91, 113],
+  // TEMP fallback legacy: IDs hardcoded mientras se valida que 100% de
+  // empleados oficina tengan x_categoria_nomina='hourly_sencilla' en Odoo.
+  // Eliminar en Sprint 2 (CLAUDE.md §13 deuda autoprogresiva #1+#2).
+  // F1 Sprint 1 Fase 3: nota historica — array NO se usa directamente;
+  // ver esSinCheckDiario() abajo que es el reemplazo autoprogresivo.
+  SIN_CHECK_DIARIO_LEGACY: [89, 91, 113],
 
   N8N_BASE: 'https://primary-production-5c3c.up.railway.app',
 
@@ -65,8 +70,27 @@ window.PLANEACION_EMPLEADOS = {
       name:           e.name || e.nombre || ('Empleado ' + e.id),
       job_title:      e.job_title || e.cargo || e.puesto || '',
       department_id:  [deptId, deptName],   // formato Odoo many2one canónico
-      active:         e.active !== false
+      active:         e.active !== false,
+      // F1 Sprint 1 Fase 3 (2026-05-11): preservar campos custom del workflow
+      // kiosk/empleados v3.1 para que horarios-base.js perfilParaDepto() pueda
+      // leer x_categoria_nomina autoprogresivamente. Ver PLAN_NOMINA §0.5.
+      x_studio_hora_entrada: e.x_studio_hora_entrada || 0,
+      x_categoria_nomina:    e.x_categoria_nomina || null,
+      x_aplica_ppa:          e.x_aplica_ppa === true
     };
+  },
+
+  // F1 Sprint 1 Fase 3: reemplazo autoprogresivo del array SIN_CHECK_DIARIO.
+  // Empleados con categoría hourly_sencilla o confianza NO requieren check
+  // diario (oficina con horario fijo, sin HE hourly). Override automático
+  // cuando Ana setea x_categoria_nomina en Odoo — sin tocar código.
+  esSinCheckDiario(empleadoId){
+    const emp = this.todos.find(e => e.id === empleadoId);
+    if (!emp) return false;
+    if (emp.x_categoria_nomina === 'hourly_sencilla') return true;
+    if (emp.x_categoria_nomina === 'confianza') return true;
+    // TEMP fallback legacy (eliminar en Sprint 2 cuando 100% categorizados):
+    return this.SIN_CHECK_DIARIO_LEGACY.indexOf(empleadoId) !== -1;
   },
 
   _reindexar(){
@@ -133,12 +157,12 @@ window.PLANEACION_EMPLEADOS = {
   },
 
   // ID de Odoo (hr.employee.id). Usa config persistente si está disponible;
-  // sino cae al hardcoded SIN_CHECK_DIARIO.
+  // sino cae a esSinCheckDiario() autoprogresivo (x_categoria_nomina).
   requiereCheck(empleadoId){
     if (window.PLANEACION_CONFIG && window.PLANEACION_CONFIG.config){
       return window.PLANEACION_CONFIG.requiereCheck(empleadoId);
     }
-    return this.SIN_CHECK_DIARIO.indexOf(empleadoId) === -1;
+    return !this.esSinCheckDiario(empleadoId);
   },
 
   byId(id){


### PR DESCRIPTION
## Resumen

Bug detectado post-merge PR #37 (Fase 3 sync workflow): el refactor autoprogresivo de \`operaciones/planeacion/js/horarios-base.js\` no funcionaba en producción porque el workflow \`kiosk/empleados (v3.1)\` no exponía los campos custom (\`x_categoria_nomina\`, \`x_aplica_ppa\`, \`x_studio_hora_entrada\`) y el frontend \`_normalizar()\` STRIPS campos extra del response.

**Fix dual:** workflow + frontend. **Breaking change risk: cero** (audit completo de 8 consumers).

## Bug pre-fix

Gerardo (id 59, dept Operaciones, x_categoria_nomina='hourly_sencilla' en Odoo desde Sprint 1 Fase 1) aparecía como perfil **operaciones_campo** (7:00-17:06) en lugar de **operaciones_oficina** (7:30-17:36) en frontend planeación.

Causa: el frontend nunca recibía `x_categoria_nomina` aunque el campo ya estuviera poblado en Odoo. La cadena rota:
```
Odoo (categoria poblada) → workflow kiosk/empleados (fieldsList NO incluye categoria)
  → response sin categoria → frontend _normalizar() (whitelist sin categoria)
  → horarios-base.js recibe empleado sin categoria → fallback erróneo
```

## Cambios aplicados

### Commit 1 `ae59912` — feat(n8n): workflow expone campos custom

Workflow `2UGWLjNwYRGtXq5y` (kiosk/empleados v3.1):
- **Nodo `Odoo - Empleados (todos)` fieldsList:** 11 → 14 campos (+`x_studio_hora_entrada`, `x_categoria_nomina`, `x_aplica_ppa`)
- **Nodo `Code - Filtrar y mapear` jsCode:** mapped object propaga 3 campos nuevos

CLAUDE.md §2 actualizado con nota del fix.

### Commit 2 `169355c` — fix(planeacion): _normalizar + SIN_CHECK_DIARIO refactor

`operaciones/planeacion/js/empleados.js`:
1. **`_normalizar()` preserva** los 3 campos custom (antes los strippeaba).
2. **Refactor autoprogresivo** del array hardcoded `SIN_CHECK_DIARIO: [89, 91, 113]` → función `esSinCheckDiario(empleadoId)` que lee `x_categoria_nomina === 'hourly_sencilla' || 'confianza'`. Array renombrado a `SIN_CHECK_DIARIO_LEGACY` como fallback temporal hasta Sprint 2.
3. `requiereCheck()` delega a `!esSinCheckDiario()`.
4. Build header: `20260428-planeacion-f2-empleados-v2` → `20260512-planeacion-fase3-empleados-categoria`

## Smoke test workflow post-fix (validado)

```
$ curl -s -X POST '.../webhook/kiosk/empleados' -d '{}'
Total: 38 empleados

Validación 8 empleados clave:
✅ id= 32 Esteban       cat=ceo                ppa=False  hora=7.0
✅ id= 75 Mateo         cat=confianza          ppa=True   hora=7.0
✅ id=112 Felipe        cat=confianza          ppa=True   hora=7.0
✅ id= 59 Gerardo       cat=hourly_sencilla    ppa=True   hora=7.5
✅ id= 60 Teresa        cat=hourly_sencilla    ppa=True   hora=7.5
✅ id= 62 Gibrán        cat=hourly_sencilla    ppa=True   hora=7.5
✅ id= 68 Jésus M       cat=hourly_sencilla    ppa=True   hora=8.0
✅ id=135 Abraham       cat=hourly_sencilla    ppa=True   hora=7.5

Keys en response (sample id 59):
['cargo', 'department_id', 'department_name', 'email', 'id',
 'manager_id', 'manager_name', 'mobile', 'name', 'pin',
 'x_aplica_ppa', 'x_categoria_nomina', 'x_studio_hora_entrada']
```

## Test pre/post tabla

| id | Nombre | Cargo | Pre-fix horarios-base | Post-fix esperado |
|---|---|---|---|---|
| 32 | Esteban | CEO | dirección (correcto, dept 5) | dirección ✓ |
| 59 | Gerardo | Operaciones | campo (mal, 7:00-17:06) | **oficina (7:30-17:36) ✓** |
| 60 | Teresa | Operaciones | campo (mal) | **oficina ✓** |
| 62 | Gibrán | Operaciones | campo (mal) | **oficina ✓** |
| 68 | Jésus M | Operaciones | campo (mal) | **oficina ✓** |
| 75 | Mateo | Operaciones | campo (mal) | **oficina ✓** |
| 112 | Felipe | Operaciones | campo (mal) | **oficina ✓** |
| 135 | Abraham | Operaciones | campo (mal) | **oficina ✓** |
| 121 | Stephany | Operaciones | campo ✓ | campo ✓ (hourly_doble default) |

## Validación syntactic local

Node ejecución del archivo `empleados.js` con mocks:
- ✅ Sintaxis OK
- ✅ Module shape: 14 keys (esSinCheckDiario agregado)
- ✅ 7/7 test cases esSinCheckDiario pasados
- ✅ requiereCheck() devuelve false para oficina, true para campo

## Análisis breaking change — 8 consumers en repo

| # | Consumer | Pattern | Breaking? |
|---|---|---|---|
| 1 | operaciones/kiosk/js/odoo.js | `data.empleados` directo | ❌ No |
| 2 | operaciones/planeacion/js/empleados.js | **STRIPS** en _normalizar() | 🟡 **Fixed en este PR** |
| 3 | shared/admin/editor-asistencias.html | `data.empleados \|\| []` | ❌ No |
| 4-5 | shared/admin/config-master.html | Ping test + map permisivo | ❌ No |
| 6 | shared/keepalive.js | Solo HTTP status check | ❌ No |
| 7 | shared/mi-perfil/index.html | Acceso por propiedad con \|\| | ❌ No |
| 8 | diagnostico.html | Validación Array + name | ❌ No |

Performance impact: response 3.32s → 3.42s (~3% diferencia, dominado por base64 fotos).

## Plan rollback

**Tiempo:** <1 minuto.

```javascript
// Revert workflow fieldsList:
n8n_update_partial_workflow('2UGWLjNwYRGtXq5y', [
  {type: 'updateNode', nodeName: 'Odoo - Empleados (todos)',
   updates: {'parameters.options.fieldsList': [/* 11 campos originales */]}}
]);

// Revert frontend:
git revert 169355c
```

## Test plan post-merge (Esteban)

- [ ] Hard refresh https://yinyo1.github.io/fts-suite/operaciones/planeacion/
- [ ] Validar que Gerardo (59), Teresa (60), Gibrán (62), Jésus M (68), Abraham (135) aparecen como **OFICINA 7:30-17:36** (no campo 7:00)
- [ ] Spot check Mateo (75) y Felipe (112) — deben ser **OFICINA** también (categoría confianza)
- [ ] Spot check Stephany (121), Mario (116), etc. — deben seguir como **CAMPO 7:00-17:06**
- [ ] Smoke test kiosk principal (https://yinyo1.github.io/fts-suite/operaciones/kiosk/) — empleados cargan sin error
- [ ] Smoke test Mi Perfil (https://yinyo1.github.io/fts-suite/shared/mi-perfil/) — login funciona

## Qué viene después del merge

Sprint 1 Fase 3 **completa** (incluyendo este fix).

**Sprint 1 Fase 4 (~6h, futuro):**
- Panel admin RH `modulos/rh/config-empleados/` 
- HMAC en webhook `rh/empleados-master/refresh`
- Eliminar `SIN_CHECK_DIARIO_LEGACY` fallback (cuando 100% empleados oficina tengan categoría)
- Eliminar `shared/planeacion-config.json` duplicado (CLAUDE.md §13 #2)
- Eliminar `oficinaIdsLegacy` en horarios-base.js (CLAUDE.md §13 #4)

**Sprint 2 (~12-15h):** workflow `nomina/calcular-semanal` aplicando 8 reglas progresivas LFT.

🤖 Generated with [Claude Code](https://claude.com/claude-code)