### PR TITLE
cleanup(incidencias): cerrar INC-AUTO-CIERRE-98 obsoleta post Railway outage

### DIFF
--- a/shared/incidencias-asistencia.json
+++ b/shared/incidencias-asistencia.json
@@ -4,7 +4,7 @@
     {
       "id_interno": "INC-AUTO-CIERRE-98-2026-05-19T14-43-31-312Z",
       "tipo": "auto_cierre_pendiente",
-      "status": "pendiente_rh",
+      "status": "aprobada_tal_cual",
       "fecha_creacion": "2026-05-19T14:43:33.879Z",
       "empleado_id": 98,
       "empleado_nombre": "Ricardo Alán Hernández González",
@@ -22,7 +22,18 @@
       "department_name": null,
       "supervisor_id": null,
       "supervisor_name": null,
-      "propuestas": []
+      "propuestas": [],
+      "resolucion_rh": {
+        "resuelto_por": {
+          "user_id": 2,
+          "nombre": "Esteban De La Cruz (cleanup admin post-Railway-outage)",
+          "role": "direccion"
+        },
+        "resuelto_at": "2026-05-20T07:47:14.000Z",
+        "accion": "cleanup_admin",
+        "comentario": "Incidencia obsoleta. Attendance 13179 cerrado manual con check_out 2026-05-19 23:30:00 UTC (5:30 PM CST) durante recuperación de caída Railway 19-may-2026. Incidencia auto_cierre original no aplica porque Esteban escribió directamente la hora real reportada en hoja Topo Chico.",
+        "hora_final_check_out": "2026-05-19T23:30:00Z"
+      }
     },
     {
       "id_interno": "INC-OLV-137-2026-05-19T14-28-01-946Z",


### PR DESCRIPTION
## Contexto

Caída de Railway/n8n el 19-may-2026 (≈14:43 UTC / 08:43 CST) impidió que 31 empleados pudieran registrar checkout normal vía kiosk. Esteban cerró manualmente las 31 attendances en Odoo (consola F12) con la hora real reportada en hoja Topo Chico.

Una de esas attendances era la 13179 de Ricardo Hernández (employee_id 98), check_out aplicado manual a **2026-05-19 23:30:00 UTC (5:30 PM CST)**.

Antes de la caída, el workflow auto-rescate F1.5 había detectado huérfana previa de Ricardo (att 13142, check_in 18-may 14:35) y creó la incidencia `INC-AUTO-CIERRE-98-2026-05-19T14-43-31-312Z` con `attendance_id_cerrado: 13142, attendance_id_nuevo: 13179, status: pendiente_rh, autoincidencia: true`.

Esa incidencia ya no aplica: el cierre manual de Esteban sustituye lo que el flujo auto_cierre habría propuesto.

## Diff

`shared/incidencias-asistencia.json` — única incidencia tocada:

- `status`: `pendiente_rh` → **`aprobada_tal_cual`**
- Agregado bloque `resolucion_rh` con:
  - `resuelto_por`: Esteban De La Cruz (rol `direccion`, cleanup admin)
  - `resuelto_at`: 2026-05-20T07:47:14.000Z
  - `accion`: `cleanup_admin`
  - `comentario`: explicación del contexto Railway + cierre manual
  - `hora_final_check_out`: `2026-05-19T23:30:00Z`

Resto del registro intacto (`fecha_creacion`, `attendance_id_*`, `motivo`, `tag_disputa_activo`, `autoincidencia`, `propuestas: []`, etc.) — preserva historial.

## Validación

- `node -e "require('./shared/incidencias-asistencia.json')"` → parsea OK, 30 incidencias
- Status tally post-edit: `pendiente_rh` bajó de 6→5; `aprobada_tal_cual` subió 16→17

## No incluye

- ❌ No toca attendance Odoo (Esteban ya lo hizo manual con check_out real)
- ❌ No procesa otras incidencias (Hugo 137 y demás siguen su flujo)
- ❌ No es flujo visor RH normal — es cleanup admin documentado

## Referencias

- Incidente operación: caída Railway 19-may-2026, ~14:43-? UTC, n8n entera abajo (404 "Application not found" en todas rutas)
- 31 attendances cerradas manual via consola F12 con hora real Topo Chico
- Ref incidencia: `INC-AUTO-CIERRE-98-2026-05-19T14-43-31-312Z`

🤖 Generated with [Claude Code](https://claude.com/claude-code)