### PR TITLE
hotfix(kiosk): UX clara cuando workflow no responde (eliminar demos fallback)

### DIFF
--- a/docs/audit-kiosk-empleados-fallback.md
+++ b/docs/audit-kiosk-empleados-fallback.md
@@ -1,0 +1,106 @@
+# Audit — Kiosk empleados fallback (hotfix 20260520)
+
+**Fecha:** 2026-05-20
+**Disparador:** Caída Railway 19-may-2026. Kiosk siguió funcionando, pero la lista de empleados que mostró eran los demos hardcoded (`Mateo Salazar`, `Felipe Pérez`, `Esteban De La Cruz`, `Ana Ramírez`, `Carlos Hernández`). PINs eran `1234/5678/0000/1111/2222`. Generó crisis comunicacional: usuarios pensaron que el sistema funcionaba normal e intentaron checkin contra demos.
+
+## Comportamiento actual (pre-hotfix)
+
+`operaciones/kiosk/js/kiosk.js:402-414`:
+
+```javascript
+const DEMO_EMPLEADOS = [
+  { id:1, nombre:'Mateo Salazar',     puesto:'Ingeniero',  foto:'', pin:'1234' },
+  { id:2, nombre:'Felipe Pérez',      puesto:'Supervisor', foto:'', pin:'5678' },
+  { id:3, nombre:'Esteban De La Cruz',puesto:'Director',   foto:'', pin:'0000' },
+  { id:4, nombre:'Ana Ramírez',       puesto:'Soldador',   foto:'', pin:'1111' },
+  { id:5, nombre:'Carlos Hernández',  puesto:'Ayudante',   foto:'', pin:'2222' },
+];
+// + DEMO_SOS análogo
+```
+
+`loadEmpleados` (L416-429) y `loadSOs` (L431-443) tenían patrón idéntico:
+
+```javascript
+async function loadEmpleados(){
+  if(K.config.demoMode || !K.config.n8nUrl){     // opt-in legítimo
+    K.empleados = DEMO_EMPLEADOS.slice();
+    return;
+  }
+  try{
+    K.empleados = await window.OdooKiosk.getEmpleados();
+  } catch(e){
+    console.warn('Odoo no disponible, usando demo:', e);
+    K.empleados = DEMO_EMPLEADOS.slice();   // ⬅ EL BUG: catch silencioso → demos
+    K.demoMode = true;                       // runtime flag (separado de K.config.demoMode)
+  }
+}
+```
+
+UI `operaciones/kiosk/index.html:36-38`:
+
+```html
+<div class="kiosk-list" id="ksEmpleadosList">
+  <div style="text-align:center;color:#666;padding:24px">Cargando empleados…</div>
+</div>
+```
+
+Placeholder estático que nunca se reemplaza por mensaje de error. Cuando user tipea, `renderEmpleados()` toma su lugar mostrando datos (reales o demos, indistintamente).
+
+**Footer connection status** (`updateConnStatus`, L1273-1278) lee `K.config.demoMode` (config explícita) en vez de `K.demoMode` (runtime fallback). Inconsistencia: footer dice `"conectado"` aunque internamente esté usando demos. Usuario engañado doblemente.
+
+## Patrón de referencia — Mi Perfil login
+
+`shared/mi-perfil/index.html:615-632` (`mp_load_empleados`):
+
+```javascript
+async function mp_load_empleados(){
+  const status = $('mp-search-status');
+  status.textContent = '⏳ Cargando empleados…';
+  try {
+    const res = await fetch(EMPLEADOS_ENDPOINT, { method:'POST', /*...*/ });
+    if (!res.ok) throw new Error('HTTP ' + res.status);
+    const data = await res.json();
+    _empleados = Array.isArray(data) ? data : (data && data.empleados) || [];
+    status.textContent = _empleados.length + ' empleados disponibles';
+  } catch(e) {
+    status.textContent = '❌ Error cargando empleados: ' + e.message;
+    _empleados = [];   // ⬅ clave: NO fallback a demos
+  }
+}
+```
+
+Mi Perfil ya implementaba el patrón correcto: `_empleados = []` en catch. El kiosk principal quedó atrás.
+
+## Comparación side-by-side
+
+| Aspecto | Mi Perfil (referencia) | Kiosk actual (bug) |
+|---|---|---|
+| Loading state | `'⏳ Cargando empleados…'` (texto inline) | Placeholder HTML estático que nunca actualiza |
+| OK state | `'N empleados disponibles'` | Silencioso |
+| Error state | `'❌ Error cargando empleados: HTTP 502'` + `_empleados=[]` | `console.warn` + `K.empleados=DEMO.slice()` + `K.demoMode=true` |
+| Schema raro | `_empleados=[]` | `K.empleados=[]` (igual, pero sin warning) |
+| Timeout fetch | Default browser | 10s × 3 intentos (~34s peor caso) |
+
+## Fix aplicado (hotfix 20260520)
+
+### Commit refactor — eliminar fallback automático
+- `DEMO_EMPLEADOS`/`DEMO_SOS` renombrados a `_LEGACY_DEMOS_FALLBACK_REMOVED_20260520` con comentario explicativo. Solo accesibles por opt-in explícito `K.config.demoMode === true` (controlado por `localStorage.ops_demo_mode === '1'`, mantenido para testing).
+- `loadEmpleados` / `loadSOs`: en `catch`, `K.empleados = []` / `K.sos = []`. **No fallback a demos.** Setea `K.empleadosState='error'` / `K.sosState='error'`.
+- `updateConnStatus` lee también el state runtime, no solo `K.config.demoMode`.
+- `KIOSK_BUILD` → `20260520-kiosk-fix-fallback-error-ux`.
+
+### Commit feat — UX de error con banner + retry
+- Nuevo wrapper en `#ks-search`: `#ksLoadEmp` (spinner+texto dinámico) y `#ksErrorEmp` (banner rojo + subtítulo + botón reintentar). Reemplazan el placeholder estático.
+- Search input arranca `disabled`, se habilita solo en estado OK.
+- Spinner reusa `@keyframes ksSpinAnim` ya existente.
+- Texto del loading escala a `"Conectando con el servidor…"` después de 5s sin respuesta.
+- Botón **Reintentar** dispara `loadEmpleados()` nuevamente. Banner muestra timestamp último intento + contador.
+- Subtítulo del banner: instrucción de fallback humano ("registra tu hora manualmente en la libreta o avisa a tu supervisor").
+
+## Decisión sobre el flag opt-in `localStorage.ops_demo_mode`
+
+**Conservado.** Cuando `ops_demo_mode='1'` está explícitamente puesto, kiosk usa demos (escenario testing local sin n8n). Para el modo de producción (`'0'` o ausente), el catch ya no hace fallback. Esteban sigue pudiendo poner el flag a propósito para test sin red.
+
+## Plan de rollback
+
+Single PR. `git revert <merge-commit>` lo restaura completo en <1 min. GitHub Pages re-publishea automático.

--- a/operaciones/kiosk/css/kiosk.css
+++ b/operaciones/kiosk/css/kiosk.css
@@ -52,6 +52,48 @@ html,body{height:100%;overflow:hidden;font-family:'Inter',-apple-system,sans-ser
 .kiosk-list::-webkit-scrollbar{width:8px}
 .kiosk-list::-webkit-scrollbar-thumb{background:#e0e0e0;border-radius:4px}
 
+/* ═══ Estados de carga empleados (hotfix 20260520) ═══ */
+.kiosk-search:disabled{
+  background:#f5f5f5;color:#999;cursor:not-allowed;
+  border-color:#e0e0e0;box-shadow:none;
+}
+.kiosk-loading{
+  display:flex;flex-direction:column;align-items:center;justify-content:center;
+  gap:14px;padding:32px 20px;width:100%;max-width:500px;margin-top:16px;
+}
+.kiosk-loading[hidden]{display:none}
+.kiosk-loading-spinner{
+  width:44px;height:44px;
+  border:4px solid #e0e0e0;border-top:4px solid #107C10;border-radius:50%;
+  animation:ksSpinAnim 0.8s linear infinite;
+}
+.kiosk-loading-text{
+  font-size:15px;color:#555;text-align:center;
+}
+.kiosk-error-banner{
+  width:100%;max-width:500px;margin-top:20px;
+  background:#fff0f0;border:2px solid #D83B01;border-radius:14px;
+  padding:20px 18px;text-align:center;
+  box-shadow:0 4px 14px rgba(216,59,1,0.12);
+}
+.kiosk-error-banner[hidden]{display:none}
+.kiosk-error-title{
+  font-size:18px;font-weight:700;color:#D83B01;margin-bottom:10px;
+}
+.kiosk-error-sub{
+  font-size:14px;color:#5a2010;line-height:1.45;margin-bottom:16px;
+}
+.kiosk-error-retry{
+  display:inline-block;background:#D83B01;color:#fff;border:none;
+  border-radius:10px;padding:14px 22px;font-size:16px;font-weight:600;
+  cursor:pointer;min-height:48px;width:100%;font-family:inherit;
+}
+.kiosk-error-retry:hover{background:#b73101}
+.kiosk-error-retry:active{transform:scale(0.97)}
+.kiosk-error-meta{
+  margin-top:12px;font-size:12px;color:#8a5040;
+}
+
 .kiosk-employee-card{
   display:flex;align-items:center;gap:16px;
   background:#fff;border-radius:12px;

--- a/operaciones/kiosk/index.html
+++ b/operaciones/kiosk/index.html
@@ -32,10 +32,27 @@
   <button class="kiosk-back" onclick="goHome()">← Volver</button>
   <div class="kiosk-logo-sm" style="margin-bottom:16px">F</div>
   <div class="kiosk-title">¿Quién eres?</div>
-  <input type="search" id="ksSearch" class="kiosk-search" placeholder="Busca tu nombre…" oninput="searchEmpleados(this.value)" autocomplete="off" inputmode="search" onfocus="setTimeout(()=>this.scrollIntoView({behavior:'smooth',block:'center'}),300)">
-  <div class="kiosk-list" id="ksEmpleadosList">
-    <div style="text-align:center;color:#666;padding:24px">Cargando empleados…</div>
+  <input type="search" id="ksSearch" class="kiosk-search" placeholder="Busca tu nombre…" oninput="searchEmpleados(this.value)" autocomplete="off" inputmode="search" onfocus="setTimeout(()=>this.scrollIntoView({behavior:'smooth',block:'center'}),300)" disabled>
+
+  <!-- Estado A: cargando empleados -->
+  <div id="ksLoadEmp" class="kiosk-loading">
+    <div class="kiosk-loading-spinner" aria-hidden="true"></div>
+    <div class="kiosk-loading-text" id="ksLoadEmpText">Cargando empleados…</div>
   </div>
+
+  <!-- Estado C/D: error de conexión -->
+  <div id="ksErrorEmp" class="kiosk-error-banner" hidden>
+    <div class="kiosk-error-title">⚠️ Sistema temporalmente no disponible</div>
+    <div class="kiosk-error-sub">
+      No podemos conectar con el servidor en este momento. Por favor, registra
+      tu hora manualmente en la libreta o avisa a tu supervisor.
+    </div>
+    <button type="button" class="kiosk-error-retry" onclick="retryLoadEmpleados()">🔄 Reintentar</button>
+    <div class="kiosk-error-meta" id="ksErrorEmpMeta"></div>
+  </div>
+
+  <!-- Estado B: lista cargada (se llena con renderEmpleados al tipear) -->
+  <div class="kiosk-list" id="ksEmpleadosList"></div>
 </div>
 
 <!-- ═══════ PANTALLA 2.5 — ESTADO EMPLEADO ═══════ -->

--- a/operaciones/kiosk/js/kiosk.js
+++ b/operaciones/kiosk/js/kiosk.js
@@ -1,7 +1,7 @@
 // ═══ FTS Kiosk — Lógica principal ═══
 // Script clásico, estado global compartido
 
-const KIOSK_BUILD = '20260504-kiosk-olvide-checkout-v3-boton-jornada';
+const KIOSK_BUILD = '20260520-kiosk-fix-fallback-error-ux';
 console.log('[kiosk] build:', KIOSK_BUILD);
 
 const K = {
@@ -16,6 +16,16 @@ const K = {
   returnTimer: null,
   faceReady: false,
   demoMode: false,
+  // Estado de carga runtime (hotfix 20260520):
+  //   'loading' = fetch en vuelo
+  //   'ok'      = datos cargados de n8n/Odoo (o opt-in demo explícito)
+  //   'error'   = fetch falló, K.empleados/K.sos quedan vacíos (NO fallback a demos)
+  empleadosState: 'loading',
+  empleadosError: null,
+  empleadosLastTryAt: null,
+  empleadosTryCount: 0,
+  sosState: 'loading',
+  sosError: null,
 };
 
 // ═══ Carga de configuración (nuevo schema) ═══
@@ -399,14 +409,18 @@ function terminarYHome(){
 window.terminarYHome = terminarYHome;
 
 // ═══ Carga de empleados/SOs ═══
-const DEMO_EMPLEADOS = [
+// Hotfix 20260520: los arrays demo viven SOLO para el opt-in explícito de testing
+// (localStorage.ops_demo_mode = '1'). El catch del fetch NO regresa a demos:
+// cae en estado 'error' con K.empleados/K.sos = [] y la UI muestra banner.
+// Ver docs/audit-kiosk-empleados-fallback.md
+const _LEGACY_DEMOS_OPTIN_ONLY_EMPLEADOS = [
   { id:1, nombre:'Mateo Salazar',     puesto:'Ingeniero',  foto:'', pin:'1234' },
   { id:2, nombre:'Felipe Pérez',      puesto:'Supervisor', foto:'', pin:'5678' },
   { id:3, nombre:'Esteban De La Cruz',puesto:'Director',   foto:'', pin:'0000' },
   { id:4, nombre:'Ana Ramírez',       puesto:'Soldador',   foto:'', pin:'1111' },
   { id:5, nombre:'Carlos Hernández',  puesto:'Ayudante',   foto:'', pin:'2222' },
 ];
-const DEMO_SOS = [
+const _LEGACY_DEMOS_OPTIN_ONLY_SOS = [
   { id:101, name:'🛠️ SO-2026-001 - Topo Chico Radium',        cliente:'Ecolab Nalco',        nombre:'Topo Chico — Radium',       num:'SO-2026-001' },
   { id:102, name:'🛠️ SO-2026-002 - Arca Mezzanine',           cliente:'Arca Continental',    nombre:'Arca Continental — Mezzanine', num:'SO-2026-002' },
   { id:103, name:'🛠️ SO-2026-003 - Sigma Polipasto 2T',       cliente:'Sigma Alimentos',     nombre:'Sigma — Polipasto 2T',      num:'SO-2026-003' },
@@ -414,31 +428,45 @@ const DEMO_SOS = [
 ];
 
 async function loadEmpleados(){
+  K.empleadosState = 'loading';
+  K.empleadosError = null;
+  K.empleadosLastTryAt = new Date();
+  K.empleadosTryCount = (K.empleadosTryCount || 0) + 1;
+  // Opt-in explícito: solo si Esteban setea ops_demo_mode='1' a propósito para testing.
   if(K.config.demoMode || !K.config.n8nUrl){
-    K.empleados = DEMO_EMPLEADOS.slice();
+    K.empleados = _LEGACY_DEMOS_OPTIN_ONLY_EMPLEADOS.slice();
+    K.empleadosState = 'ok';
     return;
   }
   try{
     const data = await window.OdooKiosk.getEmpleados();
     K.empleados = Array.isArray(data) ? data : (data.empleados || []);
+    K.empleadosState = 'ok';
   } catch(e){
-    console.warn('Odoo no disponible, usando demo:', e);
-    K.empleados = DEMO_EMPLEADOS.slice();
-    K.demoMode = true;
+    console.warn('Odoo no disponible (sin fallback a demos):', e);
+    K.empleados = [];
+    K.empleadosState = 'error';
+    K.empleadosError = e && e.message ? e.message : String(e);
   }
 }
 
 async function loadSOs(){
+  K.sosState = 'loading';
+  K.sosError = null;
   if(K.config.demoMode || !K.config.n8nUrl){
-    K.sos = DEMO_SOS.slice();
+    K.sos = _LEGACY_DEMOS_OPTIN_ONLY_SOS.slice();
+    K.sosState = 'ok';
     return;
   }
   try{
     const data = await window.OdooKiosk.getSOs();
     K.sos = Array.isArray(data) ? data : (data.sos || []);
+    K.sosState = 'ok';
   } catch(e){
-    console.warn('Odoo no disponible, usando demo:', e);
-    K.sos = DEMO_SOS.slice();
+    console.warn('SOs no disponibles (sin fallback a demos):', e);
+    K.sos = [];
+    K.sosState = 'error';
+    K.sosError = e && e.message ? e.message : String(e);
   }
 }
 
@@ -1273,8 +1301,18 @@ function autoReturn(){
 function updateConnStatus(){
   const el = document.getElementById('ksConnStatus');
   if(!el) return;
-  if(K.config.demoMode || !K.config.n8nUrl) el.textContent = 'MODO DEMO';
-  else el.textContent = 'conectado';
+  if(K.config.demoMode || !K.config.n8nUrl){
+    el.textContent = 'MODO DEMO';
+    return;
+  }
+  // Hotfix 20260520: reflejar también estado runtime, no solo K.config.demoMode
+  if(K.empleadosState === 'error' || K.sosState === 'error'){
+    el.textContent = '⚠️ sin conexión';
+  } else if(K.empleadosState === 'loading' || K.sosState === 'loading'){
+    el.textContent = 'conectando…';
+  } else {
+    el.textContent = 'conectado';
+  }
 }
 
 // ═══ Init ═══

--- a/operaciones/kiosk/js/kiosk.js
+++ b/operaciones/kiosk/js/kiosk.js
@@ -427,26 +427,78 @@ const _LEGACY_DEMOS_OPTIN_ONLY_SOS = [
   { id:104, name:'🛠️ SO-2026-004 - HEB Tanque 5000L',         cliente:'HEB México',          nombre:'HEB — Tanque 5000L',        num:'SO-2026-004' },
 ];
 
+// ═══ State machine UI carga empleados (hotfix 20260520) ═══
+// Estados: 'loading' (spinner) | 'ok' (search habilitado) | 'error' (banner + retry).
+// Aplica solo a la pantalla #ks-search; los SOs viven en otro screen.
+let _empEscalateTimer = null;
+function setEmpState(state){
+  const loadEl  = document.getElementById('ksLoadEmp');
+  const errEl   = document.getElementById('ksErrorEmp');
+  const listEl  = document.getElementById('ksEmpleadosList');
+  const searchEl= document.getElementById('ksSearch');
+  const textEl  = document.getElementById('ksLoadEmpText');
+  const metaEl  = document.getElementById('ksErrorEmpMeta');
+  if(_empEscalateTimer){ clearTimeout(_empEscalateTimer); _empEscalateTimer = null; }
+  if(state === 'loading'){
+    if(loadEl)   loadEl.hidden = false;
+    if(errEl)    errEl.hidden  = true;
+    if(listEl)   listEl.innerHTML = '';
+    if(searchEl) searchEl.disabled = true;
+    if(textEl)   textEl.textContent = 'Cargando empleados…';
+    // Escalación: si >5s, cambiar mensaje a "Conectando con el servidor…"
+    _empEscalateTimer = setTimeout(function(){
+      if(K.empleadosState === 'loading' && textEl) textEl.textContent = 'Conectando con el servidor…';
+    }, 5000);
+  } else if(state === 'ok'){
+    if(loadEl)   loadEl.hidden = true;
+    if(errEl)    errEl.hidden  = true;
+    if(searchEl) searchEl.disabled = false;
+  } else if(state === 'error'){
+    if(loadEl)   loadEl.hidden = true;
+    if(errEl)    errEl.hidden  = false;
+    if(listEl)   listEl.innerHTML = '';
+    if(searchEl) searchEl.disabled = true;
+    if(metaEl){
+      const ts = K.empleadosLastTryAt
+        ? K.empleadosLastTryAt.toLocaleTimeString('es-MX', { hour:'2-digit', minute:'2-digit', second:'2-digit' })
+        : '—';
+      const tries = K.empleadosTryCount || 1;
+      const errMsg = K.empleadosError ? ' · ' + K.empleadosError : '';
+      metaEl.textContent = 'Último intento: ' + ts + ' · Intentos: ' + tries + errMsg;
+    }
+  }
+}
+
+async function retryLoadEmpleados(){
+  await loadEmpleados();
+  if(typeof updateConnStatus === 'function') updateConnStatus();
+}
+window.retryLoadEmpleados = retryLoadEmpleados;
+
 async function loadEmpleados(){
   K.empleadosState = 'loading';
   K.empleadosError = null;
   K.empleadosLastTryAt = new Date();
   K.empleadosTryCount = (K.empleadosTryCount || 0) + 1;
+  setEmpState('loading');
   // Opt-in explícito: solo si Esteban setea ops_demo_mode='1' a propósito para testing.
   if(K.config.demoMode || !K.config.n8nUrl){
     K.empleados = _LEGACY_DEMOS_OPTIN_ONLY_EMPLEADOS.slice();
     K.empleadosState = 'ok';
+    setEmpState('ok');
     return;
   }
   try{
     const data = await window.OdooKiosk.getEmpleados();
     K.empleados = Array.isArray(data) ? data : (data.empleados || []);
     K.empleadosState = 'ok';
+    setEmpState('ok');
   } catch(e){
     console.warn('Odoo no disponible (sin fallback a demos):', e);
     K.empleados = [];
     K.empleadosState = 'error';
     K.empleadosError = e && e.message ? e.message : String(e);
+    setEmpState('error');
   }
 }
 


### PR DESCRIPTION
## Contexto

Durante la caída de Railway/n8n del **19-may-2026**, el kiosk seguía mostrando una lista de empleados al buscar — pero eran los demos hardcoded (`Mateo Salazar`, `Felipe Pérez`, `Esteban De La Cruz`, `Ana Ramírez`, `Carlos Hernández`) porque el `catch` en `loadEmpleados()` caía silenciosamente a `DEMO_EMPLEADOS.slice()`. Los PINs eran `1234/5678/0000/1111/2222`. Footer decía `"conectado"`. Generó crisis comunicacional: empleados intentaron checkin contra demos sin entender por qué nada parecía registrar.

Mi Perfil ya tenía el patrón correcto (`mp_load_empleados` en `shared/mi-perfil/index.html:615-632` — sin fallback a demos, status line con error). Este hotfix lleva el kiosk al mismo estándar + agrega banner UX prominente con botón reintentar.

## Diff

| Archivo | Cambios |
|---|---|
| `docs/audit-kiosk-empleados-fallback.md` | nuevo, +106 líneas (audit completo) |
| `operaciones/kiosk/js/kiosk.js` | +50/−12 (refactor) + +52 (state machine + retry) = **+102 netas** |
| `operaciones/kiosk/index.html` | +20/−3 wrappers loading/error en `#ks-search` |
| `operaciones/kiosk/css/kiosk.css` | +42 líneas (3 clases nuevas, reusa `@keyframes ksSpinAnim`) |
| `operaciones/kiosk/js/odoo.js` | **sin cambios** (opción A: no tocar el helper de fetch) |

### Lo que se eliminó
- Fallback automático `K.empleados = DEMO_EMPLEADOS.slice()` en el `catch` de `loadEmpleados` / `loadSOs`
- Auto-set de `K.demoMode = true` en runtime
- Placeholder estático `<div>Cargando empleados…</div>` que nunca se actualizaba

### Lo que se agregó
- `K.empleadosState` / `K.sosState` con valores `'loading' | 'ok' | 'error'`
- `K.empleadosError`, `K.empleadosLastTryAt`, `K.empleadosTryCount`
- `setEmpState(state)` — state machine UI (3 wrappers, search disabled toggle)
- `retryLoadEmpleados()` expuesto a `window` para el botón
- Escalación: texto cambia a `"Conectando con el servidor…"` después de 5s
- Banner rojo `#fff0f0` con borde `#D83B01`, mobile-first (botón retry min-height 48px)
- `updateConnStatus` ahora refleja runtime: `"⚠️ sin conexión"` / `"conectando…"` / `"conectado"`
- `KIOSK_BUILD` → `20260520-kiosk-fix-fallback-error-ux`

### Lo que se preservó (opt-in explícito)
- `_LEGACY_DEMOS_OPTIN_ONLY_EMPLEADOS` y `_LEGACY_DEMOS_OPTIN_ONLY_SOS` siguen existiendo
- Si `localStorage.ops_demo_mode === '1'` (control explícito de Esteban), el kiosk SÍ los usa
- Sin ese flag, catch nunca regresa a demos

## ASCII de los 3 estados

**Estado A — Cargando:**
```
┌──────────────────────────────┐
│      ¿Quién eres?            │
│  ┌────────────────────────┐  │
│  │ Busca tu nombre…   (🚫)│  │  ← disabled
│  └────────────────────────┘  │
│                              │
│          ⟳ (spinner)         │
│      Cargando empleados…     │
│         (>5s: "Conectando    │
│          con el servidor…")  │
└──────────────────────────────┘
```

**Estado B — OK:**
```
┌──────────────────────────────┐
│      ¿Quién eres?            │
│  ┌────────────────────────┐  │
│  │ felipe                 │  │  ← habilitado
│  └────────────────────────┘  │
│  ┌────────────────────────┐  │
│  │ 📷 Felipe Pérez Guzmán │  │  ← empleado REAL de Odoo
│  │    Operaciones · Mgr   │  │
│  └────────────────────────┘  │
└──────────────────────────────┘
```

**Estado C — Error:**
```
┌──────────────────────────────┐
│      ¿Quién eres?            │
│  ┌────────────────────────┐  │
│  │ Busca tu nombre…   (🚫)│  │  ← disabled
│  └────────────────────────┘  │
│  ╔══════════════════════════╗│
│  ║ ⚠️ Sistema temporalmente ║│  ← rojo prominente
│  ║    no disponible         ║│
│  ║                          ║│
│  ║ No podemos conectar con  ║│
│  ║ el servidor en este      ║│
│  ║ momento. Por favor,      ║│
│  ║ registra tu hora         ║│
│  ║ manualmente en la libreta║│
│  ║ o avisa a tu supervisor. ║│
│  ║                          ║│
│  ║   [ 🔄 Reintentar ]      ║│  ← min-height 48px touch
│  ║                          ║│
│  ║ Último intento: 14:23:47 ║│
│  ║ · Intentos: 3 · n8n 502  ║│
│  ╚══════════════════════════╝│
└──────────────────────────────┘
```

## Test plan post-merge (Esteban)

1. **Con Railway down (estado actual real):** recargar `https://yinyo1.github.io/fts-suite/operaciones/kiosk/`
   - ✅ Ver Estado A (spinner + "Cargando empleados…")
   - ✅ Después de 5s: texto cambia a "Conectando con el servidor…"
   - ✅ Después de timeout (~10-34s peor caso): Estado C (banner rojo + retry)
   - ✅ **CERO empleados demo visibles**
   - ✅ Footer dice "⚠️ sin conexión"
2. **Con Railway up (cuando vuelva):** recargar
   - ✅ Spinner brevemente → desaparece → search habilitado
   - ✅ Tipear "Felipe" → ver Felipe Pérez Guzmán **real** (no Felipe Pérez demo)
   - ✅ Footer dice "conectado"
3. **Forzar error en consola:** `localStorage.setItem('ops_n8n_url','https://example.invalid'); location.reload();`
   - ✅ Estado C aparece dentro de ~14s
4. **Click Reintentar:** vuelve a Estado A; si fetch resuelve → B, si no → C de nuevo (contador subió, timestamp actualizado)
5. **Opt-in demos preservado:** `localStorage.setItem('ops_demo_mode','1'); location.reload();`
   - ✅ Mostrar los demos a propósito (Mateo, Felipe demo, etc.)
   - ✅ Footer dice "MODO DEMO"
6. **Opt-in apagado:** `localStorage.setItem('ops_demo_mode','0'); location.reload();`
   - ✅ Si Railway up → empleados reales
   - ✅ Si Railway down → Estado C, sin demos
7. **Regresión flujo checkin completo (con Railway up):** Felipe real → tipea nombre → PIN → selfie → SO → checkin OK

## Plan rollback (<1 min)

```bash
git revert <merge-commit-sha>
git push origin main
```

GitHub Pages re-publishea en ~1 min. Comportamiento vuelve al pre-hotfix (fallback a demos).

## No incluido en este PR

- ❌ No toca `operaciones/kiosk/js/odoo.js` (timeout 10s × 3 intentos sigue igual; el control de UX vive en `kiosk.js`)
- ❌ No toca workflows n8n
- ❌ No toca Mi Perfil (referencia)
- ❌ No toca el flujo auth/PIN/selfie
- ❌ No mergeado — Esteban valida y mergea mañana

🤖 Generated with [Claude Code](https://claude.com/claude-code)