### PR TITLE
fix(kiosk): bugs visuales hotfix PR #42

### DIFF
--- a/operaciones/kiosk/css/kiosk.css
+++ b/operaciones/kiosk/css/kiosk.css
@@ -63,12 +63,15 @@ html,body{height:100%;overflow:hidden;font-family:'Inter',-apple-system,sans-ser
 }
 .kiosk-loading[hidden]{display:none}
 .kiosk-loading-spinner{
+  box-sizing:border-box;
+  flex-shrink:0;            /* evita deformación dentro del flex-column padre */
   width:44px;height:44px;
   border:4px solid #e0e0e0;border-top:4px solid #107C10;border-radius:50%;
   animation:ksSpinAnim 0.8s linear infinite;
 }
 .kiosk-loading-text{
   font-size:15px;color:#555;text-align:center;
+  animation:none;           /* defensivo: ningún ancestro debe rotarlo */
 }
 .kiosk-error-banner{
   width:100%;max-width:500px;margin-top:20px;
@@ -310,11 +313,11 @@ html,body{height:100%;overflow:hidden;font-family:'Inter',-apple-system,sans-ser
   text-align:center;font-size:12px;color:#999;
 }
 
-.kiosk-loading{
-  display:inline-block;width:24px;height:24px;
-  border:3px solid #e0e0e0;border-top-color:#107C10;
-  border-radius:50%;animation:spin 1s linear infinite;
-}
+/* Eliminado regla `.kiosk-loading` duplicada (display:inline-block; 24x24;
+   animation:spin) que era código muerto pre-hotfix 20260520. Colisión con
+   `.kiosk-loading` wrapper (L60) hacía rotar texto + deformar spinner en
+   #ksLoadEmp por la regla de cascade (last-rule-wins). Sin consumers en
+   HTML/JS — borrado seguro. Ver fix(kiosk): bugs visuales hotfix PR #42. */
 
 @keyframes ksSpinAnim {
   0%   { transform: rotate(0deg); }

--- a/operaciones/kiosk/js/kiosk.js
+++ b/operaciones/kiosk/js/kiosk.js
@@ -536,6 +536,11 @@ function searchEmpleados(q){
 function renderEmpleados(list){
   const el = document.getElementById('ksEmpleadosList');
   if(!el) return;
+  // Hotfix bugs visuales: si aún no terminamos de cargar empleados (loading/error),
+  // NO escribir "Sin resultados" en la lista — esa zona la maneja setEmpState
+  // (spinner o banner). showScreen('ks-search') llama aquí al volver al search
+  // screen y antes pintaba "Sin resultados" sobre la zona de loading.
+  if(K.empleadosState !== 'ok'){ el.innerHTML = ''; return; }
   if(!list.length){
     el.innerHTML = '<div style="text-align:center;color:#666;padding:24px">Sin resultados</div>';
     return;


### PR DESCRIPTION
## Contexto

Post-merge de #42, Esteban abrió kiosk en móvil y reportó 3 bugs visuales en el nuevo Estado A (loading):

1. **Spinner deformado** — se veía como dos círculos sobrepuestos, no un círculo perfecto rotando.
2. **Texto rotando** — `"Cargando empleados…"` aparecía inclinado/girando junto con el spinner.
3. **"Sin resultados"** — texto aparecía debajo del spinner durante loading.

## Root cause

**Bugs 1 + 2 — colisión CSS:** existía una regla `.kiosk-loading` huérfana en `kiosk.css:313` (anterior al hotfix de ayer):

```css
.kiosk-loading{
  display:inline-block;width:24px;height:24px;
  border:3px solid #e0e0e0;border-top-color:#107C10;
  border-radius:50%;animation:spin 1s linear infinite;
}
```

Sin consumers en HTML/JS — era código muerto. Pero el cascade `last-rule-wins` la hacía ganar sobre mi `.kiosk-loading` wrapper (L60). El resultado: el wrapper entero se renderizaba como spinner 24x24 con animación spin → el spinner real dentro (44x44) quedaba dentro de un padre rotando → texto hijo también rotaba.

**Bug 3 — `renderEmpleados` sin gate:** `showScreen('ks-search')` (kiosk.js:320) llama `renderEmpleados(K.empleados)` cada vez que el usuario navega al search screen. Durante loading, `K.empleados = []` → la rama `if(!list.length)` escribía `"Sin resultados"` en `#ksEmpleadosList`, encima del estado limpio que `setEmpState('loading')` había dejado.

## Diff

`operaciones/kiosk/css/kiosk.css` (+8/−5):
- ❌ Eliminada regla huérfana `.kiosk-loading{display:inline-block; 24x24; animation:spin}` (L313)
- ✅ Agregado `box-sizing:border-box; flex-shrink:0` a `.kiosk-loading-spinner` (defensivo)
- ✅ Agregado `animation:none` a `.kiosk-loading-text` (defensivo)
- 💬 Comentario explicativo donde estaba el código muerto

`operaciones/kiosk/js/kiosk.js` (+5/−0):
- ✅ Gate temprano en `renderEmpleados`: `if(K.empleadosState !== 'ok'){ el.innerHTML=''; return; }`
- 💬 Comentario explicando el caso `showScreen('ks-search')`

## Test plan (Esteban en móvil después)

1. **Estado A (con Railway down ahora):**
   - ✅ Spinner gris-verde circular perfecto, rotando suavemente
   - ✅ Texto `"Cargando empleados…"` estático debajo, NO rotando
   - ✅ Nada de `"Sin resultados"` visible
2. **Navegación home → search durante loading:**
   - Tocar home → tocar para ir a search
   - ✅ Spinner sigue visible, sin `"Sin resultados"` debajo
3. **Estado C (error tras timeout):** comportamiento intacto (banner rojo + retry)
4. **Estado B (Railway up):** búsqueda normal, sigue mostrando `"Sin resultados"` cuando el query no matchea (porque ahí `K.empleadosState === 'ok'` y la rama `!list.length` se ejecuta normal)

## Riesgo

Mínimo. Eliminada regla CSS sin consumers + 5 líneas de gate defensivo en JS. Estado B no afectado (gate solo aplica fuera de 'ok').

## Rollback (<1 min)

```bash
git revert <merge-commit-sha>
git push origin main
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)