### PR TITLE
fix(kiosk): face-api CDN 404 + endurecer initKiosk no-bloqueante

### DIFF
--- a/operaciones/kiosk/js/face.js
+++ b/operaciones/kiosk/js/face.js
@@ -1,7 +1,11 @@
 // ═══ FTS Kiosk — Verificación facial con face-api.js ═══
 
 const FACE_THRESHOLD = parseFloat(localStorage.getItem('ops_kiosk_face_threshold') || '0.5');
-const FACE_MODELS_URL = 'https://cdn.jsdelivr.net/npm/face-api.js@0.22.2/weights';
+// jsdelivr-npm dejó de servir /weights del paquete 0.22.2 (404 confirmado 21-may-2026).
+// Cambio a jsdelivr-gh (sirve el repo source directamente) — 7/7 assets verificados 200 OK.
+// Override opcional via localStorage.ops_kiosk_face_models_url (testing local con server propio).
+const FACE_MODELS_URL = localStorage.getItem('ops_kiosk_face_models_url') ||
+  'https://cdn.jsdelivr.net/gh/justadudewhohacks/face-api.js@master/weights';
 
 let faceModelsLoaded = false;
 

--- a/operaciones/kiosk/js/kiosk.js
+++ b/operaciones/kiosk/js/kiosk.js
@@ -1,7 +1,7 @@
 // ═══ FTS Kiosk — Lógica principal ═══
 // Script clásico, estado global compartido
 
-const KIOSK_BUILD = '20260520-kiosk-fix-fallback-error-ux';
+const KIOSK_BUILD = '20260521-kiosk-fix-face-cdn-resilient-init';
 console.log('[kiosk] build:', KIOSK_BUILD);
 
 const K = {
@@ -1399,16 +1399,24 @@ async function initKiosk(){
   await loadEmpleados();
   await loadSOs();
 
-  // Cargar modelos de face-api en background
-  if(K.config.faceEnabled && window.FaceVerify){
+  // Cargar modelos de face-api en background — feature opcional, NO bloqueante.
+  // Si el CDN responde 404 / red caída / face-api.js no cargó, desactivamos la
+  // feature en runtime (K.faceReady=false + K.config.faceEnabled=false) para
+  // que los call sites downstream salten verificación facial sin crashear el
+  // flow de checkin. Loading de empleados/SOs ya corrió arriba.
+  // (Fix 21-may-2026: previene regresión si vuelve a fallar cualquier CDN.)
+  if(K.config.faceEnabled && window.FaceVerify && typeof window.FaceVerify.loadFaceModels === 'function'){
     try{
       await window.FaceVerify.loadFaceModels();
       K.faceReady = true;
       console.log('✅ Modelos faciales listos');
     } catch(e){
-      console.warn('Error cargando modelos faciales:', e);
+      console.warn('[face] modelos NO disponibles, feature desactivada en runtime:', e && e.message || e);
       K.faceReady = false;
+      K.config.faceEnabled = false;
     }
+  } else {
+    K.faceReady = false;
   }
 }
 


### PR DESCRIPTION
## ⚠ Hallazgo previo al fix

Esteban reportó stack trace exacto:
```
GET https://cdn.jsdelivr.net/npm/face-api.js@0.22.2/weights/tiny_face_detector_model-weights_manifest.json 404
Error cargando modelos faciales: Error: failed to fetch: (404)
  at loadFaceModels (face.js:13)
  at initKiosk (kiosk.js:1405)
```

Al inspeccionar `main` (commit `5bbb8c5`), el código **ya tenía la Opción A** en su forma básica:
- `loadEmpleados()` corre en L1399, **ANTES** de `loadFaceModels()` en L1402-1412
- `loadFaceModels()` envuelto en try/catch desde el hotfix `20260520-kiosk-fix-fallback-error-ux`

Eso significa que el bug reportado ("`initKiosk` no completaba, `K.empleados` undefined") probablemente venía de un **navegador con cache servida pre-hotfix** (kiosk.js viejo sin try/catch ni el orden corregido). El bump de `KIOSK_BUILD` en este PR fuerza invalidación.

## Diagnóstico CDN confirmado (21-may-2026)

```
HTTP 404  jsdelivr-npm/face-api.js@0.22.2/weights/tiny_face_detector_model-weights_manifest.json
HTTP 404  jsdelivr-npm/face-api.js@0.22.2/weights/face_landmark_68_tiny_model-weights_manifest.json
HTTP 404  jsdelivr-npm/face-api.js@0.22.2/weights/face_recognition_model-weights_manifest.json
HTTP 404  unpkg/face-api.js@0.22.2/weights/...                       (alt npm también roto)
HTTP 404  jsdelivr-npm/@vladmandic/face-api/model/...                (fork distinto)

HTTP 200  jsdelivr-gh/justadudewhohacks/face-api.js@master/weights/  ✅
```

7/7 assets en el CDN-gh: 3 manifests + 4 shards (`tiny_face_detector_model-shard1`, `face_landmark_68_tiny_model-shard1`, `face_recognition_model-shard1`, `face_recognition_model-shard2`).

## Cambios

### 1. `face.js` — CDN alternativo (Opción B)

```diff
-const FACE_MODELS_URL = 'https://cdn.jsdelivr.net/npm/face-api.js@0.22.2/weights';
+const FACE_MODELS_URL = localStorage.getItem('ops_kiosk_face_models_url') ||
+  'https://cdn.jsdelivr.net/gh/justadudewhohacks/face-api.js@master/weights';
```

`localStorage.ops_kiosk_face_models_url` permite override para testing con server local.

### 2. `kiosk.js initKiosk()` — Opción A endurecida

```diff
-  if(K.config.faceEnabled && window.FaceVerify){
+  if(K.config.faceEnabled && window.FaceVerify && typeof window.FaceVerify.loadFaceModels === 'function'){
     try{
       await window.FaceVerify.loadFaceModels();
       K.faceReady = true;
       console.log('✅ Modelos faciales listos');
     } catch(e){
-      console.warn('Error cargando modelos faciales:', e);
+      console.warn('[face] modelos NO disponibles, feature desactivada en runtime:', e && e.message || e);
       K.faceReady = false;
+      K.config.faceEnabled = false;
     }
+  } else {
+    K.faceReady = false;
   }
```

Mejoras:
- **Guard `typeof === 'function'`:** defensivo si `face-api.min.js` falló al cargar (CDN del lib mismo cae). Sin esto, llamar `.loadFaceModels()` sobre undefined lanzaría TypeError no atrapado por el try (en realidad sí lo atraparía, pero más limpio gate antes).
- **`K.config.faceEnabled = false` en runtime:** los call sites downstream (`compareFaces` en checkin flow) consultan `K.config.faceEnabled` — desactivarlo asegura que NO intenten ejecutar verificación facial con modelos que no cargaron.
- **`else` branch:** si `faceEnabled` está off de inicio o `FaceVerify` no existe, deja `K.faceReady=false` explícito.

### 3. `KIOSK_BUILD` bumpeado

```diff
-const KIOSK_BUILD = '20260520-kiosk-fix-fallback-error-ux';
+const KIOSK_BUILD = '20260521-kiosk-fix-face-cdn-resilient-init';
```

Clave: invalida cache de navegadores que tengan el `kiosk.js` viejo. La línea `console.log('[kiosk] build:', KIOSK_BUILD)` se imprime al arrancar → Esteban puede confirmar versión en console en 2 segundos.

## Validaciones

- `node -c operaciones/kiosk/js/kiosk.js` → PARSE OK
- `node -c operaciones/kiosk/js/face.js` → PARSE OK
- CDN gh verificado HTTP 200 para los 7 assets necesarios
- Sin cambios en `odoo.js` (helper fetch intacto)
- Sin cambios en workflows n8n
- Sin cambios en PIN/selfie flow más allá del gate en initKiosk

## Test plan (Esteban móvil)

1. **Hard refresh kiosk** (Ctrl+Shift+R en desktop · "Borrar cache de sitio" en móvil)
2. **Console F12 → buscar `[kiosk] build:`**
   - ✅ Debe decir `20260521-kiosk-fix-face-cdn-resilient-init`
   - ❌ Si dice `20260520...` o anterior: cache no invalidó, retry hard refresh
3. **Esperar 2-3s después de cargar:**
   - ✅ console: `[GEO] Sincronizado: N sitios` + un mensaje empleados (loading→ok)
   - ✅ console: `✅ Modelos faciales listos` (si CDN-gh OK) **O** `[face] modelos NO disponibles, feature desactivada en runtime` (defensa funcionando)
4. **Buscar "Felipe"** en search box → debe aparecer **Felipe Pérez Guzmán real** (de Odoo, no demo)
5. **Footer:** `conectado` (no "MODO DEMO" ni "sin conexión")
6. **`window.K.empleadosState`** en console → `"ok"` (no undefined)
7. **`window.K.empleados.length`** → `>= 30` (no `0` ni undefined)
8. **Flow checkin completo:** Felipe → PIN → si `K.faceReady=true` pide selfie; si `false` salta a SO → checkin OK

## Plan rollback (<1 min)

```bash
git revert <merge-commit-sha>
git push origin main
```

Vuelve a `KIOSK_BUILD 20260520`. Cache viejo de browsers persiste — esto es deseable en rollback (los browsers no se ven afectados por el revert si ya tienen versión nueva en cache; el revert los devuelve a la versión 20260520 limpia).

## NO incluido en este PR

- ❌ No toca `odoo.js`
- ❌ No toca workflows n8n
- ❌ No toca Mi Perfil
- ❌ No toca PIN/selfie HTML flow

🤖 Generated with [Claude Code](https://claude.com/claude-code)