### PR TITLE
fix(kiosk): elimina regla .kiosk-loading duplicada/huérfana + @keyframes spin

### DIFF
--- a/operaciones/kiosk/css/kiosk.css
+++ b/operaciones/kiosk/css/kiosk.css
@@ -310,17 +310,20 @@ html,body{height:100%;overflow:hidden;font-family:'Inter',-apple-system,sans-ser
   text-align:center;font-size:12px;color:#999;
 }
 
-.kiosk-loading{
-  display:inline-block;width:24px;height:24px;
-  border:3px solid #e0e0e0;border-top-color:#107C10;
-  border-radius:50%;animation:spin 1s linear infinite;
-}
+/* Eliminadas reglas duplicadas/huérfanas pre-hotfix-20260520 (21-may-2026):
+   - .kiosk-loading{display:inline-block;width:24px;height:24px;animation:spin}
+     Estaba ANTES en el archivo (L313) pero por orden CSS ganaba sobre la
+     regla wrapper L60 del hotfix (#ksLoadEmp como flex container). El bug
+     se manifestaba en móvil: spinner 24x24 deformado + texto rotando. Único
+     consumer en HTML: index.html:38 ya usa la regla L60 correcta.
+   - @keyframes spin: solo lo usaba la regla legacy. Otros archivos del repo
+     (pmo/, seguridad/, shared/admin/) definen su propio @keyframes spin
+     localmente, no dependen de este. */
 
 @keyframes ksSpinAnim {
   0%   { transform: rotate(0deg); }
   100% { transform: rotate(360deg); }
 }
-@keyframes spin{to{transform:rotate(360deg)}}
 
 .kiosk-shake{animation:shake 0.4s}
 @keyframes shake{

--- a/operaciones/kiosk/js/kiosk.js
+++ b/operaciones/kiosk/js/kiosk.js
@@ -1,7 +1,7 @@
 // ═══ FTS Kiosk — Lógica principal ═══
 // Script clásico, estado global compartido
 
-const KIOSK_BUILD = '20260521-kiosk-fix-face-cdn-resilient-init';
+const KIOSK_BUILD = '20260521-kiosk-fix-css-duplicate-rule';
 console.log('[kiosk] build:', KIOSK_BUILD);
 
 const K = {


### PR DESCRIPTION
## Diagnóstico (CSS rules dump móvil, Esteban)

Dos reglas `.kiosk-loading` en `operaciones/kiosk/css/kiosk.css`:

| Línea | Regla | Origen |
|---|---|---|
| L60 | `display:flex; flex-direction:column; width:100%; max-width:500px;...` | Hotfix `20260520-kiosk-fix-fallback-error-ux` (PR #42, mergeado) |
| L313 | `display:inline-block; width:24px; height:24px; border:3px solid; border-radius:50%; animation:spin 1s linear infinite` | Legacy pre-hotfix |

CSS cascade: regla L313 gana sobre L60 por orden. El wrapper `#ksLoadEmp` del hotfix se renderiza como **spinner 24x24 inline-block rotando** en vez de **flex column container**. Síntomas:

- Spinner `.kiosk-loading-spinner` (44x44) hijo de un padre 24x24 rotando → deformado
- Texto "Cargando empleados…" gira junto con el padre

## Cambios

`operaciones/kiosk/css/kiosk.css`:
- ❌ Eliminada regla legacy `.kiosk-loading{display:inline-block;...}` (L313-317)
- ❌ Eliminado `@keyframes spin{...}` (L323) — único consumer era la regla legacy
- ✅ Preservado `@keyframes ksSpinAnim` (lo usa `.kiosk-loading-spinner` L68)
- 💬 Comentario explicativo en lugar del código borrado

`operaciones/kiosk/js/kiosk.js`:
- `KIOSK_BUILD` → `20260521-kiosk-fix-css-duplicate-rule` (invalida cache navegador)

## Auditoría pre-cambio (cero refs huérfanas)

```bash
grep -c '^\.kiosk-loading{' operaciones/kiosk/css/kiosk.css           # antes: 2, después: 1 ✅
grep -rn 'class="kiosk-loading"' --include="*.html" .                 # 1 uso (index.html:38 → ya usa la regla L60 correcta)
grep -rn 'animation:.*\bspin\b' operaciones/kiosk/css/kiosk.css       # antes: 1 (legacy), después: 0
```

`@keyframes spin` definido en otros archivos del repo (`pmo/index.html`, `seguridad/`, `shared/admin/`, `ingenieria/`, `FTS-Memoria-Calculo-v2.html`, `hatch/`) — todos con scope CSS local, sin dependencia cross-file con `kiosk.css`. Cero impacto.

## ¿Por qué pasó esto si ya lo arreglé en PR #43?

**PR #43 nunca se mergeó** (rama `fix/kiosk-spinner-visual-bugs`, abierta pero stalled). En este sprint anterior:
- PR #42 mergeado (hotfix-20260520 — agregó la regla nueva L60, no tocó la legacy L313)
- PR #43 abierto pero no mergeado (borraba la legacy)
- PR siguientes (cleanup CSS `tr-cancelled`, PMO updates, hallazgo #13, face-api fix #44) → ninguno tocó esta regla

Este PR cierra definitivamente con build bump para asegurar invalidación de cache en quienes tengan kiosk.js viejo.

## Test plan (Esteban móvil)

1. **Hard refresh kiosk**
2. **Console F12 → buscar `[kiosk] build:`**
   - ✅ Debe decir `20260521-kiosk-fix-css-duplicate-rule`
   - ❌ Si dice `20260521-kiosk-fix-face-cdn-resilient-init` o anterior: cache no invalidó, retry
3. **Estado A (loading durante init):**
   - ✅ Spinner gris-verde circular **perfecto 44x44** rotando suavemente
   - ✅ Texto `"Cargando empleados…"` **estático** debajo (NO rotando)
4. **Estado B (Railway up + empleados cargados):** búsqueda normal
5. **Estado C (si Railway 502/down):** banner rojo + retry — sin cambio respecto al hotfix-20260520

## Rollback (<1 min)

```bash
git revert <merge-commit-sha>
git push origin main
```

Vuelve a tener las 2 reglas duplicadas + bug visual. Los browsers con cache nueva persisten OK; el revert solo restaura el archivo legacy.

## NO incluido

- ❌ No toca workflows n8n
- ❌ No toca odoo.js / face.js (PR #44 face-api ya mergeado en main, sigue activo)
- ❌ No toca HTML del kiosk (la única ref `class="kiosk-loading"` en index.html:38 ya apunta a la regla correcta L60)
- ❌ No toca otros archivos del repo con `animation:spin` (cada uno tiene su propio scope)

🤖 Generated with [Claude Code](https://claude.com/claude-code)