### PR TITLE
feat(incidencias): incidencia validación RH Ricardo Hernández

### DIFF
--- a/shared/incidencias-asistencia.json
+++ b/shared/incidencias-asistencia.json
@@ -2129,6 +2129,31 @@
       "sin_supervisor": false,
       "depto_invalido": false,
       "tag_disputa_activo": false
+    },
+    {
+      "id_interno": "INC-VALIDACION-98-2026-05-28T23-09-36-918Z",
+      "empleado_id": 98,
+      "empleado_nombre": "Ricardo Alán Hernández González",
+      "tipo": "validacion_rh",
+      "fecha_creacion": "2026-05-28T23:09:36.918Z",
+      "fecha_evento": "2026-05-26",
+      "status": "pendiente_rh",
+      "creado_por": "admin_cleanup",
+      "attendance_id": 13334,
+      "descripcion": "Orphan preexistente recuperado. Att 13334 cerrado a horario razonable (18:00 CST 26-may). RH debe validar si Ricardo trabajó 27-may y 28-may.",
+      "datos_referencia": {
+        "att_id": 13334,
+        "check_in_original": "2026-05-26 15:29:24 UTC",
+        "check_out_aplicado": "2026-05-27 00:00:00 UTC",
+        "evidencia_magaly": "17:45 CST 27-may (libreta)",
+        "kiosko_27_may": "sin checkin",
+        "kiosko_28_may": "sin checkin"
+      },
+      "accion_requerida_rh": [
+        "Confirmar con Ricardo si trabajó 27-may y 28-may",
+        "Si sí: crear attendances manuales con horarios reales",
+        "Si no: documentar ausencia/permiso/campo"
+      ]
     }
   ]
 }


### PR DESCRIPTION
## Summary

Agrega 1 incidencia a `shared/incidencias-asistencia.json` (49 → 50) para que RH valide el caso de **Ricardo Alán Hernández González (id 98)**, un orphan **preexistente al outage del 27-may**:

- Att **13334**: check_in 26-may 09:29 CST, **sin checkout** (cerrado a horario razonable, 18:00 CST 26-may).
- Ricardo **no checó ni el 27 ni el 28-may** en el kiosko → el recovery reactivo nunca se disparó para él.
- Magaly reporta en libreta haberlo visto el **27-may 17:45 CST** → discrepancia que RH debe validar.

Entrada: `tipo: validacion_rh`, `status: pendiente_rh`, con `descripcion`, `datos_referencia` y `accion_requerida_rh`.

## Comportamiento en el visor (verificado)

- El visor RH filtra por **status**, no por tipo (`visor-incidencias.html:405-409`) → aparece en la vista "🟡 Pendiente RH".
- Tipo desconocido → fallback al string crudo `validacion_rh` (mismo trato que los 20 `auto_cierre_pendiente` ya en producción). No requiere cambio de frontend ni rompe el detalle.
- **Opcional:** añadir `'validacion_rh'` a `TIPO_LABELS` (panel) y al ternario del visor para un label bonito con emoji. No bloqueante.

## Test plan

- [ ] Esteban valida la incidencia antes de mergear
- [ ] Confirmar que aparece en visor RH filtro "Pendiente RH"
- [ ] Decidir si se añade label amigable `validacion_rh` al frontend
- [ ] RH ejecuta `accion_requerida_rh` (confirmar con Ricardo 27/28-may)

**NO mergear** — Esteban valida primero.

🤖 Generated with [Claude Code](https://claude.com/claude-code)