### PR TITLE
feat(rh): Alta / Baja de empleados (5 workflows n8n + frontend modulos/rh/empleados)

### DIFF
--- a/docs/rh/ALTA_BAJA_EMPLEADOS_DISENO.md
+++ b/docs/rh/ALTA_BAJA_EMPLEADOS_DISENO.md
@@ -1,0 +1,207 @@
+# RH — Alta / Baja de empleados en Odoo · DISEÑO (read-only, 2026-06-19)
+
+> Documento de **diseño** para revisión de Esteban antes de build. NO es implementación.
+> Nueva sección del módulo RH (mismo nivel que *visor de checkins* y *visor de incidencias*), en `modulos/rh/`. **Solo RH** accede.
+> Investigación read-only: `fields_get` hr.employee (271 campos), `empleados-master.json`, código kiosk, selecciones Odoo (UID 2 read-only).
+> **Rev 2 (2026-06-19):** +foto de perfil (A.7 + A.1), +visor de empleados archivados (G), fecha de baja visible/editable + nota de baja nativa.
+
+---
+
+## 0. Resumen ejecutivo
+
+- **Correo personal nativo SÍ existe:** `private_email` (no hay que crear custom).
+- **PIN = `hr.employee.pin` nativo** (char), **legible vía API** (el kiosk ya lo lee). Pero la **comparación es CLIENT-SIDE** y el PIN viaja al browser en `/kiosk/empleados` (deuda de seguridad preexistente).
+- **🔴 Los PIN NO son únicos hoy:** `0000`×5, `1234`×2, `1596`×2, `2025`×2, + 2 empleados sin PIN. El alta debe forzar unicidad **a futuro** (no retro-corrige).
+- **Baja = archivar:** `active=false` + `departure_date` + `departure_reason_id`. Solo 3 motivos nativos y en inglés (Fired/Resigned/Retired).
+- **🔴 Riesgo principal:** Odoo 19 usa **versiones de empleado (`hr.version`)**; un CREATE vía API puede exigir campos extra (`date_version`, `hr_responsible_id`, etc.). **No verificable read-only → requiere un CREATE de prueba en build.**
+- **🔴 Gotcha:** el depto **18 "Administracion y Finanzas"** NO está en `DEPTOS_VALIDOS` de los workflows de incidencias → empleados nuevos ahí saldrían `depto_invalido`.
+- **Foto:** `image_1920` (binary) es **settable**; Odoo genera `image_128/256/512/1024` solos (computados) → el kiosk (que lee `image_128`) muestra la foto sin pasos extra.
+- **Nota de baja:** existe **nativo `departure_description`** (HTML "Additional Information") → **no se necesita campo custom** para la nota libre del motivo.
+
+---
+
+## A. Form de ALTA — campos finales
+
+Leyenda Req: ✅ obligatorio · 🟡 obligatorio para empleados operativos (que checan) · ◻ opcional.
+
+| # | Campo Odoo | Label ES (form) | Tipo | Req | Default propuesto | Validación |
+|---|---|---|---|---|---|---|
+| 1 | `name` | Nombre completo | char | ✅ | — | no vacío (nativo dice required=false pero es el `_rec_name`) |
+| 2 | `company_id` | Empresa | m2o `res.company` | ✅ | **1 — SERVICIOS FTS** | **debe ser 1** o el kiosk no lo muestra (ver E) |
+| 3 | `work_email` | Correo de empresa | char | ✅ | — | formato email; único entre activos reales |
+| 4 | `private_email` | Correo personal | char | ◻ | — | formato email |
+| 5 | `mobile_phone` | Celular (Work Mobile) | char | 🟡 | — | — |
+| 6 | `work_phone` | Teléfono | char | ◻ | — | — |
+| 7 | `image_1920` | Foto de perfil | imagen (binary base64) | ◻ | — | JPG/PNG, comprimir client-side; ver **A.1** |
+| 8 | `department_id` | Departamento | m2o `hr.department` | ✅ | — | uno de los **7 activos** (ver tabla) |
+| 9 | `parent_id` | Jefe directo (Manager) | m2o `hr.employee` | ✅ | — | empleado activo |
+| 10 | `job_id` | Puesto | m2o `hr.job` | ◻ | — | — |
+| 11 | `resource_calendar_id` | Horario | m2o `resource.calendar` | ✅ | por depto: campo→**2** / oficina→**6** | calendar de company 1 |
+| 12 | `pin` | PIN de kiosko | char | ✅ | **autogenerado 4 díg. único** | 4 dígitos; **único** vs PINs activos (ver C) |
+| 13 | `x_studio_hora_entrada` | Hora de entrada | float | 🟡 | por horario (operaciones 7.0 / oficina 8.0) | 0–23.99; 0 ⇒ sin hora (rompe retardo/PPA) |
+| 14 | `x_categoria_nomina` | Categoría nómina (override) | selection | ◻ | **vacío** (se infiere por depto) | una de 5 opciones (ver abajo) |
+| 15 | `x_aplica_ppa` | Aplica PPA | boolean | ◻ | **true** | — |
+| 16 | `active` | (interno) | boolean | — | **true** | el CREATE lo deja true |
+
+**`x_categoria_nomina` — selection real en Odoo (id field 97925):**
+`ceo` (CEO) · `confianza` (Confianza, no HE) · `hourly_doble` (Hourly doble, HE 2x) · `hourly_sencilla` (Hourly sencilla, HE 1x) · `no_he_comercial` (Comercial, no HE). Default = **vacío** → `shared/lib/get-categoria.js` lo infiere por depto (PLAN_NOMINA §0.5). Poblar solo excepciones.
+
+**Departamentos activos (todos company 1 SERVICIOS FTS):** 3 Operaciones · 5 Dirección · 6 Comercial · 9 Legal · 16 Recursos Humanos · 17 Ingenieria *(sin acento en Odoo)* · 18 Administracion y Finanzas.
+
+**Calendarios company 1 (los usados):** **2** "Horas operaciones" (50 h/sem) · **6** "Horas de oficina" (50 h/sem) · 1 "Standard 40h" · 3 "Standard 38h" · 15 "Opening time". *(El calendar 13 que usan los zombies pertenece a otra company — no usar.)*
+
+**Catálogo personal vs empresa (nativos, por si se quieren después):** `private_email`, `private_phone`, `private_street/zip/city/state/country`, `emergency_contact`/`emergency_phone`, `identification_id` (RFC/CURP), `ssnid` (NSS), `barcode` (Badge). Todos opcionales → GRUPO C.
+
+### A.1 Foto de perfil — manejo (campo `image_1920`)
+
+**Campo maestro = `image_1920`** (binary base64). Confirmado en `fields_get`: `image_1920` es `readonly=False` (settable vía API); `image_128 / image_256 / image_512 / image_1024` y `avatar_*` son `readonly=True` = **thumbnails que Odoo computa solo** a partir de `image_1920`. ⇒ **basta setear `image_1920` en el CREATE**; Odoo genera el `image_128` (el que usa el kiosk) automáticamente. No hay que escribir los thumbnails.
+
+**El kiosk SÍ muestra foto.** `operaciones/kiosk/js/kiosk.js` mapea `ops_kiosk_field_photo` → **`image_128`** (default) y la pinta en la pantalla de selección/PIN (`photoEl.src`, con fallback a un SVG con la inicial). ⇒ subir la foto en el alta = el empleado aparece **con cara** en el kiosk desde el primer checkin. *(El webhook `/kiosk/empleados` debe seguir devolviendo `image_128`; verificar en build que el field map del workflow lo incluya.)*
+
+**Future-proof face-recognition.** CLAUDE.md Hallazgo #14: `image_128` es **baja resolución** para descriptores face-api confiables (backlog: migrar a `image_512`). Subir un `image_1920` de buena calidad deja los `image_256/512` ya generados → la migración futura no requiere re-pedir fotos.
+
+**Cómo viaja por n8n (`rh/empleado/crear`):**
+1. El form **comprime client-side** (canvas: resize a ~máx 1024 px lado mayor, `toDataURL('image/jpeg', ~0.8)`) → string base64.
+2. Va como campo del payload del webhook → en el CREATE se asigna a **`image_1920`** (el nodo Odoo binary acepta el base64 string directo, sin el prefijo `data:image/...;base64,` — quitarlo client-side).
+3. **Límite de tamaño:** aunque n8n/Railway aceptan bodies grandes, **cap recomendado ~1–1.5 MB** post-compresión; si excede, rechazar client-side con mensaje. (Mismo espíritu que el cap de 3 MB del adjunto PO en §17.)
+
+**Validación (form):** tipo `image/jpeg|png`; peso post-compresión < ~1.5 MB; **opcional** (sin foto → kiosk usa el SVG con la inicial).
+
+---
+
+## B. Flujo de BAJA (archivar) — paso a paso
+
+Esteban quiere "solo ponerle el motivo y listo". Mecánica mínima que **no deja basura**:
+
+1. **RH selecciona** un empleado activo → botón **"Dar de baja"**.
+2. **Form de baja (3 campos, todos VISIBLES y EDITABLES):**
+   - `departure_date` — date. **VISIBLE y EDITABLE.** Default = **hoy**, pero RH lo ajusta a la **fecha real de salida** del empleado. Este es el campo que después se ve en el visor de archivados (§G).
+   - `departure_reason_id` — **m2o `hr.departure.reason`**. Valores reales hoy: **1 Fired · 2 Resigned · 3 Retired** (inglés, 3 opciones). → *decisión abierta #2: traducir/ampliar.*
+   - `departure_description` — **HTML nativo "Additional Information"** = la **nota libre del motivo** (texto largo). VISIBLE y EDITABLE, opcional. **Es nativo → NO requiere campo custom** (ver §F #11).
+3. **Pre-chequeos del workflow (read antes de escribir):**
+   - **Attendance abierta** (`hr.attendance` sin `check_out` del empleado): **cerrar primero** (patrón auto-cierre a 9.6 h + TAG, §11 #12) o avisar a RH. No dejar un turno abierto colgado.
+   - **Incidencias pendientes** (`status` en `pendiente_*` en `shared/incidencias-asistencia.json`): **avisar** (no bloquear) — RH decide resolverlas o dejarlas históricas.
+4. **UPDATE Odoo** (un solo write): `active=false`, `departure_date`, `departure_reason_id`, (`departure_description`).
+5. **Re-sync inmediato** de `empleados-master.json` (webhook `/rh/empleados-master/refresh` ya existe). El sync **solo dumpea `active=true`** → el baja **desaparece** del master → el kiosk deja de mostrarlo. Sin esto, espera al cron 6am.
+6. **Resultado limpio:** attendances cerradas, incidencias quedan como histórico, empleado oculto (no borrado) → reversible (`active=true`).
+
+> Nota: archivar un empleado que es `parent_id` (manager) de otros **NO** reasigna a sus subordinados → quedarían con manager archivado. *Decisión abierta #5b: ¿bloquear baja de un manager con subordinados activos, o solo advertir?*
+
+---
+
+## G. Visor de empleados archivados
+
+Lista de los empleados dados de baja (`active=false`), para que RH consulte **cuándo y por qué** salió cada uno.
+
+**Cómo se leen (n8n, read-only):** Odoo filtra `active=True` por default → para traer los archivados el SEARCH debe usar **`context: {active_test: false}`** o dominio explícito **`[('active','=',false)]`** (o `['|',('active','=',true),('active','=',false)]` para ver ambos). Reusa el patrón del nodo Odoo; o un webhook `rh/empleados/archivados` dedicado.
+
+**Columnas propuestas:**
+
+| Columna | Campo Odoo | Notas |
+|---|---|---|
+| Nombre | `name` | — |
+| Departamento | `department_id` | el que tenía al salir |
+| Puesto | `job_id` / `job_title` | opcional |
+| **Fecha de baja** | `departure_date` | lo que Esteban quiere ver |
+| **Motivo** | `departure_reason_id` | Fired/Resigned/Retired (→ traducir, §F #2) |
+| **Nota del motivo** | `departure_description` | HTML nativo → render a texto; nota libre |
+| Última actividad | `last_check_out` (o `last_activity`) | readonly nativo; "cuándo checó por última vez" |
+| Dado de alta | `create_date` | opcional, antigüedad |
+
+**Info de salida disponible nativa** (confirmada en `fields_get`, todas readonly salvo las 3 de baja): `departure_date`, `departure_reason_id`, `departure_description` (editables en la baja) · `last_check_in` / `last_check_out` (datetime, readonly) · `last_activity` (date, readonly) · `write_date` (última modificación). **No hay** un campo de "fecha de archivado" automático distinto de `departure_date` → por eso `departure_date` (que RH fija a la fecha real) es la fuente de verdad.
+
+**Acción opcional:** "Reactivar" (`active=true`) un empleado archivado por error → *decisión abierta #13*. Si se permite, limpiar `departure_date`/`reason` al reactivar.
+
+---
+
+## C. Resolución del PIN
+
+**De dónde sale:** campo **nativo `hr.employee.pin`** (char, id field 6263). Help oficial: *"PIN used to Check In/Out in the Kiosk Mode of the Attendance application."*
+
+**Cómo lo usa FTS hoy** (confirmado en `operaciones/kiosk/js/kiosk.js`):
+- El front mapea `ops_kiosk_field_pin` → `'pin'` y compara **client-side**: `verifyPin()` hace `K.pin !== K.seleccionado.pin`.
+- ⇒ El webhook `/kiosk/empleados` **devuelve el `pin` de cada empleado al navegador**. Es legible vía API sin restricción (lo confirma que `aggregate` sobre `pin` funciona con UID 2).
+
+**Estado actual (🔴 problema de datos):** PIN **no es único**. Conteo en vivo: `0000`→5 empleados, `1234`→2, `1596`→2, `2025`→2, y **2 activos sin PIN** (`pin=false`). Como el kiosk selecciona empleado *y luego* pide PIN, los duplicados no causan login cruzado, pero rompen la regla "PIN único" y son débiles.
+
+**Propuesta de asignación en el alta:**
+- **Autogenerado**: 4 dígitos aleatorios, el workflow consulta los PINs existentes (`read_group`/`search` sobre `hr.employee.pin` activos) y reintenta hasta encontrar uno libre → **garantiza unicidad a futuro**.
+- **Editable por RH** (manual) con validación de unicidad en el mismo submit.
+- **RH lo VE**: el form/vista de empleado muestra el PIN (Esteban lo pidió explícito). Como `pin` es legible por API, el módulo RH lo trae por un webhook **autenticado solo-RH**.
+
+**Reglas de higiene:**
+- **NO** agregar `pin` a `empleados-master.json` (repo público) — hoy NO está ahí, mantenerlo así.
+- La unicidad **no** retro-corrige los `0000`×5 existentes (limpieza aparte, opcional).
+
+---
+
+## D. Workflows n8n nuevos (estructura, no implementación)
+
+Patrón FTS: el front no escribe a Odoo directo (CORS SaaS) → todo por n8n.
+
+### D.1 `rh/empleado/crear` (CREATE)
+- **Trigger:** Webhook POST (body: campos del form + token).
+- **Validar:** PIN único (SEARCH `hr.employee` `pin=` valor), `work_email` único, `department_id`/`parent_id` presentes, `resource_calendar_id` presente.
+- **Odoo CREATE** `hr.employee`: **sin `operation`** + `fieldsToCreateOrUpdate` (regla §3). Campos: name, company_id, work_email, private_email, mobile_phone, work_phone, department_id, parent_id, job_id, resource_calendar_id, pin, x_studio_hora_entrada, x_categoria_nomina(si no vacío), x_aplica_ppa.
+- **Post:** disparar `/rh/empleados-master/refresh` (re-sync inmediato) → devolver `{ employee_id, pin }`.
+- ⚠️ **Riesgo `hr.version`** (decisión #1): si el CREATE falla por campos de versión requeridos (`date_version`, `hr_responsible_id`), agregarlos al payload. **Probar CREATE real en build.**
+
+### D.2 `rh/empleado/archivar` (UPDATE active=false)
+- **Trigger:** Webhook POST `{ empleado_id, departure_reason_id, departure_date, departure_description?, token }`.
+- **Pre-check:** SEARCH attendance abierta + incidencias pendientes (avisar/cerrar).
+- **Odoo UPDATE** `hr.employee`: `"operation":"update"` + `customResourceId = empleado_id` (regla §3). Set `active=false`, `departure_date`, `departure_reason_id`, `departure_description`.
+- **Post:** `/rh/empleados-master/refresh`.
+
+### D.3 `rh/empleado/lookups` (GET, para poblar el form)
+- Devuelve catálogos vivos: departments (7), jobs, calendars (company 1), managers (empleados activos id+name), y **PINs ocupados** (solo para validar unicidad; idealmente solo el set, no a quién pertenecen). Alternativa: reusar `/kiosk/empleados` para managers.
+
+### Reglas n8n Odoo node (recordatorio §3, no re-descubrir)
+- CREATE: sin `operation`, `fieldsToCreateOrUpdate`. · UPDATE: `operation:update` + `customResourceId`.
+- Expresiones con **un solo `=`** (`={{ }}`). · "Always Output Data" **ON**. · Tras importar JSON: rellenar `customResource` + credencial `Odoo FTS` + webhook IDs a mano.
+- **Seguridad:** webhooks **sin HMAC** hoy = deuda. Crear/archivar empleados es **sensible** → recomendado al menos un shared-secret en el body antes de exponer; marcar como deuda, no bloquea MVP.
+
+### D.4 Re-sync: ¿inmediato o cron 6am?
+**Propuesta:** inmediato. Tras crear/archivar, llamar `/rh/empleados-master/refresh` (ya existe en `rh/empleados-master/sync`, webhook POST) → kiosk e incidencias al día sin esperar el cron 6am. El cron sigue como red de seguridad.
+
+---
+
+## E. Campos OBLIGATORIOS FTS + qué rompe si faltan
+
+El sync `rh/empleados-master/sync` **NO truena con nulls** (vuelca `null`, como ya pasa con CAJERO/zombies). Lo que se degrada **aguas abajo**:
+
+| Campo | Si falta… | Severidad |
+|---|---|---|
+| `pin` | Kiosk muestra *"Empleado sin PIN configurado"* → **no puede checar** | 🔴 CRÍTICO |
+| `company_id` = 1 | `/kiosk/empleados` filtra `company_id=1` → **empleado invisible en el kiosk** | 🔴 CRÍTICO |
+| `department_id` | Incidencias `sin_departamento`→escala RH; `x_categoria_nomina` no se infiere; depto fuera de `DEPTOS_VALIDOS` ⇒ `depto_invalido` | 🟠 ALTA |
+| `parent_id` | Incidencias `sin_supervisor`→escala RH (sin aprobador natural) | 🟠 ALTA |
+| `resource_calendar_id` | Cálculo de horas trabajadas/nómina incorrecto | 🟠 ALTA |
+| `x_studio_hora_entrada` | Retardos, PPA y candado de hora mínima por geocerca fallan (0 = sin hora) | 🟡 MEDIA |
+| `work_email` | Snapshot de supervisor en incidencias + notificaciones sin destinatario | 🟡 MEDIA |
+| `x_aplica_ppa` | Default true esperado; si null, PPA ambiguo | 🟢 BAJA |
+
+**Campos que `empleados-master.json` mapea (los del sync):** `id, name, department_id, parent_id, resource_calendar_id, work_email, work_phone, mobile_phone, x_studio_hora_entrada, x_studio_retardos_15_dias, x_categoria_nomina, x_aplica_ppa`. (NO incluye `pin` — correcto, repo público.)
+
+---
+
+## F. Riesgos / decisiones abiertas (confirmar antes de build)
+
+1. **🔴 Odoo 19 `hr.version`.** Crear `hr.employee` vía API puede exigir campos de versión (`date_version` required, `hr_responsible_id` required, `resource_id` auto). **No verificable read-only.** → Hacer **1 CREATE de prueba** al inicio del build y ajustar el payload. Riesgo de fricción ALTO.
+2. **Motivos de baja en inglés / solo 3.** `hr.departure.reason` = Fired/Resigned/Retired. ¿Traducir a español y/o agregar (Despido, Renuncia, Fin de contrato, Abandono, Jubilación)? Es un modelo editable.
+3. **🔴 Depto 18 "Administracion y Finanzas" NO está en `DEPTOS_VALIDOS`** de `xVNp36`/`5SW15h` (la lista es 6: Comercial, Dirección, Ingenieria, Legal, Operaciones, Recursos Humanos). Un empleado nuevo en depto 18 saldría `depto_invalido` en incidencias. → Actualizar la constante (deuda autoprogresiva, mejor leer deptos de Odoo).
+4. **PIN.** ¿Autogenerado (recomendado) vs manual? ¿4 dígitos fijos? ¿Unicidad obligatoria sabiendo que hay `0000`×5 legacy (no se retro-corrige)? ¿OK que RH vea el PIN en claro? Confirmar.
+5. **resource_calendar default por depto es heurística** (Operaciones mezcla calendars 2 y 6 en la realidad). Propuesta: default por depto + **override manual** en el form. (5b) ¿Bloquear baja de un manager con subordinados activos o solo advertir?
+6. **Seguridad preexistente (no la empeora el MVP, marcar):** (a) PIN viaja al browser y se compara client-side en el kiosk; (b) webhooks n8n sin HMAC. Crear/archivar empleados es sensible → mínimo un shared-secret.
+7. **`work_email` "único"** no se puede exigir retroactivo (varios zombies comparten `estebandelacruz@fts.mx`). Unicidad solo para altas reales nuevas.
+8. **¿Crear `user_id` (res.users) para el empleado?** MVP: **no** (el kiosk usa `hr.employee`, no `res.users`; la jerarquía es `parent_id`). Mantener sin usuario salvo que RH lo pida.
+9. **Acceso solo-RH:** el módulo vive en `modulos/rh/`; gating por rol (workflow `derivar-roles` / sesión RH). Confirmar el mecanismo de auth que ya usan los otros visores RH antes de exponer escritura.
+10. **Re-sync inmediato** (propuesta D.4): confirmar que se quiere disparar `/refresh` al crear/archivar (recomendado) vs esperar al cron 6am.
+11. **Nota de baja: nativa vs custom — RESUELTO.** `departure_description` (HTML "Additional Information") **ya existe nativo** y es editable → **usarlo, NO crear `x_baja_nota`**. Solo se justificaría un custom si se quisiera la nota *estructurada/searchable* aparte (no recomendado para MVP).
+12. **Foto de perfil (nuevas preguntas):** (a) ¿opcional (propuesto) u obligatoria? (b) ¿resolución/peso de compresión client-side (propongo máx 1024 px, JPEG ~0.8, cap ~1.5 MB)? (c) ¿subir `image_1920` alta calidad para future-proof face-api (recomendado)? (d) confirmar en build que `/kiosk/empleados` incluye `image_128` en su field map.
+13. **Reactivar archivado (visor §G):** ¿el visor permite "Reactivar" (`active=true`) un baja por error? Si sí, ¿limpia `departure_date`/`reason`? Riesgo bajo, decidir UX.
+
+---
+
+## Apéndice — Grupo C (fuera del MVP, solo listados)
+
+`bank_account_ids` (nómina/bancos) · `wage`/`hourly_cost`/`wage_type`/`structure_type_id` (sueldo) · `contract_*`/`hr.version` (contratos) · `certification_ids`/`skill_ids`/`resume_line_ids` (skills) · `identification_id`/`ssnid`/`passport_id`/`visa_*`/`permit_*` (documentos legales) · `barcode` (gafete) · `marital`/`children`/`birthday`/`sex`/`country_id` (demográficos) · `*_manager_id` (aprobadores de gastos/timesheet/leaves) · `coach_id`. Se pueden sumar por fases si RH los necesita.

--- a/docs/rh/DEPARTURE_WIZARD_ANALISIS.md
+++ b/docs/rh/DEPARTURE_WIZARD_ANALISIS.md
@@ -1,0 +1,105 @@
+# RH Baja — `hr.departure.wizard` nativo vs nuestro `rh/empleado/archivar` (read-only, 2026-06-19)
+
+> Análisis para igualar nuestra baja al comportamiento nativo de Odoo 19. **NO código, NO workflow.** Read-only (MCP UID 2).
+> Relacionado: [`ALTA_BAJA_EMPLEADOS_DISENO.md`](ALTA_BAJA_EMPLEADOS_DISENO.md) · [`FASE1_WORKFLOWS_BUILD.md`](FASE1_WORKFLOWS_BUILD.md) · PR #54.
+
+## 0. TL;DR
+- El wizard de **esta** instancia (Odoo 19) tiene **14 campos**; los funcionales: `departure_reason_id`, `departure_date`, `departure_description`, `employee_ids`, + **3 checkboxes opcionales**: `set_date_end`, `remove_related_user`, `release_campany_car`.
+- 🟢 **Nuestro `archivar` ya cubre el NÚCLEO** (active=false + los 3 campos departure). El `UPDATE active=false` directo **sí** dispara el `write()` de `hr.employee` (cascada nativa de archivado: resource, etc.) — no lo saltamos.
+- 🔴 **Lo único que falta para igualar el nativo:** la opción **`set_date_end`** (poner fecha fin de contrato). `remove_related_user` es casi irrelevante (**solo 1 empleado activo tiene user**, y es cuenta de sistema). `release_campany_car` → fleet, no aplica a FTS.
+- ⚠️ Este wizard **NO** tiene `cancel_leaves` ni `archive_private_address` (existen en otras versiones/módulos, **aquí no**) → la baja nativa **no** cancela permisos ni archiva direcciones. No hay nada que replicar ahí.
+- **Todo es replicable con UPDATEs directos** — **no** hace falta ejecutar el wizard transient.
+
+---
+
+## A. Campos del wizard `hr.departure.wizard` (14)
+
+| Campo | Tipo | Req | Qué hace al confirmar |
+|---|---|---|---|
+| `employee_ids` | m2m hr.employee | ✅ | A quién(es) aplica la baja (el wizard soporta multi-empleado). |
+| `departure_reason_id` | m2o hr.departure.reason | ✅ | Motivo → se escribe en `hr.employee.departure_reason_id`. |
+| `departure_date` | date | ✅ | Fecha de baja. **Label: "Contract End Date"** → se escribe en `hr.employee.departure_date` y, si `set_date_end`, como fin de contrato. |
+| `departure_description` | html | ◻ | Nota libre → `hr.employee.departure_description`. |
+| `set_date_end` | boolean | ◻ | **"Set the end date on the current contract."** → pone fecha fin en el contrato/versión actual (= `departure_date`). |
+| `remove_related_user` | boolean | ◻ | **"If checked, the related user will be removed from the system."** → archiva/quita el `res.users` ligado (solo visible si el empleado tiene user). |
+| `release_campany_car` | boolean | ◻ | Libera el auto de empresa asignado (módulo fleet). |
+| `is_user_employee` | boolean (RO) | — | Computado: si el empleado tiene user ligado (controla la visibilidad de `remove_related_user`). |
+| `display_name` / `id` / `create_uid` / `create_date` / `write_uid` / `write_date` | técnicos | — | Auditoría ORM, sin efecto funcional. |
+
+> **No existen aquí:** `cancel_leaves`, `archive_private_address`. La baja nativa de esta instancia **no** toca `hr.leave` ni la dirección privada.
+
+---
+
+## B. Qué escribe el wizard al confirmar (`action_register_departure`), por modelo
+
+Comportamiento estándar Odoo 19 (deducido del esquema + módulo `hr`):
+
+| Modelo | Qué escribe | ¿Cuándo |
+|---|---|---|
+| **`hr.employee`** | `departure_reason_id`, `departure_description`, `departure_date` + **`active=False`** (vía `action_archive`) | **Siempre** (núcleo) |
+| **contrato / `hr.version`** | fecha fin del contrato actual = `departure_date` (en Odoo 19 = `hr.employee.contract_date_end`, proxy a la versión) | Solo si **`set_date_end`** marcado |
+| **`res.users`** | archiva/quita el usuario ligado (`active=False`) | Solo si **`remove_related_user`** marcado (y el empleado tiene user) |
+| **fleet** | libera el auto de empresa | Solo si **`release_campany_car`** marcado |
+| `hr.leave` / dirección privada | **nada** (no hay checkbox para eso en esta instancia) | — |
+
+**Obligatorio (baja limpia) vs opcional:**
+- **Obligatorio:** los 4 de `hr.employee` (active=false + 3 departure). **Ya lo hacemos.**
+- **Opcional (decisión del usuario en el wizard):** `set_date_end`, `remove_related_user`, `release_campany_car`. El nativo los muestra como checkboxes y RH decide.
+
+---
+
+## C. Gap vs nuestro `rh/empleado/archivar` actual
+
+Hoy el workflow hace **un UPDATE**: `active=false` + `departure_date` + `departure_reason_id` + `departure_description`.
+
+| Acción del wizard | ¿La hacemos? | Impacto si NO la hacemos |
+|---|---|---|
+| `active=false` + 3 campos departure | ✅ sí | — (cubierto) |
+| Cascada de `employee.write(active=False)` (resource, etc.) | ✅ sí (el UPDATE ORM dispara el `write()` override) | — (no lo rompemos) |
+| `set_date_end` → fecha fin de contrato | ❌ **no** | El contrato/versión del empleado **queda sin fecha fin** (abierto). Impacto **bajo en FTS** (no usan payroll/work-entries de Odoo; la nómina es el kiosk custom), pero **no es "como nativo"**. |
+| `remove_related_user` → archivar user | ❌ no | **Casi irrelevante:** solo 1 empleado activo tiene user (Administracion FTS-YIN, cuenta de sistema). Para empleados reales (sin user) no aplica. |
+| `release_campany_car` | ❌ no | N/A — FTS no usa fleet por empleado (confirmar). |
+
+**¿Rompemos algo hoy?** No de forma grave. El único "no-equivalente" real es **no setear fin de contrato**; y como la baja nativa aquí **no** cancela leaves ni toca direcciones, no dejamos esos cabos sueltos (el nativo tampoco los ata).
+
+---
+
+## D. Propuesta de implementación n8n
+
+**Recomendación: UPDATEs directos, NO ejecutar el wizard transient.**
+
+**Por qué NO el wizard transient:** requeriría `create` de un `hr.departure.wizard` (con `employee_ids` m2m) + `call method` `action_register_departure` — el nodo Odoo de n8n no expone "call method" cómodamente, y un transient es más frágil. Los UPDATEs directos logran **el mismo resultado** y respetan las reglas FTS (§3).
+
+**Cambio propuesto a `rh/empleado/archivar`** (un solo UPDATE a `hr.employee`, ampliando los campos):
+```
+active = false
+departure_date = <fecha>
+departure_reason_id = <id>
+departure_description = <html>
+contract_date_end = <fecha>      ← NUEVO (replica set_date_end; campo writable en hr.employee, RO=false)
+```
+- `contract_date_end` es el proxy writable de la fecha fin de la versión actual (confirmado RO=false en `fields_get` de hr.employee). Setearlo = equivalente a `set_date_end` del wizard.
+- **`remove_related_user`** (opcional): si se quisiera, sería un **UPDATE extra** a `res.users` (`active=false`) usando `hr.employee.user_id` — solo cuando exista. Dado que solo 1 empleado lo tiene (y es de sistema), **se puede omitir en MVP**.
+- **`release_campany_car`**: omitir (fleet no aplica).
+- El `UPDATE active=false` sigue disparando el `write()` de `hr.employee` → cascada nativa intacta.
+
+**Forma del cambio (cuando se apruebe):** editar el nodo `Odoo - UPDATE archivar` para incluir `contract_date_end`. Si se hace **opcional** (checkbox "Fin de contrato" en el form de baja), el frontend manda `set_date_end:true/false` y el Code prep arma `contract_date_end = set_date_end ? departure_date : false`. Si se hace **siempre**, se setea directo.
+
+---
+
+## E. Decisiones abiertas para Esteban
+
+1. **¿Setear fin de contrato (`set_date_end`) en la baja?** Recomiendo **sí** (`contract_date_end = departure_date`) para igualar el nativo. ¿Siempre, o como **checkbox** "Fin de contrato" en el form de baja (default marcado)?
+2. **`remove_related_user`:** solo 1 empleado activo tiene user (cuenta de sistema). ¿Omitir en MVP (recomendado), o agregar el UPDATE opcional a `res.users` para cuando un empleado real sí tenga user?
+3. **`release_campany_car`:** ¿FTS usa fleet por empleado? Asumo **no** → omitir. Confirmar.
+4. **¿UPDATEs directos (recomendado) o wizard transient?** Recomiendo UPDATEs directos.
+5. **Verificar en build (no probado read-only):** que `contract_date_end` es writable vía el nodo Odoo y que propaga a la versión (Odoo 19 hr.version). Si no propagara, fallback = UPDATE directo a `hr.version` por `current_version_id`.
+6. **Default de `set_date_end` en el nativo:** no expuesto por `fields_get`; verificar si el wizard lo trae marcado por default para replicar el mismo comportamiento "out of the box".
+
+---
+
+## Apéndice — datos en vivo (read-only)
+- Wizard `hr.departure.wizard`: 14 campos (sin `cancel_leaves` / `archive_private_address`).
+- Empleados activos con `user_id`: **1** (id 148 Administracion FTS-YIN → user 25).
+- `hr.employee.contract_date_end`: existe, `Readonly=False` (writable).
+- `hr.departure.reason` (motivos): hoy 1 Fired · 2 Resigned · 3 Retired (pendiente traducir/ampliar a español, decisión previa #2 del módulo).

--- a/docs/rh/FASE1_WORKFLOWS_BUILD.md
+++ b/docs/rh/FASE1_WORKFLOWS_BUILD.md
@@ -9,7 +9,30 @@ Branch `feat/rh-alta-baja-empleados`. Diseño: [`ALTA_BAJA_EMPLEADOS_DISENO.md`]
 
 ---
 
-## Importar + activar (Esteban, por cada uno de los 5)
+## ✅ ACTUALIZACIÓN 2026-06-20 — los 5 ya están CREADOS en n8n vía MCP (solo falta Publish)
+
+Ya **NO hay que importar JSON ni rellenar customResource**. Los 5 se subieron a n8n por MCP (`n8n_create_workflow` + `n8n_update_full_workflow`), que **preserva customResource + credenciales**. Quedan **INACTIVOS**; Esteban solo da **Publish**.
+
+| Workflow | id n8n | Path webhook | Método | Nodos Odoo (customResource) | Cred | Estado | valid |
+|---|---|---|---|---|---|---|---|
+| `rh/empleado/crear` | `XFVuCSq1xCOmeeDf` | `/webhook/rh/empleado/crear` | POST | CREATE → `hr.employee` | Odoo FTS ✅ | inactivo | ✅ 0 err |
+| `rh/empleado/archivar` | `pXK0d5j5oovabsnT` | `/webhook/rh/empleado/archivar` | POST | SEARCH `hr.attendance` · UPDATE×2 `hr.employee` | Odoo FTS ✅ | inactivo | ✅ 0 err |
+| `rh/empleado/reactivar` | `j7CTVsqhjLrTbvXu` | `/webhook/rh/empleado/reactivar` | POST | UPDATE `hr.employee` | Odoo FTS ✅ | inactivo | ✅ 0 err |
+| `rh/empleado/lookups` | `SPsyzmkSuOnhUY0u` | `/webhook/rh/empleado/lookups` | GET | getAll `hr.department`,`hr.employee`,`hr.job`,`resource.calendar`,`hr.departure.reason`,`res.company` | Odoo FTS ✅ | inactivo | ✅ 0 err |
+| `rh/empleados/archivados` | `8hXuf09tDKwuHH8K` | `/webhook/rh/empleados/archivados` | GET | getAll `hr.employee` (active=false) | Odoo FTS ✅ | inactivo | ✅ 0 err |
+
+- **customResource:** poblado en los 11 nodos Odoo (validación n8n 0 errores en nodos Odoo + dump full de `crear` confirmado).
+- **Fix aplicado:** los Webhook en modo `responseNode` requieren `onError: "continueRegularOutput"` → añadido a los 5 (sin esto el validador marcaba error y el webhook podía colgarse en rutas de error).
+- **archivar nuevo:** checkbox **Fin de contrato** (default on) → rama `IF - fin contrato` con 2 UPDATE: con `contract_date_end` (si on) / sin él (si off, NO toca el campo). Ver [`DEPARTURE_WIZARD_ANALISIS.md`](DEPARTURE_WIZARD_ANALISIS.md).
+- **Warnings benignos** (no bloquean Publish): typeVersion "outdated" (2 vs 2.1, cosmético) + falso-positivo del IF de 2 salidas.
+
+**👉 Acción de Esteban: entrar a n8n y dar Publish a los 5. Nada más.** (Tras Publish: smoke test del PR #54.)
+
+> ⚠️ A verificar en el primer smoke: que `contract_date_end` writable propaga a la versión Odoo 19 (decisión #4); si no, fallback = UPDATE a `hr.version` por `current_version_id`.
+
+---
+
+## (Histórico) Importar + activar — YA NO aplica (los workflows se crearon por MCP)
 
 1. n8n → **Import from File** → `scripts/local/rh/<archivo>.json`.
 2. 🔴 **`customResource` se BLANQUEA al importar** (bug §3). Rellenar a mano en cada nodo Odoo (tabla abajo).

--- a/docs/rh/FASE1_WORKFLOWS_BUILD.md
+++ b/docs/rh/FASE1_WORKFLOWS_BUILD.md
@@ -45,11 +45,11 @@ Branch `feat/rh-alta-baja-empleados`. Diseño: [`ALTA_BAJA_EMPLEADOS_DISENO.md`]
 - `image_1920`: el prep quita el prefijo `data:...;base64,`. **PIN manual, SIN validación de unicidad** (decisión #1).
 - Respuesta: `{ ok, employee_id, name, pin }`.
 
-### 2. `rh/empleado/archivar` — POST `/webhook/rh/empleado/archivar`
-`Webhook → Code prep → HTTP GET incidencias → Odoo SEARCH att abierta → Code col → Code checks → Odoo UPDATE active=false → Code result → HTTP refresh → Respond`
-- **Pre-chequeos (no bloquean):** attendance sin `check_out` + incidencias `pendiente_*` → se devuelven en `warnings[]`.
-- UPDATE: `active=false`, `departure_date` (default hoy si no viene), `departure_reason_id`, `departure_description`.
-- Respuesta: `{ ok, empleado_id, departure_date, warnings }`.
+### 2. `rh/empleado/archivar` — POST `/webhook/rh/empleado/archivar` (12 nodos)
+`Webhook → prep → HTTP GET incidencias → SEARCH att abierta → col → Code checks → IF bloqueado → [true] Respond bloqueo · [false] UPDATE active=false → result → HTTP refresh → Respond ok`
+- 🔴 **BLOQUEA (decisión Esteban #1):** si hay attendance sin `check_out` → **NO archiva**, responde `{ ok:false, blocked:true, error, attendance_ids }`. El frontend muestra el error y no cierra el form (RH cierra el turno primero).
+- Incidencias `pendiente_*` → solo `warnings[]` (no bloquean).
+- Rama no-bloqueada: `UPDATE active=false` + `departure_date` (default hoy) + `departure_reason_id` + `departure_description`. Respuesta `{ ok, empleado_id, departure_date, warnings }`.
 
 ### 3. `rh/empleado/reactivar` — POST `/webhook/rh/empleado/reactivar`
 `Webhook → Code prep → Odoo UPDATE active=true (+ limpia departure_date/reason) → Code result → HTTP refresh → Respond`  (decisión #8).
@@ -73,9 +73,9 @@ Tras crear/archivar/reactivar, `HTTP - refresh master` hace **POST** a `https://
 
 ## Decisiones abiertas / a verificar (FASE 1)
 
-1. **`archivar` NO bloquea ni auto-cierra.** Reporta `warnings` (attendance abierta + incidencias pendientes) pero **igual archiva**. Una attendance abierta en un empleado archivado **queda colgada** (ya no aparece en kiosk para cerrarla). ¿Aceptable para MVP, o `archivar` debe **bloquear** si hay attendance abierta (forzar cerrarla antes)? *(Implementado: reporta + procede.)*
+1. ✅ **RESUELTO (decisión Esteban #1): `archivar` BLOQUEA** si hay attendance abierta — no archiva, devuelve `{ok:false, blocked:true, error}`; RH cierra el turno primero. *(Implementado: `Code checks` → `IF bloqueado` → `Respond bloqueo`.)*
 2. **Shape de `incidencias-asistencia.json`:** el filtro asume `{ incidencias:[{ empleado_id, status }] }` con `status` que empieza con `pendiente`. El Code es defensivo (prueba `.incidencias` / array / `.data.incidencias`), pero **verificar los nombres reales** en el primer smoke.
-3. **Path del `/refresh`** (arriba) — confirmar.
+3. ✅ **CONFIRMADO (decisión #2): path `/refresh`** = `https://primary-production-5c3c.up.railway.app/webhook/rh/empleados-master/refresh` (POST sin token).
 4. **`reactivar`** limpia `departure_date` + `departure_reason_id` (decisión #8) pero **deja `departure_description`** como histórico. ¿Limpiar también? *(Implementado: se conserva.)*
 5. **Sin HMAC.** Los 5 webhooks aceptan `token` en el body pero **no lo validan** (deuda preexistente §9). Crear/archivar empleados es sensible → recomendado un shared-secret antes de exponer en producción. **No bloquea MVP.**
 6. **`lookups` devuelve TODOS los managers** (empleados activos, incl. cuentas zombie/cajero). El frontend puede filtrar por departamento si se quiere.

--- a/docs/rh/FASE1_WORKFLOWS_BUILD.md
+++ b/docs/rh/FASE1_WORKFLOWS_BUILD.md
@@ -1,0 +1,87 @@
+# RH Alta/Baja — FASE 1: workflows n8n (build, 2026-06-19)
+
+Branch `feat/rh-alta-baja-empleados`. Diseño: [`ALTA_BAJA_EMPLEADOS_DISENO.md`](ALTA_BAJA_EMPLEADOS_DISENO.md) Rev 2.
+**FASE 0 cerrada:** un CREATE real de `hr.employee` (id 152, auto-archivado y verificado `active=false`) pasó con el set GRUPO A **sin** campos extra de `hr.version` → riesgo #1 descartado.
+
+**5 workflows generados** por `scripts/local/rh/gen-rh-workflows.js` (gitignored) → JSON en `scripts/local/rh/*.json` (gitignored, en disco de Esteban para importar). Self-check: **40 nodos · 0 conexiones rotas · 0 syntax err · customResource presente en los 10 nodos Odoo del generador**.
+
+> ⚠️ Estos workflows hacen **WRITES a producción** (crear/archivar/reactivar empleados). Quedan **inactivos** hasta que Esteban haga **Publish**. No están en CLAUDE.md §2 todavía (se agregan cuando estén vivos + smoke-tested).
+
+---
+
+## Importar + activar (Esteban, por cada uno de los 5)
+
+1. n8n → **Import from File** → `scripts/local/rh/<archivo>.json`.
+2. 🔴 **`customResource` se BLANQUEA al importar** (bug §3). Rellenar a mano en cada nodo Odoo (tabla abajo).
+3. Revisar credencial **`Odoo FTS`** en cada nodo Odoo (a veces se desasigna).
+4. El **webhook ID se regenera** al importar (ok, el path no cambia).
+5. **Publish** (toggle Active) — el API de esta instancia **no** deja activar vía MCP.
+
+### Checklist `customResource` por nodo
+
+| Workflow (archivo) | Nodo Odoo | customResource |
+|---|---|---|
+| `rhempleadocrear.json` | Odoo - CREATE empleado | `hr.employee` |
+| `rhempleadoarchivar.json` | Odoo - SEARCH att abierta | `hr.attendance` |
+| `rhempleadoarchivar.json` | Odoo - UPDATE archivar | `hr.employee` |
+| `rhempleadoreactivar.json` | Odoo - UPDATE reactivar | `hr.employee` |
+| `rhempleadolookups.json` | Odoo - getAll deptos | `hr.department` |
+| `rhempleadolookups.json` | Odoo - getAll managers | `hr.employee` |
+| `rhempleadolookups.json` | Odoo - getAll jobs | `hr.job` |
+| `rhempleadolookups.json` | Odoo - getAll calendars | `resource.calendar` |
+| `rhempleadolookups.json` | Odoo - getAll reasons | `hr.departure.reason` |
+| `rhempleadolookups.json` | Odoo - getAll companies | `res.company` |
+| `rhempleadosarchivados.json` | Odoo - getAll archivados | `hr.employee` |
+
+*(Los nodos UPDATE conservan `operation:update` + `customResourceId` tras importar; solo `customResource` se vacía.)*
+
+---
+
+## Mapa de los 5 workflows
+
+### 1. `rh/empleado/crear` — POST `/webhook/rh/empleado/crear`
+`Webhook → Code prep (valida requeridos + normaliza) → Odoo CREATE hr.employee → Code result → HTTP refresh → Respond`
+- CREATE **sin** `operation` + `fieldsToCreateOrUpdate` (15 campos GRUPO A + foto + company). Opcionales (`private_email/mobile/work_phone/job_id/x_categoria_nomina/image_1920`) van con `|| false` → Odoo los deja vacíos.
+- `image_1920`: el prep quita el prefijo `data:...;base64,`. **PIN manual, SIN validación de unicidad** (decisión #1).
+- Respuesta: `{ ok, employee_id, name, pin }`.
+
+### 2. `rh/empleado/archivar` — POST `/webhook/rh/empleado/archivar`
+`Webhook → Code prep → HTTP GET incidencias → Odoo SEARCH att abierta → Code col → Code checks → Odoo UPDATE active=false → Code result → HTTP refresh → Respond`
+- **Pre-chequeos (no bloquean):** attendance sin `check_out` + incidencias `pendiente_*` → se devuelven en `warnings[]`.
+- UPDATE: `active=false`, `departure_date` (default hoy si no viene), `departure_reason_id`, `departure_description`.
+- Respuesta: `{ ok, empleado_id, departure_date, warnings }`.
+
+### 3. `rh/empleado/reactivar` — POST `/webhook/rh/empleado/reactivar`
+`Webhook → Code prep → Odoo UPDATE active=true (+ limpia departure_date/reason) → Code result → HTTP refresh → Respond`  (decisión #8).
+
+### 4. `rh/empleado/lookups` — GET `/webhook/rh/empleado/lookups`
+`Webhook → getAll deptos → col → getAll managers → col → getAll jobs → col → getAll calendars → col → getAll reasons → col → getAll companies → Code combine → Respond`
+- Todo leído de Odoo en runtime (decisiones #3 deptos, #9 companies). Respuesta: `{ departments, managers, jobs, calendars, reasons, companies }`.
+- Nodos `Code col` colapsan a 1 item entre getAll (evita el multiplicado de ejecuciones, patrón watchdog).
+
+### 5. `rh/empleados/archivados` — GET `/webhook/rh/empleados/archivados`
+`Webhook → Odoo getAll (filterRequest active=false) → Code map → Respond`
+- **Verificado read-only:** dominio explícito `active=false` devuelve los archivados (85) **sin** necesitar `context active_test`.
+- Respuesta: `{ total, empleados:[{ id, name, department, job, work_email, departure_date, departure_reason, departure_description, last_check_out, create_date }] }` ordenado por fecha de baja desc.
+
+---
+
+## Re-sync inmediato (decisión #5)
+Tras crear/archivar/reactivar, `HTTP - refresh master` hace **POST** a `https://primary-production-5c3c.up.railway.app/webhook/rh/empleados-master/refresh` (best-effort, `onError:continue`). ⚠️ **Verificar el path real** del webhook del workflow `rh/empleados-master/sync` (id `5nzVRsCMlCZlq5s4`) — asumí `/rh/empleados-master/refresh` por CLAUDE.md §2.
+
+---
+
+## Decisiones abiertas / a verificar (FASE 1)
+
+1. **`archivar` NO bloquea ni auto-cierra.** Reporta `warnings` (attendance abierta + incidencias pendientes) pero **igual archiva**. Una attendance abierta en un empleado archivado **queda colgada** (ya no aparece en kiosk para cerrarla). ¿Aceptable para MVP, o `archivar` debe **bloquear** si hay attendance abierta (forzar cerrarla antes)? *(Implementado: reporta + procede.)*
+2. **Shape de `incidencias-asistencia.json`:** el filtro asume `{ incidencias:[{ empleado_id, status }] }` con `status` que empieza con `pendiente`. El Code es defensivo (prueba `.incidencias` / array / `.data.incidencias`), pero **verificar los nombres reales** en el primer smoke.
+3. **Path del `/refresh`** (arriba) — confirmar.
+4. **`reactivar`** limpia `departure_date` + `departure_reason_id` (decisión #8) pero **deja `departure_description`** como histórico. ¿Limpiar también? *(Implementado: se conserva.)*
+5. **Sin HMAC.** Los 5 webhooks aceptan `token` en el body pero **no lo validan** (deuda preexistente §9). Crear/archivar empleados es sensible → recomendado un shared-secret antes de exponer en producción. **No bloquea MVP.**
+6. **`lookups` devuelve TODOS los managers** (empleados activos, incl. cuentas zombie/cajero). El frontend puede filtrar por departamento si se quiere.
+7. **Coerción de tipos en el CREATE:** los m2o/float/bool van como expresiones `={{ }}` (ints, floats, booleans nativos). Validado estructuralmente; **el primer alta real es el smoke** que confirma que Odoo acepta el payload tal cual (FASE 0 ya probó el patrón con el set mínimo).
+
+---
+
+## Pendiente FASE 2 (frontend) — requiere confirmación de Esteban
+Antes de construir `modulos/rh/empleados/`: **confirmar el mecanismo de auth solo-RH** que usan hoy el visor de checkins y el de incidencias (¿`FTSAuth` + rol? ¿`derivar-roles`? ¿`MP_SESSION_KEY`?), para gatear la escritura. **No exponer alta/baja sin ese gate.**

--- a/modulos/rh/empleados/css/empleados.css
+++ b/modulos/rh/empleados/css/empleados.css
@@ -1,0 +1,70 @@
+/* ═══ FTS RH — Alta/Baja de empleados ═══ (reusa el lenguaje visual del hub RH) */
+:root{
+  --green:#107C10; --green2:#0d6b0d; --red:#D13438; --blue:#0078D4;
+  --text:#1a1a1a; --muted:#999; --muted2:#666; --bg:#fafafa; --card:#fff; --border:#e0e0e0;
+}
+*{box-sizing:border-box}
+html,body{margin:0;padding:0;min-height:100%;font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',sans-serif;font-size:16px;color:var(--text);background:var(--bg)}
+
+/* topbar (igual al hub) */
+.rh-topbar{position:sticky;top:0;z-index:50;background:#fff;border-bottom:1px solid var(--border);display:flex;align-items:center;justify-content:space-between;padding:10px 16px;gap:8px}
+.rh-back{display:inline-flex;align-items:center;gap:4px;color:var(--muted2);text-decoration:none;font-size:13px;font-weight:600;padding:6px 10px;border-radius:7px;border:1px solid var(--border);background:#fff;white-space:nowrap}
+.rh-back:hover{color:var(--green);border-color:var(--green);background:#f0f9f0}
+.rh-title-wrap{display:flex;align-items:center;gap:6px;min-width:0;flex:1;justify-content:center}
+.rh-title{font-size:14px;font-weight:700;white-space:nowrap;overflow:hidden;text-overflow:ellipsis}
+.rh-build{font-size:10px;color:var(--muted)}
+.rh-user{display:flex;flex-direction:column;align-items:flex-end;gap:2px}
+.rh-user-name{font-size:12px;color:var(--muted2);max-width:140px;white-space:nowrap;overflow:hidden;text-overflow:ellipsis}
+.rh-logout{background:none;border:none;color:var(--blue);font-size:12px;cursor:pointer;padding:2px 6px;border-radius:4px;font-family:inherit}
+
+.rh-main{max-width:960px;margin:0 auto;padding:16px;padding-bottom:40px}
+.rh-h2{font-size:18px;margin:0 0 14px;color:var(--green)}
+
+/* tabs */
+.rh-tabs{display:flex;gap:6px;margin-bottom:18px;border-bottom:1px solid var(--border)}
+.rh-tab{background:none;border:none;border-bottom:3px solid transparent;padding:10px 14px;font-size:14px;font-weight:600;color:var(--muted2);cursor:pointer;font-family:inherit}
+.rh-tab.active{color:var(--green);border-bottom-color:var(--green)}
+.rh-panel{display:none}
+.rh-panel.active{display:block}
+.rh-panel-head{display:flex;align-items:center;justify-content:space-between;margin-bottom:12px}
+
+/* form */
+.rh-form{background:var(--card);border:1px solid var(--border);border-radius:14px;padding:18px}
+.rh-grid{display:grid;grid-template-columns:1fr 1fr;gap:12px 16px}
+@media (max-width:640px){ .rh-grid{grid-template-columns:1fr} }
+.rh-f{display:flex;flex-direction:column;gap:4px;font-size:13px;color:var(--muted2)}
+.rh-f-wide{grid-column:1 / -1}
+.rh-f em{color:var(--muted);font-style:normal;font-size:11px}
+.rh-f input,.rh-f select,.rh-f textarea{font-size:14px;padding:8px 10px;border:1px solid var(--border);border-radius:8px;font-family:inherit;color:var(--text);background:#fff}
+.rh-f input:focus,.rh-f select:focus,.rh-f textarea:focus{outline:none;border-color:var(--green)}
+.rh-check{flex-direction:row;align-items:center;gap:8px}
+.rh-check input{width:18px;height:18px}
+
+/* foto */
+.rh-foto{margin-top:14px;padding-top:14px;border-top:1px dashed var(--border)}
+.rh-foto-label{font-size:13px;color:var(--muted2)} .rh-foto-label em{color:var(--muted);font-size:11px}
+.rh-foto-row{display:flex;align-items:center;gap:12px;margin-top:8px;flex-wrap:wrap}
+.rh-foto-preview{width:64px;height:64px;border-radius:10px;object-fit:cover;background:#f0f0f0;border:1px solid var(--border)}
+.rh-foto-info{font-size:12px;color:var(--muted2)}
+
+/* actions / buttons / msg */
+.rh-actions{display:flex;align-items:center;gap:14px;margin-top:18px;flex-wrap:wrap}
+.rh-btn{font-size:14px;font-weight:600;padding:9px 18px;border-radius:9px;border:1px solid var(--border);background:#fff;color:var(--text);cursor:pointer;font-family:inherit}
+.rh-btn:disabled{opacity:.55;cursor:not-allowed}
+.rh-btn-primary{background:var(--green);border-color:var(--green);color:#fff}
+.rh-btn-danger{background:var(--red);border-color:var(--red);color:#fff}
+.rh-btn-ghost{color:var(--muted2)}
+.rh-btn-mini{padding:5px 10px;font-size:12px;color:var(--blue);border-color:var(--blue)}
+.rh-msg{font-size:13px}
+.rh-msg-ok{color:var(--green)} .rh-msg-err{color:var(--red)}
+
+/* table archivados */
+.rh-table-wrap{overflow-x:auto;background:var(--card);border:1px solid var(--border);border-radius:14px}
+.rh-table{width:100%;border-collapse:collapse;font-size:13px;min-width:760px}
+.rh-table th{text-align:left;padding:10px 12px;background:#f4f6f8;color:var(--muted2);font-weight:600;border-bottom:1px solid var(--border);white-space:nowrap}
+.rh-table td{padding:9px 12px;border-bottom:1px solid var(--border);vertical-align:top}
+.rh-table tr:last-child td{border-bottom:none}
+.rh-nota{max-width:220px;color:var(--muted2)}
+.rh-empty{text-align:center;color:var(--muted);padding:24px}
+
+.rh-footer{text-align:center;font-size:11px;color:var(--muted);margin-top:28px}

--- a/modulos/rh/empleados/index.html
+++ b/modulos/rh/empleados/index.html
@@ -1,0 +1,113 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>RH — Alta / Baja de empleados — FTS Suite</title>
+<script>
+  (function(){ window.BUILD_DATE = '20260619-rh-empleados-v1'; })();
+</script>
+<script src="../../../shared/auth-suite.js"></script>
+<link rel="stylesheet" href="css/empleados.css">
+</head>
+<body>
+
+<div class="rh-topbar">
+  <a class="rh-back" href="../index.html">← Módulo RH</a>
+  <div class="rh-title-wrap">
+    <span class="rh-title">👥 Alta / Baja de empleados</span>
+    <span class="rh-build">build 20260619-rh-empleados-v1</span>
+  </div>
+  <div class="rh-user">
+    <span class="rh-user-name" id="rh-user-name">—</span>
+    <button class="rh-logout" onclick="rh_logout()">Cerrar sesión</button>
+  </div>
+</div>
+
+<main class="rh-main">
+
+  <!-- Tabs -->
+  <div class="rh-tabs">
+    <button class="rh-tab active" data-tab="alta">➕ Alta</button>
+    <button class="rh-tab" data-tab="baja">📤 Baja</button>
+    <button class="rh-tab" data-tab="archivados">🗄️ Archivados</button>
+  </div>
+
+  <!-- ════════════ TAB ALTA ════════════ -->
+  <section class="rh-panel active" id="panel-alta">
+    <h2 class="rh-h2">Nuevo empleado</h2>
+    <form id="formAlta" class="rh-form" autocomplete="off">
+      <div class="rh-grid">
+        <label class="rh-f"><span>Nombre completo *</span><input name="name" type="text" required></label>
+        <label class="rh-f"><span>Empresa *</span><select name="company_id" required></select></label>
+        <label class="rh-f"><span>Correo de empresa *</span><input name="work_email" type="email" required></label>
+        <label class="rh-f"><span>Correo personal</span><input name="private_email" type="email"></label>
+        <label class="rh-f"><span>Celular</span><input name="mobile_phone" type="tel"></label>
+        <label class="rh-f"><span>Teléfono</span><input name="work_phone" type="tel"></label>
+        <label class="rh-f"><span>Departamento *</span><select name="department_id" required></select></label>
+        <label class="rh-f"><span>Jefe directo *</span><select name="parent_id" required></select></label>
+        <label class="rh-f"><span>Puesto</span><select name="job_id"></select></label>
+        <label class="rh-f"><span>Horario *</span><select name="resource_calendar_id" required></select></label>
+        <label class="rh-f"><span>PIN de kiosko * <em>(lo elige el empleado)</em></span><input name="pin" type="text" inputmode="numeric" required></label>
+        <label class="rh-f"><span>Hora de entrada</span><input name="x_studio_hora_entrada" type="number" step="0.01" min="0" max="23.99"></label>
+        <label class="rh-f"><span>Categoría nómina <em>(vacío = auto por depto)</em></span><select name="x_categoria_nomina"></select></label>
+        <label class="rh-f rh-check"><input name="x_aplica_ppa" type="checkbox" checked><span>Aplica PPA</span></label>
+      </div>
+
+      <div class="rh-foto">
+        <span class="rh-foto-label">Foto de perfil <em>(opcional)</em></span>
+        <div class="rh-foto-row">
+          <img id="fotoPreview" class="rh-foto-preview" alt="">
+          <input id="fotoInput" type="file" accept="image/jpeg,image/png">
+          <span id="fotoInfo" class="rh-foto-info"></span>
+        </div>
+      </div>
+
+      <div class="rh-actions">
+        <button type="submit" class="rh-btn rh-btn-primary" id="btnAlta">Crear empleado</button>
+        <span id="altaMsg" class="rh-msg"></span>
+      </div>
+    </form>
+  </section>
+
+  <!-- ════════════ TAB BAJA ════════════ -->
+  <section class="rh-panel" id="panel-baja">
+    <h2 class="rh-h2">Dar de baja (archivar)</h2>
+    <form id="formBaja" class="rh-form" autocomplete="off">
+      <div class="rh-grid">
+        <label class="rh-f rh-f-wide"><span>Empleado *</span><select name="empleado_id" required></select></label>
+        <label class="rh-f"><span>Fecha de baja *</span><input name="departure_date" type="date" required></label>
+        <label class="rh-f"><span>Motivo *</span><select name="departure_reason_id" required></select></label>
+        <label class="rh-f rh-f-wide"><span>Nota del motivo</span><textarea name="departure_description" rows="2"></textarea></label>
+      </div>
+      <div class="rh-actions">
+        <button type="submit" class="rh-btn rh-btn-danger" id="btnBaja">Dar de baja</button>
+        <span id="bajaMsg" class="rh-msg"></span>
+      </div>
+    </form>
+  </section>
+
+  <!-- ════════════ TAB ARCHIVADOS ════════════ -->
+  <section class="rh-panel" id="panel-archivados">
+    <div class="rh-panel-head">
+      <h2 class="rh-h2">Empleados archivados</h2>
+      <button class="rh-btn rh-btn-ghost" id="btnReloadArch">↻ Recargar</button>
+    </div>
+    <div class="rh-table-wrap">
+      <table class="rh-table" id="tablaArchivados">
+        <thead><tr>
+          <th>Nombre</th><th>Depto</th><th>Puesto</th><th>Fecha baja</th>
+          <th>Motivo</th><th>Nota</th><th>Última actividad</th><th>Alta</th><th></th>
+        </tr></thead>
+        <tbody><tr><td colspan="9" class="rh-empty">Cargando…</td></tr></tbody>
+      </table>
+    </div>
+  </section>
+
+  <div class="rh-footer">FTS Industrial Suite — RH · Alta / Baja de empleados</div>
+</main>
+
+<script src="js/foto.js"></script>
+<script src="js/empleados.js"></script>
+</body>
+</html>

--- a/modulos/rh/empleados/index.html
+++ b/modulos/rh/empleados/index.html
@@ -78,6 +78,7 @@
         <label class="rh-f rh-f-wide"><span>Empleado *</span><select name="empleado_id" required></select></label>
         <label class="rh-f"><span>Fecha de baja *</span><input name="departure_date" type="date" required></label>
         <label class="rh-f"><span>Motivo *</span><select name="departure_reason_id" required></select></label>
+        <label class="rh-f rh-check"><input name="fin_contrato" type="checkbox" checked><span>Fin de contrato <em>(pone fecha fin = fecha de baja)</em></span></label>
         <label class="rh-f rh-f-wide"><span>Nota del motivo</span><textarea name="departure_description" rows="2"></textarea></label>
       </div>
       <div class="rh-actions">

--- a/modulos/rh/empleados/js/empleados.js
+++ b/modulos/rh/empleados/js/empleados.js
@@ -1,0 +1,211 @@
+// ═══════════════════════════════════════════════════════════════
+// FTS RH — Alta / Baja de empleados (orquestación)
+// Gate solo-RH (FTSAuth) + 5 webhooks n8n (rh/empleado/*).
+// ═══════════════════════════════════════════════════════════════
+'use strict';
+
+// ─── Config ───
+var N8N = 'https://primary-production-5c3c.up.railway.app';
+var EP = {
+  lookups:    N8N + '/webhook/rh/empleado/lookups',
+  crear:      N8N + '/webhook/rh/empleado/crear',
+  archivar:   N8N + '/webhook/rh/empleado/archivar',
+  reactivar:  N8N + '/webhook/rh/empleado/reactivar',
+  archivados: N8N + '/webhook/rh/empleados/archivados'
+};
+// Defaults autoprogresivos: deptos de campo (Operaciones 3, Ingenieria 17) → calendar 2 / hora 7; oficina → 6 / 8.
+var CAMPO_DEPTS = [3, 17];
+var CATEGORIAS = [
+  ['', '(auto por depto)'], ['ceo', 'CEO'], ['confianza', 'Confianza (no HE)'],
+  ['hourly_doble', 'Hourly doble (HE 2x)'], ['hourly_sencilla', 'Hourly sencilla (HE 1x)'],
+  ['no_he_comercial', 'Comercial (no HE)']
+];
+var REASON_ES = { 'Fired': 'Despido', 'Resigned': 'Renuncia', 'Retired': 'Fin de contrato' }; // cortesía hasta que se renombre en Odoo
+
+var LK = null;        // lookups cacheados
+var fotoB64 = null;   // foto comprimida (base64 sin prefijo)
+
+// ─── Auth gate (mismo patrón que el hub RH) ───
+function rh_check_auth(){
+  var s = (window.FTSAuth && FTSAuth.getSession && FTSAuth.getSession()) || null;
+  if (!s){ alert('Sesión no válida.'); location.href = '../../../index.html'; return null; }
+  var tieneRH = s.role === 'master' || s.modulos === 'all' || (s.modulos && s.modulos.rh && s.modulos.rh.acceso === true);
+  if (!tieneRH){ alert('No tienes acceso al módulo RH.'); location.href = '../../../index.html'; return null; }
+  return s;
+}
+function rh_logout(){ try { FTSAuth.logout(); } catch(e){} location.href = '../../../index.html'; }
+window.rh_logout = rh_logout;
+
+// ─── Helpers ───
+function $(s, r){ return (r || document).querySelector(s); }
+function elName(n){ return document.querySelector('[name="' + n + '"]'); }
+async function api(url, body){
+  var opt = { method: body ? 'POST' : 'GET', cache: 'no-store' };
+  if (body){ opt.headers = { 'Content-Type': 'application/json' }; opt.body = JSON.stringify(body); }
+  var res = await fetch(url, opt);
+  var data = null; try { data = await res.json(); } catch(e){}
+  if (!res.ok) throw new Error((data && (data.error || data.message)) || ('HTTP ' + res.status + ' — ¿workflow publicado?'));
+  return data || {};
+}
+function fillSelect(sel, items, valKey, labelFn, placeholder){
+  sel.innerHTML = '';
+  if (placeholder != null){ var o = document.createElement('option'); o.value = ''; o.textContent = placeholder; sel.appendChild(o); }
+  (items || []).forEach(function(it){
+    var o = document.createElement('option');
+    o.value = it[valKey]; o.textContent = labelFn(it); sel.appendChild(o);
+  });
+}
+function msg(el, text, kind){ el.textContent = text || ''; el.className = 'rh-msg' + (kind ? ' rh-msg-' + kind : ''); }
+
+// ─── Lookups → poblar selects ───
+async function cargarLookups(){
+  LK = await api(EP.lookups);
+  fillSelect(elName('company_id'), LK.companies, 'id', function(c){ return c.name; });
+  if (elName('company_id').querySelector('option[value="1"]')) elName('company_id').value = '1';
+  fillSelect(elName('department_id'), LK.departments, 'id', function(d){ return d.name; }, '— elige —');
+  fillSelect(elName('parent_id'), LK.managers, 'id', function(m){ return m.name; }, '— elige —');
+  fillSelect(elName('job_id'), LK.jobs, 'id', function(j){ return j.name; }, '— ninguno —');
+  fillSelect(elName('resource_calendar_id'), LK.calendars, 'id', function(c){ return c.name + ' (' + (c.hours_per_week || '?') + 'h)'; }, '— elige —');
+  // categorías nómina (fijas)
+  var catSel = elName('x_categoria_nomina'); catSel.innerHTML = '';
+  CATEGORIAS.forEach(function(c){ var o = document.createElement('option'); o.value = c[0]; o.textContent = c[1]; catSel.appendChild(o); });
+  // motivos de baja (de Odoo, con traducción de cortesía)
+  fillSelect(elName('departure_reason_id'), LK.reasons, 'id', function(r){ return REASON_ES[r.name] || r.name; }, '— elige —');
+  // empleados activos para la baja
+  fillSelect(elName('empleado_id'), LK.managers, 'id', function(m){ return m.name; }, '— elige —');
+}
+
+// ─── ALTA: defaults autoprogresivos por depto ───
+function aplicarDefaultsDepto(){
+  var dep = parseInt(elName('department_id').value, 10);
+  if (!dep) return;
+  var esCampo = CAMPO_DEPTS.indexOf(dep) > -1;
+  elName('resource_calendar_id').value = esCampo ? '2' : '6';
+  if (!elName('x_studio_hora_entrada').value) elName('x_studio_hora_entrada').value = esCampo ? '7' : '8';
+}
+
+// ─── ALTA: foto ───
+async function onFoto(e){
+  var f = e.target.files && e.target.files[0];
+  var info = $('#fotoInfo'), prev = $('#fotoPreview');
+  fotoB64 = null; prev.removeAttribute('src'); info.textContent = '';
+  if (!f) return;
+  try {
+    var r = await FTSFoto.comprimirFoto(f);
+    fotoB64 = r.base64; prev.src = r.dataUrl;
+    info.textContent = r.w + '×' + r.h + ' · ' + (r.bytes / 1024).toFixed(0) + ' KB';
+  } catch (err){ info.textContent = '⚠️ ' + err.message; }
+}
+
+// ─── ALTA: submit ───
+async function onAlta(e){
+  e.preventDefault();
+  var f = e.target, m = $('#altaMsg'), btn = $('#btnAlta');
+  var hora = elName('x_studio_hora_entrada').value;
+  if (hora !== '' && (parseFloat(hora) < 0 || parseFloat(hora) > 23.99)) return msg(m, 'Hora de entrada fuera de 0–23.99', 'err');
+  var body = {
+    name: f.name.value.trim(), company_id: f.company_id.value, work_email: f.work_email.value.trim(),
+    private_email: f.private_email.value.trim(), mobile_phone: f.mobile_phone.value.trim(), work_phone: f.work_phone.value.trim(),
+    department_id: f.department_id.value, parent_id: f.parent_id.value, job_id: f.job_id.value || null,
+    resource_calendar_id: f.resource_calendar_id.value, pin: f.pin.value.trim(),
+    x_studio_hora_entrada: hora, x_categoria_nomina: f.x_categoria_nomina.value || null,
+    x_aplica_ppa: f.x_aplica_ppa.checked, image_1920: fotoB64 || null
+  };
+  btn.disabled = true; msg(m, 'Creando…');
+  try {
+    var r = await api(EP.crear, body);
+    if (!r.ok) throw new Error(r.error || 'No se pudo crear');
+    msg(m, '✅ Empleado creado (id ' + r.employee_id + ', PIN ' + r.pin + ').', 'ok');
+    f.reset(); fotoB64 = null; $('#fotoPreview').removeAttribute('src'); $('#fotoInfo').textContent = '';
+    if (elName('company_id').querySelector('option[value="1"]')) elName('company_id').value = '1';
+  } catch (err){ msg(m, '❌ ' + err.message, 'err'); }
+  finally { btn.disabled = false; }
+}
+
+// ─── BAJA: submit (maneja el bloqueo por attendance abierta) ───
+async function onBaja(e){
+  e.preventDefault();
+  var f = e.target, m = $('#bajaMsg'), btn = $('#btnBaja');
+  var body = {
+    empleado_id: f.empleado_id.value, departure_date: f.departure_date.value,
+    departure_reason_id: f.departure_reason_id.value, departure_description: f.departure_description.value.trim()
+  };
+  btn.disabled = true; msg(m, 'Archivando…');
+  try {
+    var r = await api(EP.archivar, body);
+    if (r.blocked){ msg(m, '🚫 ' + r.error, 'err'); return; }            // NO cerrar el form
+    if (!r.ok) throw new Error(r.error || 'No se pudo archivar');
+    var warn = (r.warnings && r.warnings.length) ? ' ⚠️ ' + r.warnings.map(function(w){ return w.detalle; }).join(' ') : '';
+    msg(m, '✅ Empleado archivado.' + warn, 'ok');
+    f.reset();
+  } catch (err){ msg(m, '❌ ' + err.message, 'err'); }
+  finally { btn.disabled = false; }
+}
+
+// ─── ARCHIVADOS: render + reactivar ───
+function esc(s){ return String(s == null ? '' : s).replace(/[&<>"]/g, function(c){ return { '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;' }[c]; }); }
+async function cargarArchivados(){
+  var tb = $('#tablaArchivados tbody');
+  tb.innerHTML = '<tr><td colspan="9" class="rh-empty">Cargando…</td></tr>';
+  try {
+    var r = await api(EP.archivados);
+    var rows = r.empleados || [];
+    if (!rows.length){ tb.innerHTML = '<tr><td colspan="9" class="rh-empty">Sin empleados archivados.</td></tr>'; return; }
+    tb.innerHTML = rows.map(function(e){
+      var nota = String(e.departure_description || '').replace(/<[^>]*>/g, ' ').trim();
+      return '<tr>' +
+        '<td>' + esc(e.name) + '</td>' +
+        '<td>' + esc(e.department) + '</td>' +
+        '<td>' + esc(e.job) + '</td>' +
+        '<td>' + esc(e.departure_date || '—') + '</td>' +
+        '<td>' + esc(REASON_ES[e.departure_reason] || e.departure_reason || '—') + '</td>' +
+        '<td class="rh-nota">' + esc(nota) + '</td>' +
+        '<td>' + esc((e.last_check_out || '').slice(0, 10) || '—') + '</td>' +
+        '<td>' + esc((e.create_date || '').slice(0, 10) || '—') + '</td>' +
+        '<td><button class="rh-btn rh-btn-mini" data-react="' + e.id + '">Reactivar</button></td>' +
+      '</tr>';
+    }).join('');
+  } catch (err){ tb.innerHTML = '<tr><td colspan="9" class="rh-empty">❌ ' + esc(err.message) + '</td></tr>'; }
+}
+async function onReactivar(id, btn){
+  if (!confirm('¿Reactivar este empleado? Se limpiará la fecha y motivo de baja.')) return;
+  btn.disabled = true; btn.textContent = '…';
+  try {
+    var r = await api(EP.reactivar, { empleado_id: id });
+    if (!r.ok) throw new Error(r.error || 'No se pudo reactivar');
+    await cargarLookups();   // vuelve a estar activo → refrescar selects
+    await cargarArchivados();
+  } catch (err){ alert('❌ ' + err.message); btn.disabled = false; btn.textContent = 'Reactivar'; }
+}
+
+// ─── Tabs ───
+function setTab(name){
+  document.querySelectorAll('.rh-tab').forEach(function(t){ t.classList.toggle('active', t.dataset.tab === name); });
+  document.querySelectorAll('.rh-panel').forEach(function(p){ p.classList.toggle('active', p.id === 'panel-' + name); });
+  if (name === 'archivados') cargarArchivados();
+}
+
+// ─── Init ───
+document.addEventListener('DOMContentLoaded', async function(){
+  var s = rh_check_auth(); if (!s) return;
+  $('#rh-user-name').textContent = '👤 ' + (s.nombre || s.username || '—');
+  try { FTSAuth.initActivityTracking && FTSAuth.initActivityTracking(); } catch(e){}
+
+  // default fecha baja = hoy
+  elName('departure_date').value = new Date().toISOString().slice(0, 10);
+
+  // eventos
+  document.querySelectorAll('.rh-tab').forEach(function(t){ t.addEventListener('click', function(){ setTab(t.dataset.tab); }); });
+  elName('department_id').addEventListener('change', aplicarDefaultsDepto);
+  $('#fotoInput').addEventListener('change', onFoto);
+  $('#formAlta').addEventListener('submit', onAlta);
+  $('#formBaja').addEventListener('submit', onBaja);
+  $('#btnReloadArch').addEventListener('click', cargarArchivados);
+  $('#tablaArchivados').addEventListener('click', function(ev){
+    var b = ev.target.closest('[data-react]'); if (b) onReactivar(b.dataset.react, b);
+  });
+
+  try { await cargarLookups(); }
+  catch (err){ alert('No se pudieron cargar los catálogos (lookups). ¿Está publicado el workflow rh/empleado/lookups?\n\n' + err.message); }
+  console.log('[rh-empleados] init OK build=' + window.BUILD_DATE);
+});

--- a/modulos/rh/empleados/js/empleados.js
+++ b/modulos/rh/empleados/js/empleados.js
@@ -128,7 +128,8 @@ async function onBaja(e){
   var f = e.target, m = $('#bajaMsg'), btn = $('#btnBaja');
   var body = {
     empleado_id: f.empleado_id.value, departure_date: f.departure_date.value,
-    departure_reason_id: f.departure_reason_id.value, departure_description: f.departure_description.value.trim()
+    departure_reason_id: f.departure_reason_id.value, departure_description: f.departure_description.value.trim(),
+    fin_contrato: f.fin_contrato.checked
   };
   btn.disabled = true; msg(m, 'Archivando…');
   try {

--- a/modulos/rh/empleados/js/foto.js
+++ b/modulos/rh/empleados/js/foto.js
@@ -1,0 +1,41 @@
+// ═══ FTS RH — compresión de foto de perfil (client-side) ═══
+// Reduce a ~1024px lado mayor, JPEG 0.8, y devuelve base64 SIN el prefijo data:
+// (el workflow rh/empleado/crear lo asigna directo a hr.employee.image_1920).
+// Cap 1.5 MB tras compresión → si excede, rechaza.
+(function(global){
+  'use strict';
+  var MAX_LADO = 1024;
+  var CALIDAD  = 0.8;
+  var CAP_BYTES = 1.5 * 1024 * 1024;
+
+  function comprimirFoto(file){
+    return new Promise(function(resolve, reject){
+      if (!file) return resolve(null);
+      if (!/^image\/(jpe?g|png)$/i.test(file.type)) return reject(new Error('Formato no soportado (usa JPG o PNG).'));
+      var reader = new FileReader();
+      reader.onerror = function(){ reject(new Error('No se pudo leer la imagen.')); };
+      reader.onload = function(){
+        var img = new Image();
+        img.onerror = function(){ reject(new Error('Imagen inválida.')); };
+        img.onload = function(){
+          var w = img.width, h = img.height;
+          if (w > h && w > MAX_LADO){ h = Math.round(h * MAX_LADO / w); w = MAX_LADO; }
+          else if (h >= w && h > MAX_LADO){ w = Math.round(w * MAX_LADO / h); h = MAX_LADO; }
+          var cv = document.createElement('canvas');
+          cv.width = w; cv.height = h;
+          cv.getContext('2d').drawImage(img, 0, 0, w, h);
+          var dataUrl = cv.toDataURL('image/jpeg', CALIDAD);
+          var b64 = dataUrl.split('base64,')[1] || '';
+          // tamaño aprox en bytes del base64
+          var bytes = Math.ceil(b64.length * 3 / 4);
+          if (bytes > CAP_BYTES) return reject(new Error('La foto pesa ' + (bytes/1048576).toFixed(1) + ' MB tras comprimir (máx 1.5 MB). Usa una más chica.'));
+          resolve({ base64: b64, dataUrl: dataUrl, bytes: bytes, w: w, h: h });
+        };
+        img.src = reader.result;
+      };
+      reader.readAsDataURL(file);
+    });
+  }
+
+  global.FTSFoto = { comprimirFoto: comprimirFoto };
+})(window);

--- a/modulos/rh/index.html
+++ b/modulos/rh/index.html
@@ -110,6 +110,11 @@
       <div class="rh-card-title">Visor de Incidencias</div>
       <div class="rh-card-sub">Revisa el estado de incidencias reportadas por empleados.</div>
     </a>
+    <a class="rh-card" href="empleados/index.html">
+      <div class="rh-card-icon">👤</div>
+      <div class="rh-card-title">Alta / Baja de empleados</div>
+      <div class="rh-card-sub">Crear empleados nuevos, archivar bajas y reactivar. Escribe en Odoo.</div>
+    </a>
   </div>
 
   <div class="rh-footer">


### PR DESCRIPTION
## Resumen
Nueva sección del módulo RH: **Alta / Baja de empleados** en Odoo (al nivel de los visores de checkins/incidencias, **solo-RH**). Escribe a Odoo vía n8n (MCP es read-only).

### FASE 0 — probe `hr.version` (cerrada)
CREATE real de `hr.employee` (id 152, auto-archivado) pasó con el set GRUPO A **sin** campos extra de versión → riesgo descartado.

### FASE 1 — 5 workflows n8n (en `scripts/local/rh/`, gitignored; importar en n8n)
`rh/empleado/crear` · `rh/empleado/archivar` (🔴 **bloquea** si hay turno abierto) · `rh/empleado/reactivar` · `rh/empleado/lookups` · `rh/empleados/archivados`. 42 nodos, 0 conexiones rotas, 0 syntax err. Re-sync `/refresh` inmediato tras cada write. Detalle: `docs/rh/FASE1_WORKFLOWS_BUILD.md`.

### FASE 2 — frontend `modulos/rh/empleados/`
Gate `FTSAuth`/`rh_check_auth()`. 3 tabs: **Alta** (16 campos, defaults autoprogresivos por depto, PIN manual, foto canvas→image_1920), **Baja** (selector activo + departure_date/reason/nota, maneja el bloqueo), **Archivados** (tabla §G + Reactivar). + card en el hub RH.

### Decisiones de Esteban aplicadas
PIN manual sin unicidad · motivos baja español (Odoo) · deptos/companies runtime · re-sync inmediato · foto opcional · `departure_description` nativo · reactivar limpia date+reason · `company_id` capturado siempre · **archivar bloquea turno abierto**.

## ⚠️ Antes del smoke: los 5 workflows requieren **Publish manual** + llenar `customResource` (checklist en el doc de build). Webhooks sin HMAC = deuda anotada (no bloquea MVP).

## Smoke test (orden sugerido)
1. **Publica** los 5 workflows en n8n + rellena `customResource` (11 nodos Odoo) + credencial Odoo FTS.
2. **lookups**: abre la sección → deben poblarse deptos/managers/jobs/calendars/motivos/empresas.
3. **Alta**: crea un empleado de prueba (PIN manual + foto) → verifica id + que aparece en kiosk (company 1) con su foto.
4. **Baja con turno abierto**: intenta archivar a alguien con check-in sin salida → debe **bloquear** con mensaje.
5. **Baja normal**: archiva → aparece en tab Archivados con fecha/motivo.
6. **Reactivar**: desde Archivados → vuelve a activo (sin fecha/motivo).
7. Verifica que `empleados-master.json` se actualizó (re-sync `/refresh`) tras cada paso.
8. Borra/archiva los registros de prueba.

🤖 Generated with [Claude Code](https://claude.com/claude-code)