### PR TITLE
feat(rh): tab Editar empleado (detalle + editar + horario HH:MM)

### DIFF
--- a/modulos/rh/empleados/index.html
+++ b/modulos/rh/empleados/index.html
@@ -5,7 +5,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 <title>RH — Alta / Baja de empleados — FTS Suite</title>
 <script>
-  (function(){ window.BUILD_DATE = '20260619-rh-empleados-v1'; })();
+  (function(){ window.BUILD_DATE = '20260620-rh-empleados-v2'; })();
 </script>
 <script src="../../../shared/auth-suite.js"></script>
 <link rel="stylesheet" href="css/empleados.css">
@@ -16,7 +16,7 @@
   <a class="rh-back" href="../index.html">← Módulo RH</a>
   <div class="rh-title-wrap">
     <span class="rh-title">👥 Alta / Baja de empleados</span>
-    <span class="rh-build">build 20260619-rh-empleados-v1</span>
+    <span class="rh-build">build 20260620-rh-empleados-v2</span>
   </div>
   <div class="rh-user">
     <span class="rh-user-name" id="rh-user-name">—</span>
@@ -29,6 +29,7 @@
   <!-- Tabs -->
   <div class="rh-tabs">
     <button class="rh-tab active" data-tab="alta">➕ Alta</button>
+    <button class="rh-tab" data-tab="editar">✏️ Editar</button>
     <button class="rh-tab" data-tab="baja">📤 Baja</button>
     <button class="rh-tab" data-tab="archivados">🗄️ Archivados</button>
   </div>
@@ -84,6 +85,45 @@
       <div class="rh-actions">
         <button type="submit" class="rh-btn rh-btn-danger" id="btnBaja">Dar de baja</button>
         <span id="bajaMsg" class="rh-msg"></span>
+      </div>
+    </form>
+  </section>
+
+  <!-- ════════════ TAB EDITAR ════════════ -->
+  <section class="rh-panel" id="panel-editar">
+    <h2 class="rh-h2">Editar empleado</h2>
+    <label class="rh-f rh-f-wide" style="max-width:440px"><span>Empleado activo *</span><select id="editEmpSel"></select></label>
+    <form id="formEditar" class="rh-form" autocomplete="off" style="display:none;margin-top:14px">
+      <input type="hidden" name="empleado_id">
+      <div class="rh-grid">
+        <label class="rh-f"><span>Nombre completo *</span><input name="name" type="text" required></label>
+        <label class="rh-f"><span>Empresa *</span><select name="company_id" required></select></label>
+        <label class="rh-f"><span>Correo de empresa *</span><input name="work_email" type="email" required></label>
+        <label class="rh-f"><span>Correo personal</span><input name="private_email" type="email"></label>
+        <label class="rh-f"><span>Celular</span><input name="mobile_phone" type="tel"></label>
+        <label class="rh-f"><span>Teléfono</span><input name="work_phone" type="tel"></label>
+        <label class="rh-f"><span>Departamento *</span><select name="department_id" required></select></label>
+        <label class="rh-f"><span>Jefe directo *</span><select name="parent_id" required></select></label>
+        <label class="rh-f"><span>Puesto</span><select name="job_id"></select></label>
+        <label class="rh-f"><span>Horario *</span><select name="resource_calendar_id" required></select></label>
+        <label class="rh-f"><span>PIN de kiosko *</span><input name="pin" type="text" inputmode="numeric" required></label>
+        <label class="rh-f"><span>Hora de entrada <em>(HH:MM)</em></span><input name="hora_hhmm" type="time"></label>
+        <label class="rh-f"><span>Categoría nómina <em>(vacío = auto por depto)</em></span><select name="x_categoria_nomina"></select></label>
+        <label class="rh-f rh-check"><input name="x_aplica_ppa" type="checkbox"><span>Aplica PPA</span></label>
+      </div>
+
+      <div class="rh-foto">
+        <span class="rh-foto-label">Foto de perfil <em>(deja vacío para no cambiarla)</em></span>
+        <div class="rh-foto-row">
+          <img id="editFotoPreview" class="rh-foto-preview" alt="">
+          <input id="editFotoInput" type="file" accept="image/jpeg,image/png">
+          <span id="editFotoInfo" class="rh-foto-info"></span>
+        </div>
+      </div>
+
+      <div class="rh-actions">
+        <button type="submit" class="rh-btn rh-btn-primary" id="btnEditar">Guardar cambios</button>
+        <span id="editMsg" class="rh-msg"></span>
       </div>
     </form>
   </section>

--- a/modulos/rh/empleados/js/empleados.js
+++ b/modulos/rh/empleados/js/empleados.js
@@ -11,7 +11,9 @@ var EP = {
   crear:      N8N + '/webhook/rh/empleado/crear',
   archivar:   N8N + '/webhook/rh/empleado/archivar',
   reactivar:  N8N + '/webhook/rh/empleado/reactivar',
-  archivados: N8N + '/webhook/rh/empleados/archivados'
+  archivados: N8N + '/webhook/rh/empleados/archivados',
+  detalle:    N8N + '/webhook/rh/empleado/detalle',
+  editar:     N8N + '/webhook/rh/empleado/editar'
 };
 // Defaults autoprogresivos: deptos de campo (Operaciones 3, Ingenieria 17) → calendar 2 / hora 7; oficina → 6 / 8.
 var CAMPO_DEPTS = [3, 17];
@@ -23,7 +25,13 @@ var CATEGORIAS = [
 var REASON_ES = { 'Fired': 'Despido', 'Resigned': 'Renuncia', 'Retired': 'Fin de contrato' }; // cortesía hasta que se renombre en Odoo
 
 var LK = null;        // lookups cacheados
-var fotoB64 = null;   // foto comprimida (base64 sin prefijo)
+var fotoB64 = null;   // foto comprimida (base64 sin prefijo) — alta
+var editFotoB64 = null; // foto nueva en edición (null = no cambiar la existente)
+
+// hora float 24h <-> "HH:MM" (7.5 = 07:30)
+function pad2(n){ return (n < 10 ? '0' : '') + n; }
+function floatToHHMM(f){ f = parseFloat(f) || 0; var h = Math.floor(f); var mn = Math.round((f - h) * 60); if (mn === 60){ h++; mn = 0; } return pad2(h) + ':' + pad2(mn); }
+function hhmmToFloat(s){ if (!s) return 0; var p = String(s).split(':'); return (parseInt(p[0], 10) || 0) + (parseInt(p[1], 10) || 0) / 60; }
 
 // ─── Auth gate (mismo patrón que el hub RH) ───
 function rh_check_auth(){
@@ -73,6 +81,16 @@ async function cargarLookups(){
   fillSelect(elName('departure_reason_id'), LK.reasons, 'id', function(r){ return REASON_ES[r.name] || r.name; }, '— elige —');
   // empleados activos para la baja
   fillSelect(elName('empleado_id'), LK.managers, 'id', function(m){ return m.name; }, '— elige —');
+  // ─── form de EDICIÓN: selects scoped al form + selector de empleado ───
+  var fe = document.getElementById('formEditar');
+  fillSelect(fe.elements['company_id'], LK.companies, 'id', function(c){ return c.name; });
+  fillSelect(fe.elements['department_id'], LK.departments, 'id', function(d){ return d.name; }, '— elige —');
+  fillSelect(fe.elements['parent_id'], LK.managers, 'id', function(m){ return m.name; }, '— elige —');
+  fillSelect(fe.elements['job_id'], LK.jobs, 'id', function(j){ return j.name; }, '— ninguno —');
+  fillSelect(fe.elements['resource_calendar_id'], LK.calendars, 'id', function(c){ return c.name + ' (' + (c.hours_per_week || '?') + 'h)'; }, '— elige —');
+  var ecat = fe.elements['x_categoria_nomina']; ecat.innerHTML = '';
+  CATEGORIAS.forEach(function(c){ var o = document.createElement('option'); o.value = c[0]; o.textContent = c[1]; ecat.appendChild(o); });
+  fillSelect(document.getElementById('editEmpSel'), LK.managers, 'id', function(m){ return m.name; }, '— elige empleado —');
 }
 
 // ─── ALTA: defaults autoprogresivos por depto ───
@@ -104,7 +122,7 @@ async function onAlta(e){
   var hora = elName('x_studio_hora_entrada').value;
   if (hora !== '' && (parseFloat(hora) < 0 || parseFloat(hora) > 23.99)) return msg(m, 'Hora de entrada fuera de 0–23.99', 'err');
   var body = {
-    name: f.name.value.trim(), company_id: f.company_id.value, work_email: f.work_email.value.trim(),
+    name: f.elements['name'].value.trim(), company_id: f.company_id.value, work_email: f.work_email.value.trim(),
     private_email: f.private_email.value.trim(), mobile_phone: f.mobile_phone.value.trim(), work_phone: f.work_phone.value.trim(),
     department_id: f.department_id.value, parent_id: f.parent_id.value, job_id: f.job_id.value || null,
     resource_calendar_id: f.resource_calendar_id.value, pin: f.pin.value.trim(),
@@ -179,6 +197,66 @@ async function onReactivar(id, btn){
   } catch (err){ alert('❌ ' + err.message); btn.disabled = false; btn.textContent = 'Reactivar'; }
 }
 
+// ─── EDITAR: cargar detalle + pre-llenar el form ───
+async function onEditSelect(){
+  var id = $('#editEmpSel').value, fe = $('#formEditar'), m = $('#editMsg');
+  if (!id){ fe.style.display = 'none'; return; }
+  msg(m, 'Cargando…');
+  try {
+    var r = await api(EP.detalle, { empleado_id: id });
+    if (!r.ok || !r.empleado) throw new Error(r.error || 'No se encontró el empleado');
+    var e = r.empleado, E = fe.elements;
+    E['empleado_id'].value = e.id;
+    E['name'].value = e.name || '';
+    E['work_email'].value = e.work_email || '';
+    E['private_email'].value = e.private_email || '';
+    E['mobile_phone'].value = e.mobile_phone || '';
+    E['work_phone'].value = e.work_phone || '';
+    E['department_id'].value = e.department_id || '';
+    E['parent_id'].value = e.parent_id || '';
+    E['job_id'].value = e.job_id || '';
+    E['resource_calendar_id'].value = e.resource_calendar_id || '';
+    E['company_id'].value = e.company_id || '';
+    E['pin'].value = e.pin || '';
+    E['x_categoria_nomina'].value = e.x_categoria_nomina || '';
+    E['x_aplica_ppa'].checked = !!e.x_aplica_ppa;
+    E['hora_hhmm'].value = floatToHHMM(e.x_studio_hora_entrada);
+    editFotoB64 = null; $('#editFotoInput').value = ''; $('#editFotoInfo').textContent = '';
+    var prev = $('#editFotoPreview');
+    if (e.image_128) prev.src = 'data:image/png;base64,' + e.image_128; else prev.removeAttribute('src');
+    fe.style.display = ''; msg(m, '');
+  } catch (err){ msg(m, '❌ ' + err.message, 'err'); fe.style.display = 'none'; }
+}
+async function onEditFoto(e){
+  var f = e.target.files && e.target.files[0], info = $('#editFotoInfo'), prev = $('#editFotoPreview');
+  editFotoB64 = null;
+  if (!f){ info.textContent = ''; return; }
+  try { var r = await FTSFoto.comprimirFoto(f); editFotoB64 = r.base64; prev.src = r.dataUrl; info.textContent = r.w + '×' + r.h + ' · ' + (r.bytes / 1024).toFixed(0) + ' KB'; }
+  catch (err){ info.textContent = '⚠️ ' + err.message; }
+}
+async function onEditar(e){
+  e.preventDefault();
+  var f = e.target, E = f.elements, m = $('#editMsg'), btn = $('#btnEditar');
+  if (!E['empleado_id'].value) return msg(m, 'Elige un empleado primero', 'err');
+  var horaF = hhmmToFloat(E['hora_hhmm'].value);
+  if (horaF < 0 || horaF > 23.99) return msg(m, 'Hora de entrada fuera de 0–23.99', 'err');
+  var body = {
+    empleado_id: E['empleado_id'].value, name: E['name'].value.trim(), company_id: E['company_id'].value, work_email: E['work_email'].value.trim(),
+    private_email: E['private_email'].value.trim(), mobile_phone: E['mobile_phone'].value.trim(), work_phone: E['work_phone'].value.trim(),
+    department_id: E['department_id'].value, parent_id: E['parent_id'].value, job_id: E['job_id'].value || null,
+    resource_calendar_id: E['resource_calendar_id'].value, pin: E['pin'].value.trim(),
+    x_studio_hora_entrada: horaF, x_categoria_nomina: E['x_categoria_nomina'].value || null, x_aplica_ppa: E['x_aplica_ppa'].checked
+  };
+  if (editFotoB64) body.image_1920 = editFotoB64;   // SOLO si subió foto nueva (si no, el workflow no toca la existente)
+  btn.disabled = true; msg(m, 'Guardando…');
+  try {
+    var r = await api(EP.editar, body);
+    if (!r.ok) throw new Error(r.error || 'No se pudo guardar');
+    msg(m, '✅ Cambios guardados (' + esc(body.name) + ').', 'ok');
+  } catch (err){ msg(m, '❌ ' + err.message, 'err'); }
+  finally { btn.disabled = false; }
+}
+
 // ─── Tabs ───
 function setTab(name){
   document.querySelectorAll('.rh-tab').forEach(function(t){ t.classList.toggle('active', t.dataset.tab === name); });
@@ -201,6 +279,9 @@ document.addEventListener('DOMContentLoaded', async function(){
   $('#fotoInput').addEventListener('change', onFoto);
   $('#formAlta').addEventListener('submit', onAlta);
   $('#formBaja').addEventListener('submit', onBaja);
+  $('#editEmpSel').addEventListener('change', onEditSelect);
+  $('#editFotoInput').addEventListener('change', onEditFoto);
+  $('#formEditar').addEventListener('submit', onEditar);
   $('#btnReloadArch').addEventListener('click', cargarArchivados);
   $('#tablaArchivados').addEventListener('click', function(ev){
     var b = ev.target.closest('[data-react]'); if (b) onReactivar(b.dataset.react, b);


### PR DESCRIPTION
## Resumen
Agrega la sección **Editar** al módulo RH `modulos/rh/empleados/` (al lado de Alta/Baja/Archivados). Ana (y Magaly vía el login de `ana.acevedo`) pueden editar la info de un empleado existente, incluido su **horario de entrada**.

## Qué incluye
- **Tab "Editar"**: selector de empleado activo → form **pre-llenado** con sus datos actuales → editar → Guardar = UPDATE.
- **Horario** como input amigable `HH:MM` ↔ float (`07:30` ↔ `7.5`).
- **Foto** opcional (reusa `foto.js`): si no subes una nueva, NO se toca la existente (preview vía `image_128`).
- PIN editable (sin validación de unicidad, decisión previa). Validaciones client-side (email, requeridos, hora 0–23.99).
- Fix: acceso `f.name` del alta (choque con la propiedad IDL del `<form>`) → `f.elements['name']`.

## Workflows n8n usados (ya publicados / activos)
- `rh/empleado/detalle` (`p0hX1i9ZIFR8Olhf`) — READ por id para pre-llenar.
- `rh/empleado/editar` (`a4FxaHTFPW7KJygM`) — UPDATE por id; foto opcional vía `IF has_image`; dispara `/refresh` de empleados-master.

🤖 Generated with [Claude Code](https://claude.com/claude-code)