### PR TITLE
feat(ops): panel B4 «Confirmar Horas» + workflows n8n (Fase 1 Carga MO)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -270,6 +270,7 @@ Pendiente F4: usar este mapeo al guardar planes operativos.
 - **Nunca** commitear API keys, tokens, ni credenciales en el repo.
 - Si se detecta una credencial hardcoded, **alertar inmediatamente** y mover a env var de n8n.
 - Webhook secrets HMAC: pendientes de implementar (Bloque A pending).
+- **Pendiente HMAC (B4 Carga MO, 2026-07-06):** los webhooks nuevos `planeacion/horas-dia` (lectura) y `planeacion/confirmar-horas` (UPDATE hr.attendance) heredan el modelo sin secreto. `confirmar-horas` **escribe a producción** (`x_studio_manager_approval` + `x_studio_sales_order_2`) → priorizar HMAC/token cuando se aborde el hardening de webhooks. Gate actual: solo frontend (auth Felipe/master).
 
 ---
 

--- a/operaciones/confirmar-horas/README.md
+++ b/operaciones/confirmar-horas/README.md
@@ -1,0 +1,56 @@
+# Módulo «Confirmar Horas» (Carga MO — B4)
+
+Panel para que **Felipe Pérez (Supervisor Operaciones)** y **ftsmaster** revisen
+las horas reales de los operativos (por rango de fechas, default = ayer),
+**confirmen** las horas y **corrijan la SO** cuando esté mal o falte.
+
+Es el bloque **B4** de la Fase 1 de Carga de Mano de Obra
+(ver `docs/operaciones/FASE1_CARGA_MO_PLAN.md`). **No toca dinero** (ni
+`analytic.line`, ni budgets): solo marca la aprobación del manager y corrige el
+enlace SO del attendance.
+
+## Acceso
+Gate en `js/confirmar-horas.js`: `FTSAuth` + (`role === 'master'` ó
+`username === 'felipe.perez'`). La tarjeta en `operaciones/index.html` es visible
+para todos, pero la página deniega a quien no sea Felipe/master.
+
+## Estructura
+| Archivo | Rol |
+|---|---|
+| `index.html` | UI (topbar + rango + tabla + modal SO), CSS inline |
+| `js/confirmar-horas.js` | auth gate, carga, confirmar, corregir SO |
+
+## Workflows n8n (creados INACTIVOS — activar en UI antes de usar)
+| Workflow | ID | Endpoint | Qué hace |
+|---|---|---|---|
+| `planeacion/horas-dia (B4 lectura)` | `pQ3vVbRkMYvfICQf` | `POST /webhook/planeacion/horas-dia` | SEARCH `hr.attendance` dept Operaciones (3) en rango CST → filas empleado×SO×horas+estado. **Read-only.** |
+| `planeacion/confirmar-horas (B4 update)` | `7D3lgaYmH2DmqCWy` | `POST /webhook/planeacion/confirmar-horas` | UPDATE `hr.attendance`: `x_studio_manager_approval=true` (`action:confirm`) y/o `x_studio_sales_order_2=so_id` (`action:correct_so`) + nota al chatter (author auto). **Escribe a producción.** |
+
+Ambos usan credencial Odoo `Wansi69xesEqEiY1` (`Odoo FTS`). La lista de SO para
+corregir reusa `POST /webhook/kiosk/sos`.
+
+## Contratos
+- **horas-dia** → body `{ fecha_desde:"YYYY-MM-DD", fecha_hasta?, dept_id?=3 }`
+  → `{ success, count, rows:[{ attendance_id, empleado_id, empleado_nombre,
+  check_in_cst, check_out_cst, abierta, worked_hours, so_id, so_nombre,
+  confirmado, en_disputa, out_mode }] }`.
+- **confirmar-horas** → body `{ attendance_id, action:"confirm"|"correct_so",
+  so_id?, supervisor_nombre? }` → `{ success, attendance_id, manager_approval, so_id }`.
+
+## Checklist de deploy (Esteban)
+1. **Activar** en la UI de n8n los 2 workflows (el API MCP no activa; hay que hacerlo a mano).
+2. Validar en browser: entrar como Felipe/master a `operaciones/confirmar-horas/`,
+   cargar "ayer", confirmar 1 registro y corregir 1 SO. Verificar en Odoo que
+   el attendance quedó con `x_studio_manager_approval=true` (y la SO corregida) + nota en chatter.
+3. **Reset de los 75 `x_studio_manager_approval=true` históricos** (decisión D2):
+   correr **una sola vez** un workflow one-shot que ponga `manager_approval=false`
+   en los attendances viejos, **NO vía MCP** (que es read-only). Junto al go-live de B4.
+4. HMAC de los 2 webhoooks nuevos: pendiente (ver `CLAUDE.md §9`).
+
+## Notas / límites v1
+- **Plan vs real:** la columna "plan" llega en Fase 1 B1/B2 (`planning.slot`).
+  B4 v1 muestra solo lo **real** (attendance) + confirmar/corregir. Sin dependencia de B1.
+- Solo dept **Operaciones (3)** por default (`dept_id` override en el body).
+- La UI muestra éxito **solo tras el OK del POST** (anti-patrón Hallazgo #15).
+- Validación n8n marca 1 "error" en el nodo Webhook (`responseNode` sin `onError`):
+  **falso positivo** — patrón idéntico al productivo `panel/derivar-roles`.

--- a/operaciones/confirmar-horas/index.html
+++ b/operaciones/confirmar-horas/index.html
@@ -1,0 +1,111 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Confirmar Horas — FTS Suite</title>
+<script>
+  (function(){ window.CH_BUILD = '20260706-b4-confirmar-horas-v1'; })();
+</script>
+<script src="../../shared/auth-suite.js"></script>
+<style>
+  :root{ --azul:#1a4480; --azul2:#0C447C; --ok:#1a7a3a; --warn:#BA7517; --err:#b3261e; --bg:#f4f6f9; }
+  *{ box-sizing:border-box; }
+  body{ margin:0; font-family:'Segoe UI',Arial,sans-serif; background:var(--bg); color:#1c1c1c; }
+  .ch-topbar{ display:flex; align-items:center; gap:14px; background:var(--azul); color:#fff; padding:10px 16px; }
+  .ch-back{ color:#fff; text-decoration:none; font-size:14px; opacity:.9; }
+  .ch-title-wrap{ display:flex; flex-direction:column; flex:1; }
+  .ch-title{ font-size:16px; font-weight:600; }
+  .ch-build{ font-size:10px; opacity:.7; }
+  .ch-user{ font-size:13px; opacity:.9; }
+  .ch-gate{ max-width:520px; margin:60px auto; background:#fff; border-radius:12px; padding:28px; text-align:center; box-shadow:0 2px 12px rgba(0,0,0,.08); }
+  .ch-gate a{ display:inline-block; margin-top:14px; background:var(--azul); color:#fff; text-decoration:none; padding:9px 18px; border-radius:8px; }
+  .ch-main{ max-width:1000px; margin:0 auto; padding:16px; }
+  .ch-controls{ display:flex; flex-wrap:wrap; align-items:end; gap:12px; background:#fff; border-radius:10px; padding:14px; box-shadow:0 1px 6px rgba(0,0,0,.06); margin-bottom:14px; }
+  .ch-field{ display:flex; flex-direction:column; gap:3px; }
+  .ch-field label{ font-size:11px; color:#555; font-weight:600; }
+  .ch-field input{ padding:7px 9px; border:1px solid #ccc; border-radius:7px; font-size:14px; }
+  .ch-btn{ border:none; border-radius:8px; padding:8px 16px; font-size:14px; cursor:pointer; font-weight:500; }
+  .ch-btn-primary{ background:var(--azul); color:#fff; }
+  .ch-btn-sm{ padding:5px 10px; font-size:12px; }
+  .ch-btn-ok{ background:var(--ok); color:#fff; }
+  .ch-btn-edit{ background:#eef2f8; color:var(--azul2); border:1px solid #cfdcf0; }
+  .ch-btn:disabled{ opacity:.55; cursor:not-allowed; }
+  .ch-summary{ font-size:13px; color:#444; margin:2px 4px 12px; }
+  .ch-table{ width:100%; border-collapse:collapse; background:#fff; border-radius:10px; overflow:hidden; box-shadow:0 1px 6px rgba(0,0,0,.06); font-size:13px; }
+  .ch-table th{ background:var(--azul); color:#fff; text-align:left; padding:9px 10px; font-weight:500; }
+  .ch-table td{ padding:8px 10px; border-top:1px solid #eee; vertical-align:middle; }
+  .ch-badge{ display:inline-block; font-size:11px; padding:2px 8px; border-radius:10px; font-weight:600; }
+  .b-ok{ background:#e3f4e8; color:var(--ok); }
+  .b-pend{ background:#fff3df; color:var(--warn); }
+  .b-disp{ background:#fdeceb; color:var(--err); }
+  .b-open{ background:#eceff3; color:#555; }
+  .ch-sinso{ color:var(--err); font-weight:600; }
+  .ch-actions{ display:flex; gap:6px; white-space:nowrap; }
+  .ch-msg{ padding:10px 12px; border-radius:8px; margin-bottom:12px; font-size:13px; display:none; }
+  .ch-msg-ok{ background:#e3f4e8; color:var(--ok); }
+  .ch-msg-err{ background:#fdeceb; color:var(--err); }
+  .ch-placeholder{ text-align:center; color:#777; padding:28px; }
+  .ch-modal{ position:fixed; inset:0; background:rgba(0,0,0,.45); display:none; align-items:center; justify-content:center; z-index:50; }
+  .ch-modal-box{ background:#fff; border-radius:12px; width:min(440px,92vw); max-height:80vh; display:flex; flex-direction:column; overflow:hidden; }
+  .ch-modal-head{ display:flex; justify-content:space-between; align-items:center; padding:14px 16px; border-bottom:1px solid #eee; }
+  .ch-modal-body{ padding:14px 16px; overflow:auto; }
+  .ch-so-search{ width:100%; padding:9px; border:1px solid #ccc; border-radius:8px; font-size:14px; margin-bottom:10px; }
+  .ch-so-item{ padding:9px 10px; border:1px solid #e5e5e5; border-radius:8px; margin-bottom:6px; cursor:pointer; }
+  .ch-so-item:hover{ background:#f0f4f9; }
+  .ch-so-item .n{ font-weight:600; color:var(--azul); }
+  .ch-so-item .c{ font-size:12px; color:#666; }
+  .ch-x{ background:none; border:none; font-size:18px; cursor:pointer; color:#888; }
+</style>
+</head>
+<body>
+
+<div class="ch-topbar">
+  <a class="ch-back" href="../index.html">← Operaciones</a>
+  <div class="ch-title-wrap">
+    <span class="ch-title">✅ Confirmar Horas</span>
+    <span class="ch-build" id="ch-build">build …</span>
+  </div>
+  <div class="ch-user"><span id="ch-user-nombre">—</span></div>
+</div>
+
+<div id="auth-gate" class="ch-gate" style="display:none"></div>
+
+<main id="main-content" class="ch-main" style="display:none">
+  <div class="ch-controls">
+    <div class="ch-field">
+      <label for="f-desde">Desde</label>
+      <input type="date" id="f-desde">
+    </div>
+    <div class="ch-field">
+      <label for="f-hasta">Hasta</label>
+      <input type="date" id="f-hasta">
+    </div>
+    <button class="ch-btn ch-btn-primary" id="btn-cargar">Cargar</button>
+  </div>
+
+  <div class="ch-msg" id="ch-msg"></div>
+  <div class="ch-summary" id="ch-summary"></div>
+
+  <div id="tabla-zone">
+    <div class="ch-placeholder">Elige un rango y presiona <strong>Cargar</strong>.</div>
+  </div>
+</main>
+
+<!-- Modal corregir SO -->
+<div id="modal-so" class="ch-modal">
+  <div class="ch-modal-box">
+    <div class="ch-modal-head">
+      <strong id="modal-so-title">Corregir SO</strong>
+      <button class="ch-x" id="modal-so-close">✕</button>
+    </div>
+    <div class="ch-modal-body">
+      <input type="text" class="ch-so-search" id="modal-so-search" placeholder="Buscar SO… (nombre o cliente)" autocomplete="off">
+      <div id="modal-so-list"></div>
+    </div>
+  </div>
+</div>
+
+<script src="js/confirmar-horas.js"></script>
+</body>
+</html>

--- a/operaciones/confirmar-horas/js/confirmar-horas.js
+++ b/operaciones/confirmar-horas/js/confirmar-horas.js
@@ -1,0 +1,282 @@
+// ═══ FTS · Panel «Confirmar Horas» (B4) ═══
+// Felipe (Supervisor Ops) + ftsmaster confirman las horas reales de operativos
+// y corrigen la SO cuando aplique. Escribe x_studio_manager_approval y/o
+// x_studio_sales_order_2 vía workflows n8n (Odoo write server-side).
+// Anti-patrón Hallazgo #15: la UI muestra éxito SÓLO tras el OK del POST.
+'use strict';
+
+(function(){
+  var BUILD = window.CH_BUILD || 'b4-v1';
+  var N8N_BASE = 'https://primary-production-5c3c.up.railway.app';
+  var COMPANY_ID = 1;
+
+  var CH = {
+    rows: [],
+    sos: null,            // cache lista SO (lazy)
+    sosCargando: false,
+    supervisor: 'Supervisor',
+    modalAttId: null
+  };
+
+  function $(id){ return document.getElementById(id); }
+  function esc(s){ return String(s == null ? '' : s).replace(/[&<>"']/g, function(c){
+    return {'&':'&amp;','<':'&lt;','>':'&gt;','"':'&quot;',"'":'&#39;'}[c]; }); }
+
+  function n8n(path, body){
+    return fetch(N8N_BASE + path, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(body || {})
+    }).then(function(res){
+      if(!res.ok) throw new Error('HTTP ' + res.status);
+      return res.json();
+    });
+  }
+
+  function ymd(d){ return d.toISOString().slice(0,10); }
+  function ayerCST(){
+    var nowCst = new Date(Date.now() - 6*3600*1000);
+    return new Date(nowCst.getTime() - 24*3600*1000);
+  }
+
+  function showMsg(texto, tipo){
+    var el = $('ch-msg');
+    if(!el) return;
+    el.textContent = texto;
+    el.className = 'ch-msg ' + (tipo === 'ok' ? 'ch-msg-ok' : 'ch-msg-err');
+    el.style.display = 'block';
+    if(tipo === 'ok') setTimeout(function(){ el.style.display = 'none'; }, 4000);
+  }
+  function clearMsg(){ var el = $('ch-msg'); if(el) el.style.display = 'none'; }
+
+  // ─── Cargar horas del rango ───
+  function cargar(){
+    clearMsg();
+    var desde = $('f-desde').value;
+    var hasta = $('f-hasta').value;
+    if(!desde){ showMsg('Elige la fecha "Desde".', 'err'); return; }
+    if(!hasta) hasta = desde;
+    var btn = $('btn-cargar');
+    btn.disabled = true;
+    var orig = btn.textContent;
+    btn.textContent = 'Cargando…';
+    $('tabla-zone').innerHTML = '<div class="ch-placeholder">⏳ Consultando Odoo…</div>';
+
+    n8n('/webhook/planeacion/horas-dia', { fecha_desde: desde, fecha_hasta: hasta })
+      .then(function(data){
+        var r = Array.isArray(data) ? data[0] : data;
+        if(!r || r.success === false){
+          throw new Error((r && r.mensaje) || 'Respuesta inválida');
+        }
+        CH.rows = r.rows || [];
+        renderTabla();
+        var conf = CH.rows.filter(function(x){ return x.confirmado; }).length;
+        $('ch-summary').textContent = CH.rows.length + ' registro(s) · ' + conf +
+          ' confirmado(s) · ' + (CH.rows.length - conf) + ' pendiente(s)';
+      })
+      .catch(function(e){
+        $('tabla-zone').innerHTML = '<div class="ch-placeholder">❌ Error cargando: ' + esc(e.message) + '</div>';
+        $('ch-summary').textContent = '';
+      })
+      .finally(function(){ btn.disabled = false; btn.textContent = orig; });
+  }
+
+  function estadoBadge(row){
+    if(row.en_disputa) return '<span class="ch-badge b-disp">⚠ En disputa</span>';
+    if(row.abierta)    return '<span class="ch-badge b-open">⏳ Abierta</span>';
+    if(row.confirmado) return '<span class="ch-badge b-ok">✓ Confirmada</span>';
+    return '<span class="ch-badge b-pend">Pendiente</span>';
+  }
+
+  function renderTabla(){
+    if(!CH.rows.length){
+      $('tabla-zone').innerHTML = '<div class="ch-placeholder">Sin registros en el rango.</div>';
+      return;
+    }
+    var filas = CH.rows.map(function(row){
+      var so = row.so_id
+        ? esc(row.so_nombre || ('SO ' + row.so_id))
+        : '<span class="ch-sinso">⚠ Sin SO</span>';
+      var horario = (row.check_in_cst || '—') + (row.check_out_cst ? ' → ' + row.check_out_cst.slice(11) : ' → …');
+      var horas = row.worked_hours != null ? row.worked_hours.toFixed(2) + 'h' : '—';
+      var confirmarDisabled = (row.confirmado || row.en_disputa || row.abierta) ? ' disabled' : '';
+      return '<tr data-att="' + row.attendance_id + '">' +
+          '<td>' + esc(row.empleado_nombre || ('#' + row.empleado_id)) + '</td>' +
+          '<td>' + esc(horario) + '</td>' +
+          '<td>' + horas + '</td>' +
+          '<td class="cell-so">' + so + '</td>' +
+          '<td class="cell-estado">' + estadoBadge(row) + '</td>' +
+          '<td><div class="ch-actions">' +
+            '<button class="ch-btn ch-btn-sm ch-btn-ok" data-act="confirm" data-att="' + row.attendance_id + '"' + confirmarDisabled + '>✔ Confirmar</button>' +
+            '<button class="ch-btn ch-btn-sm ch-btn-edit" data-act="editso" data-att="' + row.attendance_id + '">✎ SO</button>' +
+          '</div></td>' +
+        '</tr>';
+    }).join('');
+
+    $('tabla-zone').innerHTML =
+      '<table class="ch-table"><thead><tr>' +
+        '<th>Empleado</th><th>Entrada → Salida (CST)</th><th>Horas</th><th>SO</th><th>Estado</th><th>Acciones</th>' +
+      '</tr></thead><tbody>' + filas + '</tbody></table>';
+
+    $('tabla-zone').querySelectorAll('button[data-act]').forEach(function(b){
+      b.addEventListener('click', function(){
+        var att = parseInt(b.dataset.att, 10);
+        if(b.dataset.act === 'confirm') confirmar(att, b);
+        else abrirModalSO(att);
+      });
+    });
+  }
+
+  function findRow(attId){ return CH.rows.find(function(x){ return x.attendance_id === attId; }); }
+
+  // ─── Confirmar horas (set manager_approval) ───
+  function confirmar(attId, btn){
+    clearMsg();
+    if(btn){ btn.disabled = true; btn.textContent = '⏳'; }
+    n8n('/webhook/planeacion/confirmar-horas', {
+      attendance_id: attId, action: 'confirm', supervisor_nombre: CH.supervisor
+    }).then(function(data){
+      var r = Array.isArray(data) ? data[0] : data;
+      if(!r || r.success === false) throw new Error((r && r.mensaje) || 'Error');
+      // Éxito confirmado por el backend → recién ahora actualizamos UI (anti #15)
+      var row = findRow(attId);
+      if(row) row.confirmado = true;
+      actualizarFila(attId);
+      showMsg('✓ Horas confirmadas (att ' + attId + ')', 'ok');
+    }).catch(function(e){
+      showMsg('❌ No se pudo confirmar: ' + e.message, 'err');
+      if(btn){ btn.disabled = false; btn.textContent = '✔ Confirmar'; }
+    });
+  }
+
+  function actualizarFila(attId){
+    var row = findRow(attId);
+    var tr = document.querySelector('tr[data-att="' + attId + '"]');
+    if(!row || !tr) return;
+    tr.querySelector('.cell-estado').innerHTML = estadoBadge(row);
+    tr.querySelector('.cell-so').innerHTML = row.so_id
+      ? esc(row.so_nombre || ('SO ' + row.so_id))
+      : '<span class="ch-sinso">⚠ Sin SO</span>';
+    var btnC = tr.querySelector('button[data-act="confirm"]');
+    if(btnC){
+      var dis = (row.confirmado || row.en_disputa || row.abierta);
+      btnC.disabled = dis;
+      btnC.textContent = '✔ Confirmar';
+    }
+    var conf = CH.rows.filter(function(x){ return x.confirmado; }).length;
+    $('ch-summary').textContent = CH.rows.length + ' registro(s) · ' + conf +
+      ' confirmado(s) · ' + (CH.rows.length - conf) + ' pendiente(s)';
+  }
+
+  // ─── Modal corregir SO ───
+  function abrirModalSO(attId){
+    CH.modalAttId = attId;
+    var row = findRow(attId);
+    $('modal-so-title').textContent = 'Corregir SO — ' + ((row && row.empleado_nombre) || ('att ' + attId));
+    $('modal-so-search').value = '';
+    $('modal-so').style.display = 'flex';
+    $('modal-so-search').focus();
+    cargarSOs().then(function(){ renderSOList(''); });
+  }
+  function cerrarModalSO(){ $('modal-so').style.display = 'none'; CH.modalAttId = null; }
+
+  function cargarSOs(){
+    if(CH.sos) return Promise.resolve(CH.sos);
+    if(CH.sosCargando) return Promise.resolve([]);
+    CH.sosCargando = true;
+    $('modal-so-list').innerHTML = '<div class="ch-placeholder">⏳ Cargando SOs…</div>';
+    return n8n('/webhook/kiosk/sos', { company_id: COMPANY_ID }).then(function(data){
+      var arr = Array.isArray(data) ? data : (data && data.sos) || [];
+      CH.sos = arr.map(function(s){
+        return { id: s.id, nombre: s.nombre || s.name || ('SO ' + s.id), cliente: s.cliente || '' };
+      }).filter(function(s){ return s.id != null; });
+      return CH.sos;
+    }).catch(function(e){
+      $('modal-so-list').innerHTML = '<div class="ch-placeholder">❌ ' + esc(e.message) + '</div>';
+      return [];
+    }).finally(function(){ CH.sosCargando = false; });
+  }
+
+  function renderSOList(q){
+    var lista = CH.sos || [];
+    var nq = q ? q.toLowerCase() : '';
+    if(nq) lista = lista.filter(function(s){
+      return (s.nombre || '').toLowerCase().indexOf(nq) !== -1 ||
+             (s.cliente || '').toLowerCase().indexOf(nq) !== -1;
+    });
+    if(!lista.length){ $('modal-so-list').innerHTML = '<div class="ch-placeholder">Sin resultados</div>'; return; }
+    $('modal-so-list').innerHTML = lista.slice(0, 40).map(function(s){
+      return '<div class="ch-so-item" data-so="' + s.id + '">' +
+        '<div class="n">' + esc(s.nombre) + '</div>' +
+        (s.cliente ? '<div class="c">' + esc(s.cliente) + '</div>' : '') +
+      '</div>';
+    }).join('');
+    $('modal-so-list').querySelectorAll('.ch-so-item').forEach(function(it){
+      it.addEventListener('click', function(){ corregirSO(CH.modalAttId, parseInt(it.dataset.so, 10)); });
+    });
+  }
+
+  function corregirSO(attId, soId){
+    if(!attId || !soId) return;
+    var so = (CH.sos || []).find(function(s){ return s.id === soId; });
+    $('modal-so-list').innerHTML = '<div class="ch-placeholder">⏳ Guardando…</div>';
+    n8n('/webhook/planeacion/confirmar-horas', {
+      attendance_id: attId, action: 'correct_so', so_id: soId, supervisor_nombre: CH.supervisor
+    }).then(function(data){
+      var r = Array.isArray(data) ? data[0] : data;
+      if(!r || r.success === false) throw new Error((r && r.mensaje) || 'Error');
+      var row = findRow(attId);
+      if(row){ row.so_id = soId; row.so_nombre = so ? so.nombre : ('SO ' + soId); row.confirmado = true; }
+      actualizarFila(attId);
+      cerrarModalSO();
+      showMsg('✓ SO corregida a ' + (so ? so.nombre : soId) + ' y horas confirmadas', 'ok');
+    }).catch(function(e){
+      $('modal-so-list').innerHTML = '<div class="ch-placeholder">❌ ' + esc(e.message) + '</div>';
+    });
+  }
+
+  // ─── Auth gate + bootstrap ───
+  function denyAccess(reason){
+    $('auth-gate').style.display = 'block';
+    $('auth-gate').innerHTML = '<h2>🔒 Acceso restringido</h2><p>' + esc(reason) +
+      '</p><a href="../index.html">Volver a Operaciones</a>';
+  }
+
+  document.addEventListener('DOMContentLoaded', function(){
+    $('ch-build').textContent = 'build ' + BUILD;
+
+    if(!window.FTSAuth || !window.FTSAuth.isLoggedIn()){
+      window.location.href = '../../index.html';
+      return;
+    }
+    var session = window.FTSAuth.getSession();
+    if(!session){ window.location.href = '../../index.html'; return; }
+    try { window.FTSAuth.initActivityTracking && window.FTSAuth.initActivityTracking(); } catch(e){}
+
+    CH.supervisor = session.nombre || session.username || 'Supervisor';
+    $('ch-user-nombre').textContent = '👤 ' + CH.supervisor;
+
+    var isMaster = session.role === 'master' || session.modulos === 'all';
+    var isFelipe = session.username === 'felipe.perez';
+    if(!isMaster && !isFelipe){
+      denyAccess('Solo Felipe Pérez (Supervisor Operaciones) o ftsmaster pueden confirmar horas.');
+      return;
+    }
+
+    $('main-content').style.display = 'block';
+
+    // Default: ayer (CST)
+    var ayer = ymd(ayerCST());
+    $('f-desde').value = ayer;
+    $('f-hasta').value = ayer;
+
+    $('btn-cargar').addEventListener('click', cargar);
+    $('modal-so-close').addEventListener('click', cerrarModalSO);
+    $('modal-so').addEventListener('click', function(e){ if(e.target.id === 'modal-so') cerrarModalSO(); });
+    $('modal-so-search').addEventListener('input', function(e){ renderSOList(e.target.value); });
+    document.addEventListener('keydown', function(e){ if(e.key === 'Escape') cerrarModalSO(); });
+
+    // Carga inicial automática (ayer)
+    cargar();
+  });
+})();

--- a/operaciones/confirmar-horas/js/confirmar-horas.js
+++ b/operaciones/confirmar-horas/js/confirmar-horas.js
@@ -101,6 +101,7 @@
       var horas = row.worked_hours != null ? row.worked_hours.toFixed(2) + 'h' : '—';
       var confirmarDisabled = (row.confirmado || row.en_disputa || row.abierta) ? ' disabled' : '';
       return '<tr data-att="' + row.attendance_id + '">' +
+          '<td style="color:#9aa0a6;font-size:11px;font-variant-numeric:tabular-nums" title="Attendance ID (Odoo)">' + row.attendance_id + '</td>' +
           '<td>' + esc(row.empleado_nombre || ('#' + row.empleado_id)) + '</td>' +
           '<td>' + esc(horario) + '</td>' +
           '<td>' + horas + '</td>' +
@@ -115,7 +116,7 @@
 
     $('tabla-zone').innerHTML =
       '<table class="ch-table"><thead><tr>' +
-        '<th>Empleado</th><th>Entrada → Salida (CST)</th><th>Horas</th><th>SO</th><th>Estado</th><th>Acciones</th>' +
+        '<th style="width:56px">ID</th><th>Empleado</th><th>Entrada → Salida (CST)</th><th>Horas</th><th>SO</th><th>Estado</th><th>Acciones</th>' +
       '</tr></thead><tbody>' + filas + '</tbody></table>';
 
     $('tabla-zone').querySelectorAll('button[data-act]').forEach(function(b){

--- a/operaciones/index.html
+++ b/operaciones/index.html
@@ -109,6 +109,13 @@
         <span>Plan diario operaciones</span>
       </div>
     </a>
+    <a id="card-confirmar-horas" href="confirmar-horas/index.html" class="op-card">
+      <div class="op-icon">✅</div>
+      <div class="op-info">
+        <strong>Confirmar Horas</strong>
+        <span>Validar horas reales y SO (supervisor)</span>
+      </div>
+    </a>
     <a id="card-dashboard" href="dashboard/index.html" class="op-card">
       <div class="op-icon">📊</div>
       <div class="op-info">


### PR DESCRIPTION
## Summary
**B4** de Fase 1 Carga MO (ver `docs/operaciones/FASE1_CARGA_MO_PLAN.md`). Panel para que **Felipe/ftsmaster** confirmen horas reales de operativos y corrijan la SO. **No toca dinero** (sin analytic.line/budgets) — solo `x_studio_manager_approval` + `x_studio_sales_order_2`.

- Frontend: `operaciones/confirmar-horas/` (index.html + js) + card en `operaciones/index.html`.
- 2 workflows n8n **creados INACTIVOS**: `planeacion/horas-dia` (`pQ3vVbRkMYvfICQf`, read) + `planeacion/confirmar-horas` (`7D3lgaYmH2DmqCWy`, UPDATE + chatter).
- Anti-patrón Hallazgo #15 respetado (éxito solo tras OK del POST). HMAC pendiente en `CLAUDE.md §9`.

## Deploy (antes de validar en browser)
1. **Activar** los 2 workflows en la UI de n8n (el API MCP no activa).
2. Entrar como Felipe/master a `operaciones/confirmar-horas/`, cargar "ayer", **confirmar 1** y **corregir 1 SO**.
3. Verificar en Odoo: `x_studio_manager_approval=true`, SO corregida, nota en chatter.

## Test plan
- [ ] Workflows activados en n8n
- [ ] Carga "ayer" muestra operativos con horas/SO/estado
- [ ] Confirmar → estado ✓ (y en Odoo `manager_approval=true` + chatter)
- [ ] Corregir SO → SO actualizada en Odoo
- [ ] Empleado sin SO se marca ⚠ Sin SO

## Pendiente aparte (go-live)
- Reset de los 75 `manager_approval=true` históricos (D2) vía workflow one-shot (no MCP).
- Plan-vs-real: llega con B1/B2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)