### PR TITLE
feat(planeacion): B1 — botón Publicar → planeacion/guardar (upsert planning.slot)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -262,6 +262,8 @@ Pendiente F4: usar este mapeo al guardar planes operativos.
 - **Después de cada cambio:** dejar resumen con archivos tocados, IDs de workflows modificados, y siguiente paso sugerido.
 - **No usar lenguaje IA-ish** en outputs externos (correos a clientes, mensajes a empleados). Tono directo, ejecutivo, español MX.
 - **Confirmación entre etapas:** Esteban prefiere validar entre fase y fase, no batches grandes.
+- **Bump de build obligatorio (verificación visual):** todo PR que toque un módulo con `version.json` (o con indicador de build en pantalla como `CH_BUILD`) DEBE bumpear el build. Esteban verifica en pantalla que su cambio quedó desplegado. Convención de build: `YYYYMMDD-<modulo>-<hito>`.
+- **No cambiar el working dir mientras Esteban valida:** cuando Esteban esté validando un branch en su browser local, NO hacer `git checkout` a otros branches en el working directory compartido (le cambia el piso). Usar `git worktree` para branches paralelos, o avisarle antes.
 
 ---
 

--- a/operaciones/planeacion/js/planeacion.js
+++ b/operaciones/planeacion/js/planeacion.js
@@ -509,7 +509,9 @@ window.BUILD_DATE = '20260428-planeacion-f3-export-v3';
               '<button id="btn-copiar" class="pl-btn-export">📋 Copiar texto</button>' +
               '<button id="btn-imagen" class="pl-btn-export">🖼️ Generar PNG</button>' +
               '<button id="btn-wa"     class="pl-btn-export pl-btn-wa">📱 Enviar a WhatsApp</button>' +
+              '<button id="btn-publicar" class="pl-btn-export">💾 Publicar (guardar plan)</button>' +
             '</div>' +
+            '<div id="pl-publicar-msg" style="font-size:12px;margin-top:8px"></div>' +
           '</div>' +
         '</div>';
 
@@ -555,6 +557,8 @@ window.BUILD_DATE = '20260428-planeacion-f3-export-v3';
         const texto = window.PLANEACION_EXPORTAR.generarTextoWA(this.asignaciones, this.fechaFormateadaCorta());
         window.PLANEACION_EXPORTAR.compartirWA(texto);
       });
+
+      $('btn-publicar').addEventListener('click', () => this.publicarPlan());
     },
 
     actualizarPreviewExport(){
@@ -562,6 +566,65 @@ window.BUILD_DATE = '20260428-planeacion-f3-export-v3';
       if (!preview) return;
       const texto = window.PLANEACION_EXPORTAR.generarTextoWA(this.asignaciones, this.fechaFormateadaCorta());
       preview.textContent = texto;
+    },
+
+    // ─── B1: publicar plan → planning.slot (upsert vía n8n) ───
+    async publicarPlan(){
+      const J = window.PLANEACION_JORNADA;
+      const N8N = 'https://primary-production-5c3c.up.railway.app';
+      const session = (window.FTSAuth && window.FTSAuth.getSession()) || {};
+      const msg = $('pl-publicar-msg');
+      const btn = $('btn-publicar');
+
+      const asigns = this.asignaciones.map(a => ({
+        empleado_id:      a.empleado_id,
+        so_id:            a.so_id || null,
+        so_nombre:        a.so_nombre || '',
+        entrada:          a.entrada,
+        salida:           a.salida,
+        he:               a.he || 0,
+        sitio:            a.sitio || '',
+        actividad:        a.actividad || '',
+        origen:           a.origen || '',
+        externo:          !!a.externo,
+        empleado_dept_id: a.empleado_dept_id || 0,
+        horas_netas:      J.calcularNeta(a.entrada, a.salida)
+      }));
+
+      if (!asigns.length){
+        if (msg){ msg.style.color = '#b3261e'; msg.textContent = 'No hay asignaciones que publicar.'; }
+        return;
+      }
+
+      const payload = {
+        fecha: this.fechaActual,
+        supervisor: { username: session.username || '', nombre: session.nombre || '' },
+        asignaciones: asigns
+      };
+
+      if (btn){ btn.disabled = true; btn.textContent = '⏳ Publicando…'; }
+      if (msg){ msg.style.color = '#555'; msg.textContent = 'Guardando en Odoo…'; }
+
+      try {
+        const res = await fetch(N8N + '/webhook/planeacion/guardar', {
+          method: 'POST', headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify(payload)
+        });
+        if (!res.ok) throw new Error('HTTP ' + res.status);
+        const data = await res.json();
+        const r = Array.isArray(data) ? data[0] : data;
+        if (!r || r.success === false) throw new Error((r && r.mensaje) || 'Error');
+        // Éxito confirmado por el backend → recién ahora mostramos OK (anti #15)
+        if (msg){
+          msg.style.color = '#1a7a3a';
+          msg.textContent = '✓ Plan publicado — ' + (r.created || 0) + ' creados, ' +
+            (r.updated || 0) + ' actualizados' + (r.skipped ? ', ' + r.skipped + ' omitidos' : '') + '.';
+        }
+      } catch (e){
+        if (msg){ msg.style.color = '#b3261e'; msg.textContent = '❌ No se pudo publicar: ' + e.message; }
+      } finally {
+        if (btn){ btn.disabled = false; btn.textContent = '💾 Publicar (guardar plan)'; }
+      }
     },
 
     fechaFormateadaCorta(){

--- a/operaciones/planeacion/js/planeacion.js
+++ b/operaciones/planeacion/js/planeacion.js
@@ -88,6 +88,7 @@ window.BUILD_DATE = '20260428-planeacion-f3-export-v3';
             '<button class="pl-btn-nav" id="next-day" aria-label="Día siguiente">›</button>' +
           '</div>' +
           '<div class="pl-acciones-header">' +
+            '<button class="pl-btn-secondary" id="btn-colapsar" title="Colapsar lista para ir a publicar">▼ Ocultar lista</button>' +
             '<button class="pl-btn-secondary" id="btn-jalar">+ Jalar de otro departamento</button>' +
             '<button class="pl-btn-secondary pl-btn-icon" id="btn-config" title="Configuración" aria-label="Configuración">⚙️</button>' +
           '</div>' +
@@ -97,6 +98,21 @@ window.BUILD_DATE = '20260428-planeacion-f3-export-v3';
       $('next-day').addEventListener('click', () => this.cambiarDia(1));
       $('btn-jalar').addEventListener('click', () => this.abrirModalJalar());
       $('btn-config').addEventListener('click', () => window.PLANEACION_CONFIG.abrirMenuConfig());
+      $('btn-colapsar').addEventListener('click', () => this.toggleLista());
+    },
+
+    // Colapsa/expande el listado de empleados para llegar rápido a publicar.
+    toggleLista(){
+      const z = $('empleados-zone');
+      const btn = $('btn-colapsar');
+      if (!z) return;
+      const oculto = z.style.display === 'none';
+      z.style.display = oculto ? '' : 'none';
+      if (btn) btn.textContent = oculto ? '▼ Ocultar lista' : '▶ Mostrar lista';
+      if (!oculto){
+        const ez = $('export-zone');
+        if (ez && ez.scrollIntoView) ez.scrollIntoView({ behavior: 'smooth', block: 'start' });
+      }
     },
 
     cambiarDia(delta){

--- a/operaciones/planeacion/version.json
+++ b/operaciones/planeacion/version.json
@@ -1,10 +1,10 @@
 {
   "module": "operaciones/planeacion",
-  "version": "2.2.0",
-  "build": "20260428-planeacion-f3-export-v3",
+  "version": "2.3.0",
+  "build": "20260706-planeacion-b1-v1",
   "status": "in_development",
-  "fase": "F3",
-  "actualizado": "2026-04-28",
+  "fase": "F4-B1",
+  "actualizado": "2026-07-06",
   "rebuilt_from_scratch": true,
-  "notas": "F3: config persistente + selector SO desde Odoo + dropdowns origen + exportación WhatsApp/PNG + renombres HE→Horas extras"
+  "notas": "B1 Carga MO: boton Publicar (upsert planning.slot con tag SO, solo asignaciones con SO) + toggle colapsar lista"
 }


### PR DESCRIPTION
## Summary
**B1** de Fase 1 Carga MO. Botón **💾 Publicar (guardar plan)** en el módulo Planeación → POST del plan del día a `/webhook/planeacion/guardar`.

- **Frontend:** `operaciones/planeacion/js/planeacion.js` (botón + `publicarPlan()`).
- **Workflow n8n** `planeacion/guardar` (`IDzF71h0f1EYHVhH`, **INACTIVO**): upsert idempotente de `planning.slot` por empleado+día — resuelve `resource_id` del empleado, ventana CST→UTC, **SO como tag en `name`** (`SO#<id>|<nombre>`, decisión D1), `state=published`. Responde `{created, updated, skipped}`.
- **No toca dinero** (sin analytic.line/budgets). Anti-patrón #15 respetado.

## Deploy (antes de validar)
1. **Activar** `planeacion/guardar` en la UI de n8n.
2. En Planeación (Felipe/master), arma el plan de un día, presiona **Publicar**.
3. Verifica en Odoo (Planning): se crearon/actualizaron `planning.slot` con `resource_id`, horario CST correcto (13:00–23:00Z = 07:00–17:00 CST), y `name` con el tag `SO#…`.
4. Re-publica el mismo día → debe **actualizar** (no duplicar) — idempotencia.

## Test plan
- [ ] Workflow activado
- [ ] Publicar crea slots (created = N)
- [ ] Re-publicar el mismo día actualiza (updated = N, created = 0)
- [ ] `name` trae el tag `SO#<id>` cuando hay SO
- [ ] Empleado sin `resource_id` → skipped (no rompe)

## Siguiente
B2 `planeacion/dia` (kiosk consume el plan para pre-llenar SO). B3 (kiosk) queda para tu aprobación explícita.

🤖 Generated with [Claude Code](https://claude.com/claude-code)