### PR TITLE
feat(confirmar-horas): B4.1 — cross-depto con SO + badge de depto

### DIFF
--- a/operaciones/confirmar-horas/index.html
+++ b/operaciones/confirmar-horas/index.html
@@ -5,7 +5,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 <title>Confirmar Horas — FTS Suite</title>
 <script>
-  (function(){ window.CH_BUILD = '20260706-b4-confirmar-horas-v1'; })();
+  (function(){ window.CH_BUILD = '20260706-b4.1-dept-badge'; })();
 </script>
 <script src="../../shared/auth-suite.js"></script>
 <style>

--- a/operaciones/confirmar-horas/js/confirmar-horas.js
+++ b/operaciones/confirmar-horas/js/confirmar-horas.js
@@ -102,7 +102,10 @@
       var confirmarDisabled = (row.confirmado || row.en_disputa || row.abierta) ? ' disabled' : '';
       return '<tr data-att="' + row.attendance_id + '">' +
           '<td style="color:#9aa0a6;font-size:11px;font-variant-numeric:tabular-nums" title="Attendance ID (Odoo)">' + row.attendance_id + '</td>' +
-          '<td>' + esc(row.empleado_nombre || ('#' + row.empleado_id)) + '</td>' +
+          '<td>' + esc(row.empleado_nombre || ('#' + row.empleado_id)) +
+            (row.es_operaciones === false && row.department_name
+              ? ' <span title="Cargó horas a un proyecto (otro depto)" style="background:#eef2f8;color:#0C447C;font-size:10px;padding:1px 7px;border-radius:8px;white-space:nowrap">' + esc(row.department_name) + '</span>'
+              : '') + '</td>' +
           '<td>' + esc(horario) + '</td>' +
           '<td>' + horas + '</td>' +
           '<td class="cell-so">' + so + '</td>' +


### PR DESCRIPTION
## Summary
**B4.1** (ajuste rápido). El panel Confirmar Horas ahora muestra **también** a gente de otros departamentos que cargó horas a un proyecto ese día — no solo Operaciones.

- **Workflow `planeacion/horas-dia`** (ya actualizado y activo en n8n): filtro cambiado de `department_id=3` a **Operaciones OR `x_studio_sales_order_2` poblada**; agrega `department_id`, `department_name`, `es_operaciones` por fila.
- **Frontend** (este PR): badge de depto junto al nombre para filas cross-depto (no-Operaciones). Sin otros cambios de UI.

Validado en vivo (2026-07-02): 24 filas — Operaciones + Comercial/RH/Ingeniería/Legal/Admin con SO.

## Test plan
- [ ] Cargar un día con gente de otros deptos que checó con SO → aparecen con badge de depto
- [ ] Operaciones sin badge; cross-depto con badge
- [ ] Confirmar/corregir SO sigue funcionando igual

🤖 Generated with [Claude Code](https://claude.com/claude-code)