### PR TITLE
feat(planeacion): B2 — merge automático del plan publicado (planeacion/dia)

### DIFF
--- a/operaciones/planeacion/index.html
+++ b/operaciones/planeacion/index.html
@@ -20,7 +20,7 @@
   <a class="pl-back" href="../index.html">← Operaciones</a>
   <div class="pl-title-wrap">
     <span class="pl-title">📅 Planeación Operativa</span>
-    <span class="pl-build">build 20260428-planeacion-f3-export-v3</span>
+    <span class="pl-build" id="pl-build">build …</span>
   </div>
   <div class="pl-user">
     <span id="pl-user-nombre">—</span>
@@ -71,6 +71,21 @@
 <script src="js/turnos.js"></script>
 <script src="js/exportar.js"></script>
 <script src="js/planeacion.js"></script>
+
+<!-- Build indicator: lee version.json (cache-bust) para verificación visual del deploy -->
+<script>
+  (function(){
+    fetch('version.json?t=' + Date.now(), { cache: 'no-store' })
+      .then(function(r){ return r.ok ? r.json() : null; })
+      .then(function(d){
+        if (!d || !d.build) return;
+        window.BUILD_DATE = d.build;
+        var el = document.getElementById('pl-build');
+        if (el) el.textContent = 'build ' + d.build;
+      })
+      .catch(function(){});
+  })();
+</script>
 
 </body>
 </html>

--- a/operaciones/planeacion/js/planeacion.js
+++ b/operaciones/planeacion/js/planeacion.js
@@ -32,12 +32,56 @@ window.BUILD_DATE = '20260428-planeacion-f3-export-v3';
       });
 
       this.cargarAsignacionesDelDia();
+      await this.mergePlanPublicado();
       this.renderHeader();
       this.renderProgresoBanner();
       this.renderJornadaBanner();
       this.renderLista();
       this.renderExportZone();
       this.bindEventosGlobales();
+    },
+
+    // ─── B2: trae el plan ya publicado (planning.slot vía planeacion/dia) y lo mergea ───
+    // Empleados con slot llegan pre-cargados (SO, horario, actividad) y marcados
+    // "ya_publicado"; los demás quedan normal. Editar + re-publicar = upsert B1.
+    async mergePlanPublicado(){
+      const N8N = 'https://primary-production-5c3c.up.railway.app';
+      try {
+        const res = await fetch(N8N + '/webhook/planeacion/dia', {
+          method: 'POST', headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ fecha: this.fechaActual })
+        });
+        if (!res.ok) return;
+        const data = await res.json();
+        const r = Array.isArray(data) ? data[0] : data;
+        if (!r || !Array.isArray(r.slots)) return;
+        r.slots.forEach(slot => {
+          if (slot.empleado_id == null) return;
+          let a = this.asignaciones.find(x => x.empleado_id === slot.empleado_id);
+          if (!a){
+            // externo publicado que no está en el roster base de Operaciones
+            a = {
+              empleado_id: slot.empleado_id,
+              empleado_nombre: slot.empleado_nombre || ('#' + slot.empleado_id),
+              empleado_dept: 'Externo', empleado_dept_id: 0, empleado_job: '',
+              externo: true, requiere_check: true,
+              origen: 'FTS Monterrey', sitio: '', he: 0,
+              entrada: slot.entrada || '07:00', salida: slot.salida || '17:06',
+              horario_base: { entrada: slot.entrada || '07:00', salida: slot.salida || '17:06' }
+            };
+            this.asignaciones.push(a);
+          }
+          if (slot.entrada)   a.entrada   = slot.entrada;
+          if (slot.salida)    a.salida    = slot.salida;
+          if (slot.actividad) a.actividad = slot.actividad;
+          a.so_id = slot.so_id || null;
+          a.so_nombre = slot.so_nombre || '';
+          a.ya_publicado = true;
+          a.confirmado = true;
+        });
+      } catch (e){
+        console.warn('[planeacion] mergePlanPublicado falló (se muestra plan base):', e);
+      }
     },
 
     cargarAsignacionesDelDia(){
@@ -115,11 +159,12 @@ window.BUILD_DATE = '20260428-planeacion-f3-export-v3';
       }
     },
 
-    cambiarDia(delta){
+    async cambiarDia(delta){
       const d = new Date(this.fechaActual + 'T12:00:00');
       d.setDate(d.getDate() + delta);
       this.fechaActual = d.toISOString().split('T')[0];
       this.cargarAsignacionesDelDia();
+      await this.mergePlanPublicado();
       this.renderHeader();
       this.renderProgresoBanner();
       this.renderJornadaBanner();
@@ -206,6 +251,8 @@ window.BUILD_DATE = '20260428-planeacion-f3-export-v3';
       const externoLabel  = a.externo    ? '<span class="pl-badge pl-badge-externo">🔄 ' + esc(a.empleado_dept) + '</span>' : '';
       const jornadaLabel  = (jornadaCorta && a.requiere_check)
         ? '<span class="pl-badge pl-badge-warn">⚠️ ' + horasJornada.toFixed(1) + 'h</span>' : '';
+      const publicadoLabel = a.ya_publicado
+        ? '<span class="pl-badge" style="background:#e3f4e8;color:#1a7a3a">📂 publicado</span>' : '';
 
       const checkOrAuto = a.requiere_check
         ? '<input type="checkbox" class="pl-emp-check" data-emp-id="' + a.empleado_id + '"' + (a.confirmado ? ' checked' : '') + ' />'
@@ -219,7 +266,7 @@ window.BUILD_DATE = '20260428-planeacion-f3-export-v3';
         '<div class="pl-card-empleado ' + cardClass + '" data-emp-id="' + a.empleado_id + '">' +
           '<div class="pl-card-content">' +
             '<div class="pl-card-info">' +
-              '<div class="pl-card-nombre">' + esc(a.empleado_nombre) + heLabel + externoLabel + jornadaLabel + '</div>' +
+              '<div class="pl-card-nombre">' + esc(a.empleado_nombre) + heLabel + externoLabel + jornadaLabel + publicadoLabel + '</div>' +
               '<div class="pl-card-detalles">🕐 ' + J.fmtAMPM(a.entrada) + ' → ' + J.fmtAMPM(a.salida) + ' · 📍 ' + sitio + ' · ' + so + '</div>' +
               '<div class="pl-card-actividad">' + actividad + '</div>' +
             '</div>' +

--- a/operaciones/planeacion/version.json
+++ b/operaciones/planeacion/version.json
@@ -1,10 +1,10 @@
 {
   "module": "operaciones/planeacion",
-  "version": "2.3.0",
-  "build": "20260706-planeacion-b1-v1",
+  "version": "2.4.0",
+  "build": "20260706-planeacion-b2-v1",
   "status": "in_development",
-  "fase": "F4-B1",
+  "fase": "F4-B2",
   "actualizado": "2026-07-06",
   "rebuilt_from_scratch": true,
-  "notas": "B1 Carga MO: boton Publicar (upsert planning.slot con tag SO, solo asignaciones con SO) + toggle colapsar lista"
+  "notas": "B2 Carga MO: merge automatico del plan publicado (planeacion/dia) al entrar/cambiar dia + indicador 'publicado'"
 }


### PR DESCRIPTION
## Summary
**B2** de Fase 1 Carga MO. Cierra el ciclo cargar→editar→re-publicar del plan de Felipe.

- **Workflow `planeacion/dia`** (`3NjfelLFVcIWOe9N`, activo, validado): 2 modos.
  - Kiosk: `{empleado_id}` → `{plan, so_id, so_nombre}` (match por día del **check-in**; sin slot / sin SO → `plan:false`).
  - Planeación: `{fecha}` → `{slots:[{empleado_id, so_id, so_nombre, actividad, entrada, salida, horas_netas}]}`.
- **Frontend** (este PR): al **entrar o cambiar de día**, planeación consulta `{fecha}` y hace **merge**: empleados con slot llegan pre-cargados (SO/horario/actividad) y marcados **📂 publicado** (editables); los demás quedan normal. Editar + Publicar = upsert B1.
- Bump `version.json` → `20260706-planeacion-b2-v1`.

## Validado (backend, MCP)
- `{empleado_id:76}` planeado martes, hoy lunes → `plan:false` (correcto).
- `{empleado_id:32}` sin plan → `plan:false`.
- `{fecha:"2026-07-07"}` → 2 slots con SO parseada (Carlos + Cesar).

## Test plan (frontend)
- [ ] Entrar a Planeación en un día con plan publicado → los empleados publicados aparecen con SO/horario/actividad + badge 📂 publicado
- [ ] Cambiar de día → re-consulta y re-mergea
- [ ] Editar un publicado + Publicar → actualiza el slot (no duplica)
- [ ] Día sin plan → todos normal, sin badge

## Nota
B3 (kiosk.js consume el modo kiosk) sigue en STOP hasta aprobación explícita.

🤖 Generated with [Claude Code](https://claude.com/claude-code)