### PR TITLE
Paso D (rampa): panel relabel Proyecto + doc horas-dia (⚠ NO merge hasta verificar C)

### DIFF
--- a/docs/finanzas/PASO_D_READY.md
+++ b/docs/finanzas/PASO_D_READY.md
@@ -1,0 +1,42 @@
+# Paso D — Repuntar lectores a `x_studio_project_id` (LISTO EN LA RAMPA, sin desplegar)
+
+> **Estado:** ✅ construido, ❌ **NO desplegado**. Ver `MIGRACION_PROJECT_ID.md` (Opción 2). Deploy cuando **C se verifique** (primer checkout real con ambos campos = mismo id).
+> **Objetivo:** los lectores muestran el **NOMBRE real del proyecto** leyendo `x_studio_project_id` (no el m2o cruzado `x_studio_sales_order_2`).
+
+---
+
+## Cambios
+
+### 1. Workflow `horas-dia` (`pQ3vVbRkMYvfICQf`) — 2 cambios (aplicar por `update_full` al deploy)
+Actualmente lee `x_studio_sales_order_2` (nombre de SO cruzado). Cambios:
+- **SEARCH** (`Odoo - SEARCH Asistencias`): agregar **`x_studio_project_id`** a `fieldsList`.
+- **Build response** (`Code - Build response`): cambiar la línea
+  ```js
+  const so = m2o(a.x_studio_sales_order_2);   // ANTES
+  const so = m2o(a.x_studio_project_id);       // DESPUÉS
+  ```
+  → `so_id` = id de proyecto · `so_nombre` = **NOMBRE de proyecto** (correcto). El filtro "Ops OR con SO" pasa a usar `x_studio_project_id` (poblado en TODOS por el backfill Paso B + escritura de Paso C).
+- El resto del workflow no cambia. Los keys de respuesta siguen siendo `so_id`/`so_nombre` (compat frontend) — ahora con el proyecto correcto.
+- ⚠️ `update_full` de 7 nodos: verificar `active:true` en la respuesta.
+
+### 2. Frontend panel Confirmar Horas (`confirmar-horas.js` + `index.html`) — cosmético (ESTE PR)
+- Columna **"SO" → "Proyecto"** · "⚠ Sin SO" → "⚠ Sin proyecto" · "✎ SO" → "✎ Proy" · "Corregir SO" → "Corregir Proyecto".
+- `CH_BUILD` bumpeado.
+- El modal de corrección sigue usando `/kiosk/sos` (catálogo de **proyectos**) → `so_id` = id de proyecto; `confirmar-horas` ya escribe **ambos** campos (Paso C).
+
+### 3. B1 / B2 / kiosk.js / proyectos.js — **SIN cambio**
+Ya muestran el NOMBRE correcto: el tag del slot (`SO#<id>|<nombre de proyecto>`) y el catálogo `/kiosk/sos` usan el nombre de `project.project`. El `so_id` que pasan es id de proyecto → consistente con `x_studio_project_id`.
+- (Opcional futuro, no urgente: renombrar `so_id`→`project_id` en las respuestas por claridad.)
+
+---
+
+## Checklist de deploy (cuando C se verifique)
+1. **Confirmar C:** primer checkout real (mañana PM) tiene `x_studio_project_id` = `x_studio_sales_order_2` (mismo id), resolviendo al **proyecto correcto**.
+2. `update_full` a `horas-dia` con los 2 cambios (§1).
+3. **Mergear este PR** (relabel + CH_BUILD).
+4. **Validar:** panel Confirmar Horas muestra el **nombre de proyecto correcto** (Vertiv, no SO121); pre-llenado B2/B3 igual (ya correcto).
+5. **Paso E (aparte):** congelar `x_studio_sales_order_2` (dejar de escribirlo o mantener espejo) + marcar deprecated en `CLAUDE.md §4`.
+
+## Notas
+- `horas-dia` es **read-only** → bajo riesgo; aun así se despliega tras verificar C para no mostrar `x_studio_project_id` vacío en attendances nuevas si la escritura de C fallara.
+- El backfill (Paso B) ya dejó los 1,433 históricos con `x_studio_project_id` correcto → el panel mostrará bien el histórico desde el minuto 1 del deploy.

--- a/operaciones/confirmar-horas/index.html
+++ b/operaciones/confirmar-horas/index.html
@@ -5,7 +5,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 <title>Confirmar Horas — FTS Suite</title>
 <script>
-  (function(){ window.CH_BUILD = '20260706-b4.1-dept-badge'; })();
+  (function(){ window.CH_BUILD = '20260707-paso-d-relabel'; })();
 </script>
 <script src="../../shared/auth-suite.js"></script>
 <style>

--- a/operaciones/confirmar-horas/js/confirmar-horas.js
+++ b/operaciones/confirmar-horas/js/confirmar-horas.js
@@ -95,8 +95,8 @@
     }
     var filas = CH.rows.map(function(row){
       var so = row.so_id
-        ? esc(row.so_nombre || ('SO ' + row.so_id))
-        : '<span class="ch-sinso">⚠ Sin SO</span>';
+        ? esc(row.so_nombre || ('Proy ' + row.so_id))
+        : '<span class="ch-sinso">⚠ Sin proyecto</span>';
       var horario = (row.check_in_cst || '—') + (row.check_out_cst ? ' → ' + row.check_out_cst.slice(11) : ' → …');
       var horas = row.worked_hours != null ? row.worked_hours.toFixed(2) + 'h' : '—';
       var confirmarDisabled = (row.confirmado || row.en_disputa || row.abierta) ? ' disabled' : '';
@@ -112,14 +112,14 @@
           '<td class="cell-estado">' + estadoBadge(row) + '</td>' +
           '<td><div class="ch-actions">' +
             '<button class="ch-btn ch-btn-sm ch-btn-ok" data-act="confirm" data-att="' + row.attendance_id + '"' + confirmarDisabled + '>✔ Confirmar</button>' +
-            '<button class="ch-btn ch-btn-sm ch-btn-edit" data-act="editso" data-att="' + row.attendance_id + '">✎ SO</button>' +
+            '<button class="ch-btn ch-btn-sm ch-btn-edit" data-act="editso" data-att="' + row.attendance_id + '">✎ Proy</button>' +
           '</div></td>' +
         '</tr>';
     }).join('');
 
     $('tabla-zone').innerHTML =
       '<table class="ch-table"><thead><tr>' +
-        '<th style="width:56px">ID</th><th>Empleado</th><th>Entrada → Salida (CST)</th><th>Horas</th><th>SO</th><th>Estado</th><th>Acciones</th>' +
+        '<th style="width:56px">ID</th><th>Empleado</th><th>Entrada → Salida (CST)</th><th>Horas</th><th>Proyecto</th><th>Estado</th><th>Acciones</th>' +
       '</tr></thead><tbody>' + filas + '</tbody></table>';
 
     $('tabla-zone').querySelectorAll('button[data-act]').forEach(function(b){
@@ -159,8 +159,8 @@
     if(!row || !tr) return;
     tr.querySelector('.cell-estado').innerHTML = estadoBadge(row);
     tr.querySelector('.cell-so').innerHTML = row.so_id
-      ? esc(row.so_nombre || ('SO ' + row.so_id))
-      : '<span class="ch-sinso">⚠ Sin SO</span>';
+      ? esc(row.so_nombre || ('Proy ' + row.so_id))
+      : '<span class="ch-sinso">⚠ Sin proyecto</span>';
     var btnC = tr.querySelector('button[data-act="confirm"]');
     if(btnC){
       var dis = (row.confirmado || row.en_disputa || row.abierta);
@@ -176,7 +176,7 @@
   function abrirModalSO(attId){
     CH.modalAttId = attId;
     var row = findRow(attId);
-    $('modal-so-title').textContent = 'Corregir SO — ' + ((row && row.empleado_nombre) || ('att ' + attId));
+    $('modal-so-title').textContent = 'Corregir Proyecto — ' + ((row && row.empleado_nombre) || ('att ' + attId));
     $('modal-so-search').value = '';
     $('modal-so').style.display = 'flex';
     $('modal-so-search').focus();


### PR DESCRIPTION
## ⚠️ NO MERGEAR hasta verificar Paso C
Deploy junto con el cambio de `horas-dia`, cuando el **primer checkout real** confirme que `x_studio_project_id` = `x_studio_sales_order_2` (mismo id, proyecto correcto).

## Summary
**Paso D** de la migración project_id (Opción 2), construido en la rampa **sin desplegar**.
- **Frontend panel Confirmar Horas** (este PR): relabel **SO → Proyecto** (columna, "Sin proyecto", "✎ Proy", "Corregir Proyecto") + `CH_BUILD` bump. Cuando `horas-dia` devuelva el nombre de proyecto, el panel lo muestra correcto.
- **`docs/finanzas/PASO_D_READY.md`**: cambio exacto de `horas-dia` (leer `x_studio_project_id`) + checklist de deploy.
- **B1/B2/kiosk**: sin cambio (ya muestran nombre de proyecto vía tag/catálogo).

## Deploy (cuando C se verifique)
1. Verificar C (checkout real: ambos campos = mismo id, proyecto correcto).
2. `update_full` a `horas-dia` (leer `x_studio_project_id`).
3. Mergear este PR.
4. Validar panel muestra proyecto correcto.

🤖 Generated with [Claude Code](https://claude.com/claude-code)