### PR TITLE
fix(planeacion): default fechaActual en CST, no UTC (borde post-18:00 CST)

### DIFF
--- a/operaciones/planeacion/js/planeacion.js
+++ b/operaciones/planeacion/js/planeacion.js
@@ -15,7 +15,7 @@ window.BUILD_DATE = '20260428-planeacion-f3-export-v3';
   // PlaneacionApp — UI principal
   // ═══════════════════════════════════════════════
   const PlaneacionApp = {
-    fechaActual: new Date().toISOString().split('T')[0],
+    fechaActual: new Date(Date.now() - 6*3600*1000).toISOString().split('T')[0], // hoy en CST (UTC-6), NO UTC — evita que el plan default caiga en manana tras 18:00 CST
     asignaciones: [],
     empleadoEditando: null,
 

--- a/operaciones/planeacion/version.json
+++ b/operaciones/planeacion/version.json
@@ -1,10 +1,10 @@
 {
   "module": "operaciones/planeacion",
-  "version": "2.4.0",
-  "build": "20260706-planeacion-b2-v1",
+  "version": "2.4.1",
+  "build": "20260706-planeacion-fecha-cst-fix",
   "status": "in_development",
   "fase": "F4-B2",
   "actualizado": "2026-07-06",
   "rebuilt_from_scratch": true,
-  "notas": "B2 Carga MO: merge automatico del plan publicado (planeacion/dia) al entrar/cambiar dia + indicador 'publicado'"
+  "notas": "Fix borde timezone: fechaActual default en CST (UTC-6) en vez de UTC (planeacion.js:18) — el plan ya no cae en manana cuando se publica despues de 18:00 CST. B2 Carga MO: merge automatico del plan publicado (planeacion/dia) al entrar/cambiar dia + indicador 'publicado'"
 }


### PR DESCRIPTION
## Summary
El planner de operaciones defaultaba la fecha del plan a **hoy en UTC** (`new Date().toISOString()`). Publicando **después de 18:00 CST** (= día siguiente en UTC), el plan se guardaba **un día adelante** → el checkout del día real no encontraba el slot y el modal de proyecto salía **vacío**.

**Caso reproducido (empleado 32, 2026-07-06):**
- Check-in/checkout a las 21:40–21:43 CST Jul-6 (= 03:40–03:43 UTC Jul-7).
- Slot publicado (842, Vertiv SO#121) quedó en **CST Jul-7**; Jul-6 sin slots.
- B2 (`planeacion/dia`) buscó correctamente **Jul-6 CST** → 0 slots → modal vacío.

Diagnóstico read-only confirmó que **B2 y B1 ya convierten a CST correctamente** — el único punto que usaba UTC era el default del frontend.

## Cambio
- `operaciones/planeacion/js/planeacion.js:18` — `fechaActual` ahora se calcula en **CST (UTC-6)**, convención del repo (§11 #1). `cambiarDia` (L119) ya era seguro (ancla en `T12:00:00` local).
- `version.json` 2.4.0 → **2.4.1**, build `20260706-planeacion-fecha-cst-fix`.

## Test plan
- [ ] Abrir el planner **después de 18:00 CST** → la fecha default es **hoy CST** (no mañana).
- [ ] Publicar un plan con SO para hoy → el slot queda en el día CST correcto.
- [ ] Checkout del mismo día → el modal pre-selecciona el proyecto del plan.
- [ ] Verificar `CH_BUILD`/version en pantalla = `20260706-planeacion-fecha-cst-fix`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)