### PR TITLE
feat(kiosk): pantalla de proyecto en 3 estados + fix header (checkout)

### DIFF
--- a/operaciones/kiosk/css/kiosk.css
+++ b/operaciones/kiosk/css/kiosk.css
@@ -360,6 +360,45 @@ html,body{height:100%;overflow:hidden;font-family:'Inter',-apple-system,sans-ser
   position:static;padding:8px 14px;font-size:18px;
   min-width:44px;
 }
+.kiosk-topbar-title{
+  flex:1;text-align:center;
+  font-weight:700;font-size:18px;color:#1a1a1a;
+  white-space:nowrap;overflow:hidden;text-overflow:ellipsis;
+}
+
+/* ─── ks-project: selector de proyecto en 3 estados ─── */
+/* Contenido bajo el topbar absoluto (no se encima con "← Volver") */
+#ks-project{ justify-content:flex-start; padding-top:76px; }
+#ksProjectLoading{ margin-top:12vh; }
+#ksProjectPlan{ width:100%;max-width:500px; }
+#ksProjectListWrap{
+  width:100%;max-width:500px;
+  display:flex;flex-direction:column;align-items:center;
+}
+/* Estado 2 — banner del plan */
+.ksp-plan-banner{
+  background:#e8f4ea;border:2px solid #b6dcc0;border-radius:16px;
+  padding:22px 18px;text-align:center;margin-bottom:14px;
+}
+.ksp-plan-label{ font-size:14px;color:#3a6b46;font-weight:600;margin-bottom:6px; }
+.ksp-plan-name{ font-size:22px;font-weight:800;color:#0f3d18;margin-bottom:18px;line-height:1.25; }
+.ksp-plan-confirm{
+  width:100%;background:#107C10;color:#fff;border:none;border-radius:12px;
+  padding:16px 22px;font-size:18px;font-weight:700;cursor:pointer;font-family:inherit;
+}
+.ksp-plan-confirm:active{ background:#0b5e0b; }
+.ksp-plan-cambiar{
+  display:block;width:100%;background:none;border:none;
+  color:#0078D4;font-size:14px;text-decoration:underline;cursor:pointer;
+  padding:10px;font-family:inherit;
+}
+/* Estado 3 — botón "sin proyecto" (candado BLANDO) */
+.ksp-sinso-btn{
+  width:100%;max-width:500px;background:#f4f6f9;color:#555;border:1px solid #ccc;
+  border-radius:10px;padding:12px;font-size:14px;cursor:pointer;
+  margin-top:14px;font-family:inherit;
+}
+.ksp-sinso-warn{ font-size:12px;color:#BA7517;text-align:center;margin-top:8px; }
 
 /* ─── Botones de tipo de evento ─── */
 .kiosk-tipo-btn{

--- a/operaciones/kiosk/index.html
+++ b/operaciones/kiosk/index.html
@@ -163,14 +163,31 @@
   </button>
 </div>
 
-<!-- ═══════ PANTALLA 4 — SELECCIONAR SO ═══════ -->
+<!-- ═══════ PANTALLA 4 — SELECCIONAR SO (3 estados) ═══════ -->
 <div class="kiosk-screen" id="ks-project">
-  <button class="kiosk-back" onclick="showScreen('ks-verify')">← Volver</button>
-  <div class="kiosk-title">¿En qué proyecto trabajas hoy?</div>
-  <div id="ksProjectBanner"></div>
-  <input type="text" id="ksSoSearch" class="kiosk-search" placeholder="Busca la SO o proyecto…" oninput="searchSOs(this.value)" autocomplete="off">
-  <div class="kiosk-list" id="ksSOsList">
-    <div style="text-align:center;color:#666;padding:24px">Cargando proyectos…</div>
+  <div class="kiosk-topbar">
+    <button class="kiosk-back" onclick="showScreen('ks-verify')">←</button>
+    <span class="kiosk-topbar-title">Proyecto de hoy</span>
+    <span style="min-width:44px"></span>
+  </div>
+
+  <!-- Estado 1: CARGANDO -->
+  <div id="ksProjectLoading" class="kiosk-loading" style="display:none">
+    <div class="kiosk-loading-spinner"></div>
+    <div style="font-size:16px;color:#555;text-align:center">⏳ Buscando tu plan de hoy…</div>
+  </div>
+
+  <!-- Estado 2: CON PLAN (banner + confirmar) -->
+  <div id="ksProjectPlan" style="display:none"></div>
+
+  <!-- Estado 3: SIN PLAN / Estado 2 expandido (buscador + lista + sin proyecto) -->
+  <div id="ksProjectListWrap" style="display:none">
+    <div class="kiosk-title">¿En qué proyecto trabajas hoy?</div>
+    <input type="text" id="ksSoSearch" class="kiosk-search" placeholder="Busca la SO o proyecto…" oninput="searchSOs(this.value)" autocomplete="off">
+    <div class="kiosk-list" id="ksSOsList">
+      <div style="text-align:center;color:#666;padding:24px">Cargando proyectos…</div>
+    </div>
+    <div id="ksProjectNoSO"></div>
   </div>
 </div>
 

--- a/operaciones/kiosk/js/kiosk.js
+++ b/operaciones/kiosk/js/kiosk.js
@@ -1,7 +1,7 @@
 // ═══ FTS Kiosk — Lógica principal ═══
 // Script clásico, estado global compartido
 
-const KIOSK_BUILD = '20260521-kiosk-face-opt-in-default';
+const KIOSK_BUILD = '20260706-kiosk-ksproject-3estados';
 console.log('[kiosk] build:', KIOSK_BUILD);
 
 const K = {
@@ -317,10 +317,10 @@ function showScreen(id){
     renderEmpleados(K.empleados);
   }
   if(id === 'ks-project'){
-    renderPreLlenadoSO();
     const input = document.getElementById('ksSoSearch');
     if(input){ input.value=''; }
     renderSOs(K.sos);
+    renderProjectScreen();
   }
   if(id === 'ks-historial'){
     const input = document.getElementById('hist-search');
@@ -867,49 +867,106 @@ async function iniciarSalida(){
   var perfil = perfilEmpleado(emp);
   K.perfilSalida = perfil;
   K.planSO = null;
+  K.planExpandido = false;
   if(perfil === 'admin'){
     // Administrativos: no piden SO
     K.soSeleccionada = null;
     registrarAsistencia();
     return;
   }
-  // Operativo / comercial: mostrar la pantalla YA (con "buscando plan…") y
-  // pre-llenar la SO del plan de HOY cuando llegue (no bloquea el flujo).
+  // Operativo / comercial: Estado 1 CARGANDO (nada seleccionable) hasta que B2
+  // responda. Timeout defensivo 6s → cae a Estado 3 SIN PLAN (nunca deja atorado
+  // al técnico). Hooks PRE-POST (Hallazgo #15): NO tocan registrarAsistencia.
   K.planLoading = true;
   showScreen('ks-project');
+  var settled = false;
+  var timer = setTimeout(function(){
+    if(settled) return;
+    settled = true;
+    console.warn('[kiosk] getPlanDia timeout 6s → Estado 3 (sin plan)');
+    K.planLoading = false;
+    K.planSO = null;
+    renderProjectScreen();
+  }, 6000);
   try{
     var r = await window.OdooKiosk.getPlanDia(emp.id);
+    if(settled) return;   // el timeout ya cayó a Estado 3; ignorar respuesta tardía
+    settled = true;
+    clearTimeout(timer);
     var rr = Array.isArray(r) ? r[0] : r;
     if(rr && rr.plan && rr.so_id){
       K.planSO = { id: rr.so_id, nombre: rr.so_nombre || ('SO ' + rr.so_id) };
     }
-  } catch(e){ /* sin plan / error → modal normal, no bloquea */ }
+  } catch(e){
+    if(settled) return;
+    settled = true;
+    clearTimeout(timer);
+    /* sin plan / error → Estado 3, no bloquea */
+  }
   K.planLoading = false;
-  renderPreLlenadoSO();
+  renderProjectScreen();
 }
 
-// Banner de ks-project: pre-llenado del plan + opción "sin SO" (candado BLANDO)
-function renderPreLlenadoSO(){
-  var el = document.getElementById('ksProjectBanner');
+// ks-project: 3 estados mutuamente excluyentes (CARGANDO / CON PLAN / SIN PLAN).
+// Solo un contenedor visible a la vez → nunca hay dos caminos activos ni se puede
+// teclear/elegir durante la carga (le ganaba al pre-llenado).
+function renderProjectScreen(){
+  var loadingEl = document.getElementById('ksProjectLoading');
+  var planEl    = document.getElementById('ksProjectPlan');
+  var listEl    = document.getElementById('ksProjectListWrap');
+  if(!loadingEl || !planEl || !listEl) return;
+
+  // Estado 1: CARGANDO — solo el mensaje; buscador/lista/sin-proyecto ocultos
+  if(K.planLoading){
+    loadingEl.style.display = '';
+    planEl.style.display    = 'none';
+    listEl.style.display    = 'none';
+    planEl.innerHTML = '';
+    return;
+  }
+  loadingEl.style.display = 'none';
+
+  // Estado 2: CON PLAN (colapsado) — banner + "Confirmar" como única acción visible
+  if(K.planSO && !K.planExpandido){
+    planEl.style.display = '';
+    listEl.style.display = 'none';
+    planEl.innerHTML =
+      '<div class="ksp-plan-banner">'+
+        '<div class="ksp-plan-label">📋 Tu plan de hoy</div>'+
+        '<div class="ksp-plan-name">'+ (K.planSO.nombre || '') +'</div>'+
+        '<button onclick="confirmarPlanSO()" class="ksp-plan-confirm">✔ Confirmar este proyecto</button>'+
+      '</div>'+
+      '<button onclick="expandirListaSO()" class="ksp-plan-cambiar">¿Trabajaste en otro proyecto? Cámbialo aquí</button>';
+    return;
+  }
+
+  // Estado 3: SIN PLAN (o Estado 2 expandido) — buscador + lista + "sin proyecto"
+  planEl.style.display = 'none';
+  listEl.style.display = '';
+  renderNoSOButton();
+}
+
+// Botón "sin proyecto" (candado BLANDO) — solo operativo/comercial, vive dentro
+// de la vista de lista (Estado 3 / Estado 2 expandido), no en la principal.
+function renderNoSOButton(){
+  var el = document.getElementById('ksProjectNoSO');
   if(!el) return;
   var html = '';
-  if(K.planLoading){
-    html += '<div style="text-align:center;color:#666;padding:10px;font-size:14px">⏳ Buscando tu plan de hoy…</div>';
-  }
-  if(K.planSO){
-    html += '<div style="background:#e8f4ea;border:1px solid #b6dcc0;border-radius:12px;padding:14px;margin-bottom:14px;text-align:center">'+
-      '<div style="font-size:15px;color:#1a4480;margin-bottom:8px">📋 Tu plan de hoy: <strong>'+ (K.planSO.nombre || '') +'</strong></div>'+
-      '<button onclick="confirmarPlanSO()" style="background:#107C10;color:#fff;border:none;border-radius:10px;padding:12px 22px;font-size:16px;font-weight:600;cursor:pointer">✔ Confirmar este proyecto</button>'+
-      '<div style="font-size:12px;color:#666;margin-top:8px">o elige otro de la lista</div>'+
-    '</div>';
-  }
   if(K.perfilSalida === 'operativo' || K.perfilSalida === 'comercial'){
-    html += '<button onclick="registrarSinSO()" style="width:100%;background:#f4f6f9;color:#555;border:1px solid #ccc;border-radius:10px;padding:10px;font-size:14px;cursor:pointer;margin-bottom:6px">Registrar salida sin proyecto</button>';
+    html += '<button onclick="registrarSinSO()" class="ksp-sinso-btn">Registrar salida sin proyecto</button>';
     if(K.perfilSalida === 'operativo'){
-      html += '<div style="font-size:12px;color:#BA7517;text-align:center;margin-bottom:10px">⚠️ Sin SO tu salida no queda ligada a un proyecto.</div>';
+      html += '<div class="ksp-sinso-warn">⚠️ Sin SO tu salida no queda ligada a un proyecto.</div>';
     }
   }
   el.innerHTML = html;
+}
+
+// Estado 2 → expandir a lista para elegir otro proyecto (oculta el banner: un solo camino).
+function expandirListaSO(){
+  K.planExpandido = true;
+  renderProjectScreen();
+  var input = document.getElementById('ksSoSearch');
+  if(input){ input.value = ''; searchSOs(''); input.focus(); }
 }
 
 function confirmarPlanSO(){
@@ -2183,6 +2240,7 @@ window.searchSOs = searchSOs;
 window.selectSO = selectSO;
 window.confirmarPlanSO = confirmarPlanSO;
 window.registrarSinSO = registrarSinSO;
+window.expandirListaSO = expandirListaSO;
 window.selectTipo = selectTipo;
 window.cancelarGeo = cancelarGeo;
 window.confirmarGeo = confirmarGeo;


### PR DESCRIPTION
## Summary
Rediseño de la pantalla de selección de proyecto del kiosk (`ks-project`, en checkout) con **3 estados mutuamente excluyentes**. Todo es render/UI **PRE-POST** — **NO toca `registrarAsistencia`** (zona #15, Hallazgo #15).

Motiva: en producción el pre-llenado del plan salía vacío / se le podía "ganar" tecleando durante la carga; y el título se encimaba con "← Volver".

## Estados (solo un contenedor visible a la vez)
1. **CARGANDO** — solo `⏳ Buscando tu plan de hoy…`. Buscador, lista y botón "sin proyecto" **ocultos** → nada seleccionable hasta que B2 responda.
2. **CON PLAN** — banner verde prominente + **✔ Confirmar este proyecto** como única acción; link discreto **"¿Trabajaste en otro proyecto? Cámbialo aquí"** que expande a la lista **y oculta el banner** (un solo camino activo). El botón **"Registrar salida sin proyecto"** (candado blando) vive dentro de la vista expandida.
3. **SIN PLAN** (`plan:false` / error / timeout) — buscador + lista + "sin proyecto" con aviso (flujo actual). Admin sigue ruteado directo, no llega aquí.

## Extras
- **Timeout defensivo 6s** en Estado 1 → cae a Estado 3 (nunca deja atorado al técnico; ignora respuesta tardía de B2).
- **Fix header**: back button en `.kiosk-topbar` a la izquierda + título centrado con ellipsis → ya no se encima. Viewport tablet/móvil.
- Bump `KIOSK_BUILD` → `20260706-kiosk-ksproject-3estados`.

## Archivos
- `operaciones/kiosk/index.html` — markup de `#ks-project` (topbar + 3 contenedores).
- `operaciones/kiosk/js/kiosk.js` — `renderProjectScreen()` / `renderNoSOButton()` / `expandirListaSO()`, timeout en `iniciarSalida`, `KIOSK_BUILD`. (elimina `renderPreLlenadoSO`).
- `operaciones/kiosk/css/kiosk.css` — estilos de los 3 estados + `.kiosk-topbar-title`.

## Test plan (local, con checkout vivo — attendance 14159 / slot VERTIV hoy)
- [ ] **Estado 2**: checkout como operativo con plan → banner VERTIV + "Confirmar"; no hay lista debajo. Confirmar → POST con ese `so_id`.
- [ ] **Cambiar**: link "¿otro proyecto?" → aparece lista, desaparece banner; elegir otro → POST con el nuevo. "Registrar sin proyecto" visible aquí.
- [ ] **Estado 1**: al entrar solo se ve "Buscando tu plan…"; no se puede teclear/seleccionar.
- [ ] **Estado 3**: empleado sin plan → lista directa + "sin proyecto" con aviso.
- [ ] **Timeout**: simular B2 lento (>6s) → cae a lista, no se queda atorado.
- [ ] **Header**: título "Proyecto de hoy" centrado, "←" a la izquierda sin encimarse (tablet + móvil).
- [ ] `console` muestra build `20260706-kiosk-ksproject-3estados`.

⚠️ NO mergear hasta validación local de Esteban.

🤖 Generated with [Claude Code](https://claude.com/claude-code)