### PR TITLE
fix(kiosk): pantalla de confirmación muestra la bolsa (checkout por cuenta indirecta)

### DIFF
--- a/operaciones/kiosk/js/kiosk.js
+++ b/operaciones/kiosk/js/kiosk.js
@@ -1,7 +1,7 @@
 // ═══ FTS Kiosk — Lógica principal ═══
 // Script clásico, estado global compartido
 
-const KIOSK_BUILD = '20260709-kiosk-bolsa-default';
+const KIOSK_BUILD = '20260709-kiosk-confirm-bolsa';
 console.log('[kiosk] build:', KIOSK_BUILD);
 
 const K = {
@@ -1155,7 +1155,9 @@ async function registrarAsistencia(){
     confirmTipo.className = 'kiosk-big-type ' + (entradaLike ? 'in' : 'out');
   }
   if(confirmNombre) confirmNombre.textContent = payload.empleado_nombre || '—';
-  if(confirmSO)     confirmSO.textContent     = payload.so_nombre || '—';
+  // PR-2 fix: si el checkout fue por BOLSA (cuenta indirecta) y no por proyecto,
+  // mostrar la bolsa en vez de "—" (payload.so_nombre viene vacío en ese caso).
+  if(confirmSO)     confirmSO.textContent     = payload.so_nombre || (payload.cuenta_nombre ? 'Bolsa: ' + payload.cuenta_nombre : '—');
   if(confirmHora)   confirmHora.textContent   = now.toLocaleTimeString('es-MX');
   if(confirmGeo){
     confirmGeo.innerHTML = payload.geo_autorizada

--- a/operaciones/kiosk/js/kiosk.js
+++ b/operaciones/kiosk/js/kiosk.js
@@ -1157,7 +1157,7 @@ async function registrarAsistencia(){
   if(confirmNombre) confirmNombre.textContent = payload.empleado_nombre || '—';
   // PR-2 fix: si el checkout fue por BOLSA (cuenta indirecta) y no por proyecto,
   // mostrar la bolsa en vez de "—" (payload.so_nombre viene vacío en ese caso).
-  if(confirmSO)     confirmSO.textContent     = payload.so_nombre || (payload.cuenta_nombre ? 'Bolsa: ' + payload.cuenta_nombre : '—');
+  if(confirmSO)     confirmSO.textContent     = payload.so_nombre || (payload.cuenta_nombre ? '🗂️ Bolsa: ' + payload.cuenta_nombre : '—');
   if(confirmHora)   confirmHora.textContent   = now.toLocaleTimeString('es-MX');
   if(confirmGeo){
     confirmGeo.innerHTML = payload.geo_autorizada


### PR DESCRIPTION
## Resumen
Micro-fix cosmético de PR-2. En un checkout por **bolsa** (cuenta indirecta), `payload.so_nombre` viene vacío → la pantalla de confirmación final mostraba **"—"** en el campo Proyecto. Ahora muestra **"Bolsa: DIRECCION"** cuando hay `cuenta_nombre` y no hay proyecto.

**El write funcional NUNCA falló** — validado en vivo (att 14217: `x_studio_many2one_field_GUbBF = [3095, DIRECCION]`, `x_studio_project_id` vacío). Esto es solo la pantalla.

## Cambio (`operaciones/kiosk/js/kiosk.js`, 1 línea)
```js
// antes:
confirmSO.textContent = payload.so_nombre || '—';
// ahora:
confirmSO.textContent = payload.so_nombre || (payload.cuenta_nombre ? 'Bolsa: ' + payload.cuenta_nombre : '—');
```
Bump `KIOSK_BUILD → 20260709-kiosk-confirm-bolsa`.

## Test plan
- [ ] Checkout por bolsa (Esteban → DIRECCION) → pantalla final muestra "Bolsa: DIRECCION" (no "—").
- [ ] Checkout por proyecto → sigue mostrando el proyecto.
- [ ] Checkout sin proyecto ni bolsa (técnico) → sigue "—".

🤖 Generated with [Claude Code](https://claude.com/claude-code)