### PR TITLE
feat(confirmar-horas): PR-5 corregir atribución proyecto|bolsa (excluyencia mutua)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -81,6 +81,11 @@ Siempre revisar y rellenar a mano:
 2. Credential en cada nodo (a veces se desasigna)
 3. Webhook IDs (n8n los regenera)
 
+### ⚠️ Verificación de reportes de construcción (regla anti-fantasma, 2026-07-09)
+Origen: en una sesión previa degradada (>290k contexto) se **fabricó** un reporte de "PR-5" (workflow `confirmar-horas v2 (bolsas)` id `Y2g0so5J6EBWXTdV`, branch `feat/ch-corregir-bolsa`, PR #73) que **nunca existió** — ni el workflow, ni el branch, ni el PR. Reglas obligatorias:
+1. **Todo reporte de construcción se verifica contra el artefacto real antes de darse por hecho:** branch → `git branch -a`; PR → `gh pr list`; workflow n8n → **read-back con `n8n_get_workflow` por su id** (no basta el `success:true` del create — leerlo de vuelta). Solo tras el read-back se reporta "creado". (Nota: los one-shots reales de esta sesión —poblado, `RaFw1Y63O9lLK64v`— SÍ se verificaron con read-back; por eso existen.)
+2. **Sesiones >250k de contexto: sus reportes de ejecución se re-verifican en sesión fresca** antes de construir sobre ellos. No confiar en "ya lo creé" de una sesión larga sin re-chequear el id/branch/PR contra la instancia real.
+
 ### Patterns validados en producción
 - **Referenciar nodo no-adyacente:** cuando un Code node necesita output de un nodo Odoo que NO es el inmediato anterior, usar `$('Nombre exacto del nodo').all()` (validado en `crear-olvido-entrada` v3.2).
 - **Parsing defensive de Odoo many2one:** los campos many2one (ej. `department_id`) pueden venir como `[id, name]` (array tuple), `{id, name}` (object) o `id` (number) según versión/contexto. Siempre parsear con `Array.isArray()` antes de acceder por índice.

--- a/operaciones/confirmar-horas/index.html
+++ b/operaciones/confirmar-horas/index.html
@@ -5,7 +5,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 <title>Confirmar Horas — FTS Suite</title>
 <script>
-  (function(){ window.CH_BUILD = '20260709-ch-depto-sort'; })();
+  (function(){ window.CH_BUILD = '20260709-ch-corregir-bolsa'; })();
 </script>
 <script src="../../shared/auth-suite.js"></script>
 <style>
@@ -60,6 +60,9 @@
   .ch-so-item:hover{ background:#f0f4f9; }
   .ch-so-item .n{ font-weight:600; color:var(--azul); }
   .ch-so-item .c{ font-size:12px; color:#666; }
+  .ch-bolsa{ color:var(--azul2); font-weight:600; }
+  .ch-grp{ font-size:11px; font-weight:700; color:#555; text-transform:uppercase; margin:10px 0 6px; letter-spacing:.3px; }
+  .ch-item-bolsa{ background:#f5f8fc; border-color:#cfdcf0; }
   .ch-x{ background:none; border:none; font-size:18px; cursor:pointer; color:#888; }
 </style>
 </head>

--- a/operaciones/confirmar-horas/js/confirmar-horas.js
+++ b/operaciones/confirmar-horas/js/confirmar-horas.js
@@ -10,6 +10,33 @@
   var N8N_BASE = 'https://primary-production-5c3c.up.railway.app';
   var COMPANY_ID = 1;
 
+  // PR-5: corrección de atribución (proyecto O bolsa, excluyencia mutua) → workflow
+  // separado planeacion/corregir-bolsa (O61Abp4s26yYpFEq). El botón ✔ Confirmar sigue
+  // usando /planeacion/confirmar-horas (sin cambios).
+  var CORREGIR_URL = '/webhook/planeacion/corregir-bolsa';
+  var BOLSAS = [
+    { id: 3095, nombre: 'DIRECCION' },
+    { id: 3096, nombre: 'ADMIN DE OPERACIONES' },
+    { id: 608,  nombre: 'VENTAS' },
+    { id: 513,  nombre: 'Administración' },
+    { id: 768,  nombre: 'LEGAL' },
+    { id: 478,  nombre: 'RH' }
+  ];
+
+  // Celda de atribución: proyecto (🛠️) > bolsa (🗂️) > sin atribución.
+  function celdaAtribucion(row){
+    if(row.so_id) return esc(row.so_nombre || ('Proy ' + row.so_id));
+    if(row.cuenta_id) return '<span class="ch-bolsa">🗂️ ' + esc(row.cuenta_nombre || ('Bolsa ' + row.cuenta_id)) + '</span>';
+    return '<span class="ch-sinso">⚠ Sin atribución</span>';
+  }
+  // Etiqueta de la atribución ACTUAL (para prev_label del chatter).
+  function labelAtribucion(row){
+    if(!row) return '(sin atribución)';
+    if(row.so_id) return row.so_nombre || ('Proy ' + row.so_id);
+    if(row.cuenta_id) return row.cuenta_nombre || ('Bolsa ' + row.cuenta_id);
+    return '(sin atribución)';
+  }
+
   var CH = {
     rows: [],
     sos: null,            // cache lista SO (lazy)
@@ -97,7 +124,7 @@
     { key:'depto',    label:'Depto',                  sortable:true,  type:'str', get:function(r){ return r.department_name || ''; } },
     { key:'horario',  label:'Entrada → Salida (CST)', sortable:true,  type:'str', get:function(r){ return r.check_in_cst || ''; } },
     { key:'horas',    label:'Horas',                  sortable:true,  type:'num', get:function(r){ return r.worked_hours == null ? -1 : r.worked_hours; } },
-    { key:'proyecto', label:'Proyecto',               sortable:true,  type:'str', get:function(r){ return r.so_id ? (r.so_nombre || ('Proy ' + r.so_id)) : ''; } },
+    { key:'proyecto', label:'Proyecto / Bolsa',        sortable:true,  type:'str', get:function(r){ return r.so_id ? (r.so_nombre || ('Proy ' + r.so_id)) : (r.cuenta_id ? ('🗂️ ' + (r.cuenta_nombre || ('Bolsa ' + r.cuenta_id))) : ''); } },
     { key:'estado',   label:'Estado',                 sortable:true,  type:'num', get:function(r){ return estadoRank(r); } },
     { key:'acc',      label:'Acciones',               sortable:false }
   ];
@@ -149,9 +176,7 @@
       return;
     }
     var filas = sortedRows().map(function(row){
-      var so = row.so_id
-        ? esc(row.so_nombre || ('Proy ' + row.so_id))
-        : '<span class="ch-sinso">⚠ Sin proyecto</span>';
+      var so = celdaAtribucion(row);
       var depto = row.department_name
         ? (row.es_operaciones === false
             ? '<span class="ch-depto-cross" title="Cargó horas a un proyecto siendo de otro depto">' + esc(row.department_name) + '</span>'
@@ -170,7 +195,7 @@
           '<td class="cell-estado">' + estadoBadge(row) + '</td>' +
           '<td><div class="ch-actions">' +
             '<button class="ch-btn ch-btn-sm ch-btn-ok" data-act="confirm" data-att="' + row.attendance_id + '"' + confirmarDisabled + '>✔ Confirmar</button>' +
-            '<button class="ch-btn ch-btn-sm ch-btn-edit" data-act="editso" data-att="' + row.attendance_id + '">✎ Proy</button>' +
+            '<button class="ch-btn ch-btn-sm ch-btn-edit" data-act="editso" data-att="' + row.attendance_id + '">✎ Corregir</button>' +
           '</div></td>' +
         '</tr>';
     }).join('');
@@ -224,9 +249,7 @@
     var tr = document.querySelector('tr[data-att="' + attId + '"]');
     if(!row || !tr) return;
     tr.querySelector('.cell-estado').innerHTML = estadoBadge(row);
-    tr.querySelector('.cell-so').innerHTML = row.so_id
-      ? esc(row.so_nombre || ('Proy ' + row.so_id))
-      : '<span class="ch-sinso">⚠ Sin proyecto</span>';
+    tr.querySelector('.cell-so').innerHTML = celdaAtribucion(row);
     var btnC = tr.querySelector('button[data-act="confirm"]');
     if(btnC){
       var dis = (row.confirmado || row.en_disputa || row.abierta);
@@ -238,11 +261,12 @@
       ' confirmado(s) · ' + (CH.rows.length - conf) + ' pendiente(s)';
   }
 
-  // ─── Modal corregir SO ───
+  // ─── Modal corregir atribución (proyecto O bolsa) ───
   function abrirModalSO(attId){
     CH.modalAttId = attId;
     var row = findRow(attId);
-    $('modal-so-title').textContent = 'Corregir Proyecto — ' + ((row && row.empleado_nombre) || ('att ' + attId));
+    $('modal-so-title').textContent = 'Corregir atribución — ' + ((row && row.empleado_nombre) || ('att ' + attId)) +
+      ' · actual: ' + labelAtribucion(row);
     $('modal-so-search').value = '';
     $('modal-so').style.display = 'flex';
     $('modal-so-search').focus();
@@ -267,39 +291,65 @@
     }).finally(function(){ CH.sosCargando = false; });
   }
 
+  // Dos grupos: 🗂️ Bolsas (fijas) + 🛠️ Proyectos (de /kiosk/sos). El buscador filtra ambos.
   function renderSOList(q){
-    var lista = CH.sos || [];
     var nq = q ? q.toLowerCase() : '';
-    if(nq) lista = lista.filter(function(s){
-      return (s.nombre || '').toLowerCase().indexOf(nq) !== -1 ||
-             (s.cliente || '').toLowerCase().indexOf(nq) !== -1;
+    var bolsas = BOLSAS.filter(function(b){ return !nq || b.nombre.toLowerCase().indexOf(nq) !== -1; });
+    var proys = (CH.sos || []).filter(function(s){
+      return !nq || (s.nombre || '').toLowerCase().indexOf(nq) !== -1 ||
+                    (s.cliente || '').toLowerCase().indexOf(nq) !== -1;
     });
-    if(!lista.length){ $('modal-so-list').innerHTML = '<div class="ch-placeholder">Sin resultados</div>'; return; }
-    $('modal-so-list').innerHTML = lista.slice(0, 40).map(function(s){
-      return '<div class="ch-so-item" data-so="' + s.id + '">' +
+    var html = '';
+    if(bolsas.length){
+      html += '<div class="ch-grp">🗂️ Bolsas (cuenta indirecta)</div>';
+      html += bolsas.map(function(b){
+        return '<div class="ch-so-item ch-item-bolsa" data-tipo="bolsa" data-id="' + b.id + '" data-nombre="' + esc(b.nombre) + '">' +
+          '<div class="n">🗂️ ' + esc(b.nombre) + '</div></div>';
+      }).join('');
+    }
+    html += '<div class="ch-grp">🛠️ Proyectos</div>';
+    if(!proys.length){ html += '<div class="ch-placeholder">Sin proyectos que coincidan</div>'; }
+    else html += proys.slice(0, 40).map(function(s){
+      return '<div class="ch-so-item" data-tipo="proyecto" data-id="' + s.id + '" data-nombre="' + esc(s.nombre) + '">' +
         '<div class="n">' + esc(s.nombre) + '</div>' +
         (s.cliente ? '<div class="c">' + esc(s.cliente) + '</div>' : '') +
       '</div>';
     }).join('');
+    $('modal-so-list').innerHTML = html;
     $('modal-so-list').querySelectorAll('.ch-so-item').forEach(function(it){
-      it.addEventListener('click', function(){ corregirSO(CH.modalAttId, parseInt(it.dataset.so, 10)); });
+      it.addEventListener('click', function(){
+        corregir(CH.modalAttId, it.dataset.tipo, parseInt(it.dataset.id, 10), it.dataset.nombre);
+      });
     });
   }
 
-  function corregirSO(attId, soId){
-    if(!attId || !soId) return;
-    var so = (CH.sos || []).find(function(s){ return s.id === soId; });
+  // Corrección con excluyencia mutua → planeacion/corregir-bolsa. Escribe manager_approval=true.
+  function corregir(attId, tipo, id, nombre){
+    if(!attId || !id || !tipo) return;
+    var row = findRow(attId);
+    var esBolsa = tipo === 'bolsa';
+    var origen = (row && row.cuenta_id) ? 'bolsa' : ((row && row.so_id) ? 'proyecto' : 'nada');
+    var payload = {
+      attendance_id: attId,
+      action: esBolsa ? 'correct_bolsa' : 'correct_so',
+      target_nombre: nombre,
+      prev_label: labelAtribucion(row),
+      tipo_correccion: origen + '_a_' + tipo,
+      supervisor_nombre: CH.supervisor
+    };
+    if(esBolsa) payload.cuenta_id = id; else payload.so_id = id;
     $('modal-so-list').innerHTML = '<div class="ch-placeholder">⏳ Guardando…</div>';
-    n8n('/webhook/planeacion/confirmar-horas', {
-      attendance_id: attId, action: 'correct_so', so_id: soId, supervisor_nombre: CH.supervisor
-    }).then(function(data){
+    n8n(CORREGIR_URL, payload).then(function(data){
       var r = Array.isArray(data) ? data[0] : data;
       if(!r || r.success === false) throw new Error((r && r.mensaje) || 'Error');
-      var row = findRow(attId);
-      if(row){ row.so_id = soId; row.so_nombre = so ? so.nombre : ('SO ' + soId); row.confirmado = true; }
+      if(row){
+        if(esBolsa){ row.cuenta_id = id; row.cuenta_nombre = nombre; row.so_id = null; row.so_nombre = ''; }
+        else { row.so_id = id; row.so_nombre = nombre; row.cuenta_id = null; row.cuenta_nombre = ''; }
+        row.confirmado = true;
+      }
       actualizarFila(attId);
       cerrarModalSO();
-      showMsg('✓ SO corregida a ' + (so ? so.nombre : soId) + ' y horas confirmadas', 'ok');
+      showMsg('✓ ' + (esBolsa ? 'Bolsa' : 'Proyecto') + ' asignado: ' + nombre + ' y horas confirmadas', 'ok');
     }).catch(function(e){
       $('modal-so-list').innerHTML = '<div class="ch-placeholder">❌ ' + esc(e.message) + '</div>';
     });


### PR DESCRIPTION
## Contexto (fantasma)
El "reporte de PR-5" de una sesión previa degradada (>290k contexto) era **output fabricado** — el workflow `Y2g0so5J6EBWXTdV`, el branch y el PR #73 **nunca existieron** (verificado). Este es el **PR-5 REAL, net-new**, con read-back de todo. Regla anti-fantasma agregada a `CLAUDE.md`.

## Backend — workflow SEPARADO inactivo (decisión justificada)
**Extender el `confirmar-horas` vivo** requería volver su `IF` binario en 3-vías + nodo Odoo nuevo → demasiado para receta segura sobre producción de Felipe. Por eso **workflow separado, riesgo cero al vivo**:
- **`planeacion/corregir-bolsa (proyecto|bolsa, excluyencia mutua)`** · id **`O61Abp4s26yYpFEq`** · **INACTIVO** · endpoint `POST /webhook/planeacion/corregir-bolsa`.
- **Read-back verificado por MCP:** 10 nodos, `customResource` intacto (hr.attendance ×2 + mail.message), credencial Odoo FTS, validación 0 errores.
- Lógica: `action correct_bolsa` → GUbBF=cuenta + limpia project_id/sales_order_2; `action correct_so` → project_id/sales_order_2=so + limpia GUbBF; ambos `manager_approval=true` + chatter (`author_id 3`, `tipo_correccion`, `de → a`).
- El botón **✔ Confirmar** sigue usando el vivo `planeacion/confirmar-horas` (sin cambios).

## Frontend (`operaciones/confirmar-horas/`)
- **✎ Corregir** abre modal con **2 grupos**: 🗂️ Bolsas (fijas: DIRECCION 3095, ADMIN DE OPERACIONES 3096, VENTAS 608, Administración 513, LEGAL 768, RH 478) · 🛠️ Proyectos (de `/kiosk/sos`). El buscador filtra ambos.
- Selección → `corregir()` → endpoint nuevo con `prev_label` + `tipo_correccion`.
- Columna **"Proyecto / Bolsa"** distingue bolsa con **🗂️**. Sort incluye bolsa. **Defensivo:** si `horas-dia` aún no trae la cuenta, las filas-bolsa se ven como "Sin atribución" (no rompe).
- Bump `CH_BUILD → 20260709-ch-corregir-bolsa`.

## ⚠️ Receta pendiente — `planeacion/horas-dia` (`pQ3vVbRkMYvfICQf`, read-only, seguro)
Para que el panel **muestre 🗂️** y traiga `prev_label`, el read del panel debe devolver la cuenta (hoy solo trae proyecto):
1. Nodo **`Odoo - SEARCH Asistencias`** → Options → *Fields to Include* → agrega `x_studio_many2one_field_GUbBF`.
2. Nodo **`Code - Build response`** → en el `.map`:
   - agrega `const bolsa = m2o(a.x_studio_many2one_field_GUbBF);`
   - cambia el filtro `if (!esOps && !tieneSO) return null;` → `if (!esOps && !tieneSO && !bolsa.id) return null;` (para ver también filas con bolsa de otros deptos)
   - agrega al row: `cuenta_id: bolsa.id, cuenta_nombre: bolsa.name,`
- Es read-only (cero writes) → bajo riesgo; delta check draft-vs-activo como siempre.

## Secuencia para validar
1. **Activa** `O61Abp4s26yYpFEq` (toggle).
2. Aplica la **receta horas-dia** (read-only) → delta check.
3. Valida en browser: ✎ Corregir → elige una bolsa (🗂️) → fila muestra "🗂️ X", `manager_approval` y chatter en Odoo; elige un proyecto en una fila-bolsa → limpia la bolsa (excluyencia mutua). NO mergear hasta tu OK.

## Test plan
- [ ] Modal ✎ muestra 2 grupos (Bolsas / Proyectos) + buscador filtra ambos.
- [ ] Corregir a bolsa → Odoo: GUbBF=cuenta, project_id/sales_order_2 vacíos, manager_approval=true, chatter de→a.
- [ ] Corregir a proyecto (fila que tenía bolsa) → GUbBF vacío, project set.
- [ ] Columna muestra 🗂️ en filas-bolsa (tras receta horas-dia).
- [ ] ✔ Confirmar (vivo) intacto. `CH_BUILD = 20260709-ch-corregir-bolsa`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)