### PR TITLE
feat(confirmar-horas): PR-6 panel completo — jornadas abiertas visibles

### DIFF
--- a/operaciones/confirmar-horas/index.html
+++ b/operaciones/confirmar-horas/index.html
@@ -5,7 +5,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 <title>Confirmar Horas — FTS Suite</title>
 <script>
-  (function(){ window.CH_BUILD = '20260709-ch-corregir-bolsa'; })();
+  (function(){ window.CH_BUILD = '20260710-ch-panel-completo'; })();
 </script>
 <script src="../../shared/auth-suite.js"></script>
 <style>

--- a/operaciones/confirmar-horas/js/confirmar-horas.js
+++ b/operaciones/confirmar-horas/js/confirmar-horas.js
@@ -27,6 +27,7 @@
   function celdaAtribucion(row){
     if(row.so_id) return esc(row.so_nombre || ('Proy ' + row.so_id));
     if(row.cuenta_id) return '<span class="ch-bolsa">🗂️ ' + esc(row.cuenta_nombre || ('Bolsa ' + row.cuenta_id)) + '</span>';
+    if(row.abierta) return '<span style="color:#999">— (en curso)</span>';   // PR-6: abierta sin atribución aún ≠ hueco
     return '<span class="ch-sinso">⚠ Sin atribución</span>';
   }
   // Etiqueta de la atribución ACTUAL (para prev_label del chatter).
@@ -112,7 +113,7 @@
 
   function estadoBadge(row){
     if(row.en_disputa) return '<span class="ch-badge b-disp">⚠ En disputa</span>';
-    if(row.abierta)    return '<span class="ch-badge b-open">⏳ Abierta</span>';
+    if(row.abierta)    return '<span class="ch-badge b-open">⏳ Sin completar</span>';
     if(row.confirmado) return '<span class="ch-badge b-ok">✓ Confirmada</span>';
     return '<span class="ch-badge b-pend">Pendiente</span>';
   }
@@ -195,7 +196,7 @@
           '<td class="cell-estado">' + estadoBadge(row) + '</td>' +
           '<td><div class="ch-actions">' +
             '<button class="ch-btn ch-btn-sm ch-btn-ok" data-act="confirm" data-att="' + row.attendance_id + '"' + confirmarDisabled + '>✔ Confirmar</button>' +
-            '<button class="ch-btn ch-btn-sm ch-btn-edit" data-act="editso" data-att="' + row.attendance_id + '">✎ Corregir</button>' +
+            '<button class="ch-btn ch-btn-sm ch-btn-edit" data-act="editso" data-att="' + row.attendance_id + '"' + (row.abierta ? ' disabled title="Jornada abierta — sin acciones hasta que cierre"' : '') + '>✎ Corregir</button>' +
           '</div></td>' +
         '</tr>';
     }).join('');


### PR DESCRIPTION
## Resumen
Fase 1.5 **PR-6** — el panel de Felipe muestra **TODOS los empleados con check-in en el rango, de TODOS los deptos, incluyendo jornadas ABIERTAS** con estado "⏳ Sin completar" (solo visibilidad; sin acciones sobre abiertas).

## Evaluación C: **frontend + receta horas-dia** (ambos)
El filtro que hoy oculta (no-Ops sin proyecto) vive en `horas-dia`, no en el front → hay que relajarlo ahí. Además descubrí que **la receta horas-dia de PR-5 (traer bolsa) NUNCA se aplicó** → el 🗂️ en reload no funcionaba. **Esta receta cierra ambos.**

## Frontend (`operaciones/confirmar-horas/`, este PR)
- Estado **"⏳ Sin completar"** para `abierta` (antes "Abierta").
- **✎ Corregir DESHABILITADO** en abiertas (title explicativo); ✔ Confirmar ya estaba disabled en abiertas. **Acciones solo en cerradas.**
- Celda atribución **"— (en curso)"** para abierta sin proyecto/bolsa (no es hueco W1).
- El front **renderiza lo que horas-dia devuelva** → una vez relajado el filtro, aparecen todos. Bump `CH_BUILD → 20260710-ch-panel-completo`.

## ⚠️ Receta `planeacion/horas-dia` (`pQ3vVbRkMYvfICQf`, read-only, seguro) — REEMPLAZO COMPLETO del nodo `Code - Build response`
**1.** Nodo `Odoo - SEARCH Asistencias` → Options → *Fields to Include* → agrega `x_studio_many2one_field_GUbBF`.
**2.** Nodo `Code - Build response` → reemplaza TODO por:
```javascript
// PR-6: TODAS las jornadas del rango (todos los deptos, abiertas + cerradas). Sin filtro. Trae bolsa (GUbBF).
const prev = $('Code - Validar payload').item.json;
const DEPT_OPS = prev.dept_id || 3;
function m2o(f){ if(!f) return {id:null,name:null}; if(Array.isArray(f)) return {id:f[0]||null,name:f[1]||null}; if(typeof f==='object') return {id:f.id||null,name:f.name||null}; if(typeof f==='number') return {id:f,name:null}; return {id:null,name:null}; }
function cst(dt){ if(!dt) return null; const d=new Date(String(dt).replace(' ','T')+'Z'); return new Date(d.getTime()-6*3600*1000).toISOString().slice(0,16).replace('T',' '); }
const rows = $input.all().map(it => {
  const a = it.json || {};
  if (!a.id) return null;
  const emp = m2o(a.employee_id);
  const so = m2o(a.x_studio_project_id);
  const bolsa = m2o(a.x_studio_many2one_field_GUbBF);
  const dep = m2o(a.department_id);
  const esOps = dep.id === DEPT_OPS;
  return {
    attendance_id: a.id, empleado_id: emp.id, empleado_nombre: emp.name,
    department_id: dep.id, department_name: dep.name, es_operaciones: esOps,
    check_in_cst: cst(a.check_in), check_out_cst: cst(a.check_out), abierta: !a.check_out,
    worked_hours: Math.round((a.worked_hours || 0) * 100) / 100,
    so_id: so.id, so_nombre: so.name,
    cuenta_id: bolsa.id, cuenta_nombre: bolsa.name,
    confirmado: a.x_studio_manager_approval === true, en_disputa: a.x_studio_horario_en_disputa === true,
    incidencia_id: a.x_studio_incidencia_pendiente_id || null, out_mode: a.out_mode || null
  };
}).filter(Boolean);
rows.sort((x,y)=> String(x.empleado_nombre||'').localeCompare(String(y.empleado_nombre||'')) || String(x.check_in_cst||'').localeCompare(String(y.check_in_cst||'')) );
return [{ json: { success:true, fecha_desde:prev.fecha_desde, fecha_hasta:prev.fecha_hasta, dept_id:prev.dept_id, count:rows.length, rows } }];
```
**Cambio vs actual:** +`const bolsa`, se **quita** `if (!esOps && !tieneSO) return null;`, +`cuenta_id/cuenta_nombre` en el row. Delta check draft-vs-activo antes de publicar.

## Test plan (browser, rango que incluya HOY)
- [ ] Aparecen TODOS los deptos + jornadas abiertas con "⏳ Sin completar".
- [ ] ✎ Corregir y ✔ Confirmar deshabilitados en abiertas; activos en cerradas.
- [ ] Filas-bolsa muestran 🗂️ en reload (receta aplicada).
- [ ] `CH_BUILD = 20260710-ch-panel-completo`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)