### PR TITLE
feat(pwa): PR-7 — auto version-check (kiosk + confirmar-horas)

### DIFF
--- a/operaciones/confirmar-horas/index.html
+++ b/operaciones/confirmar-horas/index.html
@@ -5,9 +5,14 @@
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 <title>Confirmar Horas — FTS Suite</title>
 <script>
-  (function(){ window.CH_BUILD = '20260710-ch-panel-completo'; })();
+  (function(){ window.CH_BUILD = '20260710-ch-versioncheck'; })();
 </script>
 <script src="../../shared/auth-suite.js"></script>
+<script src="../../shared/version-check.js"></script>
+<script>
+  // PR-7: auto version-check — detecta bundle viejo cacheado y fuerza refresh (ver FASE15 Parte 12).
+  try { if (window.FTSVersionCheck) FTSVersionCheck.run({ versionUrl: 'version.json', localBuild: window.CH_BUILD, tag: 'ch' }); } catch (e) {}
+</script>
 <style>
   :root{ --azul:#1a4480; --azul2:#0C447C; --ok:#1a7a3a; --warn:#BA7517; --err:#b3261e; --bg:#f4f6f9; }
   *{ box-sizing:border-box; }

--- a/operaciones/confirmar-horas/version.json
+++ b/operaciones/confirmar-horas/version.json
@@ -1,0 +1,6 @@
+{
+  "build": "20260710-ch-versioncheck",
+  "modulo": "confirmar-horas",
+  "updated": "2026-07-10",
+  "_nota": "build DEBE coincidir con CH_BUILD en index.html. Bumpear ambos al mismo string en cada deploy (ver FASE15 Parte 12)."
+}

--- a/operaciones/kiosk/index.html
+++ b/operaciones/kiosk/index.html
@@ -265,6 +265,7 @@
   </div>
 </div>
 
+<script src="../../shared/version-check.js"></script>
 <script src="js/geo.js"></script>
 <script src="js/face.js"></script>
 <script src="js/odoo.js"></script>

--- a/operaciones/kiosk/js/kiosk.js
+++ b/operaciones/kiosk/js/kiosk.js
@@ -1,8 +1,12 @@
 // ═══ FTS Kiosk — Lógica principal ═══
 // Script clásico, estado global compartido
 
-const KIOSK_BUILD = '20260709-kiosk-confirm-bolsa';
+const KIOSK_BUILD = '20260710-kiosk-versioncheck';
 console.log('[kiosk] build:', KIOSK_BUILD);
+window.KIOSK_BUILD = KIOSK_BUILD;
+// PR-7: auto version-check — si el navegador sirve un bundle viejo cacheado
+// (payload sin cuenta_id, ver FASE15 Parte 12), detecta y fuerza refresh.
+try { if (window.FTSVersionCheck) FTSVersionCheck.run({ versionUrl: 'version.json', localBuild: KIOSK_BUILD, tag: 'kiosk' }); } catch (e) {}
 
 const K = {
   empleados: [],

--- a/operaciones/kiosk/version.json
+++ b/operaciones/kiosk/version.json
@@ -1,0 +1,6 @@
+{
+  "build": "20260710-kiosk-versioncheck",
+  "modulo": "kiosk",
+  "updated": "2026-07-10",
+  "_nota": "build DEBE coincidir con KIOSK_BUILD en js/kiosk.js. Bumpear ambos al mismo string en cada deploy (ver FASE15 Parte 12)."
+}

--- a/shared/version-check.js
+++ b/shared/version-check.js
@@ -1,0 +1,109 @@
+/*
+ * FTS Suite — auto version-check (PR-7)
+ * ─────────────────────────────────────
+ * Detecta cuando el navegador sirve un bundle VIEJO cacheado y fuerza refresh.
+ * Motivación: GitHub Pages sirve los assets con Cache-Control: max-age=600 (10 min)
+ * SIN service worker; una pestaña de kiosco de larga vida (o el navegador móvil que
+ * no re-navega) puede correr el bundle stale durante DÍAS y generar huecos de datos
+ * (ej. checkout sin `cuenta_id`). Ver docs/operaciones/FASE15_CUENTAS_WATCHDOGS.md
+ * Parte 12 (evidencia execution n8n 33625) + CLAUDE.md Hallazgo #14.
+ *
+ * Uso (después de que el build local esté disponible):
+ *   FTSVersionCheck.run({ versionUrl:'version.json', localBuild: KIOSK_BUILD, tag:'kiosk' });
+ *
+ * Contrato de version.json:  { "build": "<mismo string que el build en pantalla>" }
+ * Convención de deploy: al bumpear KIOSK_BUILD / CH_BUILD, bumpear version.json.build
+ * al MISMO string (misma disciplina que "bump de build obligatorio", CLAUDE.md §8).
+ *
+ * ES5-safe (navegadores móviles viejos). Sin dependencias.
+ */
+(function () {
+  var COOLDOWN_MS = 11 * 60 * 1000; // > max-age 600s de GH Pages: si el 1er reload cayó
+                                    // dentro de la ventana y trajo JS viejo, reintenta pasada la ventana.
+
+  // Limpieza defensiva: hoy NO hay service worker, pero si algún día se agrega, esto
+  // lo desregistra + borra Cache Storage antes del reload. No-op si no existen.
+  function cleanupCaches() {
+    var tasks = [];
+    try {
+      if (navigator && navigator.serviceWorker && navigator.serviceWorker.getRegistrations) {
+        tasks.push(
+          navigator.serviceWorker.getRegistrations().then(function (rs) {
+            return Promise.all((rs || []).map(function (r) {
+              try { return r.unregister(); } catch (e) { return null; }
+            }));
+          })['catch'](function () {})
+        );
+      }
+    } catch (e) {}
+    try {
+      if (window.caches && caches.keys) {
+        tasks.push(
+          caches.keys().then(function (ks) {
+            return Promise.all((ks || []).map(function (k) { return caches['delete'](k); }));
+          })['catch'](function () {})
+        );
+      }
+    } catch (e) {}
+    if (window.Promise) return Promise.all(tasks);
+    return { then: function (cb) { cb(); } }; // fallback si no hay Promise (no debería pasar; hay fetch)
+  }
+
+  function check(opts) {
+    var url = opts.versionUrl || 'version.json';
+    var local = opts.localBuild || '';
+    var tag = opts.tag || 'app';
+    if (!local) return; // sin build local no hay con qué comparar
+    var sep = url.indexOf('?') < 0 ? '?' : '&';
+    fetch(url + sep + 'ts=' + Date.now(), { cache: 'no-store' })
+      .then(function (r) { return (r && r.ok) ? r.json() : null; })
+      .then(function (v) {
+        if (!v || !v.build) return;
+        var guard = 'fts_vc_' + tag + '_' + v.build;
+        if (v.build === local) {
+          // Ya estamos en el build servido: limpiar el guard por si venía de un reload previo.
+          try { sessionStorage.removeItem(guard); } catch (e) {}
+          return;
+        }
+        // build local != servido → el bundle en memoria es viejo (cacheado).
+        try {
+          var last = parseInt(sessionStorage.getItem(guard) || '0', 10);
+          if (last && (Date.now() - last) < COOLDOWN_MS) return; // reintentado hace <11 min → esperar
+          sessionStorage.setItem(guard, String(Date.now()));
+        } catch (e) {}
+        cleanupCaches().then(function () {
+          try {
+            // ?v= busta el cache del DOCUMENTO. GH Pages ignora el query (sirve index.html);
+            // pasada la ventana de max-age los subrecursos (js) también llegan frescos.
+            location.replace(location.pathname + '?v=' + encodeURIComponent(v.build));
+          } catch (e) { location.reload(); }
+        });
+      })
+      ['catch'](function () { /* offline / sin version.json → no-op silencioso */ });
+  }
+
+  // Debounce: focus + visibilitychange pueden dispararse juntos.
+  var running = false;
+  function safeCheck(opts) {
+    if (running) return;
+    running = true;
+    try { check(opts); } finally {
+      setTimeout(function () { running = false; }, 3000);
+    }
+  }
+
+  window.FTSVersionCheck = {
+    run: function (opts) {
+      opts = opts || {};
+      if (!('fetch' in window)) return; // navegadores muy viejos: no-op (no rompe nada)
+      safeCheck(opts);
+      // Pestañas de larga vida (kiosco / panel abierto todo el día): re-chequear al volver el foco.
+      try {
+        document.addEventListener('visibilitychange', function () {
+          if (document.visibilityState === 'visible') safeCheck(opts);
+        });
+        window.addEventListener('focus', function () { safeCheck(opts); });
+      } catch (e) {}
+    }
+  };
+})();


### PR DESCRIPTION
## Summary
Mata la **reincidencia de bundle viejo cacheado** (tercera esta semana; hoy genera huecos de datos). Ver `docs/operaciones/FASE15_CUENTAS_WATCHDOGS.md` Parte 12 — evidencia execution n8n `33625` (checkout de Eduardo sin la llave `cuenta_id` = `kiosk.js` pre-PR-2 servido de cache).

**No hay service worker** en el repo: la "cache PWA" es HTTP cache del navegador sobre `kiosk.js` (los `<script>` cargan sin cache-bust). GH Pages usa `max-age=600` → el stale se cura en ≤10 min **solo si la página recarga**; una pestaña de kiosco de larga vida nunca recarga → stale de días.

## Mecánica
- `shared/version-check.js` (nuevo, ES5-safe): al cargar **y al volver el foco** (`visibilitychange`/`focus`, cubre pestañas de larga vida) hace `fetch('version.json', {cache:'no-store'})`. Si `remote.build ≠ localBuild` → limpieza defensiva (unregister SW + `caches.delete`, por si algún día se agrega un SW) + `location.replace(path + '?v=' + build)` (busta el documento).
- **Anti-loop:** guard `sessionStorage` con **cooldown 11 min** (> `max-age` 600s) por cada `remote.build`. Si el 1er reload cayó dentro de la ventana y trajo JS viejo, reintenta pasada la ventana; nunca en bucle apretado.
- Aplica a **kiosk** y **panel confirmar-horas**.
- No-op silencioso si no hay `fetch` o `version.json` (offline).

## Archivos
- `shared/version-check.js` (nuevo)
- `operaciones/kiosk/version.json` + `operaciones/confirmar-horas/version.json` (nuevos)
- `operaciones/kiosk/js/kiosk.js` — `KIOSK_BUILD` → `20260710-kiosk-versioncheck` + expone + llama al check
- `operaciones/kiosk/index.html` + `operaciones/confirmar-horas/index.html` — include + llamada; `CH_BUILD` → `20260710-ch-versioncheck`

## Convención de deploy (nueva)
Al bumpear `KIOSK_BUILD`/`CH_BUILD`, bumpear también `version.json.build` al **mismo string** (misma disciplina de CLAUDE.md §8, un archivo más).

## Test plan
- [ ] Cargar kiosk con build viejo en cache + deploy nuevo → recarga sola a `?v=<build>` y toma el bundle fresco.
- [ ] Sin cambio de build → no recarga (comparación == , guard limpio).
- [ ] Offline / sin `version.json` → no-op, la app carga normal.
- [ ] Panel confirmar-horas idem.
- [ ] Verificar en pantalla el nuevo build tras refresco.

🤖 Generated with [Claude Code](https://claude.com/claude-code)