### PR TITLE
feat(carga-mo): correcciones SEM 28 (080→143, solo_bolsa=3, vacación parcial, periodo) + seguridad JWT

### DIFF
--- a/comercial/CHECKLIST-MANUAL.md
+++ b/comercial/CHECKLIST-MANUAL.md
@@ -1,0 +1,177 @@
+# Checklist manual — MVP Comercial
+
+**Tiempo estimado: ~15 min.** En orden; los pasos 1–2 son prerequisitos de todo lo demás.
+
+Nada de esto se pudo hacer desde la sesión autónoma: el API de n8n de esta instancia **no permite activar workflows vía MCP** (regla de la casa #6 + CLAUDE.md §16), y el campo `customResource` **se blanquea al importar**.
+
+---
+
+## 0. Mergear el PR
+
+Rama: `feat/comercial-mvp`.
+
+⚠️ **Hazlo primero.** El watchdog lee su config de `main` en vivo (`shared/comercial/watchdog_enviadas.json`). Si corres el watchdog antes de mergear, la URL da 404 → corre con valores por defecto y te avisa en el propio correo con un banner amarillo (no truena, pero el destinatario y los umbrales serán los defaults, no los del archivo).
+
+---
+
+## 1. Crear la variable de entorno `FTS_COMERCIAL_HMAC`
+
+**Dónde:** Railway → proyecto n8n → Variables.
+
+**Valor:** una cadena aleatoria larga. Genérala tú, en tu laptop (no me la mandes, no la pegues en el chat, no la commitees):
+
+```bash
+node -e "console.log(require('crypto').randomBytes(32).toString('hex'))"
+```
+
+| Variable | Valor | Ya existe |
+|---|---|---|
+| `FTS_COMERCIAL_HMAC` | *(la que acabas de generar)* | ❌ **Crear** |
+| `FINANZAS_JWT_SECRET` | *(sin cambios)* | ✅ Ya existe — la reusan los 2 webhooks |
+
+Railway reinicia n8n al guardar la variable. Espera a que levante.
+
+> Guarda el valor en tu gestor de contraseñas: lo necesitas otra vez en el paso 5.
+
+---
+
+## 2. Rellenar `customResource` en cada nodo Odoo
+
+El campo se blanquea al importar/crear (CLAUDE.md §3). **Sin esto los workflows fallan.**
+
+Abre cada workflow en la UI, entra al nodo y escribe el valor exacto en *Custom Resource*:
+
+### `comercial/watchdog-enviadas (T2 canary)` — id `hJNTUd8E57W4rfjU`
+| Nodo | `customResource` |
+|---|---|
+| `Odoo - sale.order enviadas` | `sale.order` |
+
+### `comercial/captura (T3)` — id `tEra7MVCvnWjAqjR`
+| Nodo | `customResource` |
+|---|---|
+| `Odoo - res.users lookup` | `res.users` |
+| `Odoo - CREATE crm.lead` | `crm.lead` |
+
+### `comercial/pipeline (T3)` — id `60ZLskz1xJ7nU5kt`
+| Nodo | `customResource` |
+|---|---|
+| `Odoo - res.users lookup` | `res.users` |
+| `Odoo - crm.lead abiertos` | `crm.lead` |
+| `Odoo - sale.order enviadas` | `sale.order` |
+
+**De paso verifica en cada nodo Odoo:**
+- Credencial = `Odoo FTS` (a veces se desasigna).
+- **"Always Output Data" = ON.** En `Odoo - res.users lookup` es **crítico**: el no-match es el caso *normal* (ningún `res.users` tiene login `finanzas`), y en OFF un lookup vacío mata el workflow en silencio.
+
+---
+
+## 3. Publicar los 3 workflows
+
+Toggle **Active** en la UI. Los 3 se crearon inactivos a propósito.
+
+| Workflow | ID | Qué verificar al activar |
+|---|---|---|
+| `comercial/watchdog-enviadas (T2 canary)` | `hJNTUd8E57W4rfjU` | **Settings → Timezone = `UTC`** ⚠️ ver abajo · luego `active:true` + `triggerCount:1` |
+| `comercial/captura (T3)` | `tEra7MVCvnWjAqjR` | webhook responde en `/webhook/comercial/captura` |
+| `comercial/pipeline (T3)` | `60ZLskz1xJ7nU5kt` | webhook responde en `/webhook/comercial/pipeline` |
+
+> ⚠️ **El timezone del watchdog no es opcional.** n8n **descarta `settings.timezone` al importar** (CLAUDE.md §18 lección #1). Si queda vacío hereda el TZ de la instancia — que es **America/New_York**, no Monterrey — y el cron de las 08:45 correría a las **06:45 CST**. El cron está escrito en UTC (`45 14 * * 1-5`) igual que `ops/watchdog-mo`, así que **Timezone debe decir `UTC`**.
+>
+> Nota: México eliminó el horario de verano en 2022, así que Monterrey es UTC−6 fijo y `14:45 UTC = 08:45 CST` todo el año. No hay que ajustarlo en invierno/verano.
+
+---
+
+## 4. Correr el watchdog una vez (manual)
+
+En `comercial/watchdog-enviadas` → botón **Execute Workflow** (usa el Manual Trigger que trae para esto).
+
+**Lo que DEBES recibir** (te llega a `estebandelacruz@fts.mx`, es el canary):
+
+> Asunto: `[Cotizaciones enviadas] 2026-07-16 — 122 rojas / 0 amarillas`
+
+**Esto es lo esperado, no un bug.** El baseline (§5) midió que **ninguna de las 122 cotizaciones enviadas se ha tocado en más de 6 días**: con la regla 4/6, el 100% sale rojo el día 1. El correo trae:
+
+- Header: totales + valor en riesgo en MXN normalizado + ventana.
+- Bucket **`SIN OWNER ⚠` primero** — ~12 cotizaciones sin responsable, incluida **SO11258 de Terra Energy por $2.3M**. Eso es fuga real, no un error del reporte.
+- Bucket **`Sales FTS`** con el resto — es la cuenta genérica, no una persona (baseline RIESGO-3).
+- Tope de 15 filas por bucket; el resto sale como *"+N más"* con su monto agregado.
+
+**Si NO llega el correo**, revisa en este orden:
+1. ¿El nodo `HTTP - Graph send` dio **202** con body vacío `{}`? Eso es éxito. Si trae ~700KB, el sendMail falló.
+2. ¿Salió el banner amarillo *"No se pudo leer la config"*? → el PR no está mergeado (paso 0).
+3. ¿`Code - MAIN` devolvió 0 items? → mira si `Odoo - sale.order enviadas` trajo filas; si vino vacío, revisa `customResource`.
+
+**Para el rollout al equipo** (decisión tuya, no la tomé): edita `shared/comercial/watchdog_enviadas.json` en main → `"canary": false` + llena `recipients.equipo: ["..."]`. **No hay que re-importar ni re-activar** el workflow: la config se lee de main en vivo.
+
+---
+
+## 5. Aprovisionar tu dispositivo para la captura
+
+El front es una página **pública** en GitHub Pages: no puede llevar el secreto HMAC en el código sin publicarlo. Por eso se aprovisiona por dispositivo.
+
+Abre `https://yinyo1.github.io/fts-suite/comercial/` → consola del navegador (F12) → pega:
+
+```js
+localStorage.setItem('fts_comercial_hmac', 'EL_MISMO_VALOR_DE_FTS_COMERCIAL_HMAC')
+```
+
+Recarga. Si no lo haces, al entrar verás un aviso amarillo *"Este dispositivo no está aprovisionado"* y la captura fallará con `NO_HMAC`. **Mi Pipeline sí funciona sin esto** (solo necesita el JWT).
+
+> Repite en cada teléfono/equipo que vaya a capturar. Ese es justamente el punto: el password de Finanzas solo no basta, hay que estar en un equipo aprovisionado.
+
+---
+
+## 6. Probar el flujo end-to-end
+
+⚠️ **Este paso no lo pude hacer yo y es el único criterio de aceptación de T3 que queda sin verificar.** Ver `SUPUESTOS.md` §T3-E2E. Razones:
+- Los workflows nacen inactivos y el API de n8n no deja activarlos vía MCP.
+- El MCP de Odoo es **read-only** (UID 2), y el límite duro de la sesión dice que solo el workflow de captura puede escribir `crm.lead`.
+
+Por eso **no existen leads `[TEST-CC]` que borrar** — la tabla de IDs a limpiar está vacía. No inventé registros que no creé.
+
+**Prueba tú:**
+
+1. Entra a `https://yinyo1.github.io/fts-suite/` → card **COMERCIAL** (badge "MVP").
+2. Login con las credenciales de Finanzas (usuario `finanzas`).
+3. Pestaña **Captura**. Para que sea borrable fácil, pon en Cliente: **`[TEST-CC] Prueba`**.
+   - Descripción: cualquier texto · Rango: `<200K` · Origen: `otro`.
+4. **Crear oportunidad** → debe responder `✅ Oportunidad creada · lead <id>`.
+   - Va a decir *"Quedó asignada a Jesus Esteban De La Cruz por defecto: reasígnala en Odoo"*. **Es lo esperado**, no un bug: el JWT no lleva identidad de persona (ver `ROADMAP.md` §1).
+5. En Odoo: CRM → busca `[TEST-CC] Prueba`. Verifica `partner_name`, `expected_revenue = 100,000` (punto medio de `<200K`), y que la `description` traiga el Origen, el Rango y la marca `[!] Asignado a Esteban por defecto`.
+6. Pestaña **Mi Pipeline** → **Refrescar**. El lead debe aparecer en *Oportunidades abiertas*.
+7. **Borra el lead de prueba en Odoo.** Anota aquí el id por si acaso: `_____`
+
+**Errores que puedes ver y qué significan:**
+
+| Código | Qué pasó |
+|---|---|
+| `NO_HMAC` | Falta el paso 5 en ese dispositivo |
+| `BAD_SIGNATURE` | El `localStorage` no coincide con `FTS_COMERCIAL_HMAC` de Railway |
+| `STALE_REQUEST` | Reloj del dispositivo desfasado >10 min |
+| `SERVER_MISCONFIG` | Falta `FTS_COMERCIAL_HMAC` en Railway (paso 1) |
+| `BAD_TOKEN` / `TOKEN_EXPIRED` | Sesión vencida (el token dura 8h) → vuelve a entrar |
+
+---
+
+## 7. Verificar el link en el launcher
+
+`https://yinyo1.github.io/fts-suite/` → la card **COMERCIAL** debe estar activa con badge **"MVP"** y llevar a `comercial/index.html`.
+
+Era un `<div class="disabled">` con badge "Próximamente"; ahora es un `<a>`. **Es el único cambio al front existente.**
+
+> No la metí en `shared/modules-registry.js` a propósito: eso la gatearía por permisos por usuario y podría dejar gente fuera sin que lo pidieras. El módulo ya se gatea solo con su propio login.
+
+---
+
+## Resumen de lo que quedó pendiente de tu lado
+
+| # | Paso | Bloquea |
+|---|---|---|
+| 0 | Mergear PR `feat/comercial-mvp` | La config del watchdog |
+| 1 | Crear `FTS_COMERCIAL_HMAC` en Railway | Toda la captura |
+| 2 | Rellenar 6 `customResource` | Los 3 workflows |
+| 3 | Activar 3 workflows + **Timezone=UTC** en el watchdog | Todo |
+| 4 | Correr el watchdog manual 1 vez | Validar T2 |
+| 5 | Aprovisionar tu dispositivo (localStorage) | La captura desde ese equipo |
+| 6 | Probar e2e + borrar el lead de prueba | Validar T3 |
+| 7 | Verificar el link del launcher | — |

--- a/comercial/ROADMAP.md
+++ b/comercial/ROADMAP.md
@@ -1,0 +1,132 @@
+# Roadmap Comercial — lo que quedó fuera del MVP
+
+Orden por impacto. **§1 no es una mejora: es lo que hace que el módulo sirva para lo que se construyó.**
+
+---
+
+## §1 · Identidad real por usuario 🔴 BLOQUEANTE
+
+**El problema.** El auth de Finanzas que este módulo reusa tiene **un solo usuario** (`sub:'finanzas'` hardcodeado, `role:null`, un par salt/hash compartido). Consecuencias hoy:
+
+1. **Todo lead capturado se asigna a Esteban** (`SUPUESTOS.md` §T3-IDENTIDAD). El baseline identificó la falta de atribución por vendedor como el **problema #1** del área comercial (77% del volumen en la cuenta genérica `Sales FTS`). **El MVP no lo resuelve** — lo hace visible con una marca en la `description`, nada más.
+2. **Dar acceso a Comercial = dar acceso a Finanzas** (facturas, bills). Mismo password, misma sesión. Es un problema de seguridad, no de comodidad.
+3. **No hay roles.** `role` siempre `null` → dirección se resuelve con lista blanca hardcodeada.
+
+**Qué hay que hacer.** Auth multi-usuario en `auth/finanzas-login` (o un `auth/suite-login` nuevo):
+- Tabla de usuarios (Odoo `res.users` como fuente, o JSON con salt/hash por persona).
+- `sub` = login real de la persona.
+- `app` como *lista* de módulos autorizados, o un claim `scopes` → separa Comercial de Finanzas.
+- `role` poblado de verdad → mata la lista blanca hardcodeada.
+- Lockout **por usuario/IP**, no global (hoy 5 fallos bloquean a todos 15 min).
+
+**Ya está listo para engancharse:** los dos webhooks aceptan un campo opcional `capturado_por` que tiene prioridad sobre `sub`. Cuando el auth mande identidad real, se conecta ahí sin re-tocar los workflows.
+
+**Estimado:** 4–6 h. **Sin esto, §2, §4 y §5 no tienen sentido.**
+
+---
+
+## §2 · Campos FTS-4 en `crm.lead` (los creas tú en Studio)
+
+El MVP usa **solo campos nativos** (límite duro de la sesión). Los campos esperados:
+
+| Campo | Tipo sugerido | Para qué |
+|---|---|---|
+| `x_studio_fts4_falla` | Text | Qué falla del cliente resuelve |
+| `x_studio_fts4_fecha` | Date | Fecha comprometida |
+| `x_studio_fts4_sponsor` | Char | Quién firma del lado del cliente |
+| `x_studio_fts4_presupuesto` | Monetary | Presupuesto declarado (vs `expected_revenue` estimado por rango) |
+| `x_studio_temperatura` | Selection | Frío / Tibio / Caliente |
+| `x_studio_carril` | Selection | Carril del pipeline |
+| `x_studio_en_revision` | Boolean | Flag de revisión |
+| `x_studio_proximo_paso` | Char/Text | Siguiente acción concreta |
+
+**Cuando existan:**
+1. Agregar los campos al form de Captura (hoy son 4; con FTS-4 se vuelven ~8 → considerar 2 pasos para no matar el mobile-first).
+2. Agregarlos al `fieldsToCreateOrUpdate` del nodo `Odoo - CREATE crm.lead`.
+3. Exponerlos en Mi Pipeline.
+
+⚠️ **`x_studio_proximo_paso` + `x_studio_fts4_fecha` son la base del §3.** Un watchdog que vigila *"¿tiene próximo paso y ya venció?"* es infinitamente mejor que uno que vigila `write_date`.
+
+**Estimado:** 2–3 h después de que existan los campos.
+
+---
+
+## §3 · Watchdog v2 — vigilar la señal correcta 🔴 IMPORTANTE
+
+**El problema** (`baseline.md` §6 RIESGO-2 · `SUPUESTOS.md` §T2-WRITE_DATE): el v1 mide `write_date`, que es *"la última vez que **cualquier** proceso tocó la orden"* — no seguimiento comercial. **60 de 122 órdenes comparten el mismo `write_date` al segundo** por una escritura masiva.
+
+Hoy no molesta porque todo está rojo. **El día que el equipo empiece a trabajar, cualquier script que toque `sale.order` en masa resetea todos los semáforos a verde sin que nadie haya llamado a un cliente.** Falso negativo silencioso.
+
+**v2 debe:**
+1. **Medir `mail.message` del chatter** (comunicación real con el cliente) en vez de `write_date`. Patrón ya probado en `ops/watchdog-mo`, que consulta `mail.message` con filtros `model` + `body like`.
+2. **Cadencias por rango.** El baseline dice que el ciclo mediano es 11.5 días, pero 3M–5M tarda ~107. Un umbral 4/6 uniforme es demasiado agresivo para lo grande y quizá laxo para lo chico. Sugerido: `<200K` → 3/5 · `200K–1M` → 5/8 · `>1M` → 7/14. Config por rango en el JSON.
+3. **Vigilar `draft`.** El baseline (§3, RIESGO-4) encontró **275 borradores (51%) que nunca se enviaron** — ni ganados ni perdidos, invisibles. Probablemente el mayor valor económico oculto. Antes de automatizar: revisar 20 a mano para saber si es basura o fuga.
+4. **Escalar por antigüedad**, no solo colorear: >30 días sin movimiento con monto >1M debería ir a dirección, no al vendedor.
+5. **Registro de atendidas.** El v1 dice *"responde a este digest"* (manual). El v2 necesita un endpoint o botón para marcar atendido y sacarlo del siguiente correo.
+
+**Estimado:** 4–5 h.
+
+---
+
+## §4 · Dashboard con roles
+
+Depende de §1. La vista de dirección (todo el pipeline, por vendedor, con win rate por rango) es literalmente el `baseline.md` pero **vivo**. Los cálculos ya están hechos y verificados ahí; es portarlos a un endpoint + una vista.
+
+Incluir: win rate por rango y por vendedor · tiempo de ciclo · valor en pipeline · fuga (SIN OWNER + borradores viejos) · concentración de clientes (**Nalco de México está en ~30 de las 122 cotizaciones vivas** — es un riesgo de concentración que nadie está midiendo).
+
+**Estimado:** 6–8 h.
+
+---
+
+## §5 · Submódulo Marketing
+
+Origen de leads → conversión por canal. El campo `origen` del MVP (`referido` / `cliente_existente` / `marketing` / `portal` / `otro`) ya lo está sembrando en la `description`. **Cuando exista un campo Studio propio para origen, esto se vuelve reportable de verdad** (hoy está enterrado en texto libre).
+
+Ojo: `portal` se va a mezclar con el ruido real del portal web (baseline RIESGO-5: carritos de $0/$1.16). Hay que separarlos.
+
+**Estimado:** 5–6 h. Depende de §2.
+
+---
+
+## §6 · N2 con Claude
+
+Captura conversacional: dictar por voz *"Nalco quiere una jaula para tanque, como millón y medio, me lo pidió Tito"* → el modelo extrae cliente/descripción/rango/origen y precarga el form.
+
+**Precedente en el repo:** `pmo/chat-apply` (id `G9mo4xkJKpbPDaT4`) ya hace exactamente esta forma — parsea lenguaje natural y muta registros. **Reusar su patrón, incluida la heurística de DETECCIÓN REACTIVA de duplicados** (CLAUDE.md Hallazgo #13): antes de crear, comparar `nombre.toLowerCase().normalize()` + cliente contra los leads abiertos; si hay match >70%, devolver `clarify` en vez de crear un duplicado. En un CRM con **1,849 leads** eso no es opcional.
+
+⚠️ El workflow `pmo/chat-apply` tiene un **secreto HMAC filtrado** en `docs/n8n-workflows/pmo-chat-apply-code-code-validar-auth.js` (CLAUDE.md §15 #3). **Rotarlo antes de reusar ese patrón.**
+
+**Estimado:** 8–10 h. Depende de §1 y §2.
+
+---
+
+## Deuda técnica del MVP
+
+| # | Qué | Dónde | Prioridad |
+|---|---|---|---|
+| 1 | 127 órdenes de la empresa MX marcadas USD → ningún reporte por monto es defendible | Odoo (Gerardo) | 🔴 alta |
+| 2 | Sin timestamp de envío → los 2 tiempos de ciclo del funnel son ciegos | Studio | 🟡 media |
+| 3 | Migrar `Sales FTS` (416 órdenes) a vendedores reales | Odoo + §1 | 🔴 alta |
+| 4 | 12 cotizaciones sin `user_id`, incl. **SO11258 Terra Energy $2.3M** | Odoo | 🟡 media |
+| 5 | `expected_revenue` = punto medio del rango, no el monto real | §2 (`x_studio_fts4_presupuesto`) | 🟢 baja |
+| 6 | Comercial y Finanzas comparten sesión (`localStorage`) | §1 | 🔴 alta |
+| 7 | HMAC se aprovisiona a mano por dispositivo | §1 (auth real lo mata) | 🟢 baja |
+| 8 | Filtrar ganados de "oportunidades abiertas" requiere leer `crm.stage.is_won` | pipeline | 🟢 baja |
+| 9 | Sin rate limiting en `/comercial/captura` | hardening | 🟡 media |
+
+---
+
+## Orden sugerido
+
+```
+§1 identidad real  ──┬──> §2 campos FTS-4 ──┬──> §5 marketing
+   (bloqueante)      │                      └──> §6 N2 con Claude
+                     ├──> §4 dashboard
+                     └──> §3 watchdog v2  (parcialmente independiente:
+                                           lo de mail.message y cadencias
+                                           se puede hacer ya)
+```
+
+**Si solo hay tiempo para una cosa: §1.** Todo lo demás depende de saber quién es quién.
+
+**Si solo hay tiempo para media:** la parte de `mail.message` del §3 — porque el watchdog v1 tiene fecha de caducidad silenciosa, y cuando falle no va a avisar que falló.

--- a/comercial/SUPUESTOS.md
+++ b/comercial/SUPUESTOS.md
@@ -1,0 +1,174 @@
+# Supuestos — MVP Comercial
+
+Toda decisión que tomé solo, sin preguntar (la sesión era autónoma). Ordenadas por impacto: las 4 primeras cambian lo que el módulo *hace*, no solo cómo se ve.
+
+Formato: **qué decidí · por qué · qué pasa si estaba mal**.
+
+---
+
+## 🔴 Las que importan
+
+### T3-IDENTIDAD · Todo lead capturado se asigna a Esteban
+
+**Contexto.** La spec dice: *"user_id = el usuario que captura (viene en el JWT; mapea contra res.users — si no hay match, asigna a Esteban y márcalo en description)"*.
+
+**Lo que encontré.** El JWT de `auth/finanzas-login` construye su payload así:
+
+```js
+{ sub:'finanzas', iat, exp, app:'finanzas', ver:1, role:null }
+```
+
+`sub` está **hardcodeado al literal `'finanzas'`** — no se copia del request. `role` es **siempre `null`**. Hay **un solo usuario** posible (un par salt/hash en env, comparado contra el literal `'finanzas'`). Y verifiqué en Odoo: **ningún `res.users` tiene login `finanzas`** (los internos son `estebandelacruz@fts.mx`, `ventas@fts.mx`, `montalvo@fts.mx`, `miriam@fts.mx`, `julio.ramirez@fts.mx`).
+
+**Decisión.** Implementé el mapeo tal cual pide la spec. Consecuencia: **el lookup nunca matchea y el 100% de los leads cae en el fallback a Esteban**, marcado en la `description` con:
+
+```
+[!] Asignado a Esteban por defecto: no se encontro un usuario interno de Odoo
+para el login "finanzas" (sub del JWT: "finanzas"). Reasignar al vendedor real.
+```
+
+**Por qué igual lo dejé así.** Es literalmente lo especificado, y la marca hace que la fuga sea *visible* en vez de silenciosa. Añadí `capturado_por` como campo **opcional** del API (no expuesto en el front) que tiene prioridad sobre `sub`: es el hook listo para cuando el auth tenga identidad real, sin re-tocar el workflow.
+
+**Si estaba mal.** Si esperabas atribución real desde el día 1, **no la vas a tener**: el módulo no arranca la atribución por vendedor que el baseline (§2, RIESGO-3) identifica como el problema #1. Requiere auth multi-usuario → `ROADMAP.md` §1. **Es la decisión que más vale la pena que revises.**
+
+---
+
+### T3-HMAC · El secreto se aprovisiona por dispositivo, no va en el código
+
+**Contexto.** La spec pide HMAC-SHA256 del body con secret en `FTS_COMERCIAL_HMAC`, y un front en GitHub Pages.
+
+**La contradicción.** El front es **estático y público**. Cualquier secreto escrito ahí queda commiteado en el repo y servido a quien lo pida. Un HMAC cuyo secreto es público **no es seguridad, es decoración** — y encima viola §9 ("nunca commitear credenciales").
+
+**Decisión.** El workflow valida el HMAC exactamente como se pidió. El front lee el secreto de `localStorage['fts_comercial_hmac']`, aprovisionado una vez por dispositivo desde la consola (paso 5 del checklist). **Nunca se commitea.**
+
+**Efecto lateral bueno:** el HMAC se convierte en un **factor de dispositivo real**. Tener el password de Finanzas no basta; hay que estar en un equipo aprovisionado. Sin él, el front avisa al entrar y la captura devuelve `NO_HMAC`.
+
+**Si estaba mal.** Si querías que cualquiera con el password capture desde cualquier equipo, esto añade fricción (un paso de consola por dispositivo). La alternativa —secreto en el código— publica el secreto; no la tomé sin preguntar.
+
+---
+
+### T3-CANONICO · Se firma una cadena canónica, no el JSON crudo
+
+**Contexto.** La spec dice *"HMAC-SHA256 del body"*.
+
+**El problema.** n8n entrega el body **ya parseado**. Re-serializarlo con `JSON.stringify` en el server **no reproduce byte a byte** lo que mandó el browser: orden de llaves, espaciado, escapes unicode. La firma fallaría de forma **intermitente** y el síntoma (`BAD_SIGNATURE`) no diría por qué.
+
+**Decisión.** Se firma:
+
+```
+v1|<cliente>|<descripcion>|<rango>|<origen>|<ts>
+```
+
+Determinista y versionado (el prefijo `v1` permite rotar el esquema). Más un **`ts` con ventana anti-replay de ±10 min**.
+
+**Verificado:** `comercial/tests/hmac-interop.test.js` — 12/12 pass. Confirma que Web Crypto (navegador) y el JS puro (n8n) dan el mismo hash con acentos, ñ, emoji, saltos de línea, los `<`/`>` de los rangos, y secretos >64 bytes.
+
+**Si estaba mal.** Si un integrador externo asume "HMAC del body crudo", su firma no va a validar. Está documentado en el propio nodo.
+
+**Alternativa que descarté:** `rawBody` del webhook n8n (lo que hace Stripe/GitHub). Es más estándar, pero en n8n el raw llega como binario y complica el Code node. La cadena canónica es equivalente en garantías para este caso.
+
+---
+
+### T2-WRITE_DATE · El watchdog mide una señal que no es seguimiento comercial
+
+**Contexto.** La spec pide *"días desde `write_date`"*.
+
+**Lo que encontré** (baseline §6, RIESGO-2): **60 de las 122** cotizaciones enviadas comparten el `write_date` **exacto** `2025-11-28 03:13:06`, y otras 27 comparten `2026-05-27 17:56:35`. Son escrituras masivas, no toques humanos. `write_date` = *"la última vez que cualquier proceso tocó cualquier campo"*, no *"la última vez que alguien le dio seguimiento al cliente"*.
+
+**Decisión.** Lo implementé con `write_date` **como se pidió**. Hoy da igual: el 100% está rojo de cualquier forma. Pero está documentado en el código del nodo, en el pie del correo y en el ROADMAP, porque **en cuanto el equipo empiece a trabajar, cualquier script que toque `sale.order` en masa va a resetear todos los semáforos a verde sin que nadie haya llamado a un cliente**. Es un falso negativo silencioso esperando a pasar.
+
+**La señal correcta** es `mail.message` del chatter (comunicación real con el cliente) → Watchdog v2, `ROADMAP.md` §3.
+
+---
+
+## 🟡 Decisiones de alcance
+
+### T2-VENTANA · Ventana de 365 días + tope de filas
+
+**Por qué.** `state=sent` **sin filtro de fecha son 1,131 órdenes históricas**, todas rojas. Un correo con 1,131 filas es ilegible y se ignora al segundo día — y una alerta ignorada es peor que ninguna. Con ventana de 365d son 122, que **también** salen todas rojas.
+
+**Decisión.** `ventana_dias: 365` + `top_n_por_vendedor: 15`. Las filas cortadas **nunca se ocultan en silencio**: salen como *"+N más (tope top_n=15), suman ~$X MXN"*. Ambos son config viva en `shared/comercial/watchdog_enviadas.json`.
+
+### T2-MONTO-MINIMO · Filtro de $1,000
+
+**Por qué** (baseline RIESGO-5): hay órdenes de `Public user` por $0, $1.16, $1.68 y 50 cancelaciones USD de ~$44 — carritos del portal web. Contaminan el digest.
+
+**Decisión.** `monto_minimo: 1000` (config, poner en `0` para no filtrar). El correo reporta cuántas filtró, no las esconde.
+
+### T1-MONEDA · La empresa es la autoridad de moneda, no `currency_id`
+
+**Por qué** (baseline RIESGO-1): **127 órdenes de la empresa 1 (mexicana) están marcadas USD**. SO11771 (Conmet de México) = `53,190,685 USD` → serían **$923M MXN**, imposible. Pero coexisten órdenes empresa-1-en-USD que **sí** son dólares (Visionary $1,624). La bandera no es confiable ni para creerle ni para ignorarla.
+
+**Decisión.** `company 1 → MXN` tal cual; `company 6 → USD × 17.35`. Aplicado igual en baseline, watchdog y pipeline para que los tres cuadren.
+
+**Ambigüedad residual:** las 2 órdenes de Mission Foods (empresa 6, $1.35M y $1.20M USD) podrían ser MXN mal etiquetadas. Si lo son, el pipeline normalizado baja ~$44M MXN. El correo muestra **monto nominal + moneda** además del normalizado, para que puedas juzgar.
+
+### T3-GET · `/comercial/pipeline` es POST, no GET
+
+**La spec dice GET.** Pero el patrón de Finanzas —que la misma spec manda reusar *"exacto"*— manda el **JWT en el body** (RIESGO-2 del PLAN: el header `Authorization` fuerza preflight CORS que el webhook n8n puede no contestar). GET + body es contradictorio, y GET + token en query lo deja en logs de servidor y en el historial del navegador.
+
+**Decisión.** POST. Prioricé *"reutiliza ese patrón exacto"* sobre el verbo.
+
+### T3-DIRECCION · Lista blanca hardcodeada `[2]` (Esteban)
+
+El claim `role` del JWT es **siempre `null`** → no es derivable y **no sirve como gate** (`role === 'admin'` fallaría siempre; `role !== 'guest'` pasaría siempre). La spec lo previó: *"si no es trivial, v1: lista blanca hardcodeada con Esteban"*. Es lo que hice: `DIRECCION_USER_IDS = [2]`.
+
+Combinado con T3-IDENTIDAD: como toda sesión resuelve a Esteban y Esteban es dirección, **el pipeline v1 devuelve todo sin filtrar, siempre**. El filtrado por vendedor está implementado y funciona; simplemente no se ejerce hasta que haya identidad real.
+
+### T3-ABIERTOS · "Oportunidades abiertas" = `type=opportunity` + `active=true`
+
+En Odoo un lead **perdido se archiva** (`active=false`), así que `active=true` los excluye bien. Los **ganados siguen activos**, así que aparecen. Filtrar ganados requeriría leer `stage_id.is_won` (una consulta más a `crm.stage`), y para el MVP no lo vi necesario. Ventana de **180 días** para acotar los 1,849 leads existentes.
+
+---
+
+## 🟢 Cosméticas
+
+### RUTA · `comercial/index.html`, no `comercial.html` en la raíz
+
+La spec dice *"comercial.html es archivo nuevo"*. Lo puse en `comercial/index.html` porque **todos** los módulos del repo son `<modulo>/index.html` (`finanzas/`, `pmo/`, `seguridad/`…) y las cards ya apuntan a directorios. Un `comercial.html` suelto en la raíz sería la única excepción. La carpeta `comercial/` además ya existe (baseline). Se respeta el espíritu: **un archivo de front nuevo + un link nuevo**.
+
+### LAUNCHER · No la metí en `modules-registry.js`
+
+Meterla ahí la gatearía por `modulos[id].acceso` **por usuario** → habría que configurar permisos persona por persona, y quien no los tenga vería 🔒. No me lo pediste y podría dejar gente fuera. El módulo **ya se gatea solo** con su propio login. La card queda visible; el acceso lo controla el password.
+
+### AUTH · El front carga `../finanzas/js/auth-fin.js` directo
+
+*"Reusa el código, no lo reinventes"* → lo referencio en vez de copiarlo. **Efecto lateral a saber:** comparte `localStorage['fts_fin_session']`, así que **quien entra a Comercial queda logueado en Finanzas** (facturas, bills) y viceversa. No es un bug que introduje: es inherente a reusar el mismo issuer y el mismo password compartido, que es lo que se pidió. **Pero significa que dar acceso a Comercial = dar acceso a Finanzas.** → `ROADMAP.md` §1.
+
+### CRON · `45 14 * * 1-5` en UTC, no `45 8` en America/Monterrey
+
+La regla de la casa #9 dice America/Monterrey. Lo implementé como su **equivalente UTC**, igual que `ops/watchdog-mo` (el workflow que me pediste clonar), porque CLAUDE.md §18 documenta que **n8n descarta `settings.timezone` al importar** y cae al TZ de la instancia (America/New_York). México **eliminó el DST en 2022** → Monterrey es UTC−6 fijo → `14:45 UTC = 08:45 CST` todo el año, sin ajustes estacionales. **Requiere verificar Timezone=UTC en la UI** (paso 3 del checklist).
+
+### STAGE · No seteo `stage_id` en el lead
+
+Odoo asigna el default del pipeline. Setearlo a mano requeriría hardcodear un id de `crm.stage` — justo el anti-patrón de CLAUDE.md §13.
+
+### FALLBACK-CONFIG · El watchdog degrada a defaults si el config no carga
+
+No estaba pedido. Lo agregué porque el patrón original (`watchdog-mo`) **muere en silencio** si el config 404ea: sin `recipients.esteban` no manda correo y nadie se entera de que dejó de vigilar. Es exactamente el Hallazgo #14 de CLAUDE.md (*"feature en bypass silencioso"*). Ahora corre con defaults y **avisa con un banner en el propio correo**.
+
+---
+
+## ⚠️ Lo que NO pude verificar
+
+### T3-E2E · El flujo completo login → captura → lead → pipeline
+
+**No lo probé.** El criterio de aceptación de T3 queda **sin cumplir de mi lado**. Dos bloqueos duros:
+
+1. Los workflows nacen **inactivos** (regla #6) y el API de n8n de esta instancia **no permite activarlos vía MCP**. El MCP solo dispara triggers webhook/form/chat, y ni eso sin el workflow activo.
+2. El MCP de Odoo es **read-only** (UID 2), y el límite duro de la sesión dice que **solo el workflow de captura** puede crear `crm.lead`.
+
+**Por lo tanto no existen leads `[TEST-CC]`** — la lista de IDs a borrar del checklist está **vacía**. No inventé registros que no creé (CLAUDE.md §3, regla anti-fantasma).
+
+**Lo que SÍ verifiqué, y cómo:**
+
+| Qué | Cómo | Resultado |
+|---|---|---|
+| Lógica del watchdog | 15 asserts contra data real de Odoo | 15/15 ✅ |
+| Interop HMAC browser ↔ n8n | 12 asserts, incluye UTF-8/emoji/`<`/`>` | 12/12 ✅ |
+| Estructura de los 3 workflows | `n8n_validate_workflow` | 3/3 válidos, 0 errores ✅ |
+| Que existen y están inactivos | read-back con `n8n_get_workflow` | ✅ |
+| Sintaxis del front | `node --check` + parse del script inline | ✅ |
+| Números del baseline | 2 vías independientes (agregación Odoo + bucketing client-side) | Coinciden exacto ✅ |
+
+**Lo que queda sin probar:** el cableado real n8n↔Odoo (que `customResource` quedó bien, que el CREATE de `crm.lead` acepta los campos tal como los mando, que el webhook responde). **Paso 6 del checklist.**

--- a/comercial/baseline.json
+++ b/comercial/baseline.json
@@ -1,0 +1,160 @@
+{
+  "_meta": {
+    "generado": "2026-07-16",
+    "fuente": "Odoo sale.order (read-only, MCP UID 2)",
+    "ventana": { "desde": "2025-07-01", "hasta": "2026-07-16" },
+    "companies": [1, 6],
+    "universo_ordenes": 541,
+    "fx_usd_mxn": 17.35,
+    "regla_moneda": "La empresa es la autoridad de moneda: company 1 = MXN tal cual; company 6 = USD x 17.35. El campo currency_id NO es confiable (ver riesgos.RIESGO_1).",
+    "doc": "comercial/baseline.md"
+  },
+
+  "resumen_ejecutivo": {
+    "cotizaciones_por_mes": 42.6,
+    "cotizaciones_12m_completos": 511,
+    "win_rate_global_pct": 30.1,
+    "win_rate_global_sin_cancelaciones_pct": 39.6,
+    "dias_lead_a_envio": null,
+    "dias_envio_a_cierre": null,
+    "dias_create_a_confirmacion_promedio": 21.6,
+    "dias_create_a_confirmacion_mediana": 11.5,
+    "nota_dias": "lead->envio y envio->cierre NO son medibles: Odoo no persiste timestamp de transicion a state=sent. El proxy medible es create_date -> date_order en ordenes confirmadas (ciclo completo lead->cierre)."
+  },
+
+  "cotizaciones_por_mes": [
+    { "mes": "2025-07", "count": 46, "monto_nominal": 44294711.46 },
+    { "mes": "2025-08", "count": 33, "monto_nominal": 22616243.98 },
+    { "mes": "2025-09", "count": 29, "monto_nominal": 43959963.33 },
+    { "mes": "2025-10", "count": 33, "monto_nominal": 9580585.37 },
+    { "mes": "2025-11", "count": 64, "monto_nominal": 49375786.49 },
+    { "mes": "2025-12", "count": 49, "monto_nominal": 10594698.13 },
+    { "mes": "2026-01", "count": 24, "monto_nominal": 4848983.82 },
+    { "mes": "2026-02", "count": 90, "monto_nominal": 17856588.70 },
+    { "mes": "2026-03", "count": 30, "monto_nominal": 18238494.15 },
+    { "mes": "2026-04", "count": 27, "monto_nominal": 16453438.39 },
+    { "mes": "2026-05", "count": 35, "monto_nominal": 11074629.92 },
+    { "mes": "2026-06", "count": 51, "monto_nominal": 69139754.96 },
+    { "mes": "2026-07", "count": 30, "monto_nominal": 15903247.30, "parcial": true }
+  ],
+
+  "por_vendedor": {
+    "_alerta": "77% del volumen esta en una cuenta generica compartida (Sales FTS). NO existe atribucion por vendedor real. Ver riesgos.RIESGO_3.",
+    "vendedores": [
+      { "user_id": 12, "nombre": "Sales FTS", "count": 416, "pct": 76.9, "monto_nominal": 319508419.80, "generica": true },
+      { "user_id": 2, "nombre": "Jesus Esteban De La Cruz", "count": 91, "pct": 16.8, "monto_nominal": 162428.62, "generica": false, "nota": "monto promedio ~$1.8K: ruido de portal, no venta real" },
+      { "user_id": 6, "nombre": "OPERACIONES FTS-YIN", "count": 14, "pct": 2.6, "monto_nominal": 11833786.29, "generica": true },
+      { "user_id": 25, "nombre": "Administracion FTS-YIN", "count": 8, "pct": 1.5, "monto_nominal": 82980.00, "generica": true },
+      { "user_id": null, "nombre": "SIN OWNER", "count": 12, "pct": 2.2, "monto_nominal": 2349511.29, "generica": false, "nota": "fuga: ninguna persona es responsable" }
+    ]
+  },
+
+  "distribucion_por_rango": {
+    "_regla": "MXN normalizado por empresa. Umbrales company 6 (USD): 11527 / 57637 / 172911 / 288184.",
+    "rangos": [
+      { "rango": "<200K",   "draft": 128, "sent": 42, "sale": 58, "cancel": 64, "total": 292 },
+      { "rango": "200K-1M", "draft": 82,  "sent": 48, "sale": 14, "cancel": 0,  "total": 144 },
+      { "rango": "1M-3M",   "draft": 45,  "sent": 24, "sale": 6,  "cancel": 0,  "total": 75 },
+      { "rango": "3M-5M",   "draft": 5,   "sent": 4,  "sale": 1,  "cancel": 0,  "total": 10 },
+      { "rango": ">5M",     "draft": 15,  "sent": 4,  "sale": 1,  "cancel": 0,  "total": 20 }
+    ],
+    "totales": { "draft": 275, "sent": 122, "sale": 80, "cancel": 64, "total": 541 }
+  },
+
+  "win_rate_por_rango": {
+    "_formula": "sale / (sent + sale + cancel), segun especificacion",
+    "_nota": "Las 64 cancelaciones son ruido de portal web (50 en USD sumando $2,184 total). Concentradas en <200K, hunden su win rate de 58% a 35%. El win rate honesto de <200K es ~58%.",
+    "rangos": [
+      { "rango": "<200K",   "sale": 58, "denominador": 164, "win_rate_pct": 35.4, "win_rate_sin_cancel_pct": 58.0 },
+      { "rango": "200K-1M", "sale": 14, "denominador": 62,  "win_rate_pct": 22.6, "win_rate_sin_cancel_pct": 22.6 },
+      { "rango": "1M-3M",   "sale": 6,  "denominador": 30,  "win_rate_pct": 20.0, "win_rate_sin_cancel_pct": 20.0 },
+      { "rango": "3M-5M",   "sale": 1,  "denominador": 5,   "win_rate_pct": 20.0, "win_rate_sin_cancel_pct": 20.0, "n_bajo": true },
+      { "rango": ">5M",     "sale": 1,  "denominador": 5,   "win_rate_pct": 20.0, "win_rate_sin_cancel_pct": 20.0, "n_bajo": true }
+    ],
+    "global": { "sale": 80, "denominador": 266, "win_rate_pct": 30.1, "win_rate_sin_cancel_pct": 39.6 }
+  },
+
+  "dias_por_rango": {
+    "_metrica": "create_date -> date_order (confirmacion) en ordenes state=sale. n=80.",
+    "_no_medible": ["dias_create_a_envio", "dias_envio_a_confirmacion"],
+    "_razon_no_medible": "Odoo no persiste la fecha de transicion a state=sent. write_date esta contaminado por escrituras masivas (RIESGO_2). La via correcta es reconstruir desde mail.message del chatter (ver ROADMAP).",
+    "rangos": [
+      { "rango": "<200K",   "n": 58, "promedio": 18.9, "mediana": 9.5,   "min": 0.0,   "max": 272.0 },
+      { "rango": "200K-1M", "n": 14, "promedio": 20.0, "mediana": 15.5,  "min": 0.1,   "max": 84.8 },
+      { "rango": "1M-3M",   "n": 6,  "promedio": 37.1, "mediana": 14.1,  "min": 0.1,   "max": 118.0 },
+      { "rango": "3M-5M",   "n": 1,  "promedio": 107.0, "mediana": 107.0, "min": 107.0, "max": 107.0, "n_bajo": true },
+      { "rango": ">5M",     "n": 1,  "promedio": 17.2, "mediana": 17.2,  "min": 17.2,  "max": 17.2, "n_bajo": true }
+    ],
+    "total": { "n": 80, "promedio": 21.6, "mediana": 11.5, "min": 0.0, "max": 272.0 }
+  },
+
+  "pipeline_vivo": {
+    "state": "sent",
+    "count_ventana_12m": 122,
+    "count_historico_total": 1131,
+    "monto_nominal_12m": 107537459.30,
+    "_alerta_watchdog": "CERO ordenes enviadas fueron tocadas en los ultimos 6 dias. El write_date mas reciente es 2026-07-08 (8 dias). Con la regla 4/6 dias, el 100% cae en ROJO el dia 1.",
+    "semaforo_dia_1": { "rojo": 122, "amarillo": 0, "al_dia": 0 },
+    "sin_owner": 12,
+    "concentracion_cliente": "Nalco de Mexico aparece en 6 del top 10 por monto y en ~30 de las 122.",
+    "top_10_por_monto": [
+      { "name": "SO11135", "cliente": "Nalco de Mexico", "monto_nominal": 22683898.60, "company": 1, "create_date": "2025-09-11", "dias_sin_movimiento": 50 },
+      { "name": "SO11352", "cliente": "Nalco de Mexico", "monto_nominal": 8021681.88, "company": 1, "create_date": "2025-11-27", "dias_sin_movimiento": 50 },
+      { "name": "SO11657", "cliente": "Nalco de Mexico", "monto_nominal": 4414612.00, "company": 1, "create_date": "2026-03-09", "dias_sin_movimiento": 50 },
+      { "name": "SO11183", "cliente": "Nalco de Mexico", "monto_nominal": 3887208.72, "company": 1, "create_date": "2025-09-24", "dias_sin_movimiento": 50 },
+      { "name": "SO11046", "cliente": "CBRE GCS", "monto_nominal": 3286686.00, "company": 1, "create_date": "2025-08-21", "dias_sin_movimiento": 231 },
+      { "name": "SO10988", "cliente": "BEBIDAS PURIFICADAS", "monto_nominal": 3257552.60, "company": 1, "create_date": "2025-08-11", "dias_sin_movimiento": 231 },
+      { "name": "SO11164", "cliente": "Nalco de Mexico", "monto_nominal": 2983658.04, "company": 1, "create_date": "2025-09-18", "dias_sin_movimiento": 50 },
+      { "name": "SO11493", "cliente": "QUIMITEC TRATAMIENTO DE AGUAS", "monto_nominal": 2678788.00, "company": 1, "create_date": "2025-12-19", "dias_sin_movimiento": 202 },
+      { "name": "SO11048", "cliente": "Nalco de Mexico", "monto_nominal": 2381636.60, "company": 1, "create_date": "2025-08-22", "dias_sin_movimiento": 50 },
+      { "name": "SO11258", "cliente": "Terra Energy", "monto_nominal": 2314200.00, "company": 1, "create_date": "2025-10-29", "dias_sin_movimiento": 231, "sin_owner": true }
+    ]
+  },
+
+  "riesgos": {
+    "RIESGO_1": {
+      "severidad": "alta",
+      "titulo": "amount_total no es comparable entre ordenes: moneda mal asignada",
+      "evidencia": "127 ordenes de la empresa 1 (mexicana) marcadas currency_id=USD. SO11771 (Conmet de Mexico) = 53,190,685 USD = $923M MXN, imposible. Tambien MONDELEZ, MAGNEKON, CHEMTREAT: clientes MX, empresa MX, marcados USD con montos que son pesos. Pero coexisten ordenes empresa-1-en-USD que SI son dolares genuinos (Visionary $1,624).",
+      "impacto": "Los totales en pesos son indicativos, no auditables. La distribucion por rango sigue siendo robusta (los errores son de orden de magnitud).",
+      "ambiguedad_residual": "2 ordenes Mission Foods (empresa 6, $1.35M y $1.20M USD) podrian ser MXN mal etiquetadas; si lo son, el pipeline vivo normalizado baja ~$44M MXN.",
+      "accion": "Auditar las 127 ordenes empresa-1-en-USD (trabajo Odoo/Gerardo, fuera del modulo)."
+    },
+    "RIESGO_2": {
+      "severidad": "alta",
+      "titulo": "write_date no mide seguimiento comercial",
+      "evidencia": "60 de las 122 enviadas comparten write_date exacto 2025-11-28 03:13:06; otras 27 comparten 2026-05-27 17:56:35. Son escrituras masivas, no toques humanos.",
+      "impacto": "El watchdog T2 usa 'dias desde write_date' por especificacion. Hoy da igual porque todo esta rojo, pero cualquier script futuro que toque sale.order en masa reseteara todos los semaforos a verde sin que nadie haya llamado a un cliente. Falso negativo silencioso.",
+      "accion": "Watchdog v2 debe usar mail.message del chatter (comunicacion real con cliente) como senal de movimiento. Ver ROADMAP."
+    },
+    "RIESGO_3": {
+      "severidad": "alta",
+      "titulo": "No hay atribucion por vendedor",
+      "evidencia": "416/541 (77%) en la cuenta generica 'Sales FTS'. 12 ordenes sin user_id. 81% del volumen en 3 cuentas genericas.",
+      "impacto": "El digest 'por vendedor' de T2 produce un solo bucket con ~122 ordenes. Ninguna metrica por persona, ranking o comision es posible. El bucket SIN OWNER si es senal real (12 ordenes, incluida SO11258 de $2.3M).",
+      "accion": "El WF comercial/captura (T3) es el arranque de la atribucion real. Falta migrar Sales FTS a usuarios reales."
+    },
+    "RIESGO_4": {
+      "severidad": "media",
+      "titulo": "275 borradores (51%) nunca enviados",
+      "evidencia": "275 de 541 en state=draft. Ni ganados ni perdidos: invisibles.",
+      "impacto": "Es la mitad del esfuerzo de cotizacion sin destino conocido. Puede ser basura o fuga pura; no es determinable sin revision humana.",
+      "accion": "Muestra manual de 20 antes de decidir si el watchdog debe vigilar draft (hoy solo mira sent)."
+    },
+    "RIESGO_5": {
+      "severidad": "media",
+      "titulo": "Ruido de portal web mezclado con venta real",
+      "evidencia": "Ordenes de 'Public user' por $0, $1.16, $1.68. 50 cancelaciones USD sumando $2,184 (~$44 c/u).",
+      "impacto": "Contaminan conteos y hunden el win rate de <200K de 58% a 35%.",
+      "accion": "Filtro de monto minimo (ej. >=$1,000). No aplicado en este baseline para no ocultar el fenomeno."
+    }
+  },
+
+  "campos_sanos": ["state", "create_date", "date_order", "partner_id", "company_id"],
+
+  "verificacion_cruzada": {
+    "metodo_1": "Agregacion server-side Odoo (formatted_read_group con dominios por bucket)",
+    "metodo_2": "Bucketing client-side sobre los 80 registros crudos de state=sale",
+    "resultado": "Coinciden exactamente: 58 / 14 / 6 / 1 / 1"
+  }
+}

--- a/comercial/baseline.md
+++ b/comercial/baseline.md
@@ -1,0 +1,224 @@
+# Baseline Comercial FTS — sale.order últimos 12 meses
+
+**Generado:** 2026-07-16 · **Fuente:** Odoo `sale.order` (read-only, MCP UID 2)
+**Ventana:** `create_date >= 2025-07-01` · **Empresas:** 1 (SERVICIOS FTS · MX) + 6 (FTS FULL TECHNOLOGY SYSTEMS LLC · USA)
+**Universo:** 541 cotizaciones
+
+---
+
+## 1. Tabla resumen — los 4 números clave
+
+| # | Métrica | Valor | Confianza |
+|---|---|---|---|
+| 1 | **Cotizaciones creadas / mes** | **42.6** (511 en 12 meses completos jul-25→jun-26) | 🟢 Alta |
+| 2 | **Win rate global** | **30.1%** (80 ganadas / 266 enviadas+ganadas+canceladas) · 39.6% si se excluyen cancelaciones basura | 🟡 Media — ver §3 |
+| 3 | **Días lead → envío** | **NO MEDIBLE** — Odoo no guarda timestamp de envío | 🔴 Campo inexistente |
+| 4 | **Días envío → cierre** | **NO MEDIBLE** por lo anterior. Proxy real: **create → confirmación = 21.6 días promedio / 11.5 mediana** | 🟢 Alta (proxy) |
+
+### Win rate por rango (el número accionable)
+
+| Rango (MXN) | Ganadas | Enviadas vivas | Canceladas | **Win rate** | Días create→cierre (prom / mediana) |
+|---|---|---|---|---|---|
+| **<200K** | 58 | 42 | 64 | **35.4%** | 18.9 / 9.5 |
+| **200K–1M** | 14 | 48 | 0 | **22.6%** | 20.0 / 15.5 |
+| **1M–3M** | 6 | 24 | 0 | **20.0%** | 37.1 / 14.1 |
+| **3M–5M** | 1 | 4 | 0 | **20.0%** | 107.0 / 107.0 |
+| **>5M** | 1 | 4 | 0 | **20.0%** | 17.2 / 17.2 |
+| **TOTAL** | 80 | 122 | 64 | **30.1%** | 21.6 / 11.5 |
+
+> **Lectura ejecutiva:** el negocio gana ~1 de cada 3 cotizaciones chicas y ~1 de cada 5 de las grandes. Los rangos 3M–5M y >5M tienen **n=5 cada uno** — el 20% es 1 de 5, estadísticamente no concluyente. El dato duro es que **arriba de 200K la conversión cae a ~1 de 5 y no se mueve con el tamaño**.
+
+---
+
+## 2. Cotizaciones creadas por mes
+
+| Mes | Cotizaciones | Monto nominal (sin normalizar) |
+|---|---|---|
+| 2025-07 | 46 | $44,294,711 |
+| 2025-08 | 33 | $22,616,244 |
+| 2025-09 | 29 | $43,959,963 |
+| 2025-10 | 33 | $9,580,585 |
+| 2025-11 | 64 | $49,375,786 |
+| 2025-12 | 49 | $10,594,698 |
+| 2026-01 | 24 | $4,848,984 |
+| 2026-02 | 90 | $17,856,589 |
+| 2026-03 | 30 | $18,238,494 |
+| 2026-04 | 27 | $16,453,438 |
+| 2026-05 | 35 | $11,074,630 |
+| 2026-06 | 51 | $69,139,755 |
+| 2026-07 (parcial, al día 16) | 30 | $15,903,247 |
+
+⚠️ Los montos son **sumas nominales sin normalizar moneda** — ver §6 RIESGO-1. No los uses como pipeline en pesos.
+
+### Por vendedor (`user_id`) — 🔴 el hallazgo que invalida el análisis por persona
+
+| Vendedor | Cotizaciones | % | Comentario |
+|---|---|---|---|
+| **Sales FTS (id 12)** | **416** | **76.9%** | 🔴 **Cuenta genérica compartida** — no es una persona |
+| Jesus Esteban De La Cruz (id 2) | 91 | 16.8% | Monto total $162K en 91 órdenes (~$1.8K promedio) → ruido de portal/web, no venta real |
+| OPERACIONES FTS-YIN (id 6) | 14 | 2.6% | Cuenta genérica |
+| Administracion FTS-YIN (id 25) | 8 | 1.5% | Cuenta genérica |
+| *(sin user_id)* | 12 | 2.2% | 🔴 Fuga: nadie es dueño |
+
+**Conclusión: no existe atribución por vendedor en el CRM hoy.** El 81% del volumen está en 3 cuentas genéricas y un 2.2% no tiene dueño. Cualquier métrica "por vendedor", ranking, comisión o watchdog dirigido a una persona **es imposible con la data actual**. Ver §6 RIESGO-3 e implicación directa en el Watchdog T2.
+
+---
+
+## 3. Distribución por rango de monto
+
+Normalizada a MXN usando la **empresa** como autoridad de moneda (ver §6 RIESGO-1): empresa 1 = MXN tal cual; empresa 6 = USD × 17.35.
+
+| Rango (MXN) | Draft | Enviadas | Ganadas | Canceladas | **Total** |
+|---|---|---|---|---|---|
+| <200K | 128 | 42 | 58 | 64 | **292** |
+| 200K–1M | 82 | 48 | 14 | 0 | **144** |
+| 1M–3M | 45 | 24 | 6 | 0 | **75** |
+| 3M–5M | 5 | 4 | 1 | 0 | **10** |
+| >5M | 15 | 4 | 1 | 0 | **20** |
+| **TOTAL** | **275** | **122** | **80** | **64** | **541** |
+
+**Dos cosas saltan:**
+
+1. **275 cotizaciones (51%) están en `draft` y nunca se enviaron.** Es la mitad del trabajo de cotización que jamás llegó al cliente — o son borradores basura, o es fuga pura. Este es probablemente el hallazgo de mayor valor económico del baseline.
+2. **Las 64 canceladas son basura, no pérdidas comerciales.** 50 de ellas son USD sumando $2,184 total (~$44 c/u) — carritos de portal web / `Public user`. Meterlas al win rate del rango <200K lo hunde artificialmente de 58% a 35%. **El win rate honesto de <200K es ~58%.**
+
+---
+
+## 4. Días promedio (tiempos de ciclo)
+
+### Lo que NO se puede medir
+
+Odoo **no persiste un timestamp de "cotización enviada"**. El estado `sent` existe pero la fecha en que se transicionó a `sent` no se guarda en ningún campo nativo de `sale.order`. Por lo tanto:
+
+- ❌ **días create → envío**: no medible.
+- ❌ **días envío → confirmación**: no medible.
+
+Proxies descartados y por qué:
+- `write_date` → contaminado por escrituras masivas (§6 RIESGO-2). Inservible.
+- `mail.message` / tracking del chatter → sí contiene el evento real, pero reconstruirlo para 541 órdenes excede el alcance de un baseline. **Queda en ROADMAP como la vía correcta.**
+
+### Lo que SÍ se puede medir
+
+`create_date → date_order` para órdenes confirmadas (n=80). En Odoo, al confirmar una SO el `date_order` se re-estampa con la hora de confirmación, así que esto es el **ciclo completo lead → cierre**:
+
+| Rango | n | Promedio | Mediana | Mín | Máx |
+|---|---|---|---|---|---|
+| <200K | 58 | 18.9 d | 9.5 d | 0.0 | 272.0 |
+| 200K–1M | 14 | 20.0 d | 15.5 d | 0.1 | 84.8 |
+| 1M–3M | 6 | 37.1 d | 14.1 d | 0.1 | 118.0 |
+| 3M–5M | 1 | 107.0 d | 107.0 d | — | — |
+| >5M | 1 | 17.2 d | 17.2 d | — | — |
+| **TOTAL** | **80** | **21.6 d** | **11.5 d** | 0.0 | 272.0 |
+
+La distancia entre promedio (21.6) y mediana (11.5) dice que **la mayoría cierra en ~2 semanas y una cola larga se arrastra meses**. Los mín de 0.0–0.1 días son órdenes creadas y confirmadas en la misma sesión (probablemente capturadas ya vendidas, no cotizadas).
+
+---
+
+## 5. Pipeline vivo actual (state = `sent`)
+
+**122 órdenes enviadas en la ventana de 12 meses**, con un valor nominal de $107.5M (§6 RIESGO-1 aplica al monto).
+
+### 🔴 El hallazgo crítico para el Watchdog
+
+**Ninguna de las 122 órdenes enviadas ha sido tocada en los últimos 6 días. Ni una.** La orden con el `write_date` más reciente es del 2026-07-08 (8 días). Aplicando la regla especificada (AMARILLO ≥4d / ROJO ≥6d):
+
+| Semáforo | Órdenes | % |
+|---|---|---|
+| 🔴 ROJO (≥6 días) | **122** | **100%** |
+| 🟡 AMARILLO (4–5 días) | 0 | 0% |
+| 🟢 Al día (<4 días) | 0 | 0% |
+
+**Y el backlog real es mucho peor:** filtrando sólo por `state=sent` sin ventana de fecha hay **1,131 órdenes enviadas históricas** en las empresas 1 y 6. Todas rojas.
+
+Esto tiene una consecuencia de diseño directa en T2: un digest que liste 1,131 (o 122) filas rojas es ilegible y se ignora al segundo día. El watchdog se construyó con **ventana de fecha configurable + tope de filas por bucket**. Ver `SUPUESTOS.md` §T2.
+
+### Top 10 del pipeline vivo por monto
+
+| Orden | Cliente | Monto nominal | Empresa | Creada | Días sin movimiento |
+|---|---|---|---|---|---|
+| SO11135 | Nalco de Mexico | 22,683,899 | MX | 2025-09-11 | 50 |
+| SO11352 | Nalco de Mexico | 8,021,682 | MX | 2025-11-27 | 50 |
+| SO11657 | Nalco de Mexico | 4,414,612 | MX | 2026-03-09 | 50 |
+| SO11183 | Nalco de Mexico | 3,887,209 | MX | 2025-09-24 | 50 |
+| SO11046 | CBRE GCS | 3,286,686 | MX | 2025-08-21 | 231 |
+| SO10988 | BEBIDAS PURIFICADAS | 3,257,553 | MX | 2025-08-11 | 231 |
+| SO11164 | Nalco de Mexico | 2,983,658 | MX | 2025-09-18 | 50 |
+| SO11493 | QUIMITEC | 2,678,788 | MX | 2025-12-19 | 202 |
+| SO11048 | Nalco de Mexico | 2,381,637 | MX | 2025-08-22 | 50 |
+| SO11258 | Terra Energy | 2,314,200 | MX | 2025-10-29 | 231 · ⚠️ **SIN OWNER** |
+
+Los "50 días" de las Nalco no son movimiento comercial real: son el efecto de la escritura masiva del 2026-05-27 (§6 RIESGO-2). El dato honesto es que llevan sin tocarse desde que se crearon.
+
+### Concentración de clientes
+
+El pipeline vivo está fuertemente concentrado en **Nalco de Mexico** (aparece en 6 del top 10 y en ~30 de las 122). Riesgo comercial de concentración que vale la pena mirar aparte de este baseline.
+
+---
+
+## 6. Calidad de datos — qué está roto y qué riesgo implica
+
+Ordenado por impacto. **Estos 3 riesgos definen el diseño del watchdog y del módulo.**
+
+### 🔴 RIESGO-1 — `amount_total` no es comparable entre órdenes (moneda mal asignada)
+
+**Qué encontré:** 127 órdenes de la **empresa 1 (SERVICIOS FTS, mexicana)** están marcadas con `currency_id = USD`. Varias son inequívocamente pesos mal etiquetados:
+
+| Orden | Cliente | `amount_total` | Moneda marcada | Realidad |
+|---|---|---|---|---|
+| SO11771 | Conmet de México, S.A. de C.V. | 53,190,685 | USD | Serían **$923M MXN**. Es MXN. |
+| SO11776 | MONDELEZ MEXICO | 2,928,081 | USD | Cliente MX, empresa MX |
+| SO11667 | MAGNEKON S.A. DE C.V. | 2,780,404 | USD | Cliente MX, empresa MX |
+| SO11686 | CHEMTREAT MEXICO | 2,575,275 | USD | Cliente MX, empresa MX |
+
+Al mismo tiempo hay órdenes de la empresa 1 en USD que **sí son genuinamente dólares** (Visionary $1,624, CORPORATE USA $2,685). O sea: **la bandera de moneda no es confiable ni para creerle ni para ignorarla sistemáticamente.**
+
+**Proxy usado en este baseline:** la **empresa** es la autoridad de moneda (empresa 1 → MXN; empresa 6 → USD × 17.35). Declarado en `SUPUESTOS.md`.
+**Impacto:** los totales en pesos de §2 y §5 son indicativos, **no auditables**. La distribución por rango (§3) es robusta porque los errores son de orden de magnitud y no mueven de bucket a la mayoría.
+**Ambigüedad residual:** las 2 órdenes de Mission Foods (empresa 6, $1.35M y $1.20M USD) podrían ser MXN mal etiquetadas; si lo son, el pipeline vivo normalizado baja ~$44M MXN.
+**Acción:** auditar las 127 órdenes empresa-1-en-USD. Es trabajo de Gerardo/Odoo, no de este módulo.
+
+### 🔴 RIESGO-2 — `write_date` no mide seguimiento comercial
+
+**Qué encontré:** de las 122 órdenes enviadas, **60 comparten exactamente `write_date = 2025-11-28 03:13:06`** y **27 comparten `2026-05-27 17:56:35`**. Son escrituras masivas (migración / recálculo), no toques humanos.
+
+**Impacto directo en T2:** el watchdog especificado usa "días desde `write_date`" como definición de "sin movimiento". Ese campo mide *"la última vez que cualquier proceso tocó cualquier campo"*, no *"la última vez que un vendedor le dio seguimiento al cliente"*. Hoy da lo mismo porque **todo está rojo de cualquier forma**, pero en cuanto el equipo empiece a trabajar, cualquier script que toque `sale.order` en masa **reseteará todos los semáforos a verde sin que nadie haya llamado a un cliente**. Es un falso negativo silencioso esperando a pasar.
+
+**Se implementó con `write_date` según especificación**, pero la señal correcta (`mail.message` del chatter = comunicación real con el cliente) queda documentada como Watchdog v2 en `ROADMAP.md`. Ver `SUPUESTOS.md` §T2.
+
+### 🔴 RIESGO-3 — No hay atribución por vendedor
+
+Ver §2. 77% del volumen en `Sales FTS` (cuenta genérica), 12 órdenes sin `user_id`.
+**Impacto en T2:** el digest "por vendedor" produce **un solo bucket con ~122 órdenes** llamado "Sales FTS". El agrupamiento funciona técnicamente pero no informa a nadie. El bucket `SIN OWNER ⚠` sí es señal real (12 órdenes, incluida SO11258 de $2.3M de Terra Energy).
+**Impacto en T3:** el `user_id` que asigna el WF de captura es lo único que empezará a generar atribución real. **El módulo comercial es, de facto, el arranque de la atribución por vendedor en FTS.**
+
+### 🟡 RIESGO-4 — 275 borradores (51%) nunca enviados
+
+Ni ganados ni perdidos: invisibles. No sé si son basura o fuga sin revisión humana. Vale una muestra manual de 20 antes de decidir si el watchdog debe vigilarlos también (hoy no lo hace: sólo mira `sent`).
+
+### 🟡 RIESGO-5 — Ruido de portal web mezclado con venta real
+
+Órdenes de `Public user` por $0, $1.16, $1.68; 50 cancelaciones USD de ~$44. Contaminan conteos y hunden el win rate de <200K. Un filtro de monto mínimo (ej. ≥$1,000) limpiaría el análisis. No aplicado en este baseline para no ocultar el fenómeno.
+
+### 🟢 Campos que SÍ están sanos
+
+`state`, `create_date`, `date_order`, `partner_id`, `company_id` están poblados y son confiables en el 100% de las 541 órdenes.
+
+---
+
+## 7. Verificación cruzada
+
+La distribución por rango se calculó por **dos vías independientes** que coinciden exactamente:
+1. Agregación server-side en Odoo (`formatted_read_group` con dominios por bucket).
+2. Bucketing client-side sobre los 80 registros crudos de `state=sale`.
+
+Ambas dan 58 / 14 / 6 / 1 / 1. Los conteos de este baseline son reproducibles.
+
+---
+
+## 8. Recomendaciones (orden de impacto)
+
+1. **Atribución de vendedor** — sin esto no hay gestión comercial posible. El WF `comercial/captura` (T3) es el primer paso; falta migrar `Sales FTS` a usuarios reales.
+2. **Auditar los 275 borradores** — es la mitad del esfuerzo de cotización sin destino conocido.
+3. **Limpiar las 127 órdenes empresa-1-en-USD** — hoy cualquier reporte financiero por monto es indefendible.
+4. **Timestamp de envío** — un campo con la fecha de transición a `sent` habilita las 2 métricas de ciclo que hoy son ciegas. Requiere Studio (fuera del alcance MVP, ver `ROADMAP.md`).
+5. **Filtro anti-ruido de portal** — separar carritos web de cotización industrial.

--- a/comercial/index.html
+++ b/comercial/index.html
@@ -1,0 +1,278 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+<meta charset="UTF-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover" />
+<title>FTS Suite · Comercial</title>
+<link rel="stylesheet" href="../shared/fts-styles.css" />
+<style>
+  /* Mobile-first: se usa desde el celular en planta. Nada de frameworks. */
+  body{background:var(--dark)}
+  .wrap{max-width:520px;margin:0 auto;padding:0 14px 40px}
+  .top{display:flex;align-items:center;gap:10px;padding:16px 0 12px;border-bottom:1px solid var(--border);margin-bottom:16px}
+  .top h1{font-size:19px;font-weight:700;flex:1}
+  .top .back{color:var(--muted2);text-decoration:none;font-size:22px;line-height:1}
+  .top .out{background:none;border:1px solid var(--border);border-radius:8px;color:var(--muted2);padding:5px 10px;font-size:12px;cursor:pointer;font-family:inherit}
+
+  .tabs{display:flex;gap:6px;margin-bottom:16px}
+  .tab{flex:1;padding:11px;border:1px solid var(--border);background:var(--d2);border-radius:10px;font-size:14px;font-weight:600;color:var(--muted2);cursor:pointer;font-family:inherit}
+  .tab.on{background:var(--o);border-color:var(--o);color:#fff}
+
+  .fld{margin-bottom:14px}
+  .fld label{display:block;font-size:13px;font-weight:600;margin-bottom:5px;color:var(--muted2)}
+  .fld input,.fld textarea,.fld select{width:100%;padding:13px;border:1px solid var(--border);border-radius:10px;background:var(--d2);
+    color:var(--text);font-family:inherit;font-size:16px} /* 16px evita el zoom automatico de iOS */
+  .fld textarea{min-height:110px;resize:vertical}
+  .fld input:focus,.fld textarea:focus,.fld select:focus{outline:none;border-color:var(--o)}
+
+  .big{width:100%;padding:17px;background:var(--o);color:#fff;border:none;border-radius:12px;font-size:17px;font-weight:700;
+    cursor:pointer;font-family:inherit;margin-top:6px}
+  .big:active{transform:scale(.985)}
+  .big:disabled{opacity:.5;cursor:default}
+
+  .msg{padding:12px;border-radius:10px;font-size:14px;margin-bottom:14px;display:none}
+  .msg.err{background:#fde7e9;border:1px solid var(--red);color:#8a1c20;display:block}
+  .msg.ok{background:#dff6dd;border:1px solid var(--green);color:#0b5a0b;display:block}
+  .msg.warn{background:#fff4ce;border:1px solid #d8a601;color:#6b5200;display:block}
+
+  .card{background:var(--d2);border:1px solid var(--border);border-radius:12px;padding:12px;margin-bottom:9px}
+  .card .r1{display:flex;justify-content:space-between;gap:8px;align-items:flex-start}
+  .card .nm{font-weight:700;font-size:14px}
+  .card .cl{color:var(--muted2);font-size:13px;margin-top:2px}
+  .card .mt{font-weight:700;font-size:14px;white-space:nowrap}
+  .card .mu{font-size:12px;color:var(--muted);margin-top:6px}
+  .dot{display:inline-block;width:9px;height:9px;border-radius:50%;margin-right:6px;vertical-align:middle}
+  .dot.verde{background:var(--green)} .dot.amarillo{background:#d8a601} .dot.rojo{background:var(--red)}
+
+  .sec{font-size:12px;font-weight:700;color:var(--muted);text-transform:uppercase;letter-spacing:.6px;margin:20px 0 9px}
+  .empty{color:var(--muted);font-size:14px;padding:18px;text-align:center;border:1px dashed var(--border);border-radius:10px}
+  .hidden{display:none !important}
+  .lgn{max-width:380px;margin:60px auto;padding:0 16px}
+  .lgn h2{font-size:21px;margin-bottom:5px}
+  .lgn p.sub{color:var(--muted);font-size:13px;margin-bottom:20px}
+  .foot{font-size:11px;color:var(--muted);margin-top:20px;line-height:1.6}
+</style>
+</head>
+<body>
+
+<!-- ═══ LOGIN ═══ -->
+<div id="login" class="lgn">
+  <h2>Comercial</h2>
+  <p class="sub">Captura de oportunidades y seguimiento de pipeline.</p>
+  <div id="loginMsg" class="msg"></div>
+  <form id="loginForm" autocomplete="off">
+    <div class="fld">
+      <label for="u">Usuario</label>
+      <input type="text" id="u" value="finanzas" autocomplete="username" />
+    </div>
+    <div class="fld">
+      <label for="p">Contraseña</label>
+      <input type="password" id="p" autocomplete="current-password" />
+    </div>
+    <button class="big" id="loginBtn" type="submit">Entrar</button>
+  </form>
+  <p class="foot">Usa las mismas credenciales del módulo Finanzas.</p>
+</div>
+
+<!-- ═══ APP ═══ -->
+<div id="app" class="wrap hidden">
+  <div class="top">
+    <a href="../index.html" class="back" aria-label="Volver">&#8249;</a>
+    <h1>Comercial</h1>
+    <button class="out" id="logoutBtn">Salir</button>
+  </div>
+
+  <div class="tabs">
+    <button class="tab on" id="tabCap">Captura</button>
+    <button class="tab" id="tabPipe">Mi Pipeline</button>
+  </div>
+
+  <!-- ── Captura ── -->
+  <section id="vCap">
+    <div id="capMsg" class="msg"></div>
+    <form id="capForm" autocomplete="off">
+      <div class="fld">
+        <label for="cliente">Cliente</label>
+        <input type="text" id="cliente" placeholder="Nombre del cliente" />
+      </div>
+      <div class="fld">
+        <label for="descripcion">Descripción</label>
+        <textarea id="descripcion" placeholder="¿Qué necesita? Falla, alcance, contexto…"></textarea>
+      </div>
+      <div class="fld">
+        <label for="rango">Rango de monto</label>
+        <select id="rango">
+          <option value="">Selecciona…</option>
+          <option value="&lt;200K">&lt; 200K</option>
+          <option value="200K-1M">200K – 1M</option>
+          <option value="1M-3M">1M – 3M</option>
+          <option value="3M-5M">3M – 5M</option>
+          <option value="&gt;5M">&gt; 5M</option>
+        </select>
+      </div>
+      <div class="fld">
+        <label for="origen">Origen</label>
+        <select id="origen">
+          <option value="">Selecciona…</option>
+          <option value="referido">Referido</option>
+          <option value="cliente_existente">Cliente existente</option>
+          <option value="marketing">Marketing</option>
+          <option value="portal">Portal</option>
+          <option value="otro">Otro</option>
+        </select>
+      </div>
+      <button class="big" id="capBtn" type="submit">Crear oportunidad</button>
+    </form>
+  </section>
+
+  <!-- ── Mi Pipeline ── -->
+  <section id="vPipe" class="hidden">
+    <div id="pipeMsg" class="msg"></div>
+    <button class="big" id="refreshBtn" style="background:var(--d3);color:var(--text);border:1px solid var(--border);font-size:15px;padding:12px">Refrescar</button>
+    <div id="pipeBody"></div>
+  </section>
+</div>
+
+<script src="../finanzas/js/auth-fin.js"></script>
+<script src="js/comercial-client.js"></script>
+<script>
+(function () {
+  'use strict';
+  var $ = function (id) { return document.getElementById(id); };
+  function show(el, cls, txt) { el.className = 'msg ' + cls; el.textContent = txt; }
+  function hide(el) { el.className = 'msg'; el.textContent = ''; }
+  function money(n) { return (n || 0).toLocaleString('en-US', { maximumFractionDigits: 0 }); }
+  function esc(s) { var d = document.createElement('div'); d.textContent = s == null ? '' : String(s); return d.innerHTML; }
+
+  // ── Sesión ──
+  function gate() {
+    var ok = window.FinAuth && window.FinAuth.isValid();
+    $('login').classList.toggle('hidden', !!ok);
+    $('app').classList.toggle('hidden', !ok);
+    if (ok) avisoHmac();
+  }
+  // Aviso temprano: sin clave de dispositivo la captura NO va a funcionar. Mejor decirlo
+  // al entrar que dejar que el usuario escriba todo y falle al enviar.
+  function avisoHmac() {
+    if (!window.ComercialClient.tieneHmac()) {
+      show($('capMsg'), 'warn', 'Este dispositivo no está aprovisionado para capturar. Pide a Esteban la clave del dispositivo (ver comercial/CHECKLIST-MANUAL.md). Mi Pipeline sí funciona.');
+    }
+  }
+
+  $('loginForm').addEventListener('submit', async function (e) {
+    e.preventDefault();
+    hide($('loginMsg'));
+    $('loginBtn').disabled = true;
+    $('loginBtn').textContent = 'Entrando…';
+    try {
+      var r = await window.FinAuth.login($('u').value, $('p').value);
+      if (!r.ok) show($('loginMsg'), 'err', r.msg || 'No se pudo iniciar sesión.');
+      else { $('p').value = ''; gate(); }
+    } catch (err) {
+      show($('loginMsg'), 'err', (err && err.msg) || 'Error inesperado.');
+    } finally {
+      $('loginBtn').disabled = false;
+      $('loginBtn').textContent = 'Entrar';
+    }
+  });
+
+  $('logoutBtn').addEventListener('click', function () { window.FinAuth.logout(); gate(); });
+
+  // ── Tabs ──
+  function tab(cap) {
+    $('tabCap').classList.toggle('on', cap);
+    $('tabPipe').classList.toggle('on', !cap);
+    $('vCap').classList.toggle('hidden', !cap);
+    $('vPipe').classList.toggle('hidden', cap);
+    if (!cap && !$('pipeBody').dataset.loaded) cargarPipeline();
+  }
+  $('tabCap').addEventListener('click', function () { tab(true); });
+  $('tabPipe').addEventListener('click', function () { tab(false); });
+
+  // ── Captura ──
+  $('capForm').addEventListener('submit', async function (e) {
+    e.preventDefault();
+    hide($('capMsg'));
+    var p = {
+      cliente: $('cliente').value.trim(),
+      descripcion: $('descripcion').value.trim(),
+      rango: $('rango').value,
+      origen: $('origen').value
+    };
+    if (!p.cliente)     return show($('capMsg'), 'err', 'Falta el cliente.');
+    if (!p.descripcion) return show($('capMsg'), 'err', 'Falta la descripción.');
+    if (!p.rango)       return show($('capMsg'), 'err', 'Selecciona un rango.');
+    if (!p.origen)      return show($('capMsg'), 'err', 'Selecciona un origen.');
+
+    $('capBtn').disabled = true;
+    $('capBtn').textContent = 'Creando…';
+    try {
+      var r = await window.ComercialClient.capturar(p);
+      var extra = r.fallback_owner ? ' Quedó asignada a ' + esc(r.owner) + ' por defecto: reasígnala en Odoo al vendedor real.' : ' Asignada a ' + esc(r.owner) + '.';
+      show($('capMsg'), 'ok', '✅ Oportunidad creada · lead ' + r.lead_id + '.' + extra);
+      $('capForm').reset();
+      $('pipeBody').dataset.loaded = '';   // el pipeline quedó viejo: forzar recarga
+    } catch (err) {
+      if (err && err.code === 'SESSION_EXPIRED') { gate(); return; }
+      show($('capMsg'), 'err', (err && err.msg) || 'No se pudo crear la oportunidad.');
+    } finally {
+      $('capBtn').disabled = false;
+      $('capBtn').textContent = 'Crear oportunidad';
+    }
+  });
+
+  // ── Pipeline ──
+  // Los umbrales 4/6 son los MISMOS que comercial/watchdog-enviadas: si el correo dice
+  // rojo, la pantalla debe decir rojo. El backend ya manda `semaforo` calculado con esa
+  // regla; esto es solo el fallback si faltara.
+  var AM = 4, RO = 6;
+  function semaforo(d) { if (d === null || d === undefined || d >= RO) return 'rojo'; if (d >= AM) return 'amarillo'; return 'verde'; }
+
+  async function cargarPipeline() {
+    hide($('pipeMsg'));
+    $('pipeBody').innerHTML = '<p class="empty">Cargando…</p>';
+    try {
+      var d = await window.ComercialClient.pipeline();
+      render(d);
+      $('pipeBody').dataset.loaded = '1';
+    } catch (err) {
+      if (err && err.code === 'SESSION_EXPIRED') { gate(); return; }
+      $('pipeBody').innerHTML = '';
+      show($('pipeMsg'), 'err', (err && err.msg) || 'No se pudo cargar el pipeline.');
+    }
+  }
+  $('refreshBtn').addEventListener('click', cargarPipeline);
+
+  function render(d) {
+    var h = '';
+    if (d._nota) h += '<div class="msg warn" style="display:block">' + esc(d._nota) + '</div>';
+    h += '<div class="msg ok" style="display:block">' + esc(d.owner) + (d.es_direccion ? ' · dirección (ve todo)' : '') +
+         ' · ' + d.resumen.oportunidades + ' oportunidades · ' + d.resumen.cotizaciones + ' cotizaciones (' +
+         d.resumen.rojas + ' 🔴 / ' + d.resumen.amarillas + ' 🟡 / ' + d.resumen.verdes + ' 🟢)</div>';
+
+    h += '<div class="sec">Oportunidades abiertas</div>';
+    if (!d.oportunidades.length) h += '<p class="empty">Sin oportunidades abiertas.</p>';
+    else d.oportunidades.forEach(function (o) {
+      h += '<div class="card"><div class="r1"><div><div class="nm">' + esc(o.name) + '</div>' +
+           '<div class="cl">' + esc(o.partner_name || '—') + '</div></div>' +
+           '<div class="mt">$' + money(o.expected_revenue) + '</div></div>' +
+           '<div class="mu">' + esc(o.stage || '') + (o.create_date ? ' · ' + esc(String(o.create_date).slice(0, 10)) : '') + '</div></div>';
+    });
+
+    h += '<div class="sec">Cotizaciones enviadas</div>';
+    if (!d.cotizaciones.length) h += '<p class="empty">Sin cotizaciones enviadas.</p>';
+    else d.cotizaciones.forEach(function (c) {
+      var s = c.semaforo || semaforo(c.dias_sin_movimiento);
+      h += '<div class="card"><div class="r1"><div><div class="nm"><span class="dot ' + s + '"></span>' + esc(c.name) + '</div>' +
+           '<div class="cl">' + esc(c.partner || '—') + '</div></div>' +
+           '<div class="mt">$' + money(c.amount_total) + ' <span style="font-size:11px;color:var(--muted)">' + esc(c.moneda) + '</span></div></div>' +
+           '<div class="mu">' + (c.dias_sin_movimiento === null ? 'sin fecha de movimiento' : c.dias_sin_movimiento + ' días sin movimiento') + '</div></div>';
+    });
+    $('pipeBody').innerHTML = h;
+  }
+
+  gate();
+})();
+</script>
+</body>
+</html>

--- a/comercial/js/comercial-client.js
+++ b/comercial/js/comercial-client.js
@@ -1,0 +1,119 @@
+// ═══ FTS Suite · Comercial — cliente de webhooks /comercial/* ═══
+// Auth = 2 factores:
+//   1. JWT del módulo Finanzas (window.FinAuth, reusado tal cual desde ../finanzas/js/auth-fin.js).
+//      El token viaja en el BODY, no en header Authorization — mismo patrón que FinClient
+//      (RIESGO-2 del PLAN: el header fuerza preflight CORS que n8n puede no contestar).
+//   2. HMAC-SHA256 de dispositivo en el header x-fts-signature.
+//
+// ── Por qué el HMAC vive en localStorage y no en el código ──
+// Esta página es estática y pública (GitHub Pages): CUALQUIER secreto escrito aquí queda
+// publicado en el repo y servido a quien lo pida. Por eso el secreto NO se commitea: se
+// aprovisiona una vez por dispositivo desde la consola del navegador. Eso convierte al
+// HMAC en un factor real (de dispositivo): tener el password de Finanzas no basta, hay
+// que estar en un equipo aprovisionado. Ver comercial/SUPUESTOS.md §T3-HMAC.
+//
+// Aprovisionar un dispositivo:
+//   localStorage.setItem('fts_comercial_hmac', '<mismo valor que FTS_COMERCIAL_HMAC en Railway>')
+//
+// API: window.ComercialClient.capturar({cliente,descripcion,rango,origen}) -> Promise
+//      window.ComercialClient.pipeline() -> Promise
+//      window.ComercialClient.tieneHmac() -> bool
+
+(function () {
+  'use strict';
+
+  var N8N_DEFAULT = 'https://primary-production-5c3c.up.railway.app';
+  var HMAC_KEY = 'fts_comercial_hmac';
+
+  function n8nBase() {
+    var url = localStorage.getItem('ops_n8n_url') || localStorage.getItem('n8n_url') || N8N_DEFAULT;
+    return String(url).replace(/\/$/, '');
+  }
+
+  function getHmacSecret() { return localStorage.getItem(HMAC_KEY) || ''; }
+  function tieneHmac() { return !!getHmacSecret(); }
+
+  // ─── HMAC-SHA256 vía Web Crypto (requiere contexto seguro: https o localhost) ───
+  async function hmacHex(secret, msg) {
+    if (!window.crypto || !window.crypto.subtle) {
+      throw { code: 'NO_WEBCRYPTO', msg: 'Este navegador no expone Web Crypto (¿estás en http:// en vez de https://?).' };
+    }
+    var enc = new TextEncoder();
+    var key = await crypto.subtle.importKey('raw', enc.encode(secret), { name: 'HMAC', hash: 'SHA-256' }, false, ['sign']);
+    var sig = await crypto.subtle.sign('HMAC', key, enc.encode(msg));
+    return Array.from(new Uint8Array(sig)).map(function (b) { return b.toString(16).padStart(2, '0'); }).join('');
+  }
+
+  // Cadena canónica: DEBE coincidir carácter por carácter con la del nodo
+  // "Validar JWT + HMAC" de comercial/captura. Se firman los campos en orden fijo y no el
+  // JSON crudo porque re-serializar el body parseado por n8n no es byte-estable respecto a
+  // lo que mandó el browser (orden de llaves, espaciado, escapes) => la firma fallaría de
+  // forma intermitente e imposible de depurar.
+  function canonical(p) {
+    return ['v1', p.cliente || '', p.descripcion || '', p.rango || '', p.origen || '', p.ts || ''].join('|');
+  }
+
+  async function post(path, body, headers) {
+    var res, data;
+    try {
+      res = await fetch(n8nBase() + '/webhook' + path, {
+        method: 'POST',
+        headers: Object.assign({ 'Content-Type': 'application/json' }, headers || {}),
+        body: JSON.stringify(body)
+      });
+    } catch (e) {
+      throw { code: 'NETWORK', msg: 'No se pudo conectar al servidor. Revisa tu conexión.', http: 0 };
+    }
+    try { data = await res.json(); } catch (e) { data = null; }
+
+    if (res.status === 401 || (data && data._error && (data.code === 'BAD_TOKEN' || data.code === 'TOKEN_EXPIRED'))) {
+      // Ojo: BAD_SIGNATURE / NO_SIGNATURE también son 401 pero NO son sesión muerta —
+      // son dispositivo sin aprovisionar. Cerrar sesión ahí solo confundiría al usuario.
+      if (data && data.code !== 'BAD_SIGNATURE' && data.code !== 'NO_SIGNATURE' && data.code !== 'STALE_REQUEST') {
+        if (window.FinAuth) window.FinAuth.logout();
+        throw { code: 'SESSION_EXPIRED', msg: 'Tu sesión expiró. Inicia sesión de nuevo.', http: 401 };
+      }
+    }
+    if (!data) throw { code: 'BAD_RESPONSE', msg: 'Respuesta inválida del servidor.', http: res.status };
+    if (data._error) throw { code: data.code || 'ERROR', msg: data.msg || 'Error del servidor.', http: data.http || res.status };
+    return data;
+  }
+
+  function requireSession() {
+    if (!window.FinAuth || !window.FinAuth.isValid()) {
+      throw { code: 'NO_SESSION', msg: 'Sesión no válida o expirada. Inicia sesión de nuevo.' };
+    }
+    return window.FinAuth.getToken();
+  }
+
+  // ─── POST /comercial/captura ───
+  async function capturar(p) {
+    var token = requireSession();
+    var secret = getHmacSecret();
+    if (!secret) {
+      throw { code: 'NO_HMAC', msg: 'Este dispositivo no está aprovisionado para capturar. Pide a Esteban la clave del dispositivo.' };
+    }
+    var payload = {
+      cliente: String(p.cliente || '').trim(),
+      descripcion: String(p.descripcion || '').trim(),
+      rango: String(p.rango || ''),
+      origen: String(p.origen || ''),
+      ts: new Date().toISOString()
+    };
+    var sig = await hmacHex(secret, canonical(payload));
+    return post('/comercial/captura', Object.assign({}, payload, { token: token }), { 'x-fts-signature': sig });
+  }
+
+  // ─── POST /comercial/pipeline (solo JWT) ───
+  async function pipeline() {
+    var token = requireSession();
+    return post('/comercial/pipeline', { token: token });
+  }
+
+  window.ComercialClient = {
+    capturar: capturar,
+    pipeline: pipeline,
+    tieneHmac: tieneHmac,
+    HMAC_KEY: HMAC_KEY
+  };
+})();

--- a/comercial/tests/hmac-interop.test.js
+++ b/comercial/tests/hmac-interop.test.js
@@ -1,0 +1,77 @@
+// Verifica que las DOS implementaciones de HMAC-SHA256 que se tienen que poner de acuerdo
+// produzcan el mismo byte:
+//   A) la del navegador  -> Web Crypto (crypto.subtle), en comercial/js/comercial-client.js
+//   B) la de n8n         -> JS puro, en el nodo "Validar JWT + HMAC" de comercial/captura
+//      (el sandbox del Code node no expone require/node:crypto -- CLAUDE.md §15 #1)
+//
+// Si estas dos divergen, la captura falla SIEMPRE con BAD_SIGNATURE y el sintoma no dice
+// por que. Aqui se usa el crypto de node como proxy fiel de Web Crypto: ambos son
+// HMAC-SHA256 sobre los mismos bytes UTF-8, asi que si el JS puro casa con node, casa con
+// el navegador.
+const nodeCrypto = require('crypto');
+
+// ─── B) Implementacion JS puro, copiada VERBATIM del nodo "Validar JWT + HMAC" ───
+const _K=[0x428a2f98,0x71374491,0xb5c0fbcf,0xe9b5dba5,0x3956c25b,0x59f111f1,0x923f82a4,0xab1c5ed5,0xd807aa98,0x12835b01,0x243185be,0x550c7dc3,0x72be5d74,0x80deb1fe,0x9bdc06a7,0xc19bf174,0xe49b69c1,0xefbe4786,0x0fc19dc6,0x240ca1cc,0x2de92c6f,0x4a7484aa,0x5cb0a9dc,0x76f988da,0x983e5152,0xa831c66d,0xb00327c8,0xbf597fc7,0xc6e00bf3,0xd5a79147,0x06ca6351,0x14292967,0x27b70a85,0x2e1b2138,0x4d2c6dfc,0x53380d13,0x650a7354,0x766a0abb,0x81c2c92e,0x92722c85,0xa2bfe8a1,0xa81a664b,0xc24b8b70,0xc76c51a3,0xd192e819,0xd6990624,0xf40e3585,0x106aa070,0x19a4c116,0x1e376c08,0x2748774c,0x34b0bcb5,0x391c0cb3,0x4ed8aa4a,0x5b9cca4f,0x682e6ff3,0x748f82ee,0x78a5636f,0x84c87814,0x8cc70208,0x90befffa,0xa4506ceb,0xbef9a3f7,0xc67178f2];
+function _rotr(x,n){return((x>>>n)|(x<<(32-n)))>>>0;}
+function _sha256(bytes){const len=bytes.length;const bitLen=len*8;const padLen=((len+9+63)>>>6)<<6;const p=new Uint8Array(padLen);p.set(bytes);p[len]=0x80;p[padLen-4]=(bitLen>>>24)&0xff;p[padLen-3]=(bitLen>>>16)&0xff;p[padLen-2]=(bitLen>>>8)&0xff;p[padLen-1]=bitLen&0xff;const H=[0x6a09e667,0xbb67ae85,0x3c6ef372,0xa54ff53a,0x510e527f,0x9b05688c,0x1f83d9ab,0x5be0cd19];const W=new Array(64);for(let off=0;off<padLen;off+=64){for(let i=0;i<16;i++)W[i]=((p[off+i*4]<<24)|(p[off+i*4+1]<<16)|(p[off+i*4+2]<<8)|p[off+i*4+3])>>>0;for(let i=16;i<64;i++){const s0=_rotr(W[i-15],7)^_rotr(W[i-15],18)^(W[i-15]>>>3);const s1=_rotr(W[i-2],17)^_rotr(W[i-2],19)^(W[i-2]>>>10);W[i]=(W[i-16]+s0+W[i-7]+s1)>>>0;}let a=H[0],b=H[1],c=H[2],d=H[3],e=H[4],f=H[5],g=H[6],h=H[7];for(let i=0;i<64;i++){const S1=_rotr(e,6)^_rotr(e,11)^_rotr(e,25);const ch=(e&f)^((~e)&g);const t1=(h+S1+ch+_K[i]+W[i])>>>0;const S0=_rotr(a,2)^_rotr(a,13)^_rotr(a,22);const mj=(a&b)^(a&c)^(b&c);const t2=(S0+mj)>>>0;h=g;g=f;f=e;e=(d+t1)>>>0;d=c;c=b;b=a;a=(t1+t2)>>>0;}H[0]=(H[0]+a)>>>0;H[1]=(H[1]+b)>>>0;H[2]=(H[2]+c)>>>0;H[3]=(H[3]+d)>>>0;H[4]=(H[4]+e)>>>0;H[5]=(H[5]+f)>>>0;H[6]=(H[6]+g)>>>0;H[7]=(H[7]+h)>>>0;}const out=new Uint8Array(32);for(let i=0;i<8;i++){out[i*4]=(H[i]>>>24)&0xff;out[i*4+1]=(H[i]>>>16)&0xff;out[i*4+2]=(H[i]>>>8)&0xff;out[i*4+3]=H[i]&0xff;}return out;}
+function _hmac(keyBytes,msgBytes){const bs=64;let key=keyBytes;if(key.length>bs)key=_sha256(key);if(key.length<bs){const pk=new Uint8Array(bs);pk.set(key);key=pk;}const ipad=new Uint8Array(bs),opad=new Uint8Array(bs);for(let i=0;i<bs;i++){ipad[i]=key[i]^0x36;opad[i]=key[i]^0x5c;}const inner=new Uint8Array(bs+msgBytes.length);inner.set(ipad);inner.set(msgBytes,bs);const ih=_sha256(inner);const outer=new Uint8Array(bs+32);outer.set(opad);outer.set(ih,bs);return _sha256(outer);}
+function _bytesToHex(b){let s='';for(let i=0;i<b.length;i++){const h=b[i].toString(16);s+=(h.length===1?'0':'')+h;}return s;}
+const enc = new TextEncoder();
+const hmacPuro = (secret, msg) => _bytesToHex(_hmac(enc.encode(secret), enc.encode(msg)));
+
+// ─── A) Proxy de Web Crypto ───
+const hmacNode = (secret, msg) => nodeCrypto.createHmac('sha256', Buffer.from(secret, 'utf8')).update(Buffer.from(msg, 'utf8')).digest('hex');
+
+// ─── Cadena canonica: DEBE ser identica en cliente y workflow ───
+const canonical = p => ['v1', p.cliente || '', p.descripcion || '', p.rango || '', p.origen || '', p.ts || ''].join('|');
+
+let ok = 0, fail = 0;
+const t = (n, cond, det) => { if (cond) { ok++; console.log("  PASS  " + n); } else { fail++; console.log("  FAIL  " + n + (det ? "  -> " + det : "")); } };
+
+console.log("\n=== TEST interop HMAC: navegador (Web Crypto) vs n8n (JS puro) ===\n");
+
+// Vector RFC 4231 / el mismo self-test que corre dentro del workflow.
+t("Self-test del workflow: vector conocido 'The quick brown fox...'",
+  hmacPuro('key', 'The quick brown fox jumps over the lazy dog') === 'f7bc83f430538424b13298e6aa6fb143ef4d59a14946175997479dbc2d1a3cd8');
+
+const SECRET = 'un-secreto-de-prueba-no-real-1234567890';
+
+const casos = [
+  { nombre: "payload tipico",
+    p: { cliente: 'Nalco de Mexico', descripcion: 'Fabricacion de jaula para tanque', rango: '1M-3M', origen: 'cliente_existente', ts: '2026-07-16T22:00:00.000Z' } },
+  { nombre: "acentos y enie (UTF-8 multibyte)",
+    p: { cliente: 'Bridgestone México', descripcion: 'Instalación eléctrica del chiller, año 2026 — señalización', rango: '200K-1M', origen: 'referido', ts: '2026-07-16T22:00:00.000Z' } },
+  { nombre: "rango con < y > (los que van en el <select>)",
+    p: { cliente: 'ACME', descripcion: 'proyecto chico', rango: '<200K', origen: 'otro', ts: '2026-07-16T22:00:00.000Z' } },
+  { nombre: "rango >5M",
+    p: { cliente: 'ACME', descripcion: 'proyecto grande', rango: '>5M', origen: 'marketing', ts: '2026-07-16T22:00:00.000Z' } },
+  { nombre: "comillas, backslash y pipe en el texto libre",
+    p: { cliente: 'Cliente "raro" \\ S.A.', descripcion: 'falla en linea | urgente "ya"', rango: '3M-5M', origen: 'portal', ts: '2026-07-16T22:00:00.000Z' } },
+  { nombre: "salto de linea en descripcion (textarea multilinea)",
+    p: { cliente: 'ACME', descripcion: 'linea uno\nlinea dos\nlinea tres', rango: '<200K', origen: 'otro', ts: '2026-07-16T22:00:00.000Z' } },
+  { nombre: "emoji (4 bytes UTF-8)",
+    p: { cliente: 'ACME 🔧', descripcion: 'mantenimiento 🚀', rango: '<200K', origen: 'otro', ts: '2026-07-16T22:00:00.000Z' } },
+  { nombre: "descripcion larga (>64 bytes: fuerza el camino de multi-bloque de SHA-256)",
+    p: { cliente: 'ACME', descripcion: 'x'.repeat(500), rango: '1M-3M', origen: 'otro', ts: '2026-07-16T22:00:00.000Z' } }
+];
+
+for (const c of casos) {
+  const msg = canonical(c.p);
+  const a = hmacNode(SECRET, msg);
+  const b = hmacPuro(SECRET, msg);
+  t("Coinciden: " + c.nombre, a === b, "webcrypto=" + a.slice(0, 16) + "... puro=" + b.slice(0, 16) + "...");
+}
+
+// Un secreto mas largo que el block size (64B) fuerza la rama key=_sha256(key) del HMAC.
+const SECRET_LARGO = 'z'.repeat(100);
+t("Coinciden con secreto >64 bytes (rama de key hasheada)",
+  hmacNode(SECRET_LARGO, canonical(casos[0].p)) === hmacPuro(SECRET_LARGO, canonical(casos[0].p)));
+
+// Sanidad: la firma DEBE cambiar si cambia cualquier campo. Si no, el HMAC no ata nada.
+const base = canonical(casos[0].p);
+const alterado = canonical(Object.assign({}, casos[0].p, { rango: '>5M' }));
+t("Cambiar un campo cambia la firma (el HMAC ata el payload)", hmacPuro(SECRET, base) !== hmacPuro(SECRET, alterado));
+t("Cambiar el secreto cambia la firma", hmacPuro(SECRET, base) !== hmacPuro('otro-secreto', base));
+
+console.log("\n" + ok + " pass / " + fail + " fail");
+process.exit(fail ? 1 : 0);

--- a/comercial/tests/watchdog-enviadas.test.js
+++ b/comercial/tests/watchdog-enviadas.test.js
@@ -1,0 +1,96 @@
+// Test de la logica de Code - MAIN contra data REAL de Odoo (sale.order state=sent)
+// + casos sinteticos para los caminos que la realidad no ejerce hoy (amarillo/verde/ruido).
+const NOW_ISO = "2026-07-16T22:20:00.000Z";
+const F = { hoy_ymd: "2026-07-16", ventana: 365, now_iso: NOW_ISO };
+
+// --- data REAL (muestra de las 122; incluye SO11258 SIN OWNER y company 6) ---
+const REAL = [
+  { id:11333, name:"SO11135", amount_total:22683898.6, company_id:[1,"SERVICIOS FTS"], create_date:"2025-09-11T22:10:46+00:00", write_date:"2026-05-27T17:56:35+00:00", partner_id:[94,"Nalco de Mexico SA. de .CV"], user_id:[12,"Sales FTS"] },
+  { id:11550, name:"SO11352", amount_total:8021681.88, company_id:[1,"SERVICIOS FTS"], create_date:"2025-11-27T15:56:43+00:00", write_date:"2026-05-27T17:56:35+00:00", partner_id:[94,"Nalco de Mexico SA. de .CV"], user_id:[12,"Sales FTS"] },
+  { id:11240, name:"SO11046", amount_total:3286686, company_id:[1,"SERVICIOS FTS"], create_date:"2025-08-21T23:34:13+00:00", write_date:"2025-11-28T03:13:06+00:00", partner_id:[66,"CBRE GCS, S. de R.L. de C.V."], user_id:[12,"Sales FTS"] },
+  { id:11456, name:"SO11258", amount_total:2314200, company_id:[1,"SERVICIOS FTS"], create_date:"2025-10-29T20:42:44+00:00", write_date:"2025-11-28T03:13:06+00:00", partner_id:[2003,"Terra Energy"], user_id:false },
+  { id:11886, name:"SO11687", amount_total:1352665, company_id:[6,"FTS FULL TECHNOLOGY SYSTEMS LLC"], create_date:"2026-04-24T21:33:04+00:00", write_date:"2026-04-29T21:01:42+00:00", partner_id:[1630,"Mission Foods"], user_id:[12,"Sales FTS"] },
+  { id:11250, name:"SO11055", amount_total:234, company_id:[6,"FTS FULL TECHNOLOGY SYSTEMS LLC"], create_date:"2025-08-25T23:18:08+00:00", write_date:"2025-11-28T03:13:06+00:00", partner_id:[1878,"WMC"], user_id:[12,"Sales FTS"] },
+  { id:11678, name:"SO11480", amount_total:0, company_id:[1,"SERVICIOS FTS"], create_date:"2025-12-17T00:14:33+00:00", write_date:"2025-12-17T03:49:28+00:00", partner_id:[815,"Budenheim Mexico"], user_id:[12,"Sales FTS"] },
+  { id:11415, name:"SO11217", amount_total:657.61, company_id:[1,"SERVICIOS FTS"], create_date:"2025-10-06T20:06:05+00:00", write_date:"2025-11-28T03:13:06+00:00", partner_id:[1949,"PRODELCOM"], user_id:[12,"Sales FTS"] }
+];
+// --- sinteticos: caminos que la data real NO ejerce hoy (todo esta rojo) ---
+const SYN = [
+  { id:99001, name:"SYN-AMARILLO", amount_total:500000, company_id:[1,"x"], create_date:"2026-07-01T10:00:00+00:00", write_date:"2026-07-12T10:00:00+00:00", partner_id:[1,"Cliente Amarillo"], user_id:[2,"Jesus Esteban De La Cruz"] },
+  { id:99002, name:"SYN-VERDE", amount_total:800000, company_id:[1,"x"], create_date:"2026-07-10T10:00:00+00:00", write_date:"2026-07-15T10:00:00+00:00", partner_id:[1,"Cliente Verde"], user_id:[2,"Jesus Esteban De La Cruz"] },
+  { id:99003, name:"SYN-SINFECHA", amount_total:900000, company_id:[1,"x"], create_date:"2026-07-10T10:00:00+00:00", write_date:false, partner_id:[1,"Cliente Sin Fecha"], user_id:false },
+  { id:99004, name:"SYN-OTRACOMPANY", amount_total:900000, company_id:[3,"FTS BRASIL"], create_date:"2026-07-10T10:00:00+00:00", write_date:"2025-01-01T10:00:00+00:00", partner_id:[1,"Fuera de scope"], user_id:[12,"Sales FTS"] }
+];
+const RAW = REAL.concat(SYN);
+
+const C = { activo:true, canary:true, recipients:{ esteban:"estebandelacruz@fts.mx", equipo:[] }, companies:[1,6],
+            umbral_amarillo_dias:4, umbral_rojo_dias:6, ventana_dias:365, top_n_por_vendedor:15, monto_minimo:1000, fx_usd_mxn:17.35 };
+
+// ===== logica identica a Code - MAIN =====
+const R = C.recipients, AM = C.umbral_amarillo_dias, RO = C.umbral_rojo_dias, TOP = C.top_n_por_vendedor,
+      FX = C.fx_usd_mxn, MIN = C.monto_minimo, COMPANIES = C.companies;
+const aId = v => Array.isArray(v) ? v[0] : (v || null);
+const aName = v => Array.isArray(v) ? (v[1] || '') : '';
+function parseOdooUtc(s){ if(!s) return null; return new Date(String(s).replace(' ','T').replace(/\+00:00$/,'') + 'Z'); }
+const now = new Date(F.now_iso);
+function diasDesde(dt){ const d = parseOdooUtc(dt); if(!d || isNaN(d)) return null; return (now - d) / 86400000; }
+function montoMxn(o){ return aId(o.company_id) === 6 ? (o.amount_total||0) * FX : (o.amount_total||0); }
+function monedaLabel(o){ return aId(o.company_id) === 6 ? 'USD' : 'MXN'; }
+
+const enScope = RAW.filter(o => COMPANIES.indexOf(aId(o.company_id)) !== -1);
+const ordenes = enScope.filter(o => montoMxn(o) >= MIN);
+const filtradas = enScope.length - ordenes.length;
+const rojas = [], amarillas = [], al_dia = [];
+for (const o of ordenes) {
+  const d = diasDesde(o.write_date);
+  const row = { name:o.name, cliente:aName(o.partner_id), monto:o.amount_total, monto_mxn:montoMxn(o), moneda:monedaLabel(o), dias:d, user_id:aId(o.user_id), vendedor:aName(o.user_id) };
+  if (d === null) rojas.push(row); else if (d >= RO) rojas.push(row); else if (d >= AM) amarillas.push(row); else al_dia.push(row);
+}
+const SIN_OWNER = '__sin_owner__', buckets = {};
+for (const r of rojas.concat(amarillas)) {
+  const k = r.user_id ? String(r.user_id) : SIN_OWNER;
+  if (!buckets[k]) buckets[k] = { vendedor: r.user_id ? (r.vendedor || ('user ' + r.user_id)) : 'SIN OWNER', rojas: [], amarillas: [] };
+  (r.dias === null || r.dias >= RO ? buckets[k].rojas : buckets[k].amarillas).push(r);
+}
+const orden = Object.keys(buckets).sort((a, b) => {
+  if (a === SIN_OWNER) return -1;
+  if (b === SIN_OWNER) return 1;
+  const sa = buckets[a].rojas.length, sb = buckets[b].rojas.length;
+  if (sb !== sa) return sb - sa;
+  return buckets[a].vendedor.localeCompare(buckets[b].vendedor);
+});
+
+// ===== asserts =====
+let ok = 0, fail = 0;
+const t = (n, cond, det) => { if (cond) { ok++; console.log("  PASS  " + n); } else { fail++; console.log("  FAIL  " + n + (det ? "  -> " + det : "")); } };
+console.log("\n=== TEST comercial/watchdog-enviadas . Code - MAIN ===");
+console.log("in: " + RAW.length + " | en scope: " + enScope.length + " | tras monto_minimo: " + ordenes.length + " | filtradas: " + filtradas + "\n");
+t("Excluye companies fuera de [1,6] (SYN-OTRACOMPANY)", !enScope.some(o => o.name === "SYN-OTRACOMPANY"));
+t("Filtra ruido de portal por monto_minimo ($0 y $657)", filtradas === 2, "filtradas=" + filtradas);
+t("NO filtra 234 USD (=4060 MXN, sobre el minimo)", ordenes.some(o => o.name === "SO11055"));
+t("Clasifica ROJO >=6d", rojas.some(r => r.name === "SO11135"));
+t("Clasifica AMARILLO 4-5d", amarillas.length === 1 && amarillas[0].name === "SYN-AMARILLO", "amarillas=" + amarillas.map(a => a.name));
+t("Clasifica AL DIA <4d", al_dia.length === 1 && al_dia[0].name === "SYN-VERDE", "al_dia=" + al_dia.map(a => a.name));
+t("write_date nulo => ROJO (fail-closed, no se cuela)", rojas.some(r => r.name === "SYN-SINFECHA"));
+t("SIN OWNER va PRIMERO en el orden", orden[0] === SIN_OWNER, "orden=" + orden);
+t("SIN OWNER agrupa SO11258 + SYN-SINFECHA", buckets[SIN_OWNER].rojas.length === 2);
+t("Normaliza company 6 a MXN (1,352,665 USD -> 23.46M)", Math.round(rojas.find(r => r.name === "SO11687").monto_mxn) === 23468738, "got=" + Math.round(rojas.find(r => r.name === "SO11687").monto_mxn));
+t("Conserva monto nominal + etiqueta de moneda", rojas.find(r => r.name === "SO11687").moneda === "USD" && rojas.find(r => r.name === "SO11687").monto === 1352665);
+t("company 1 NO se multiplica por FX", rojas.find(r => r.name === "SO11135").monto_mxn === 22683898.6);
+const sorted = [...buckets["12"].rojas].sort((x, y) => y.monto_mxn - x.monto_mxn);
+// El tope es SO11687, NO SO11135: 1,352,665 USD x 17.35 = $23.4M MXN supera los $22.6M MXN
+// de SO11135. Es la normalizacion haciendo su trabajo: ordena por valor real comparable,
+// no por el numero nominal. (Si esa orden resulta ser MXN mal etiquetada -- ambiguedad
+// residual de RIESGO-1 -- deja de ser la mayor. Por eso el correo muestra ambos.)
+t("Ordena por monto MXN normalizado desc (si top_n corta, corta lo chico)",
+  sorted[0].name === "SO11687" && sorted[sorted.length - 1].name === "SO11055",
+  "top=" + sorted[0].name + " last=" + sorted[sorted.length - 1].name);
+t("Normalizar cambia el ranking vs monto nominal (RIESGO-1 importa)",
+  sorted[0].name !== [...buckets["12"].rojas].sort((x, y) => y.monto - x.monto)[0].name);
+t("Bucket Sales FTS existe y es el generico (RIESGO-3)", buckets["12"].vendedor === "Sales FTS");
+console.log("\n--- Resumen del digest que se enviaria ---");
+console.log("rojas: " + rojas.length + " | amarillas: " + amarillas.length + " | al dia: " + al_dia.length);
+console.log("valor en riesgo MXN: $" + Math.round(rojas.concat(amarillas).reduce((a, r) => a + r.monto_mxn, 0)).toLocaleString('en-US'));
+for (const k of orden) console.log("  bucket[" + buckets[k].vendedor + "]  rojas=" + buckets[k].rojas.length + " amarillas=" + buckets[k].amarillas.length);
+console.log("\n" + ok + " pass / " + fail + " fail");
+process.exit(fail ? 1 : 0);

--- a/docs/finanzas/FASE2_DISTRIBUIDOR_V1_SPEC.md
+++ b/docs/finanzas/FASE2_DISTRIBUIDOR_V1_SPEC.md
@@ -1,5 +1,21 @@
 # FASE 2 — Spec del Distribuidor V1 de Carga MO (horas → pesos)
 
+> ## ⚠️ Correcciones 2026-07-16 (post browser-test de Esteban) — LEER PRIMERO
+> Aplicadas a la página `operaciones/carga-mo/index.html` (build `20260716-cmo-jwt-v2`) + workflows `HV1UE5JxN5fKdC2Y` (dry-run) y `j0V9wfpuPTLFO9DZ` (write, sigue INACTIVO):
+> 1. **Código 080 = Arturo Hernández (emp 143)**, ya existente (nombre completo "Pedro Arturo Hernández Ramírez"). **NO se crea empleado.** Mapa 080→143 en página + ambos workflows; F12 B.2 ahora incluye `143:'080'` (**27 códigos**); Pedro eliminado de B.3.
+> 2. **solo_bolsa = sólo 3** (Rissia 97, Pablo 108, Arturo 143 → **608**). Todos los demás **híbridos** (respetan checkout). Los 3 sí checan kiosko; el flag sólo afecta el dinero. Workflows leerán `x_studio_solo_bolsa` de Odoo cuando exista (fallback al mapa, hook marcado en el MOTOR).
+> 3. **Parser ignora fila fantasma** (código "00"/vacío **y** sin bruto = basura de Excel). Validación dura se mantiene para códigos reales sin cruce.
+> 4. **Semana = Periodo CONTPAQi de la fila 4** (`Periodo N ... del DD/MM al DD/MM`), NO semana ISO. La página valida que la fecha de inicio del periodo == viernes elegido (si no, error "archivo equivocado"). Llave idempotencia `MO S<periodo>/<año>`.
+> 5. **Vacación parcial:** cols 9+10 (Vacaciones + Prima) → **513**; el RESTO del bruto se reparte por horas confirmadas. Sólo si NO hay horas en toda la ventana → 100% a 513. Caso real Luis Ángel.
+> 6. **Umbral trío `<2h`** confirmadas en la semana → su monto va a excepción. (Ricardo 98 en SEM 28: 0.01h → excepción; de hecho no aparece en el Excel SEM 28.)
+> 7. **SEGURIDAD (JWT):** página detrás del auth de Finanzas (`FinAuth`, sin login no se ve nada — muestra brutos confidenciales). Ambos webhooks **validan el token por request** (mismo HMAC-SHA256 JS puro de `auth/finanzas-login`, token en el body). WRITE conserva su gate `confirm_write` como 2ª capa. Verificado en vivo: sin token/token basura/JWT con secreto falso → **401**.
+>
+> **Fix de precisión (descubierto en la re-corrida):** el reparto usaba `tot=Math.round(sum*100)/100` (redondear horas antes de dividir) → drift de **$1.80** en SEM 28. Corregido a **tot precisión completa + residuo-a-última-línea** → cada empleado suma EXACTO a su bruto → total cuadra Δ 0.00. Aplicado en ambos MOTOR + la simulación.
+>
+> **Dry-run SEM 28 con reglas nuevas (Δ control 0.00):**
+> Topo Chico 68,756.78 · Vertiv 41,295.20 · 608 VENTAS 35,486.37 · 513 ADMIN 27,089.74 · 768 LEGAL 6,562.50 · 478 RH 5,833.31 · 3096 ADMIN OPS 4,364.44 · Magnekon 4,019.10 · Chiller 2,823.37 · **Total 196,230.81** (= bruto 177,778.56 + trío 18,452.25). 0 excepciones. Reglas especiales: Juan Manuel vacación_total→513; Luis Ángel vacación_parcial (2,173.75→513 + resto por horas Magnekon/608); Juan/Juana asimilado→513; Rissia/Pablo/Arturo solo_bolsa→608; Carlos/Felipe trío por horas.
+> _(Nota: los totales por destino pueden variar ±centavos en el live según el orden de iteración de las asistencias — el total siempre cuadra exacto.)_
+
 > **Estado:** DISEÑO (cero escrituras). Diseñado 2026-07-13 contra Odoo `serviciosfts.odoo.com` (MCP UID 2 read-only) + decisiones cerradas de Esteban.
 > **Alcance V1 (MVP):** distribuir SOLO el **bruto CONTPAQi** (percepciones totales por empleado) + montos del trío facturante (Carlos/Felipe/Ricardo), ponderado por **horas confirmadas** de la ventana de nómina **VIE→JUE**, escribiendo **`account.analytic.line` compuesta (proyecto|bolsa × rubro 1177 MO)**. La línea nace etiquetada por rubro desde V1.
 > **Fuera de V1 (backlog, no diseñar):** carga patronal por factor (SUA), ISN, fondo de ahorro (columna Z del Excel), true-ups, geocercas dinámicas.

--- a/docs/finanzas/FASE2_SCRIPTS_F12.md
+++ b/docs/finanzas/FASE2_SCRIPTS_F12.md
@@ -40,18 +40,19 @@ console.log('▶ LIMPIEZA (0,0):', rest, rest2, '| IDs usados:', {bid,bl,al});
 Recomendado crearlo en **Studio** (Empleado → nuevo campo char "Código CONTPAQi", `required` al alta). Studio maneja el `ir.model.fields` + vistas correctamente. *(Vía RPC es frágil para campos Studio — usar Studio.)*
 
 ### B.2 — Poblar los códigos de los ya-existentes (27) — tras crear el campo
+> **Corrección 2026-07-16:** código **080 = Arturo Hernández (emp 143)**, que YA existe (nombre completo "Pedro Arturo Hernández Ramírez", misma persona). NO se crea empleado nuevo. Se agrega `143:'080'` al mapa → **27 códigos**.
 ```js
-const COD={25:'002',68:'003',6:'005',8:'006',55:'010',48:'011',63:'012',62:'013',57:'014',59:'016',75:'027',78:'028',79:'029',97:'036',101:'038',108:'044',121:'052',124:'056',127:'058',128:'059',131:'061',130:'062',138:'074',149:'081',153:'084',154:'085'};
+const COD={25:'002',68:'003',6:'005',8:'006',55:'010',48:'011',63:'012',62:'013',57:'014',59:'016',75:'027',78:'028',79:'029',97:'036',101:'038',108:'044',121:'052',124:'056',127:'058',128:'059',131:'061',130:'062',138:'074',143:'080',149:'081',153:'084',154:'085'};
 for(const [emp,cod] of Object.entries(COD)){ await rpc('hr.employee','write',[[+emp],{x_studio_codigo_contpaqi:cod}]); }
-console.log('▶ Poblados', Object.keys(COD).length, 'códigos');
+console.log('▶ Poblados', Object.keys(COD).length, 'códigos');  // 27
 ```
 
-### B.3 — Crear Pedro (080) + asimilados Juan (017) / Juana (018)
+### B.3 — Crear SÓLO los asimilados Juan (017) / Juana (018)
+> **Corrección 2026-07-16:** Pedro/Arturo (080) YA NO se crea (es el emp 143 existente, ver B.2). Sólo quedan los 2 asimilados.
 ```js
-const pedro=await rpc('hr.employee','create',[{name:'Pedro Arturo Hernández Ramírez', department_id:6, x_studio_codigo_contpaqi:'080', x_studio_cuenta_indirecta_default:608}]);
 const juan =await rpc('hr.employee','create',[{name:'Juan De La Cruz Maldonado (asimilado)', department_id:18, x_studio_codigo_contpaqi:'017', x_studio_cuenta_indirecta_default:513}]);
 const juana=await rpc('hr.employee','create',[{name:'Juana Camarillo Torrez (asimilado)', department_id:18, x_studio_codigo_contpaqi:'018', x_studio_cuenta_indirecta_default:513}]);
-console.log('▶ Creados:', {pedro, juan, juana});
+console.log('▶ Creados asimilados:', {juan, juana});
 ```
 ⚠️ El nombre de Juan colisiona con la **company_id 2** "JUAN DE LA CRUZ MALDONADO" — son modelos distintos (`hr.employee` vs `res.company`), no hay conflicto técnico, pero distínguelos en el nombre.
 
@@ -73,7 +74,14 @@ for(const [b,nm] of BOLSAS){
 *(También faltan las 6 líneas 1177 de proyecto de Auditoría C: 3071 sin budget, 3083/3087 sin 1177, 3038/3091/3094 placeholder −1 — se pueblan con los montos de cotización de Esteban.)*
 
 ### B.6 — Campo `x_studio_solo_bolsa` (bool) para la regla per-empleado
-Crear en Studio (Empleado, bool "Solo bolsa"). Marcar `true` en: Rissia(97), Pablo(108), Aldo(78), Arturo(143), Ana Laura(101), Magaly(63), Gerardo(59), Erick(149), Eduardo(153), Pedro(080), Juan/Juana. `false` (default) = respeta checkout (Ops, Felipe, Francisco, choferes/aux). El workflow V1 real leerá este campo en vez del mapa en memoria.
+> **Corrección 2026-07-16:** solo_bolsa FINAL = **sólo 3** (nunca cargan horas a proyecto). Todos los demás son **híbridos** (respetan checkout), incluidos Aldo, Ana Laura, Magaly, Gerardo, Erick, Eduardo, Luis Ángel, Francisco, Ricardo, Ramiro. Los 3 sí siguen checando en kiosko — el flag sólo afecta el dinero.
+
+Crear en Studio (Empleado, bool "Solo bolsa"). Marcar `true` en **sólo**: **Rissia (97)**, **Pablo (108)**, **Arturo (143)** → su bruto va 100% a la bolsa **608 VENTAS**. `false` (default) = respeta checkout (Ops, admin, legal, RH, choferes/aux — todos).
+```js
+for(const emp of [97,108,143]){ await rpc('hr.employee','write',[[emp],{x_studio_solo_bolsa:true}]); }
+console.log('▶ solo_bolsa=true en 97/108/143');
+```
+Los asimilados (017/018) NO necesitan el flag: van a 513 por la regla `asim` (columna sueldo asimilado > 0), no por solo_bolsa. El workflow V1 leerá este campo cuando exista y hará *fallback* al mapa en memoria mientras no exista (hook `x_studio_solo_bolsa` marcado en el MOTOR).
 
 ---
 

--- a/index.html
+++ b/index.html
@@ -131,11 +131,11 @@
       <div class="mod-icon">👥</div>
       <div class="mod-name">RH</div>
     </div>
-    <div id="card-comercial" class="mod-card disabled">
-      <div class="mod-badge">Próximamente</div>
+    <a id="card-comercial" href="comercial/index.html" class="mod-card active">
+      <div class="mod-badge">MVP</div>
       <div class="mod-icon">📋</div>
       <div class="mod-name">COMERCIAL</div>
-    </div>
+    </a>
     <div id="card-odoo" class="mod-card disabled">
       <div class="mod-badge">Próximamente</div>
       <div class="mod-icon">⚙️</div>

--- a/operaciones/carga-mo/index.html
+++ b/operaciones/carga-mo/index.html
@@ -4,8 +4,8 @@
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 <title>Carga MO — FTS Suite</title>
-<script>(function(){ window.CMO_BUILD = '20260716-cmo-ingesta-dryrun'; })();</script>
-<script src="../../shared/auth-suite.js"></script>
+<script>(function(){ window.CMO_BUILD = '20260716-cmo-jwt-v2'; })();</script>
+<script src="../../finanzas/js/auth-fin.js"></script>
 <script src="https://cdnjs.cloudflare.com/ajax/libs/xlsx/0.18.5/xlsx.full.min.js"></script>
 <style>
   :root{ --azul:#1a4480; --ok:#1a7a3a; --warn:#BA7517; --err:#b3261e; --bg:#f4f6f9; }
@@ -80,17 +80,19 @@
 
 <script>
 // ── Mapeo PROVISIONAL codigo CONTPAQi → empleado Odoo (dry-run; V1 real = x_studio_codigo_contpaqi) ──
+// solo_bolsa=true SÓLO 3 (nunca cargan a proyecto): Rissia 97, Pablo 108, Arturo 143.
+// Resto = híbrido (respeta checkout). Los asimilados (017/018) van a 513 por regla asim, no por solo.
 const CODE_MAP = {
- '002':{id:25,n:'Héctor Cruz',solo:false},'003':{id:68,n:'Jésus Montalvo',solo:false},'005':{id:6,n:'Leonel Cruz',solo:false},
- '006':{id:8,n:'Francisco Montalvo',solo:false},'010':{id:55,n:'Juan Manuel Sánchez',solo:false},'011':{id:48,n:'Luis Ángel García',solo:false},
- '012':{id:63,n:'Magaly Pérez',solo:true},'013':{id:62,n:'Gibrán Solís',solo:false},'014':{id:57,n:'Samuel Alcántara',solo:false},
- '016':{id:59,n:'Gerardo Lozano',solo:true},'017':{id:null,n:'Juan De La Cruz',solo:true,asim:true},'018':{id:null,n:'Juana Camarillo',solo:true,asim:true},
- '027':{id:75,n:'Mateo Salazar',solo:false},'028':{id:78,n:'Aldo Méndez',solo:true},'029':{id:79,n:'José Luis Romero',solo:false},
- '036':{id:97,n:'Rissia Araujo',solo:true},'038':{id:101,n:'Ana Laura Acevedo',solo:true},'044':{id:108,n:'Pablo Bayly',solo:true},
- '052':{id:121,n:'Stephany Ventura',solo:false},'056':{id:124,n:'Germán Merino',solo:false},'058':{id:127,n:'Cesar Gómez',solo:false},
- '059':{id:128,n:'Enoc Maldonado',solo:false},'061':{id:131,n:'Tomas Vázquez',solo:false},'062':{id:130,n:'Rolando Vázquez',solo:false},
- '074':{id:138,n:'Tomas Loredo',solo:false},'080':{id:null,n:'Pedro A. Hernández (sup com)',solo:true,crear:true},
- '081':{id:149,n:'Erick Belmont',solo:true},'084':{id:153,n:'Eduardo Garza',solo:true},'085':{id:154,n:'Ramiro Segovia',solo:true}
+ '002':{id:25,n:'Héctor Cruz'},'003':{id:68,n:'Jésus Montalvo'},'005':{id:6,n:'Leonel Cruz'},
+ '006':{id:8,n:'Francisco Montalvo'},'010':{id:55,n:'Juan Manuel Sánchez'},'011':{id:48,n:'Luis Ángel García'},
+ '012':{id:63,n:'Magaly Pérez'},'013':{id:62,n:'Gibrán Solís'},'014':{id:57,n:'Samuel Alcántara'},
+ '016':{id:59,n:'Gerardo Lozano'},'017':{id:null,n:'Juan De La Cruz',asim:true},'018':{id:null,n:'Juana Camarillo',asim:true},
+ '027':{id:75,n:'Mateo Salazar'},'028':{id:78,n:'Aldo Méndez'},'029':{id:79,n:'José Luis Romero'},
+ '036':{id:97,n:'Rissia Araujo',solo:true},'038':{id:101,n:'Ana Laura Acevedo'},'044':{id:108,n:'Pablo Bayly',solo:true},
+ '052':{id:121,n:'Stephany Ventura'},'056':{id:124,n:'Germán Merino'},'058':{id:127,n:'Cesar Gómez'},
+ '059':{id:128,n:'Enoc Maldonado'},'061':{id:131,n:'Tomas Vázquez'},'062':{id:130,n:'Rolando Vázquez'},
+ '074':{id:138,n:'Tomas Loredo'},'080':{id:143,n:'Arturo Hernández (sup com)',solo:true},
+ '081':{id:149,n:'Erick Belmont'},'084':{id:153,n:'Eduardo Garza'},'085':{id:154,n:'Ramiro Segovia'}
 };
 const TRIO_NAMES = ['CARLOS','FELIPE','RICARDO'];
 const WEBHOOK = 'https://primary-production-5c3c.up.railway.app/webhook/planeacion/carga-mo';
@@ -101,13 +103,38 @@ const HEADER_ROW = 7; // fila 8 (0-based)
 let PARSED = null;
 document.getElementById('b').textContent = window.CMO_BUILD;
 
-function gate(){
-  const s = window.FTSAuth && FTSAuth.getSession && FTSAuth.getSession();
-  if(!s){ document.getElementById('gate').style.display='block';
-    document.getElementById('gate').innerHTML='<h3>Sesión requerida</h3><a class="btn btn-p" href="../../index.html">Ir al inicio</a>'; return false; }
+// ── Auth: reusa el JWT del módulo Finanzas (server-side, token en body). Sin login no se ve nada. ──
+function boot(){
+  document.getElementById('gate').style.display='none';
   document.getElementById('main').style.display='block';
-  document.getElementById('u').textContent = s.nombre || s.username || '';
-  return true;
+  const s=window.FinAuth&&FinAuth.getSession&&FinAuth.getSession();
+  document.getElementById('u').textContent = (s&&s.user)||'nómina';
+}
+async function doLogin(){
+  const u=(document.getElementById('lg-u').value||'').trim();
+  const p=document.getElementById('lg-p').value||'';
+  const btn=document.getElementById('lg-btn'), m=document.getElementById('lg-msg');
+  btn.disabled=true; btn.textContent='Entrando…'; m.textContent='';
+  const r=await FinAuth.login(u,p);
+  if(r&&r.ok){ boot(); }
+  else{ m.textContent=(r&&r.msg)||'No se pudo iniciar sesión.'; btn.disabled=false; btn.textContent='Entrar'; }
+}
+function showGate(){
+  const g=document.getElementById('gate'); g.style.display='block';
+  document.getElementById('main').style.display='none';
+  g.innerHTML='<h3>🔒 Acceso Nómina</h3>'
+    +'<p class="mut" style="font-size:13px">Esta pantalla muestra brutos de nómina (confidencial). Inicia sesión.</p>'
+    +'<input id="lg-u" placeholder="Usuario" autocomplete="username" style="width:100%;padding:9px;border:1px solid #ccc;border-radius:7px;margin:5px 0">'
+    +'<input id="lg-p" type="password" placeholder="Contraseña" autocomplete="current-password" style="width:100%;padding:9px;border:1px solid #ccc;border-radius:7px;margin:5px 0">'
+    +'<button class="btn btn-p" id="lg-btn" style="width:100%;margin-top:6px">Entrar</button>'
+    +'<div id="lg-msg" class="chk err" style="margin-top:8px;display:none"></div>';
+  const msg=document.getElementById('lg-msg');
+  document.getElementById('lg-btn').onclick=()=>{ msg.style.display='block'; doLogin(); };
+  document.getElementById('lg-p').addEventListener('keydown',e=>{ if(e.key==='Enter'){ msg.style.display='block'; doLogin(); } });
+}
+function gate(){
+  if(window.FinAuth && FinAuth.isValid()){ boot(); return true; }
+  showGate(); return false;
 }
 function fmt(n){ return (n||0).toLocaleString('es-MX',{minimumFractionDigits:2,maximumFractionDigits:2}); }
 
@@ -137,16 +164,32 @@ function parse(f){
       const ws=wb.Sheets[wb.SheetNames[0]];
       rows=XLSX.utils.sheet_to_json(ws,{header:1,raw:true,defval:null});
     }catch(err){ return showErr('No se pudo leer el .xlsx: '+err.message); }
+    // ── Periodo CONTPAQi (fila ~4) = FUENTE DE VERDAD de la semana e idempotencia ──
+    let periodo=null, pStart=null, pEnd=null;
+    for(let i=0;i<Math.min(8,rows.length);i++){
+      const line=(rows[i]||[]).map(c=>c==null?'':String(c)).join(' ');
+      const mm=line.match(/Periodo\s+(\d+).*?del\s+(\d{1,2})\/(\d{1,2})\/(\d{4})\s+al\s+(\d{1,2})\/(\d{1,2})\/(\d{4})/i);
+      if(mm){ periodo=parseInt(mm[1],10);
+        pStart=mm[4]+'-'+String(mm[3]).padStart(2,'0')+'-'+String(mm[2]).padStart(2,'0');
+        pEnd  =mm[7]+'-'+String(mm[6]).padStart(2,'0')+'-'+String(mm[5]).padStart(2,'0'); break; }
+    }
     const emps=[], trio=[]; let totalGral=null;
     for(let i=HEADER_ROW+1;i<rows.length;i++){
-      const r=rows[i]||[]; const cod=r[C.cod], nom=(r[C.nom]||'').toString().trim();
-      if(!cod && !nom) continue;
-      if((cod||'').toString().toLowerCase().startsWith('total')){ totalGral=num(r[C.bruto]); continue; }
-      if(!cod && TRIO_NAMES.includes(nom.toUpperCase())){ trio.push({nombre:nom.toUpperCase(), neto:num(r[C.neto])}); continue; }
-      if(cod){ emps.push({ cod:String(cod).padStart(3,'0'), nombre:nom, bruto:num(r[C.bruto]),
+      const r=rows[i]||[];
+      const nom=(r[C.nom]||'').toString().trim();
+      const codStr=(r[C.cod]==null?'':String(r[C.cod]).trim());
+      const bruto=num(r[C.bruto]);
+      if(codStr.toLowerCase().startsWith('total')||nom.toLowerCase().startsWith('total')){ totalGral=bruto; continue; }
+      const isRealCod=/^0*\d+$/.test(codStr) && parseInt(codStr,10)>0;
+      // trío (sin código, nombre CARLOS/FELIPE/RICARDO, valor en NETO)
+      if(!isRealCod && TRIO_NAMES.includes(nom.toUpperCase())){ trio.push({nombre:nom.toUpperCase(), neto:num(r[C.neto])}); continue; }
+      // fila fantasma: sin código válido (ej. "00") Y sin bruto → basura de Excel, ignorar
+      if(!isRealCod && bruto===0) continue;
+      if(isRealCod){ emps.push({ cod:codStr.padStart(3,'0'), nombre:nom, bruto:bruto,
         vac:num(r[C.vac])+num(r[C.primaVac]), asim:num(r[C.asim]) }); }
     }
-    PARSED={ emps, trio, totalGral, vie:document.getElementById('f-vie').value, jue:document.getElementById('f-jue').textContent };
+    PARSED={ emps, trio, totalGral, periodo, periodoStart:pStart, periodoEnd:pEnd,
+      vie:document.getElementById('f-vie').value, jue:document.getElementById('f-jue').textContent };
     render();
   };
   rd.readAsArrayBuffer(f);
@@ -171,8 +214,21 @@ function render(){
     else checks.push(['err','✗ Suma NO cuadra: Σ brutos '+fmt(sumBruto)+' vs Total Gral '+fmt(p.totalGral)+' (Δ '+fmt(diff)+')']);
   } else checks.push(['warn','⚠ No se encontró fila "Total Gral" — no se validó la suma.']);
   checks.push(['ok','ℹ Trío: '+(p.trio.map(t=>t.nombre+' '+fmt(t.neto)).join(' · ')||'ninguno')+'. Total a distribuir = '+fmt(sumBruto+sumTrio)]);
-  // Validación 3: semana
-  if(!p.vie) checks.push(['warn','⚠ Elige el viernes de la semana antes de enviar (para idempotencia).']);
+  // Validación 3: Periodo CONTPAQi (fuente de verdad de la semana) + cruce con el viernes elegido
+  let periodoOK=false;
+  if(p.periodo==null){
+    checks.push(['err','✗ No se detectó el "Periodo N ... del DD/MM al DD/MM" en la fila 4 (¿archivo equivocado?).']);
+  } else {
+    document.getElementById('f-sem').textContent = 'S'+p.periodo+'/'+(p.periodoStart||'').slice(0,4);
+    if(!p.vie){
+      checks.push(['warn','⚠ Elige el viernes de la semana para cruzarlo con el Periodo '+p.periodo+' ('+p.periodoStart+' → '+p.periodoEnd+').']);
+    } else if(p.periodoStart && p.vie!==p.periodoStart){
+      checks.push(['err','✗ Archivo equivocado: el Excel es Periodo '+p.periodo+' ('+p.periodoStart+' → '+p.periodoEnd+') pero seleccionaste el viernes '+p.vie+'.']);
+    } else {
+      periodoOK=true;
+      checks.push(['ok','✓ Periodo '+p.periodo+' ('+p.periodoStart+' → '+p.periodoEnd+') = viernes elegido. Llave: MO S'+p.periodo+'/'+(p.periodoStart||'').slice(0,4)]);
+    }
+  }
   document.getElementById('checks').innerHTML = checks.map(c=>'<div class="chk '+c[0]+'">'+c[1]+'</div>').join('');
   // tabla
   document.getElementById('cnt').textContent=p.emps.length;
@@ -185,16 +241,20 @@ function render(){
     if(m&&m.crear) tags.push('<span class="pill nc">crear en Odoo</span>');
     return '<tr><td>'+e.cod+'</td><td>'+e.nombre+'</td><td class="r">'+fmt(e.bruto)+'</td><td>'+tags.join(' ')+'</td><td class="mut">'+(m?(m.n+(m.id?(' ('+m.id+')'):' (crear)')):'—')+'</td></tr>';
   }).join('') + p.trio.map(t=>'<tr><td>—</td><td>'+t.nombre+'</td><td class="r">'+fmt(t.neto)+'</td><td><span class="pill trio">trío (neto)</span></td><td class="mut">factura proveedor</td></tr>').join('');
-  const canSend = noCruza.length===0 && !!p.vie;
+  const canSend = noCruza.length===0 && !!p.vie && periodoOK;
   document.getElementById('send').disabled = !canSend;
 }
 
 document.getElementById('send').addEventListener('click', async ()=>{
   if(!PARSED) return;
   const btn=document.getElementById('send'); btn.disabled=true; btn.textContent='Enviando…';
-  const s=FTSAuth.getSession();
-  const payload={ modo:'dry_run', semana_vie:PARSED.vie, semana_jue:PARSED.jue,
-    solicitante:(s&&(s.username||s.nombre))||'', empleados:PARSED.emps, trio:PARSED.trio, total_gral:PARSED.totalGral };
+  const token=window.FinAuth&&FinAuth.getToken&&FinAuth.getToken();
+  if(!token){ showGate(); btn.textContent='Enviar a DRY-RUN →'; btn.disabled=false; return; }
+  const s=FinAuth.getSession();
+  const payload={ modo:'dry_run', token:token,
+    periodo:PARSED.periodo, periodo_start:PARSED.periodoStart, periodo_end:PARSED.periodoEnd,
+    semana_vie:PARSED.vie, semana_jue:PARSED.jue,
+    solicitante:(s&&s.user)||'', empleados:PARSED.emps, trio:PARSED.trio, total_gral:PARSED.totalGral };
   const msg=document.getElementById('msg'); msg.style.display='block';
   try{
     const rsp=await fetch(WEBHOOK,{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify(payload)});

--- a/shared/comercial/watchdog_enviadas.json
+++ b/shared/comercial/watchdog_enviadas.json
@@ -1,0 +1,30 @@
+{
+  "_meta": "Config de comercial/watchdog-enviadas. Se lee de GitHub raw main EN VIVO: editar + push a main, sin re-importar ni re-activar el workflow. Mismo patron que shared/operaciones/watchdogs_mo.json.",
+  "_doc": "comercial/baseline.md §5 + comercial/SUPUESTOS.md §T2",
+
+  "activo": true,
+  "canary": true,
+  "_canary_nota": "canary=true => el digest va SOLO a recipients.esteban. Poner en false y llenar recipients.equipo[] es la decision manual de rollout al equipo. Ver CHECKLIST-MANUAL.md.",
+
+  "recipients": {
+    "esteban": "estebandelacruz@fts.mx",
+    "equipo": []
+  },
+
+  "companies": [1, 6],
+
+  "umbral_amarillo_dias": 4,
+  "umbral_rojo_dias": 6,
+
+  "ventana_dias": 365,
+  "_ventana_nota": "Filtra por create_date. SIN este filtro el universo es de 1,131 ordenes enviadas historicas, todas rojas (baseline §5). 365 lo acota a ~122. Subir con cuidado.",
+
+  "top_n_por_vendedor": 15,
+  "_top_n_nota": "Tope de filas por bucket en el correo. El resto se reporta como '+N mas' con su monto agregado; NUNCA se ocultan en silencio. El dia 1 hay 122 rojas: sin tope el correo es ilegible y se ignora.",
+
+  "monto_minimo": 1000,
+  "_monto_minimo_nota": "Filtra ruido de portal web (ordenes de $0/$1.16/$44 de Public user, baseline RIESGO-5). Poner en 0 para no filtrar nada.",
+
+  "fx_usd_mxn": 17.35,
+  "_fx_nota": "La empresa es la autoridad de moneda (company 1=MXN, company 6=USD). currency_id NO es confiable: baseline RIESGO-1."
+}


### PR DESCRIPTION
## Resumen
Correcciones a la ingesta **Carga MO** (Fase 2) tras el browser-test de Esteban con SEM 28, + candado de seguridad JWT antes del go-live.

### Página `operaciones/carga-mo/index.html` (build `20260716-cmo-jwt-v2`)
- **080 → Arturo Hernández (emp 143)** — ya existía, no se crea empleado.
- **solo_bolsa = sólo 3** (Rissia 97 / Pablo 108 / Arturo 143 → 608); resto híbrido (respeta checkout).
- **Parser ignora fila fantasma** (código "00"/vacío + sin bruto).
- **Semana = Periodo CONTPAQi (fila 4)**, valida inicio == viernes elegido; llave `MO S<periodo>/<año>`.
- **Login JWT Finanzas obligatorio** (`FinAuth`) — sin sesión no se ven los brutos.

### Workflows n8n (viven en n8n, no en repo)
- `HV1UE5JxN5fKdC2Y` dry-run (**activo**) + `j0V9wfpuPTLFO9DZ` write (**INACTIVO**).
- MOTOR: mapa 080→143, solo_bolsa=3, **vacación parcial** (cols 9+10→513, resto por horas), **trío <2h→excepción**.
- Bloque **Validar JWT** en ambos (HMAC-SHA256 JS puro, token en body). WRITE conserva `confirm_write`.
- **Fix de precisión:** reparto residuo-a-última-línea + `tot` completo (antes drift $1.80).

### Verificaciones
- **Token gate en vivo:** sin token / basura / JWT con secreto falso → **401** ✓.
- **Dry-run SEM 28 (reglas nuevas, Δ control 0.00):** Topo 68,756.78 · Vertiv 41,295.20 · 608 35,486.37 · 513 27,089.74 · 768 6,562.50 · 478 5,833.31 · 3096 4,364.44 · Magnekon 4,019.10 · Chiller 2,823.37 · **Total 196,230.81**. 0 excepciones.

## Test plan
- [ ] Mergear → GitHub Pages despliega la página nueva.
- [ ] Login Finanzas en la página (token válido → carga; sin login → nada visible).
- [ ] Subir SEM 28 → confirmar Periodo 28, Δ suma 0.00, solo_bolsa sólo 3, Luis Ángel vacación parcial.
- [ ] Correr prerequisitos F12 (campo `x_studio_codigo_contpaqi` + 27 códigos con 143 + asimilados + `x_studio_solo_bolsa` en 97/108/143).
- [ ] Ensayo SEM 29 (jue 23-jul) → go-live SEM 29 (vie 24-jul): activar WRITE + cutover `unlink [47,48,9]`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)