### PR TITLE
feat(watchdog-mo): W5 destinos de ayer + flag canary

### DIFF
--- a/shared/operaciones/watchdogs_mo.json
+++ b/shared/operaciones/watchdogs_mo.json
@@ -1,5 +1,5 @@
 {
-  "_meta": "Config de ops/watchdog-mo (W1-W4 Fase 1.5). Se lee de GitHub raw main EN VIVO: editar + push, sin re-importar. Ver docs/operaciones/FASE15_CUENTAS_WATCHDOGS.md Parte 11.",
+  "_meta": "Config de ops/watchdog-mo (W1-W5 Fase 1.5). Se lee de GitHub raw main EN VIVO: editar + push, sin re-importar. Ver docs/operaciones/FASE15_CUENTAS_WATCHDOGS.md Parte 11.",
   "go_live": "2026-07-08",
   "dept_ops": 3,
   "recipients": {
@@ -8,10 +8,13 @@
     "ana_laura": "ana.acevedo@fts.mx",
     "magaly": "magaly@fts.mx"
   },
+  "canary": false,
+  "_canary_nota": "canary=true redirige TODOS los correos del watchdog solo a esteban con subject [CANARY], sin spammear a Felipe/Ana/Magaly. Usar para probar W5 con Manual Trigger, luego volver a false.",
   "w1_activo": true,
   "w2_activo": true,
   "w3_activo": true,
   "w4_activo": true,
+  "w5_activo": true,
   "w4_ventana_dias": 30,
   "w4_min_correcciones": 2
 }


### PR DESCRIPTION
## Summary
Agrega **W5 "Destinos de ayer"** al workflow `ops/watchdog-mo` (n8n `RBxoREDTfehELmyr`, ya actualizado a 13 nodos y validado) y el soporte de config para probarlo como canary.

- **W5 en el correo diario a Esteban:** pivote de **HORAS confirmadas** por destino (proyecto→nombre / bolsa→nombre, labels vivos de Odoo), con dos columnas **HOY** y **SEMANA ACUMULADA** (ventana de nómina VIE→JUE que contiene "ayer"). Empleados desglosados bajo cada destino, orden desc por semana, fila TOTAL.
- **Nuevos nodos n8n:** `Odoo - att semana` (+ collapse) — una sola lectura cubre HOY como subconjunto. `Code - Fechas` calcula `semana_desde` (viernes 00:00 CST) robusto en lunes/viernes.
- **Flag `canary`** en `watchdogs_mo.json`: `canary=true` redirige TODOS los correos solo a Esteban con subject `[CANARY]` (sin spammear a Felipe/Ana/Magaly). Default `false`.

Solo horas **confirmadas** (`x_studio_manager_approval=true`, no disputadas) = "lo que el viernes se vuelve nómina". El acumulado del jueves = cierre de semana.

## Cómo probar (canary)
1. Merge este PR (deja `canary:false` en producción).
2. Para la prueba: `canary` → `true`, push a main, correr **Manual Trigger** en n8n → llega TODO solo a Esteban con `[CANARY]`.
3. Revisar W5, luego `canary` → `false` + push.

## Test plan
- [ ] Manual Trigger con `canary:true` → correo `[CANARY]` solo a Esteban
- [ ] W5 muestra destinos con HOY/SEMANA en horas, orden desc, TOTAL cuadra
- [ ] solo_bolsa aparecen solo en su bolsa (post candado #2)
- [ ] Volver `canary:false`

🤖 Generated with [Claude Code](https://claude.com/claude-code)