### PR TITLE
feat(confirmar-horas): CC-1 candado presupuestal MO

### DIFF
--- a/operaciones/confirmar-horas/index.html
+++ b/operaciones/confirmar-horas/index.html
@@ -5,7 +5,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 <title>Confirmar Horas — FTS Suite</title>
 <script>
-  (function(){ window.CH_BUILD = '20260717-ch-candado-solobolsa'; })();
+  (function(){ window.CH_BUILD = '20260717-ch-candado-presupuestal'; })();
 </script>
 <script src="../../shared/auth-suite.js"></script>
 <script src="../../shared/version-check.js"></script>
@@ -71,6 +71,9 @@
   .ch-x{ background:none; border:none; font-size:18px; cursor:pointer; color:#888; }
   .ch-warn{ color:var(--warn); }
   .ch-solo{ font-size:12px; }
+  .ch-mo{ display:inline-block; font-size:10px; font-weight:700; padding:1px 6px; border-radius:8px; white-space:nowrap; margin-left:2px; }
+  .ch-mo-red{ background:#fdeceb; color:var(--err); }
+  .ch-mo-amber{ background:#fff3df; color:var(--warn); }
   .ch-lock-note{ background:#fff3df; color:#8a5a12; border-radius:8px; padding:8px 10px; font-size:12px; margin-bottom:8px; }
   .ch-pop-tbl{ width:100%; border-collapse:collapse; font-size:12px; margin:8px 0; }
   .ch-pop-tbl th{ background:#eef2f8; color:#333; text-align:left; padding:5px 7px; }

--- a/operaciones/confirmar-horas/js/confirmar-horas.js
+++ b/operaciones/confirmar-horas/js/confirmar-horas.js
@@ -44,7 +44,19 @@
   function soCellHtml(row){
     var so = celdaAtribucion(row);
     return (esCrossProy(row) ? '<span class="ch-warn" title="Empleado de ' + esc(row.department_name || 'otro depto') + ' cargando a proyecto">⚠️</span> ' : '') +
-      so + (row.solo_bolsa ? ' <span class="ch-solo" title="Solo-bolsa: costo fijo a su bolsa, sin proyecto">🔒</span>' : '');
+      so + (row.solo_bolsa ? ' <span class="ch-solo" title="Solo-bolsa: costo fijo a su bolsa, sin proyecto">🔒</span>' : '') +
+      budgetBadge(row);
+  }
+
+  // CC-1: estado presupuestal MO (budget rubro 1177) del renglón. Sólo aplica a proyectos (bolsas = exento).
+  function budgetEstado(row){ return (row && row.budget_mo && row.budget_mo.estado) || null; }
+  function fmtMoney(n){ return '$' + Number(n||0).toLocaleString('es-MX', { maximumFractionDigits: 0 }); }
+  function budgetBadge(row){
+    var e = budgetEstado(row);
+    if(e === 'sin_linea')   return ' <span class="ch-mo ch-mo-red" title="Sin línea de Mano de Obra (rubro 1177): no confirmable">🔴 sin MO</span>';
+    if(e === 'placeholder') return ' <span class="ch-mo ch-mo-amber" title="MO sin presupuesto asignado (placeholder)">🟠 s/fondos</span>';
+    if(e === 'agotado'){ var bm = row.budget_mo || {}; return ' <span class="ch-mo ch-mo-amber" title="MO agotada: ' + fmtMoney(bm.consumido) + ' de ' + fmtMoney(bm.presupuesto) + '">🟠 MO agotada</span>'; }
+    return '';
   }
 
   var CH = {
@@ -234,14 +246,47 @@
 
   function findRow(attId){ return CH.rows.find(function(x){ return x.attendance_id === attId; }); }
 
-  // ─── Confirmar horas (set manager_approval) ───
+  // ─── Confirmar horas (set manager_approval) — con candado presupuestal MO (CC-1) ───
+  // Regla: proyecto sin línea 1177 → BLOQUEO DURO (no envía). placeholder/agotado → popup de
+  // conciencia → reenvía con ack. El workflow re-valida server-side (la UI avisa, el candado es el server).
   function confirmar(attId, btn){
     clearMsg();
+    var row = findRow(attId);
+    var est = budgetEstado(row);
+    if(est === 'sin_linea'){
+      showMsg('🔴 No se puede confirmar: esta cuenta no contempla gasto de Mano de Obra (ej. trabajo de terceros). Corrige el destino (✎) antes de confirmar.', 'err');
+      return;
+    }
+    var ack = {};
+    if(est === 'placeholder'){
+      if(!window.confirm('⚠️ MO sin fondos asignados en esta cuenta (presupuesto placeholder).\n\n¿Confirmar de todos modos?')) return;
+      ack.ack_mo_placeholder = true;
+    } else if(est === 'agotado'){
+      var bm = row.budget_mo || {};
+      if(!window.confirm('⚠️ MO agotada: ' + fmtMoney(bm.consumido) + ' consumido de ' + fmtMoney(bm.presupuesto) + ' presupuestado.\n\n¿Confirmar el sobrecosto?')) return;
+      ack.ack_mo_agotado = true;
+    }
+    enviarConfirm(attId, btn, ack);
+  }
+
+  function enviarConfirm(attId, btn, ack){
     if(btn){ btn.disabled = true; btn.textContent = '⏳'; }
-    n8n('/webhook/planeacion/confirmar-horas', {
-      attendance_id: attId, action: 'confirm', supervisor_nombre: CH.supervisor
-    }).then(function(data){
+    var payload = Object.assign({ attendance_id: attId, action: 'confirm', supervisor_nombre: CH.supervisor }, ack || {});
+    n8n('/webhook/planeacion/confirmar-horas', payload).then(function(data){
       var r = Array.isArray(data) ? data[0] : data;
+      // Server pide ack (badge desfasado) → re-prompt con el ack correcto y reintenta
+      if(r && r.needs_ack){
+        if(window.confirm('⚠️ ' + (r.mensaje || 'Requiere confirmación consciente.') + '\n\n¿Confirmar de todos modos?')){
+          var ack2 = (r.codigo === 'MO_AGOTADO') ? { ack_mo_agotado: true } : { ack_mo_placeholder: true };
+          enviarConfirm(attId, btn, ack2);
+        } else if(btn){ btn.disabled = false; btn.textContent = '✔ Confirmar'; }
+        return;
+      }
+      if(r && r.bloqueo){
+        showMsg('🔴 ' + (r.mensaje || 'Confirmación bloqueada por presupuesto MO.'), 'err');
+        if(btn){ btn.disabled = false; btn.textContent = '✔ Confirmar'; }
+        return;
+      }
       if(!r || r.success === false) throw new Error((r && r.mensaje) || 'Error');
       // Éxito confirmado por el backend → recién ahora actualizamos UI (anti #15)
       var row = findRow(attId);
@@ -279,21 +324,41 @@
     clearMsg();
     var pend = pendientesConfirmar();
     if(!pend.length){ showMsg('No hay renglones pendientes de confirmar en el rango.', 'err'); return; }
-    var cross = pend.filter(esCrossProy);
-    if(cross.length){ abrirPopupTanda(pend, cross); }         // con ⚠️ → popup
-    else { confirmarVarios(pend.map(function(r){ return r.attendance_id; })); }  // sin ⚠️ → directo
+    // CC-1: excluir sin_linea (bloqueo duro, no se confirman); marcar placeholder/agotado (conciencia).
+    var blocked = pend.filter(function(r){ return budgetEstado(r) === 'sin_linea'; });
+    var confirmables = pend.filter(function(r){ return budgetEstado(r) !== 'sin_linea'; });
+    var cross = confirmables.filter(esCrossProy);
+    var warn = confirmables.filter(function(r){ var e = budgetEstado(r); return e === 'placeholder' || e === 'agotado'; });
+    if(blocked.length || cross.length || warn.length){
+      abrirPopupTanda(confirmables, cross, warn, blocked);
+    } else {
+      confirmarVarios(confirmables.map(function(r){ return r.attendance_id; }));
+    }
   }
-  function abrirPopupTanda(pend, cross){
-    var filas = cross.map(function(r){
+  function popTablaFilas(arr, colProy){
+    return arr.map(function(r){
       return '<tr><td>' + esc(r.empleado_nombre||'') + '</td><td>' + esc(r.department_name||'') + '</td><td>' +
-        esc(r.so_nombre || ('Proy ' + r.so_id)) + '</td><td style="text-align:right">' +
+        (colProy ? esc(r.so_nombre || ('Proy ' + r.so_id)) : esc(labelAtribucion(r))) + '</td><td style="text-align:right">' +
         (r.worked_hours!=null? r.worked_hours.toFixed(2)+'h':'—') + '</td></tr>';
     }).join('');
-    $('pop-tanda-body').innerHTML =
-      '<p>Vas a confirmar <b>' + pend.length + '</b> renglón(es). <b>' + cross.length + '</b> son de empleados de <b>otro depto</b> cargando a un <b>proyecto</b>:</p>' +
-      '<table class="ch-pop-tbl"><thead><tr><th>Empleado</th><th>Depto</th><th>Proyecto</th><th>Hrs</th></tr></thead><tbody>' + filas + '</tbody></table>' +
-      '<p style="color:#555;font-size:12px">¿Confirmas que estos empleados sí cargaron horas a proyecto?</p>';
-    CH._tandaPend = pend.map(function(r){ return r.attendance_id; });
+  }
+  function abrirPopupTanda(confirmables, cross, warn, blocked){
+    var html = '<p>Vas a confirmar <b>' + confirmables.length + '</b> renglón(es).</p>';
+    if(blocked.length){
+      html += '<p style="color:#b3261e;font-weight:600">🔴 ' + blocked.length + ' NO se confirmarán (cuenta sin Mano de Obra — trabajo de terceros). Corrige su destino primero:</p>' +
+        '<table class="ch-pop-tbl"><thead><tr><th>Empleado</th><th>Depto</th><th>Proyecto</th><th>Hrs</th></tr></thead><tbody>' + popTablaFilas(blocked, true) + '</tbody></table>';
+    }
+    if(warn.length){
+      html += '<p style="color:#BA7517;font-weight:600">🟠 ' + warn.length + ' con MO sin fondos / agotada (se registrará el sobrecosto):</p>' +
+        '<table class="ch-pop-tbl"><thead><tr><th>Empleado</th><th>Depto</th><th>Cuenta</th><th>Hrs</th></tr></thead><tbody>' + popTablaFilas(warn, true) + '</tbody></table>';
+    }
+    if(cross.length){
+      html += '<p style="color:#0C447C;font-weight:600">⚠️ ' + cross.length + ' de otro depto cargando a proyecto:</p>' +
+        '<table class="ch-pop-tbl"><thead><tr><th>Empleado</th><th>Depto</th><th>Proyecto</th><th>Hrs</th></tr></thead><tbody>' + popTablaFilas(cross, true) + '</tbody></table>';
+    }
+    html += '<p style="color:#555;font-size:12px">¿Confirmas los ' + confirmables.length + ' renglón(es) listados como confirmables?</p>';
+    $('pop-tanda-body').innerHTML = html;
+    CH._tandaPend = confirmables.map(function(r){ return r.attendance_id; });
     $('pop-tanda').style.display = 'flex';
   }
   function cerrarPopupTanda(){ $('pop-tanda').style.display = 'none'; CH._tandaPend = null; }
@@ -307,8 +372,12 @@
         return;
       }
       var att = atts[i++];
-      n8n('/webhook/planeacion/confirmar-horas', { attendance_id: att, action: 'confirm', supervisor_nombre: CH.supervisor })
-        .then(function(data){ var r = Array.isArray(data) ? data[0] : data; if(!r || r.success === false) throw new Error(); var row = findRow(att); if(row) row.confirmado = true; actualizarFila(att); ok++; })
+      // CC-1: el usuario ya consintió en el popup → mandar ack según el estado presupuestal del renglón.
+      var row = findRow(att); var est = budgetEstado(row); var ack = {};
+      if(est === 'placeholder') ack.ack_mo_placeholder = true;
+      else if(est === 'agotado') ack.ack_mo_agotado = true;
+      n8n('/webhook/planeacion/confirmar-horas', Object.assign({ attendance_id: att, action: 'confirm', supervisor_nombre: CH.supervisor }, ack))
+        .then(function(data){ var r = Array.isArray(data) ? data[0] : data; if(!r || r.success === false) throw new Error(); if(row) row.confirmado = true; actualizarFila(att); ok++; })
         .catch(function(){ fail++; })
         .finally(next);
     }

--- a/operaciones/confirmar-horas/version.json
+++ b/operaciones/confirmar-horas/version.json
@@ -1,5 +1,5 @@
 {
-  "build": "20260717-ch-candado-solobolsa",
+  "build": "20260717-ch-candado-presupuestal",
   "modulo": "confirmar-horas",
   "updated": "2026-07-17",
   "_nota": "build DEBE coincidir con CH_BUILD en index.html. Bumpear ambos al mismo string en cada deploy (ver FASE15 Parte 12)."


### PR DESCRIPTION
## Summary
**CC-1 write side + frontend** de la validación presupuestal de MO al confirmar. El backend ya está en n8n (workflows `planeacion/horas-dia` + `planeacion/confirmar-horas`, live y validados). Este PR es solo el frontend.

### Regla (idéntica a SOLO_BOLSA_LOCK: la UI avisa, el workflow es el candado)
Al confirmar un attendance que apunta a un **proyecto**, se valida su budget rubro 1177:
- **a. sin línea 1177 → BLOQUEO DURO** (🔴 sin MO): no deja confirmar. Mensaje: *"Esta cuenta no contempla gasto de Mano de Obra (ej. trabajo de terceros). Corrige el destino antes de confirmar."* (caso real: 3087 Motores).
- **b. placeholder −1 → advertencia + popup** (🟠 s/fondos) con ack para continuar (caso real: 3083 hoy).
- **c. agotado (achieved ≥ budget) → advertencia con datos + popup** (🟠 MO agotada) con ack. No bloquea (el sobrecosto se registra, no se esconde).
- **Bolsas / sin proyecto → exento** (sin badge, sin candado).

### Cambios
- **Badge por renglón** en la celda de atribución según `budget_mo.estado` que ahora emite `horas-dia`.
- **Confirmar individual**: bloqueo/popup/ack según estado. `enviarConfirm` maneja `needs_ack`/`bloqueo` del server (defensa si el badge quedó stale).
- **Confirmar tanda**: excluye los `sin_linea`, lista blocked/warn/cross en el popup, manda el ack por renglón.
- build `20260717-ch-candado-presupuestal`.

### Backend (ya live, no en este PR)
- `planeacion/horas-dia` (`pQ3vVbRkMYvfICQf`): +nodos proyectos + budget 1177 → `budget_mo` por row. Verificado: 136 rows, estados exento/ok/placeholder correctos, Vertiv 97.7% (a un paso de agotado).
- `planeacion/confirmar-horas` (`7D3lgaYmH2DmqCWy`): +cadena READ att→proyecto→cuenta→budget→`Code Candado`→`IF Candado OK?`. Bloqueo duro `sin_linea`, ack para placeholder/agotado. Verificado sin escritura: att 14257 placeholder sin ack → `needs_ack MO_PLACEHOLDER`.

## Test plan (browser, 3 casos)
- [ ] **placeholder (3083)**: renglón muestra 🟠 s/fondos; Confirmar → popup → OK → confirma.
- [ ] **sin_linea (3087)**: renglón muestra 🔴 sin MO; Confirmar → bloqueado, no envía.
- [ ] **ok normal**: sin badge; Confirmar → directo.
- [ ] **Tanda**: popup lista blocked/warn/cross; confirma solo los confirmables.

🤖 Generated with [Claude Code](https://claude.com/claude-code)