### PR TITLE
feat(confirmar-horas): overlay envio + auto-popup robusto (2s)

### DIFF
--- a/operaciones/confirmar-horas/index.html
+++ b/operaciones/confirmar-horas/index.html
@@ -5,7 +5,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 <title>Confirmar Horas — FTS Suite</title>
 <script>
-  (function(){ window.CH_BUILD = '20260718-ch-flujo-dospasos'; })();
+  (function(){ window.CH_BUILD = '20260718-ch-envio-ux'; })();
 </script>
 <script src="../../shared/auth-suite.js"></script>
 <script src="../../shared/version-check.js"></script>
@@ -84,6 +84,10 @@
   .ch-pop-tbl{ width:100%; border-collapse:collapse; font-size:12px; margin:8px 0; }
   .ch-pop-tbl th{ background:#eef2f8; color:#333; text-align:left; padding:5px 7px; }
   .ch-pop-tbl td{ padding:5px 7px; border-top:1px solid #eee; }
+  .ch-overlay{ position:fixed; inset:0; background:rgba(0,0,0,.5); display:none; align-items:center; justify-content:center; z-index:80; }
+  .ch-overlay-box{ background:#fff; border-radius:12px; padding:24px 32px; text-align:center; box-shadow:0 4px 20px rgba(0,0,0,.2); font-size:15px; color:#1c1c1c; min-width:220px; }
+  .ch-spinner{ width:32px; height:32px; border:4px solid #dde; border-top-color:var(--azul); border-radius:50%; margin:0 auto 12px; animation:ch-spin .8s linear infinite; }
+  @keyframes ch-spin{ to{ transform:rotate(360deg); } }
 </style>
 </head>
 <body>
@@ -149,6 +153,11 @@
       <button class="ch-btn ch-btn-ok" id="pop-tanda-confirm">✔ Enviar confirmación</button>
     </div>
   </div>
+</div>
+
+<!-- Overlay de progreso del envío -->
+<div id="ch-overlay" class="ch-overlay">
+  <div class="ch-overlay-box"><div class="ch-spinner"></div><div id="ch-overlay-text">Confirmando…</div></div>
 </div>
 
 <script src="js/confirmar-horas.js"></script>

--- a/operaciones/confirmar-horas/js/confirmar-horas.js
+++ b/operaciones/confirmar-horas/js/confirmar-horas.js
@@ -90,15 +90,19 @@
     return new Date(nowCst.getTime() - 24*3600*1000);
   }
 
-  function showMsg(texto, tipo){
+  function showMsg(texto, tipo, persist){
     var el = $('ch-msg');
     if(!el) return;
     el.textContent = texto;
     el.className = 'ch-msg ' + (tipo === 'ok' ? 'ch-msg-ok' : 'ch-msg-err');
     el.style.display = 'block';
-    if(tipo === 'ok') setTimeout(function(){ el.style.display = 'none'; }, 4000);
+    if(tipo === 'ok' && !persist) setTimeout(function(){ el.style.display = 'none'; }, 4000);
   }
   function clearMsg(){ var el = $('ch-msg'); if(el) el.style.display = 'none'; }
+  // Overlay de progreso del envío (batch invisible -> visible)
+  function showOverlay(t){ var o = $('ch-overlay'); if(o){ var x = $('ch-overlay-text'); if(x) x.textContent = t; o.style.display = 'flex'; } }
+  function updateOverlay(t){ var x = $('ch-overlay-text'); if(x) x.textContent = t; }
+  function hideOverlay(){ var o = $('ch-overlay'); if(o) o.style.display = 'none'; }
 
   // ─── Cargar horas del rango ───
   function cargar(){
@@ -289,17 +293,18 @@
   function modalAbierto(){ return $('pop-tanda').style.display === 'flex' || $('modal-so').style.display === 'flex'; }
   function checkAutoPopup(){
     if(CH._autoTimer){ clearTimeout(CH._autoTimer); CH._autoTimer = null; }
-    if(CH._autoDismissed) return;
     if(modalAbierto()) return;
-    var conf = CH.rows.filter(marcable);
-    if(!conf.length || !conf.every(function(r){ return r._marcado; })) return;
+    var conf = CH.rows.filter(marcable);   // disputa CUENTA (marcable por la regla nueva)
+    var allMarked = conf.length && conf.every(function(r){ return r._marcado; });
+    if(!allMarked){ CH._autoDismissed = false; return; }   // estado parcial re-arma el disparador
+    if(CH._autoDismissed) return;                          // ya se mostró/canceló para este set completo
     CH._autoTimer = setTimeout(function(){
       CH._autoTimer = null;
       var c2 = CH.rows.filter(marcable);
       if(c2.length && c2.every(function(r){ return r._marcado; }) && !CH._autoDismissed && !modalAbierto()){
         confirmarEnvio(true);
       }
-    }, 4000);
+    }, 2000);
   }
 
   function actualizarFila(attId){
@@ -374,15 +379,16 @@
   function enviarLote(atts){
     if(!atts || !atts.length){ showMsg('No había nada marcado para enviar.', 'err'); return; }
     var total = atts.length, ok = 0, fail = 0, blocked = 0, i = 0;
-    showMsg('Enviando confirmación de ' + total + ' registro(s)…', 'ok');
+    showOverlay('Confirmando… 0 de ' + total);
     function next(){
       if(i >= atts.length){
+        hideOverlay();
         var extra = [];
         if(blocked) extra.push(blocked + ' bloqueado(s)');
         if(fail) extra.push(fail + ' con error');
-        var msg = ok ? ('✓ Confirmación enviada — ' + ok + ' registro(s)' + (extra.length ? (' · ' + extra.join(' · ')) : ''))
+        var msg = ok ? ('✓ ' + ok + ' registro(s) confirmados' + (extra.length ? (' · ' + extra.join(' · ')) : ''))
                      : ('❌ No se envió ninguno' + (extra.length ? (' — ' + extra.join(' · ')) : ''));
-        showMsg(msg, (fail || blocked || !ok) ? 'err' : 'ok');
+        showMsg(msg, (fail || blocked || !ok) ? 'err' : 'ok', true);   // PERSISTENTE hasta refresh o cambio de rango
         CH._autoDismissed = false;   // re-arma para un siguiente marcado completo
         return;
       }
@@ -399,7 +405,7 @@
           actualizarFila(att); ok++;
         })
         .catch(function(){ fail++; })
-        .finally(next);
+        .finally(function(){ updateOverlay('Confirmando… ' + (ok + fail + blocked) + ' de ' + total); next(); });
     }
     next();
   }

--- a/operaciones/confirmar-horas/version.json
+++ b/operaciones/confirmar-horas/version.json
@@ -1,5 +1,5 @@
 {
-  "build": "20260718-ch-flujo-dospasos",
+  "build": "20260718-ch-envio-ux",
   "modulo": "confirmar-horas",
   "updated": "2026-07-18",
   "_nota": "build DEBE coincidir con CH_BUILD en index.html. Bumpear ambos al mismo string en cada deploy (ver FASE15 Parte 12)."


### PR DESCRIPTION
UX de envío visible (overlay + contador + banner persistente) + fix auto-popup (re-arma robusto, disputa cuenta, debounce 2s). Sin cambio de contrato server (tolerancia sigue ON). build 20260718-ch-envio-ux.

🤖 Generated with [Claude Code](https://claude.com/claude-code)