### PR TITLE
feat(finanzas): Paso 6 — Instrumentos de pago (Bancos) [demo, Real gateado]

### DIFF
--- a/docs/finanzas/BANCOS_CHECKLIST_SEGURIDAD.md
+++ b/docs/finanzas/BANCOS_CHECKLIST_SEGURIDAD.md
@@ -1,0 +1,67 @@
+# Checklist de seguridad — Instrumentos de pago (Bancos)
+
+**Fecha:** 2026-07-20 · **Estado:** entregado junto al demo (Paso 6). **Modo Real GATEADO** (`IP_REAL_ENABLED=false`) hasta que Dirección cierre este checklist.
+
+Los puntos (a) y (c) son **propuestas** — decide Esteban. El punto (b) es un **barrido ejecutado**; abajo van los resultados reales.
+
+---
+
+## (a) Expiración corta del JWT + claims por rol — PROPUESTA
+
+**Hoy:** el login de Finanzas (`auth/finanzas-login`, JWT HMAC-SHA256) emite un token con vida **8 h** y un solo usuario (`finanzas`). Cada endpoint `fin/*` revalida la firma + expiración (patrón probado en facturas/bills). El secreto vive server-side en Railway (`FINANZAS_JWT_SECRET`) — **nunca en el repo** (confirmado en el barrido (b)).
+
+**Debilidad para Bancos:** 8 h es largo para una superficie que en el futuro **escribe** (conciliación). Y no hay noción de rol: cualquier sesión válida podría, el día que exista `fin/captura-conciliar`, disparar un write.
+
+**Propuesta:**
+1. **Expiración más corta** para la superficie Bancos: token de **1–2 h** con *refresh* transparente (re-login silencioso), en vez de 8 h. Los 3 endpoints actuales son de lectura, pero el hábito corto se hereda al de escritura.
+2. **Claims por rol/scope** en el JWT. Añadir al payload:
+   - `scope: ["bancos:read"]` para status/transacciones/dataset.
+   - `scope: ["bancos:write"]` **solo** cuando exista `fin/captura-conciliar` (motor Fase 2), y **solo** para usuarios autorizados a conciliar.
+   Cada endpoint valida el scope requerido (rechazo `403 SCOPE_INSUFFICIENT` si falta), no solo la firma.
+3. **Usuarios reales por persona** (hoy hay un único `finanzas`). Para trazar quién concilia, migrar a credenciales por persona (Gera, Esteban…) con su `sub` en el token. Prerrequisito del write, no del read.
+
+**Costo:** cambios acotados al workflow `auth/finanzas-login` (payload + expiración) y a un guard de scope reutilizable en los endpoints. No toca el front (el token viaja en el body igual).
+
+---
+
+## (b) Auditoría de secretos en TODO el historial git — EJECUTADO
+
+Barrido con *pickaxe* (`git log -G/-S`) sobre **1,241 commits** (no solo HEAD). Patrones: llaves privadas, GitHub PAT, AWS `AKIA`, Slack `xox`, `FINANZAS_JWT_SECRET/USER_HASH/USER_SALT`, `SECRET/HMAC/API_KEY` con valor. **Los valores encontrados se reportan por ubicación, nunca su contenido.**
+
+### Resultado por la superficie Finanzas/Bancos: **LIMPIA ✅**
+- Los secretos del login (`FINANZAS_JWT_SECRET`, `FINANZAS_USER_HASH`, `FINANZAS_USER_SALT`) **nunca** se commitearon. En el historial solo aparecen los **nombres** de las env vars dentro de un doc (`docs/finanzas/PLAN.md`, commit `4467471`), describiendo que viven en Railway. Cero valores.
+- **Ningún JSON de workflow con secretos** fue exportado al repo en toda la historia (regla CLAUDE.md §15 #3 respetada).
+- Sin llaves privadas (`-----BEGIN`), sin AWS `AKIA`, sin Slack `xox`.
+- Único match de PAT: un **placeholder** `GITHUB_TOKEN = ghp_xxxx…` en `operaciones/incidencias/n8n-webhook.md` (commit `0adfd72`) — documentación, no es un token real.
+
+### Hallazgos ajenos a Bancos (preexistentes — reportados, no bloquean este entregable)
+1. **`pmo/index.html` — HMAC hardcodeado VIVO en HEAD** (líneas ~999 y ~1687, `HARDCODED_SECRET`/`SECRET`). Es un secreto client-side en un repo público (GitHub Pages) → **cualquiera puede leerlo**. Ya estaba registrado como deuda (memoria `pmo-hmac-secret-cliente.md`). **Recomendación:** rotar + mover la validación a server-side (n8n), como hace Finanzas. Prioridad media-alta, tarea aparte.
+2. **`docs/n8n-workflows/pmo-chat-apply-code-code-validar-auth.js`** — el `SECRET` ya fue **rotado a placeholder** en HEAD (`<SECRETO_HMAC_VIVE_EN_N8N_NO_COMMITEAR>`, 2026-07-17). El valor real **pre-rotación sigue en el historial** pero está **muerto** (ya se rotó). **Recomendación:** aceptable como está; purga total del historial (BFG / `git filter-repo`) es **opcional** — solo cosmético dado que la llave ya no sirve.
+
+### Conclusión (b)
+La integración de Bancos **no introduce ni expone ningún secreto** y su cadena de auth (secreto server-side, token en body) es el patrón correcto. Los 2 hallazgos son de PMO, preexistentes, y no bloquean el go-live de Bancos. Si se desea higiene total del historial, la purga con `git filter-repo` del secreto PMO muerto se puede agendar aparte.
+
+---
+
+## (c) Control de acceso (ej. Cloudflare Access) — PROPUESTA
+
+**Hoy:** `finanzas/` es parte de un **GitHub Pages público** (`yinyo1.github.io/fts-suite/finanzas/`). Cualquiera con la URL llega al *login gate* (JWT). La única barrera es la contraseña de Finanzas. El código front es público por definición (Pages).
+
+**Riesgo:** la superficie de ataque (fuerza bruta al login, fuzzing de endpoints) está expuesta a todo Internet. El lockout (5→15 min en `staticData`) mitiga, pero es la única defensa de red.
+
+**Opciones (de menor a mayor esfuerzo):**
+1. **Cloudflare Access (Zero Trust) delante de `/finanzas`** *(recomendada)* — gate a nivel de red **antes** de que cargue la app: solo emails/identidades autorizadas (Google Workspace / OTP) ven siquiera el login. El JWT de Finanzas queda como segundo factor. Requiere poner el dominio detrás de Cloudflare (o servir Finanzas desde un host propio proxied). Costo: config Zero Trust + posible cambio de hosting de la sección.
+2. **Allowlist de IP / VPN** — restringir Finanzas a IPs de oficina + VPN. Simple pero rígido (rompe acceso remoto legítimo).
+3. **Mover Finanzas fuera de Pages público** a un host con auth de plataforma (Cloudflare Pages con Access, o un contenedor tras Access). Más limpio a largo plazo; más trabajo.
+
+**Recomendación:** opción 1 (Cloudflare Access) cuando se habilite el modo Real de Bancos — la conciliación toca dinero, amerita el gate de red. Mientras Bancos siga en demo, la exposición es nula (no hay datos reales servidos).
+
+---
+
+## Gate de liberación del modo Real (resumen)
+
+Antes de flip `IP_REAL_ENABLED=true` + merge a main:
+- [ ] (a) Decisión sobre expiración/claims del JWT (o aceptar 8h read-only como suficiente para v1).
+- [ ] (b) ✅ Barrido de secretos — superficie Bancos limpia. (2 hallazgos PMO ajenos, opcionales.)
+- [ ] (c) Decisión sobre control de acceso de red (Cloudflare Access u aceptar riesgo para read-only).
+- [ ] Revisión visual del demo (Artifact) aprobada.

--- a/docs/receta-conciliacion-rpc.md
+++ b/docs/receta-conciliacion-rpc.md
@@ -1,0 +1,181 @@
+# Receta RPC — conciliación bancaria statement line ↔ bill (Odoo 19 SaaS)
+
+> **Núcleo del motor de conciliación de Fase 2.** Confirmado empíricamente con el piloto Birlos (2026-07-20).
+> Fuente de verdad: ejecución real vía runner n8n TMP contra `serviciosfts.odoo.com` (Odoo 19.0 Enterprise SaaS).
+> Regla canónica §11.8 (CLAUDE.md) respetada: la contrapartida va a **201.01.01**, **JAMÁS se re-postea a 601.84.01**.
+
+---
+
+## 0. TL;DR — veredicto del piloto
+
+| | Antes | Después |
+|---|---|---|
+| statement line 30443 (Birlos −150.05) | `is_reconciled=false`, residual 150.05 | **`is_reconciled=true`, residual 0** |
+| pata contrapartida (aml 198764) | cuenta **184** (suspense), sin conciliar | cuenta **201.01.01**, `reconciled=true`, `full_reconcile 8807` |
+| bill BILL3064 (aml 198717) | `payment_state=not_paid`, residual 150.05 | **`payment_state=paid`, residual 0**, `full_reconcile 8807` |
+
+**Efecto contable:** el banco Jeeves saldó la cuenta por pagar del proveedor. Cuenta de gasto `601.84.01` **intacta**. Ambas patas quedaron unidas por el mismo `account.full.reconcile` (id 8807).
+
+---
+
+## 1. ⚠️ Hallazgo raíz — Odoo 19 removió `account.bank.statement.line.reconcile`
+
+El método clásico **NO existe en Odoo 19**:
+```
+AttributeError: The method 'account.bank.statement.line.reconcile' does not exist
+```
+(v19 usa `get_public_method`, que además **bloquea métodos privados** con `_`.) El mecanismo real es a nivel `account.move.line`.
+
+---
+
+## 2. Mecanismo REAL confirmado (2 llamadas)
+
+La línea de statement tiene un asiento (`account.move`) con **2 patas**:
+- **liquidez** → cuenta del diario (`223 · 102.01.007 Jeeves`).
+- **suspense** → `184 · Bank Suspense` (la contrapartida "abierta" que hay que reemplazar).
+
+La conciliación = **reemplazar la pata de suspense por la cuenta por pagar del bill (`201.01.01`) y reconciliar ambas patas de `201.01.01`**:
+
+```
+# 1) mover la pata de suspense a la cuenta por pagar + fijar partner
+account.move.line.write([SUSP_AML], {'account_id': 17, 'partner_id': <vendor_partner>})
+
+# 2) reconciliar las dos patas 201.01.01 (misma cuenta -> Odoo las casa)
+account.move.line.reconcile([SUSP_AML, BILL_AML])
+```
+
+- `17` = `201.01.01 Proveedores nacionales` (cuenta reconciliable).
+- `SUSP_AML` = la pata suspense del statement move (account 184).
+- `BILL_AML` = la pata `201.01.01` del vendor bill (crédito abierto).
+- `account.move.line.reconcile()` **sí es público en v19** y casa líneas de la **misma cuenta** que sumen 0.
+
+Esto es exactamente lo que hace internamente el widget `bank.rec.widget` (reemplazar suspense por la cuenta contrapartida + reconciliar), hecho por API.
+
+---
+
+## 3. Cómo localizar los IDs (read-only, previo a conciliar)
+
+```
+# pata de suspense del statement line (la que hay que mover)
+account.move.line.search([('move_id.statement_line_id','=',<ST_LINE_ID>), ('account_id','=',184)])
+# -> SUSP_AML
+
+# pata 201.01.01 abierta del bill candidato
+account.move.line.search([('move_id','=',<BILL_MOVE_ID>), ('account_id','=',17), ('reconciled','=',False)])
+# -> BILL_AML  (partner_id = vendor)
+```
+
+Caso piloto: `ST_LINE=30443` · `SUSP_AML=198764` · `BILL_MOVE=58554` (BILL3064) · `BILL_AML=198717` · `vendor_partner=1341` (BIRLOS Y TORNILLOS).
+
+---
+
+## 4. Transporte RPC — JSON-RPC `execute_kw` (el nodo Odoo de n8n NO sirve)
+
+**El nodo Odoo de n8n solo hace CRUD (create/get/getAll/update/delete) — NO llama métodos** como `reconcile`. Por eso el runner usa **JSON-RPC directo** contra `/jsonrpc`:
+
+- Endpoint: `POST https://serviciosfts.odoo.com/jsonrpc`
+- Auth: `common.authenticate(db, login, api_key, {})` → `uid`
+- Llamadas: `object.execute_kw(db, uid, api_key, model, method, args, kwargs)`
+- Body JSON-RPC: `{"jsonrpc":"2.0","method":"call","params":{"service":..,"method":..,"args":[..]},"id":N}`
+
+**Credenciales (env var de Railway, patrón §15 — nunca en el JSON ni en chat):**
+- `ODOO_RPC_KEY` = la misma API key que usa `mcp-server-odoo` (en `~/.claude.json` → `mcpServers.odoo.env.ODOO_API_KEY`). La reusamos; **cero keys nuevas.**
+- db=`serviciosfts`, login=`estebandelacruz@fts.mx` (uid 2), url=`https://serviciosfts.odoo.com` — hardcodeados (no secretos).
+- ⚠️ El MCP tiene `ODOO_YOLO` (capa write en la capa MCP). Vía JSON-RPC directo, la misma key **escribe** con los permisos Odoo del usuario (uid 2 = admin). Confirmado.
+
+`args` de `reconcile`: `[[SUSP_AML, BILL_AML]]` (recordset). `write`: `[[SUSP_AML], {campos}]`.
+
+### ⚠️ Pendiente de hardening (2026-07-20)
+Existe **una `ODOO_API_KEY` vieja/distinta ya cargada en las variables de Railway** (de ahí se copió por error en el primer intento del piloto — la key correcta es la del `mcp-server-odoo` en `~/.claude.json`, no la de Railway). **Acción:** identificar **qué servicio/workflow consume esa key vieja en Railway**, y **depurarla o rotarla**. Riesgo: key huérfana con permisos de escritura Odoo circulando sin dueño claro. Prioridad: media (no bloquea, pero es superficie de credencial sin auditar).
+
+---
+
+## 5. Seguridad del runner — auto-revert + idempotencia
+
+- **Un solo intento.** Si `reconcile` falla, Odoo hace **rollback** de esa llamada (cero write).
+- **Auto-revert:** si el `write` (paso 1) tuvo éxito pero el `reconcile` (paso 2) falla, el runner **revierte** `account_id`→184 + `partner_id`→false en el mismo run → **cero estado sucio**.
+- **Idempotencia:** re-ejecutar sobre una línea ya conciliada → el `reconcile` no hace nada nuevo (residual ya 0). El matching debe filtrar `is_reconciled=false` / `reconciled=false` antes de intentar.
+- **Ritual del runner TMP:** crear → Esteban activa (abrir · Save · Active · refresh) → disparar (`n8n_test_workflow`) → **borrar**. El secreto nunca sale del server.
+
+---
+
+## 6. BONUS — join transitivo (llenar las columnas del contrato del front)
+
+Desde la línea ya conciliada se navega hasta el bill y se jala TODO. Cadena:
+
+```
+statement line (30443)
+  -> move_id (58572, el asiento del statement)
+    -> pata 201.01.01 (198764) -> full_reconcile_id (8807)
+      -> otra pata del full_reconcile = 198717 (la del bill)
+        -> move_id (58554 = BILL3064)  ← el vendor bill
+```
+
+Query práctica (una vez conciliado):
+```
+# de la pata conciliada al bill:
+aml = account.move.line.read([198764], ['full_reconcile_id'])
+fr  = account.full.reconcile.read([8807], ['reconciled_line_ids'])   # -> [198764, 198717]
+bill= account.move.read([58554], ['name','invoice_origin','l10n_mx_edi_cfdi_uuid','payment_state','partner_id'])
+# analitica + articulo: de las lineas de gasto del bill
+account.move.line.search_read([('move_id','=',58554),('account_id','=',32)], ['product_id','analytic_distribution'])
+```
+
+**Las 6 columnas transitivas del contrato v7, llenas desde el piloto Birlos:**
+
+| columna (front) | valor | fuente |
+|---|---|---|
+| `bill` | **BILL3064** | move 58554 |
+| `po` (invoice_origin) | — (sin PO) | 58554.invoice_origin = false |
+| `sb` (status_bill / payment_state) | **paid** | 58554.payment_state |
+| `ff` (folio fiscal / UUID) | **F0940225-B05E-48D6-9B21-2CC1E9206882** | 58554.l10n_mx_edi_cfdi_uuid |
+| `art` (artículo) | Tornillería inox 7/16 (arandela/tornillo/tuerca) | product_id de las líneas 601.84.01 |
+| `ana` (analítica) | `{1089:100, 1176:100}` (proyecto 1089 + rubro Materiales 1176, **separadas**) | analytic_distribution de las líneas 601.84.01 |
+
+→ **Demostrado: las transitivas `art/ana/po/bill/sb/ff` SÍ se pueden llenar** una vez conciliada la línea. El motor de Fase 2 hará este join en el endpoint `fin/captura-transacciones` (hoy vienen null).
+
+---
+
+## 7. Verificación end-to-end (Fase C del piloto)
+
+1. **Odoo:** línea 30443 `is_reconciled=true`/residual 0; bill `paid`/residual 0; `full_reconcile 8807` une ambas patas. ✓
+2. **`fin/captura-status`:** `sin_conciliar` refleja el estado vivo (coincide con el aggregate MCP). ✓ *(nota: el total del journal es un blanco móvil porque `captura-jeeves` está activo y captura líneas nuevas; el −150.05 es incontrovertible a nivel línea + full_reconcile).*
+3. **`fin/captura-transacciones`** (search "Birlos"): línea 30443 → `ok:true`, `res:0`. ✓
+4. **Join transitivo:** las 6 columnas llenas (§6). ✓
+
+---
+
+## 8. Pendientes para el motor de Fase 2 (a partir de esta receta)
+
+1. **Matching heurístico** (candidato ↔ bill): monto exacto + fecha ±5d + partner≈comercio del label. Umbral de confianza; los ambiguos (p.ej. 3 bills TELCEL de $25) → NO auto-conciliar, mandar a revisión humana.
+2. **Regla dura §11.8:** contrapartida SIEMPRE a `201.01.01`; nunca a `601.84.01`.
+3. **Transporte:** JSON-RPC `execute_kw` (el nodo Odoo n8n no llama métodos). Creds vía `ODOO_RPC_KEY` env var.
+4. **Idempotencia + seguridad:** filtrar `is_reconciled=false`; auto-revert; log de cada match (id línea, id bill, full_reconcile, monto).
+5. **Join transitivo** en `fin/captura-transacciones` para llenar `bill/po/sb/ff/art/ana` de las líneas ya conciliadas.
+6. **Compras SIN bill:** el watchdog manda a Gera la lista de líneas sin bill (del lote de 32 fueron **29 = $35,787.19**; 1 ajuste ADJUSTMENT −$5,987.20 se rutea aparte).
+
+---
+
+## 9. Fase D — segunda candidata (Telcel) para conciliación MANUAL en el widget
+
+Comparativa de vías: **RPC (Birlos, esta receta) vs UI widget (Telcel)** → deben dejar el mismo estado final.
+
+- **Candidata:** statement line `[Gerardo Lozano ****1242] Telcel` −25 (id **30462**, 07-13) ↔ **3 bills TELCEL de $25 abiertos**: BILL3052 (07-15), BILL3069 (07-17), BILL3071 (07-17).
+- **¿Cuál elegir?** El efecto económico es idéntico (cualquiera salda un Telcel de $25). Por convención de auditoría: **FIFO = el más antiguo = BILL3052 (07-15).**
+- **Pasos UI (Odoo 19 Enterprise):**
+  1. Contabilidad → Tablero → diario **Jeeves Tarjeta Credito** → **Conciliar**.
+  2. Ubica el statement line Telcel −25.00 (07-13).
+  3. Pestaña **"Buscar asientos existentes"** → busca `Telcel` o `25`.
+  4. Selecciona **BILL3052** (más antiguo).
+  5. Renglón balancea a 0.00 → **Validar**.
+  6. Verifica: línea conciliada (✓) + **BILL3052 → Pagado**.
+- **Resultado esperado (igual que Birlos):** `is_reconciled=true`, residual línea 0, bill `paid`, `full_reconcile` uniendo ambas patas en `201.01.01`.
+
+---
+
+## 10. Anexo — IDs y constantes del piloto Birlos
+
+- Journal: `61` (Jeeves Tarjeta Credito). Cuentas: suspense `184` · payable `201.01.01`=`17` · gasto `601.84.01`=`32`.
+- statement line `30443` · statement move `58572` (BNK6/2026/00630) · suspense aml `198764`.
+- Bill `BILL3064` = move `58554` · payable aml `198717` · vendor partner `1341` (BIRLOS Y TORNILLOS) · UUID `F0940225-B05E-48D6-9B21-2CC1E9206882`.
+- `account.full.reconcile` resultante: `8807`.

--- a/docs/receta-conciliacion-rpc.md
+++ b/docs/receta-conciliacion-rpc.md
@@ -179,3 +179,32 @@ Comparativa de vías: **RPC (Birlos, esta receta) vs UI widget (Telcel)** → de
 - statement line `30443` · statement move `58572` (BNK6/2026/00630) · suspense aml `198764`.
 - Bill `BILL3064` = move `58554` · payable aml `198717` · vendor partner `1341` (BIRLOS Y TORNILLOS) · UUID `F0940225-B05E-48D6-9B21-2CC1E9206882`.
 - `account.full.reconcile` resultante: `8807`.
+
+---
+
+## 11. Desactivación del auto-match nativo (`ir.cron` 52) — 2026-07-20
+
+- **id `52`** · "Try to reconcile automatically your statement lines" · código `model._cron_try_auto_reconcile_statement_lines(batch_size=100)` · modelo Bank Statement Line · **diario ~18:40 UTC** · usuario OdooBot.
+- **Desactivado el 2026-07-20** (`active=false`, vía RPC, read-back confirmado) — antes de su corrida del 21-jul 18:40 UTC.
+- **Razón:** auto-casaba las capturas nuevas de Jeeves contra el **backlog sucio de la cuenta 186 Outstanding Payments** (**$12,157,042 / 978 líneas abiertas**, pagos 2024/2025 nunca conciliados contra banco) → **falsos positivos**: Telcel 30462/30468 y Steren 30453 casados a pagos viejos en vez de a sus bills. Las 13 `account.reconcile.model` son **todas `trigger: manual`** → el cron NO usa reglas custom; usa el auto-match **nativo** de Odoo.
+- **Reversible con un clic** (`active=true`).
+- **Condición de reevaluación (para reactivar):** (a) backlog de la 186 limpio/conciliado **y** (b) motor de conciliación de Fase 2 vivo — para que el matching correcto lo haga el motor/humano, no el auto-match ciego contra basura.
+
+## 12. Receta de DESENREDO (3er flujo del motor: detectar → desenredar → re-conciliar) — CONFIRMADA
+
+Caso: falso positivo del auto-match (línea conciliada contra un pago viejo equivocado en la cuenta 186). Piloto: Telcel 30462 (2026-07-20). **Atómico en un run, con `ir.cron` 52 ya apagado.**
+
+1. **Derivar** la contrapartida mal conciliada: `search_read account.move.line [('move_id.statement_line_id','=',LINE),('reconciled','=',True),('account_id','!=',<liquidez 223>)]` → la pata en 186.
+2. **Unwind:** `account.partial.reconcile.unlink([partial_ids])` (de los `matched_debit_ids`/`matched_credit_ids` de esa pata) → desata el falso positivo. **Side-effect correcto:** el pago viejo recupera su residual real (el $200 TELCEL pasó de −75 a **−100** al liberarse el $25).
+3. **Mover** la contrapartida `186 → 201.01.01` + partner: `account.move.line.write([cp], {'account_id':17,'partner_id':P})`.
+4. **Reconcile** contra el bill correcto: `account.move.line.reconcile([cp, bill_aml])`.
+- **Auto-revert:** si (4) falla → revierte la cuenta a 186; la contrapartida queda **abierta, sin el falso positivo** (estado estrictamente mejor, nunca peor).
+- **Guards:** `NO_WRONG_COUNTERPART`, `NO_PARTIALS`, `BILL_NO_201`, `BILL_YA_CONCILIADO`.
+- **Método de unwind confirmado en v19:** `account.partial.reconcile.unlink` (callable vía RPC; `remove_move_reconcile` no se necesitó).
+- **Resultado Telcel:** 30462 conciliada a **BILL3052** (`payment_state=paid`, `full_reconcile 8825`); pago viejo $200 restaurado a −100 (aún con el falso positivo de 30468 pendiente de desenredar).
+
+## 13. Nota — el guard maneja concurrencia HUMANA (evidencia de producción)
+
+Ferre 30478 ↔ BILL3063 **no se pudo conciliar por RPC**: entre la sugerencia (~21:00) y el disparo (22:18), **un humano (`Administracion FTS-YIN`, uid 25) concilió BILL3063 manualmente** ("Manual: BILL3063", partial 12735, create_uid 25). El guard **`BILL_YA_CONCILIADO`** lo detectó y **rehusó escribir** (cero write). No fue bug ni el cron — **trabajo contable humano legítimo concurrente**.
+
+→ **Regla dura para `fin/captura-conciliar`:** re-validar el estado del bill (`reconciled`) **en el instante del write**, nunca confiar en lo que el front mostró minutos antes. El mundo cambia entre la sugerencia y el clic. El guard ya lo probó en vivo.

--- a/docs/receta-conciliacion-rpc.md
+++ b/docs/receta-conciliacion-rpc.md
@@ -208,3 +208,24 @@ Caso: falso positivo del auto-match (línea conciliada contra un pago viejo equi
 Ferre 30478 ↔ BILL3063 **no se pudo conciliar por RPC**: entre la sugerencia (~21:00) y el disparo (22:18), **un humano (`Administracion FTS-YIN`, uid 25) concilió BILL3063 manualmente** ("Manual: BILL3063", partial 12735, create_uid 25). El guard **`BILL_YA_CONCILIADO`** lo detectó y **rehusó escribir** (cero write). No fue bug ni el cron — **trabajo contable humano legítimo concurrente**.
 
 → **Regla dura para `fin/captura-conciliar`:** re-validar el estado del bill (`reconciled`) **en el instante del write**, nunca confiar en lo que el front mostró minutos antes. El mundo cambia entre la sugerencia y el clic. El guard ya lo probó en vivo.
+
+## 14. Desenredo en lote + edge case de match PARCIAL (2026-07-20/21)
+
+Tras apagar el cron 52, se desenredaron los falsos positivos conocidos (mismo runner multi-job):
+
+| línea | monto | modo | resultado |
+|---|---|---|---|
+| 30462 (Telcel) | −25 | full → BILL3052 | ✅ `paid`, full_reconcile 8825 |
+| 30468 (Telcel) | −100 | full → BILL2947 | ✅ `paid` |
+| 30453 (Steren) | −99.01 | unwind-only (sin bill) | ✅ contrapartida → suspense 184, línea limpia (`is_reconciled=false`, residual 99.01) |
+| 30466 (Ferretería) | −647.10 | unwind-only (FP parcial $576.11) | ⚠️ FP removido, **estado dividido** |
+
+**Edge case — match PARCIAL:** el cron casó **$576.11 de $647.10** (parcial). Al desenredar: el `unlink` del partial quita el FP, pero mover la contrapartida liberada (186, $576.11) a **suspense 184** falla con `UserError: "must always have exactly one suspense line"` — porque la línea ya tiene una suspense (los $70.99 restantes). Odoo prohíbe 2 líneas de suspense en el mismo asiento de statement.
+
+- **Full false match** (contrapartida 100% en 186, sin suspense separada) → unwind-only funciona directo: `186 → 184`, una sola suspense. Limpio.
+- **Partial false match** → el `unlink` quita el FP (queda consistente: liquidez + 1 suspense + resto en 186), pero **la consolidación a suspense único requiere el "Deshacer conciliación" del widget de Odoo** (recrea la suspense por el monto total), no un `write` de cuenta. Alternativa: dejar el resto en 186 abierto (no es FP, solo no-consolidado) para que el motor/humano lo tome.
+- **Regla para el motor de Fase 2:** distinguir FP **full** vs **parcial**; el parcial no se auto-consolida por RPC simple — enrutar a reset-widget o dejar el remanente abierto marcado.
+
+## 15. Auto-match nativo — mecanismo confirmado (`ir.cron` 52)
+
+El culpable de los FP fue **`ir.cron` 52 `_cron_try_auto_reconcile_statement_lines`** (diario ~18:40 UTC, OdooBot), NO una `reconcile.model` (las 13 son `trigger:manual`). Evidencia: los partials FP los creó **OdooBot** (uid 1) en la ventana del cron (12728/12729/12730 el 07-19 18:42). Los partials legítimos (ej. BILL3063) los creó un **humano** (uid 25). → Desactivado (§11).

--- a/finanzas/css/instrumentos-pago.css
+++ b/finanzas/css/instrumentos-pago.css
@@ -1,0 +1,144 @@
+/* ═══ FTS Suite · Finanzas — Instrumentos de pago (Bancos) ═══
+   Port fiel del mockup v7 (docs/mockup-finanzas-bancos.html), namespaced bajo
+   .ip-view para no colisionar con finanzas.css. Las variables de tema viven en
+   .ip-view (NO en :root). El selector de empresas usa FinCompanySelector (no se
+   replican los chips del v7). El toast propio es .ip-toast (evita choque con
+   el .toast global de facturas-core). */
+
+.ip-view{
+  --ink:#1a2129;          /* grafito */
+  --ip-panel:#ffffff;
+  --ip-line:#d7dde3;
+  --steel:#5b6875;
+  --ip-accent:#0e5fd8;    /* azul FTS acción */
+  --ip-ok:#12a150;
+  --ip-warn:#e8a500;
+  --ip-bad:#d63b2f;
+  --ip-mono:'IBM Plex Mono',monospace;
+  color:var(--ink);
+}
+
+.ip-view h2{font-size:14px;text-transform:uppercase;letter-spacing:1.2px;color:var(--steel);margin:26px 0 12px;font-weight:700}
+.ip-view h2:first-of-type{margin-top:8px}
+
+/* ---- header de la vista (título + acciones) ---- */
+.ip-head{display:flex;align-items:flex-start;gap:12px;margin-bottom:4px}
+.ip-head .ip-gearwrap{margin-left:auto}
+
+/* ---- cards journals / kpi / btn ---- */
+.ip-view .kpi{margin-top:12px;padding-top:12px;border-top:1px dashed var(--ip-line)}
+.ip-view .kpi .lbl{font-size:11px;text-transform:uppercase;letter-spacing:1px;color:var(--steel)}
+.ip-view .kpi .val{font-family:var(--ip-mono);font-size:26px;font-weight:600;color:var(--ip-bad)}
+.ip-view .kpi .note{font-size:11px;color:var(--steel);margin-top:2px}
+.ip-view .ip-btn{display:inline-flex;align-items:center;gap:8px;background:var(--ip-accent);color:#fff;border:none;border-radius:6px;padding:9px 16px;font-family:inherit;font-weight:600;font-size:14px;cursor:pointer;margin-top:14px}
+.ip-view .ip-btn:disabled{background:#8fa8cc;cursor:wait}
+.ip-view .ip-btn .spin{width:13px;height:13px;border:2px solid #fff;border-top-color:transparent;border-radius:50%;animation:ipsp .7s linear infinite;display:none}
+.ip-view .ip-btn.busy .spin{display:inline-block}
+@keyframes ipsp{to{transform:rotate(360deg)}}
+.ip-view .synced{display:flex;align-items:center;gap:8px;margin-top:12px;padding:8px 10px;background:#f0f6ff;border:1px solid #cfe0f5;border-radius:6px;font-size:13px;color:#274b7a}
+.ip-view .synced b{color:#0e5fd8}
+.ip-view .schChip{margin-left:auto;font-family:var(--ip-mono);font-size:10.5px;color:#5b6875;background:#fff;border:1px solid var(--ip-line);border-radius:4px;padding:2px 6px;white-space:nowrap}
+.ip-view .pulse{width:8px;height:8px;border-radius:50%;background:var(--ip-accent);animation:ippl 2s ease-in-out infinite}
+@keyframes ippl{0%,100%{opacity:1}50%{opacity:.3}}
+
+/* ---- toast propio (no choca con el .toast global) ---- */
+.ip-toast{position:fixed;bottom:22px;right:22px;background:var(--ink);color:#fff;padding:12px 18px;border-radius:6px;font-size:14px;display:none;box-shadow:0 6px 20px rgba(0,0,0,.25);z-index:60}
+.ip-toast b{color:#7dd89b}
+
+/* ---- fuentes colapsables ---- */
+.ip-view .srclist{display:flex;flex-direction:column;gap:8px}
+.ip-view .src{background:var(--ip-panel);border:1px solid var(--ip-line);border-radius:8px;overflow:hidden}
+.ip-view .srchead{display:flex;align-items:center;gap:12px;padding:12px 16px;cursor:pointer;user-select:none}
+.ip-view .srchead:hover{background:#f7f9fb}
+.ip-view .srchead .chev{font-family:var(--ip-mono);color:var(--steel);transition:transform .18s;font-size:12px}
+.ip-view .src.open .chev{transform:rotate(90deg)}
+.ip-view .srchead .nm{font-weight:700;font-size:15px}
+.ip-view .stchip{display:inline-flex;align-items:center;gap:6px;font-family:var(--ip-mono);font-size:11.5px;font-weight:600;border-radius:12px;padding:3px 10px}
+.ip-view .stchip.ok{background:#e7f6ed;color:#0d7a3f}
+.ip-view .stchip.err{background:#fdeae8;color:#b32d22}
+.ip-view .stchip.off{background:#eef1f4;color:#5b6875}
+.ip-view .wdbadge{display:inline-flex;align-items:center;gap:6px;background:#d63b2f;color:#fff;font-size:11.5px;font-weight:700;border-radius:12px;padding:3px 10px;margin-left:4px}
+.ip-view .wdbadge button{background:#fff;color:#b32d22;border:none;border-radius:8px;padding:1px 8px;font-size:11px;font-weight:700;cursor:pointer}
+.ip-view .srchead .sp{margin-left:auto;font-size:12px;color:var(--steel);font-family:var(--ip-mono)}
+.ip-view .srcbody{display:none;border-top:1px solid var(--ip-line);padding:16px 18px}
+.ip-view .src.open .srcbody{display:block}
+.ip-view .src .meta{font-size:13px;color:var(--steel);line-height:1.7}
+.ip-view .src .meta b{color:var(--ink);font-weight:600}
+
+/* ---- settings (agregar fuente — cosmético/demo) ---- */
+.ip-gearwrap{position:relative}
+.ip-view .gear{background:#fff;border:1px solid var(--ip-line);color:var(--steel);border-radius:6px;padding:6px 11px;cursor:pointer;font-size:15px}
+.ip-view .setmenu{display:none;position:absolute;right:0;top:40px;background:#fff;color:var(--ink);border:1px solid var(--ip-line);border-radius:8px;box-shadow:0 10px 30px rgba(0,0,0,.2);padding:16px;z-index:40;width:270px}
+.ip-view .setmenu.open{display:block}
+.ip-view .setmenu .mt{font-size:11px;text-transform:uppercase;letter-spacing:1px;color:var(--steel);font-weight:700;margin-bottom:10px}
+.ip-view .setmenu label{display:block;font-size:12px;color:var(--steel);margin:8px 0 3px}
+.ip-view .setmenu select,.ip-view .setmenu input{width:100%;font-family:inherit;font-size:13px;padding:7px 9px;border:1px solid var(--ip-line);border-radius:5px}
+.ip-view .setmenu .ip-btn{width:100%;justify-content:center;margin-top:12px}
+
+/* ---- filtros + tabla ---- */
+.ip-view .panel{background:var(--ip-panel);border:1px solid var(--ip-line);border-radius:8px;overflow:hidden}
+.ip-view .filters{display:flex;flex-wrap:wrap;gap:10px;padding:14px 16px;border-bottom:1px solid var(--ip-line);background:#f7f9fb}
+.ip-view .filters select,.ip-view .filters input{font-family:inherit;font-size:13.5px;padding:7px 10px;border:1px solid var(--ip-line);border-radius:5px;background:#fff;color:var(--ink)}
+.ip-view .colbtn{position:relative;margin-left:auto}
+.ip-view .colbtn>button{border:1px solid var(--ip-line);background:#fff;border-radius:5px;padding:7px 11px;cursor:pointer;font-weight:700;letter-spacing:2px;color:var(--steel)}
+.ip-view .colmenu{display:none;position:absolute;right:0;top:38px;background:#fff;border:1px solid var(--ip-line);border-radius:7px;box-shadow:0 8px 24px rgba(0,0,0,.14);padding:10px 14px;z-index:20;min-width:210px;max-height:320px;overflow:auto}
+.ip-view .colmenu.open{display:block}
+.ip-view .colmenu label{display:flex;gap:8px;align-items:center;font-size:13px;padding:4px 0;cursor:pointer;white-space:nowrap}
+.ip-view .colmenu .mt{font-size:11px;text-transform:uppercase;letter-spacing:1px;color:var(--steel);margin-bottom:6px;font-weight:700}
+.ip-view .colmenu .cact{display:flex;gap:10px;margin-bottom:8px;font-size:12px}
+.ip-view .colmenu .cact a{color:var(--ip-accent);cursor:pointer;font-weight:600;text-decoration:none}
+.ip-view th.sortable{cursor:pointer;user-select:none}
+.ip-view th.sortable:hover{color:var(--ink)}
+.ip-view th .sarr{font-family:var(--ip-mono);font-size:10px;margin-left:3px;color:var(--ip-accent)}
+.ip-view .xlsbtn{display:none;align-items:center;gap:6px;border:1px solid var(--ip-ok);color:var(--ip-ok);background:#fff;border-radius:5px;padding:7px 12px;cursor:pointer;font-family:inherit;font-weight:600;font-size:13px;white-space:nowrap}
+.ip-view .xlsbtn.show{display:inline-flex}
+.ip-view .xlsbtn:hover{background:#eefaf2}
+.ip-view .xlsbtn:disabled{opacity:.45;cursor:not-allowed}
+.ip-view .selbanner{display:none;background:#f0f6ff;border-bottom:1px solid #cfe0f5;padding:9px 16px;font-size:13px;color:#274b7a}
+.ip-view .selbanner.show{display:flex;align-items:center;gap:12px}
+.ip-view .selbanner b{font-family:var(--ip-mono)}
+.ip-view .selbanner a{color:var(--ip-accent);cursor:pointer;font-weight:600;text-decoration:none}
+.ip-view td.chk,.ip-view th.chk{width:34px;text-align:center;padding:9px 6px}
+.ip-view td.chk input,.ip-view th.chk input{width:15px;height:15px;cursor:pointer;accent-color:var(--ip-accent)}
+.ip-view tr.selrow{background:#f0f6ff}
+.ip-view .filters input[type=date]{width:140px}
+.ip-view .filters .grow{flex:1;min-width:160px}
+.ip-view table{width:100%;border-collapse:collapse;font-size:13.5px}
+.ip-view th{font-size:11px;text-transform:uppercase;letter-spacing:.8px;color:var(--steel);text-align:left;padding:9px 14px;border-bottom:1px solid var(--ip-line);background:#fbfcfd}
+.ip-view td{padding:9px 14px;border-bottom:1px solid #edf0f3}
+.ip-view td.amt{font-family:var(--ip-mono);text-align:right;white-space:nowrap}
+.ip-view td.amt.neg{color:var(--ip-bad)}
+.ip-view td.amt.pos{color:var(--ip-ok)}
+.ip-view .st{font-family:var(--ip-mono);font-size:12px;font-weight:600}
+.ip-view .st.ok{color:var(--ip-ok)}
+.ip-view .st.pend{color:var(--ip-warn)}
+.ip-view .jtag{font-family:var(--ip-mono);font-size:11px;background:#eef3fa;color:#274b7a;border-radius:3px;padding:2px 6px}
+.ip-view .amber{color:var(--ip-warn)}
+.ip-view .tfoot{display:flex;align-items:center;justify-content:space-between;padding:11px 16px;font-size:13px;color:var(--steel);background:#f7f9fb;border-top:1px solid var(--ip-line)}
+.ip-view .pager button{border:1px solid var(--ip-line);background:#fff;border-radius:4px;padding:4px 10px;margin-left:5px;cursor:pointer;font-family:var(--ip-mono);font-size:12px}
+.ip-view .pager button.on{background:var(--ink);color:#fff;border-color:var(--ink)}
+.ip-view .ip-empty{padding:30px;text-align:center;color:var(--steel);font-size:14px}
+
+/* ---- semáforo ---- */
+.ip-view .sem{background:var(--ink);border-radius:8px;padding:16px 18px;color:#dfe6ec}
+.ip-view .sem .title{font-size:12px;text-transform:uppercase;letter-spacing:1.4px;color:#8fa0b0;margin-bottom:12px;font-weight:700}
+.ip-view .semrow{display:grid;grid-template-columns:120px 1fr 90px 130px;gap:12px;align-items:center;padding:9px 4px;border-bottom:1px solid #2b333c;font-size:14px}
+.ip-view .semrow:last-child{border-bottom:none}
+.ip-view .semrow.total{background:#232b34;margin:8px -8px -8px;padding:12px;border-radius:6px;font-weight:700}
+.ip-view .light{width:16px;height:16px;border-radius:50%;box-shadow:0 0 0 3px rgba(255,255,255,.06);justify-self:start}
+.ip-view .light.g{background:var(--ip-ok);box-shadow:0 0 10px rgba(18,161,80,.8)}
+.ip-view .light.y{background:var(--ip-warn);box-shadow:0 0 10px rgba(232,165,0,.8)}
+.ip-view .light.r{background:var(--ip-bad);box-shadow:0 0 10px rgba(214,59,47,.8)}
+.ip-view .bar{height:7px;background:#2b333c;border-radius:4px;overflow:hidden}
+.ip-view .bar i{display:block;height:100%;border-radius:4px}
+.ip-view .pct{font-family:var(--ip-mono);font-size:14px;text-align:right}
+.ip-view .res{font-family:var(--ip-mono);font-size:13px;text-align:right;color:#f0b9b3}
+.ip-view .semnote{margin-top:10px;font-size:11.5px;color:#8fa0b0}
+
+/* ---- corridas ---- */
+.ip-view .runs td{font-family:var(--ip-mono);font-size:12.5px}
+
+@media(max-width:700px){
+  .ip-view .semrow{grid-template-columns:26px 1fr 70px 110px}
+  .ip-view .semrow .jn{font-size:13px}
+}

--- a/finanzas/data/mock/instrumentos-pago.mock.json
+++ b/finanzas/data/mock/instrumentos-pago.mock.json
@@ -1,0 +1,48 @@
+{
+  "_note": "Datos demo del módulo Instrumentos de pago (Bancos), portados del mockup v7 (docs/mockup-finanzas-bancos.html). Ficticios, no provienen de Odoo. Las filas llevan company_id (1=FTS-MX, 6=FTS-USA) para filtrar vía FinCompanySelector. Las columnas transitivas (ana/po/bill/sb/ff/art) aquí traen ejemplos; en modo real llegan null hasta que exista el motor de Fase 2.",
+  "cron": {
+    "tz": "America/Monterrey",
+    "days": [1, 2, 3, 4, 5],
+    "start_hour": 7,
+    "regular_end_hour": 16,
+    "regular_interval_min": 30,
+    "peak_hour": 17,
+    "peak_interval_min": 10,
+    "close_hour": 18,
+    "label": "L–V 7–18h · 30 min · pico 10 min"
+  },
+  "sources": [
+    { "id": "jeeves",   "co": 1, "pais": "MEX", "nm": "Jeeves Tarjeta Crédito", "jt": "journal 61",  "met": "MCP nativo", "st": "ok",  "last": "hace 12 min", "kpi": "$342,918.40",     "note": "incluye backlog histórico (50 líneas)", "movHoy": 6, "movMes": 112, "run": "OK — 6 nuevas · 0 duplicadas", "main": true },
+    { "id": "bbvag",    "co": 1, "pais": "MEX", "nm": "BBVA General MXN",       "jt": "journal 8",   "met": "CAMT.053",   "st": "ok",  "last": "hoy 07:30",   "kpi": "$1,204,330.12",   "movHoy": 3, "movMes": 88,  "run": "OK — 3 nuevas" },
+    { "id": "bbvan",    "co": 1, "pais": "MEX", "nm": "BBVA Nómina MXN",        "jt": "journal 96",  "met": "CAMT.053",   "st": "ok",  "last": "hoy 07:30",   "kpi": "$88,410.00",      "movHoy": 0, "movMes": 31,  "run": "OK — 0 nuevas" },
+    { "id": "bbvau",    "co": 1, "pais": "MEX", "nm": "BBVA USD",               "jt": "journal 58",  "met": "CAMT.053",   "st": "ok",  "last": "hoy 07:30",   "kpi": "$12,940.55",      "movHoy": 1, "movMes": 6,   "run": "OK — 1 nueva" },
+    { "id": "payana",   "co": 1, "pais": "MEX", "nm": "Payana (STP)",           "jt": "journal 75",  "met": "Portal",     "st": "ok",  "last": "ayer 17:50",  "kpi": "$310,220.90",     "movHoy": 0, "movMes": 41,  "run": "OK — 5 nuevas" },
+    { "id": "monexm",   "co": 1, "pais": "MEX", "nm": "Monex MXN",              "jt": "journal 111", "met": "MT940",      "st": "err", "last": "hace 4 días", "kpi": "$96,502.33",      "movHoy": 0, "movMes": 5,   "run": "ERROR — timeout de export", "wd": "Sin sync desde hace 4 días · Watchdog W2 notificó a Gera" },
+    { "id": "monexu",   "co": 1, "pais": "MEX", "nm": "Monex USD",              "jt": "journal 112", "met": "MT940",      "st": "ok",  "last": "hoy 07:30",   "kpi": "$4,110.00",       "movHoy": 0, "movMes": 2,   "run": "OK — 0 nuevas" },
+    { "id": "chase",    "co": 6, "pais": "USA", "nm": "JP Morgan Chase",        "jt": "journal 73",  "met": "Plaid",      "st": "ok",  "last": "hace 25 min", "kpi": "$54,208.10 USD",  "movHoy": 2, "movMes": 100, "run": "OK — 2 nuevas" },
+    { "id": "chasetdc", "co": 6, "pais": "USA", "nm": "Chase TDC",              "jt": "journal 74",  "met": "Plaid",      "st": "ok",  "last": "hace 25 min", "kpi": "$8,114.02 USD",   "movHoy": 1, "movMes": 21,  "run": "OK — 1 nueva" }
+  ],
+  "runs": [
+    { "run": "Jeeves 2026-07-18 07:30", "origen": "schedule", "rango": "07-14 → 07-18", "nuevas": 6,  "dup": 2,  "rech": 1,  "status": "ok",    "status_label": "OK" },
+    { "run": "Jeeves 2026-07-17 07:30", "origen": "schedule", "rango": "07-13 → 07-17", "nuevas": 9,  "dup": 3,  "rech": 0,  "status": "ok",    "status_label": "OK" },
+    { "run": "Jeeves 2026-07-16 11:02", "origen": "manual",   "rango": "07-12 → 07-16", "nuevas": 0,  "dup": 11, "rech": 0,  "status": "ok",    "status_label": "OK" },
+    { "run": "Jeeves 2026-07-16 07:30", "origen": "schedule", "rango": "07-12 → 07-16", "nuevas": 11, "dup": 2,  "rech": 0,  "status": "ok",    "status_label": "OK" },
+    { "run": "Jeeves 2026-07-15 07:30", "origen": "schedule", "rango": "07-11 → 07-15", "nuevas": null, "dup": null, "rech": null, "status": "abort", "status_label": "ABORTADO (total API ≠ filas)" }
+  ],
+  "rows": [
+    { "company_id": 1, "d": "2026-07-18", "j": "Jeeves", "tipo": "Egreso",   "ref": "[Primary ****6831] Costco Wholesale",               "amt": -714.04,    "mon": "MXN", "tarj": "Primary",       "comp": "Esteban",        "rs": "Servicios FTS", "art": "Consumibles",       "ana": "SO8205-OFICINA",      "po": "",       "bill": "",         "sb": "",       "ff": "",           "tk": "",  "ok": false, "res": 714.04 },
+    { "company_id": 1, "d": "2026-07-18", "j": "Jeeves", "tipo": "Egreso",   "ref": "[Mateo Salazar ****4197] Oxxo Gas Santa Catarina", "amt": -1580.00,   "mon": "MXN", "tarj": "Mateo Salazar", "comp": "Mateo Salazar",  "rs": "Servicios FTS", "art": "Gasolina",          "ana": "SO8438-GASOLINA",     "po": "PO6591", "bill": "BILL2951", "sb": "PAGADA", "ff": "A1B2-…-9F3C", "tk": "✓", "ok": false, "res": 1580.00 },
+    { "company_id": 1, "d": "2026-07-17", "j": "Jeeves", "tipo": "Egreso",   "ref": "[Felipe Pérez ****4548] Home Depot Mty",           "amt": -4231.90,   "mon": "MXN", "tarj": "Felipe Pérez",  "comp": "Felipe Pérez",   "rs": "Servicios FTS", "art": "Material eléctrico", "ana": "SO11547-TOPO CHICO",  "po": "PO6588", "bill": "BILL2948", "sb": "PAGADA", "ff": "C4D1-…-22AB", "tk": "✓", "ok": true,  "res": 0 },
+    { "company_id": 1, "d": "2026-07-17", "j": "Jeeves", "tipo": "Egreso",   "ref": "[Primary ****6831] AWS EMEA",                       "amt": -2118.33,   "mon": "MXN", "tarj": "Primary",       "comp": "Esteban",        "rs": "Servicios FTS", "art": "Cloud",             "ana": "SO8205-OFICINA",      "po": "PO6585", "bill": "BILL2945", "sb": "PAGADA", "ff": "",           "tk": "",  "ok": true,  "res": 0 },
+    { "company_id": 1, "d": "2026-07-16", "j": "Jeeves", "tipo": "Ingreso",  "ref": "[DEVOLUCIÓN ****4548] Uber Trip",                   "amt": 429.98,     "mon": "MXN", "tarj": "Felipe Pérez",  "comp": "Felipe Pérez",   "rs": "Servicios FTS", "art": "",                  "ana": "",                    "po": "",       "bill": "",         "sb": "",       "ff": "",           "tk": "",  "ok": true,  "res": 0 },
+    { "company_id": 6, "d": "2026-07-15", "j": "Jeeves", "tipo": "Egreso",   "ref": "[Ricardo Hdz ****4197] Vuelo VivaAerobus MTY-DFW", "amt": -6874.00,   "mon": "MXN", "tarj": "Ricardo Hdz",   "comp": "Ricardo Hdz",    "rs": "FTS LLC",       "art": "Viáticos",          "ana": "SO9428-VERTIV",       "po": "",       "bill": "",         "sb": "",       "ff": "",           "tk": "",  "ok": false, "res": 6874.00 },
+    { "company_id": 1, "d": "2026-07-14", "j": "Jeeves", "tipo": "Egreso",   "ref": "[Primary ****6831] Ferretería Industrial del Norte", "amt": -12408.55, "mon": "MXN", "tarj": "Primary",       "comp": "Gibrán Solís",   "rs": "Servicios FTS", "art": "Tornillería",       "ana": "SO11547-TOPO CHICO",  "po": "PO6580", "bill": "BILL2940", "sb": "PAGADA", "ff": "E8F2-…-77CD", "tk": "✓", "ok": true,  "res": 0 },
+    { "company_id": 1, "d": "2026-07-12", "j": "Jeeves", "tipo": "Egreso",   "ref": "[Mateo Salazar ****4197] Oxxo Gas Cumbres",        "amt": -1420.00,   "mon": "MXN", "tarj": "Mateo Salazar", "comp": "Mateo Salazar",  "rs": "Servicios FTS", "art": "Gasolina",          "ana": "SO8438-GASOLINA",     "po": "PO6576", "bill": "BILL2936", "sb": "PAGADA", "ff": "B7A9-…-1E2F", "tk": "✓", "ok": true,  "res": 0 },
+    { "company_id": 1, "d": "2026-07-10", "j": "Jeeves", "tipo": "Egreso",   "ref": "[Felipe Pérez ****4548] Hotel City Express Saltillo", "amt": -3890.00, "mon": "MXN", "tarj": "Felipe Pérez",  "comp": "Felipe Pérez",   "rs": "Servicios FTS", "art": "Viáticos",          "ana": "SO9428-VERTIV NALCO", "po": "PO6570", "bill": "",         "sb": "",       "ff": "",           "tk": "",  "ok": false, "res": 3890.00 },
+    { "company_id": 1, "d": "2026-07-08", "j": "Jeeves", "tipo": "Egreso",   "ref": "[Primary ****6831] Grainger México",               "amt": -18742.10,  "mon": "MXN", "tarj": "Primary",       "comp": "Gibrán Solís",   "rs": "Servicios FTS", "art": "Herramienta",       "ana": "SO11547-TOPO CHICO",  "po": "PO6566", "bill": "BILL2929", "sb": "PAGADA", "ff": "D3C8-…-44BE", "tk": "",  "ok": false, "res": 18742.10 },
+    { "company_id": 1, "d": "2026-07-02", "j": "Jeeves", "tipo": "Traspaso", "ref": "[FONDEO] Credit Line",                             "amt": 198757.85,  "mon": "MXN", "tarj": "",              "comp": "Gera",           "rs": "Servicios FTS", "art": "",                  "ana": "",                    "po": "",       "bill": "",         "sb": "",       "ff": "",           "tk": "",  "ok": false, "res": 198757.85 },
+    { "company_id": 1, "d": "2026-07-02", "j": "Jeeves", "tipo": "Traspaso", "ref": "[FONDEO] Credit Line",                             "amt": 34998.00,   "mon": "MXN", "tarj": "",              "comp": "Gera",           "rs": "Servicios FTS", "art": "",                  "ana": "",                    "po": "",       "bill": "",         "sb": "",       "ff": "",           "tk": "",  "ok": false, "res": 34998.00 },
+    { "company_id": 1, "d": "2026-07-01", "j": "Jeeves", "tipo": "Egreso",   "ref": "[Primary ****6831] Steren Tienda 44",              "amt": -1235.60,   "mon": "MXN", "tarj": "Primary",       "comp": "Esteban",        "rs": "Servicios FTS", "art": "Electrónica",       "ana": "SO8205-OFICINA",      "po": "PO6560", "bill": "BILL2920", "sb": "PAGADA", "ff": "",           "tk": "",  "ok": true,  "res": 0 },
+    { "company_id": 6, "d": "2026-07-11", "j": "Chase",  "tipo": "Egreso",   "ref": "GRAINGER US - HOUSTON TX",                         "amt": -1240.80,   "mon": "USD", "tarj": "Chase TDC",     "comp": "Jesús Montalvo", "rs": "FTS LLC",       "art": "Herramienta",       "ana": "SO9428-VERTIV",       "po": "PO6572", "bill": "BILL2933", "sb": "PAGADA", "ff": "",           "tk": "✓", "ok": true,  "res": 0 }
+  ]
+}

--- a/finanzas/index.html
+++ b/finanzas/index.html
@@ -8,6 +8,7 @@
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
 <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@300;400;500;600;700&family=IBM+Plex+Mono:wght@400;500;600&family=IBM+Plex+Sans+Condensed:wght@500;600;700&display=swap" rel="stylesheet">
 <link rel="stylesheet" href="css/finanzas.css?v=0.1.0">
+<link rel="stylesheet" href="css/instrumentos-pago.css?v=0.4.0">
 </head>
 <body>
 
@@ -66,6 +67,7 @@
 <script src="js/modules/facturas-core.js?v=0.3.0"></script>
 <script src="js/modules/facturas-odoo.js?v=0.3.0"></script>
 <script src="js/modules/bills-odoo.js?v=0.3.0"></script>
+<script src="js/modules/instrumentos-pago.js?v=0.4.0"></script>
 <script>
 /* ═══ FTS Finanzas — shell (Paso 1: auth + sidebar + empty states) ═══ */
 'use strict';
@@ -127,7 +129,7 @@ async function bootApp() {
 
   if (!MANIFEST) {
     try {
-      var res = await fetch('manifest.json?v=0.1.0', { cache: 'no-store' });
+      var res = await fetch('manifest.json?v=0.4.0', { cache: 'no-store' });
       MANIFEST = await res.json();
     } catch (e) { MANIFEST = { modules: [], blocks: {} }; }
   }

--- a/finanzas/js/modules/instrumentos-pago.js
+++ b/finanzas/js/modules/instrumentos-pago.js
@@ -1,0 +1,550 @@
+// ═══ FTS Suite · Finanzas — Instrumentos de pago (Bancos) ═══
+// Llena el slot reservado `instrumentos-pago` (B4 · Centro de transacciones) con
+// el contenido del mockup v7 (docs/mockup-finanzas-bancos.html): fuentes de pago
+// colapsables por país, tabla de 17 columnas, semáforo de conciliación, countdown
+// al próximo sync y tabla de últimas corridas (CBRUN).
+//
+// Reutiliza FinRouter (registro), FinState (modo/companies), FinCompanySelector
+// (selector único de empresa en todo Finanzas), FinClient (webhooks JWT-en-body).
+// Sin globals: todo el wiring vía addEventListener (CSP-safe).
+//
+// Modos: empty / demo (mock JSON) / real (endpoints fin/captura-*). El modo Real
+// está GATEADO tras IP_REAL_ENABLED hasta cerrar el checklist de seguridad
+// (docs/finanzas/BANCOS_CHECKLIST_SEGURIDAD.md). Flip a true = one-liner.
+
+(function () {
+  'use strict';
+  if (!window.FinRouter) return;
+
+  // ── config ──
+  var MODULE_ID = 'instrumentos-pago';
+  var MOCK_PATH = 'data/mock/instrumentos-pago.mock.json';
+  var IP_REAL_ENABLED = false;            // ⚠ gate: Real deshabilitado hasta firmar el checklist de seguridad
+  var RESIDUAL_UMBRAL_MXN = 10000;        // coherente con fin/captura-status
+  var SHEETJS_CDN = 'https://cdn.sheetjs.com/xlsx-0.20.3/package/dist/xlsx.full.min.js';
+  // Endpoints reales (contrato construido en la sesión de backend; verificar nombres de
+  // campo contra la respuesta viva al des-gatear Real — requiere runner JWT).
+  var EP_STATUS = '/fin/captura-status', EP_TX = '/fin/captura-transacciones', EP_DATASET = '/fin/captura-dataset';
+
+  var DEFAULT_CRON = { days: [1, 2, 3, 4, 5], start_hour: 7, regular_end_hour: 16, regular_interval_min: 30, peak_hour: 17, peak_interval_min: 10, close_hour: 18, label: 'L–V 7–18h · 30 min · pico 10 min' };
+
+  // ── helpers ──
+  function esc(s) {
+    return String(s == null ? '' : s).replace(/[&<>"']/g, function (c) {
+      return { '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;', "'": '&#39;' }[c];
+    });
+  }
+  function money(n) {
+    if (n == null || isNaN(n)) return '—';
+    return (n < 0 ? '−' : '') + '$' + Math.abs(n).toLocaleString('es-MX', { minimumFractionDigits: 2, maximumFractionDigits: 2 });
+  }
+  var amber = function (s) { return '<span class="amber">' + s + '</span>'; };
+
+  // 17 columnas (contrato exacto del v7). vis = visible por default (8).
+  var COLS = [
+    { k: 'd',    lbl: 'Fecha',        vis: true,  cls: 'style="font-family:var(--ip-mono);font-size:12.5px"', fmt: function (r) { return esc(r.d); } },
+    { k: 'j',    lbl: 'Instrumento',  vis: true,  fmt: function (r) { return '<span class="jtag">' + esc(r.j) + '</span>'; } },
+    { k: 'tipo', lbl: 'Tipo',         vis: false, fmt: function (r) { return esc(r.tipo); } },
+    { k: 'ref',  lbl: 'Descripción',  vis: true,  fmt: function (r) { return esc(r.ref); } },
+    { k: 'tarj', lbl: 'Tarjeta',      vis: false, fmt: function (r) { return esc(r.tarj) || '—'; } },
+    { k: 'comp', lbl: 'Comprador',    vis: true,  fmt: function (r) { return esc(r.comp) || '—'; } },
+    { k: 'rs',   lbl: 'Razón social', vis: false, fmt: function (r) { return esc(r.rs); } },
+    { k: 'art',  lbl: 'Artículo',     vis: false, fmt: function (r) { return esc(r.art) || '—'; } },
+    { k: 'ana',  lbl: 'Analítica',    vis: true,  fmt: function (r) { return r.ana ? esc(r.ana) : amber('—'); } },
+    { k: 'po',   lbl: 'PO',           vis: true,  fmt: function (r) { return r.po ? esc(r.po) : amber('—'); } },
+    { k: 'bill', lbl: 'Bill',         vis: false, fmt: function (r) { return r.bill ? esc(r.bill) : amber('—'); } },
+    { k: 'sb',   lbl: 'Status bill',  vis: false, fmt: function (r) { return r.sb ? esc(r.sb) : amber('—'); } },
+    { k: 'ff',   lbl: 'Folio fiscal', vis: false, fmt: function (r) { return r.ff ? '<span style="font-family:var(--ip-mono);font-size:11.5px">' + esc(r.ff) + '</span>' : amber('—'); } },
+    { k: 'tk',   lbl: 'Ticket',       vis: false, fmt: function (r) { return esc(r.tk) || '—'; } },
+    { k: 'mon',  lbl: 'Moneda',       vis: false, fmt: function (r) { return esc(r.mon); } },
+    { k: 'amt',  lbl: 'Monto',        vis: true,  cls: function (r) { return 'class="amt ' + (r.amt < 0 ? 'neg' : 'pos') + '"'; }, fmt: function (r) { return money(r.amt); } },
+    { k: 'ok',   lbl: 'Status',       vis: true,  cls: function (r) { return 'class="st ' + (r.ok ? 'ok' : 'pend') + '"'; }, fmt: function (r) { return r.ok ? '✓ conciliada' : '● pendiente'; } }
+  ];
+  function colAttr(col, r) { return typeof col.cls === 'function' ? col.cls(r) : (col.cls || ''); }
+
+  // ═══ vista ═══
+  function createView(container) {
+    var state = {
+      mode: currentMode(),
+      allRows: [], sources: [], runs: [], cron: DEFAULT_CRON,
+      filters: { journal: '', estado: '', from: '2026-07-01', to: '2026-07-18', search: '' },
+      sortK: 'd', sortDir: -1,
+      pageSize: 100, page: 1,
+      sel: {},                 // rowId -> true
+      loading: false, error: null,
+      timer: null
+    };
+
+    function currentMode() {
+      var m = window.FinState ? window.FinState.getMode(MODULE_ID) : 'empty';
+      if (m === 'real' && !IP_REAL_ENABLED) return 'demo';   // coerción: Real gateado
+      return m;
+    }
+
+    var q  = function (s) { return container.querySelector(s); };
+    var qa = function (s) { return Array.prototype.slice.call(container.querySelectorAll(s)); };
+
+    // ── ciclo de vida ──
+    function mount() {
+      window.FinState.subscribe(function (evt) {
+        if (!document.body.contains(container)) return;      // vista desmontada
+        if (evt.type === 'mode' && evt.id === MODULE_ID) { state.mode = currentMode(); state.sel = {}; render(); if (state.mode !== 'empty') load(); }
+        if (evt.type === 'companies') { if (state.mode !== 'empty') { if (state.mode === 'real') { load(); } else { renderSources(); paintTable(); } } }
+      });
+      render();
+      if (state.mode !== 'empty') load();
+    }
+
+    // ── carga de datos ──
+    function load() {
+      state.loading = true; state.error = null; render();
+      if (state.mode === 'demo') {
+        fetch(MOCK_PATH, { cache: 'no-store' })
+          .then(function (r) { return r.json(); })
+          .then(function (data) { ingest(data.rows || [], data.sources || [], data.runs || [], data.cron || DEFAULT_CRON); state.loading = false; render(); afterData(); })
+          .catch(function (e) { state.loading = false; state.error = 'No se pudo cargar el mock: ' + e.message; render(); });
+        return;
+      }
+      // real: status (fuentes/runs/cron) + transacciones. Verificar nombres de campo al des-gatear.
+      var params = { companies: window.FinState.getCompanies() };
+      Promise.all([
+        window.FinClient.call(EP_STATUS, params),
+        window.FinClient.call(EP_TX, txParams())
+      ]).then(function (res) {
+        var st = res[0] || {}, tx = res[1] || {};
+        ingest(tx.rows || [], st.sources || [], st.runs || [], st.cron || DEFAULT_CRON);
+        state.loading = false; render(); afterData();
+      }).catch(function (err) {
+        state.loading = false;
+        state.error = (err && err.msg) || (err && err.code) || 'Error al consultar el servidor.';
+        render();
+      });
+    }
+    function txParams() {
+      var f = state.filters;
+      return {
+        companies: window.FinState.getCompanies(),
+        journal: f.journal || null, estado: f.estado || null,
+        date_from: f.from || null, date_to: f.to || null,
+        search: f.search || null, limit: 500, offset: 0
+      };
+    }
+    function ingest(rows, sources, runs, cron) {
+      rows.forEach(function (r, i) { r._id = i; });
+      state.allRows = rows; state.sources = sources; state.runs = runs; state.cron = cron || DEFAULT_CRON;
+    }
+    function afterData() { startCountdown(); }
+
+    // ── filtrado / orden (cliente) ──
+    function visibleRows() {
+      var f = state.filters, s = (f.search || '').toLowerCase();
+      var cos = window.FinState.getCompanies();
+      var rows = state.allRows.filter(function (t) {
+        return (cos.indexOf(t.company_id) >= 0) &&
+          (!f.journal || t.j === f.journal) &&
+          (!f.estado || (f.estado === 'ok' ? t.ok : !t.ok)) &&
+          (!s || Object.keys(t).map(function (k) { return t[k]; }).join(' ').toLowerCase().indexOf(s) >= 0) &&
+          (!f.from || t.d >= f.from) && (!f.to || t.d <= f.to);
+      });
+      var k = state.sortK, dir = state.sortDir;
+      rows.sort(function (a, b) {
+        var va = a[k], vb = b[k];
+        if (typeof va === 'boolean') { va = +va; vb = +vb; }
+        if (typeof va === 'string') { va = va.toLowerCase(); vb = (vb || '').toLowerCase(); }
+        return (va > vb ? 1 : va < vb ? -1 : 0) * dir;
+      });
+      return rows;
+    }
+
+    // ── render principal (shell) ──
+    function render() {
+      var html = '<div class="page ip-view">';
+      html += '<span class="block-tag">B4 · Centro de transacciones</span>';
+      html += '<div class="ip-head"><div class="page-header" style="flex:1"><div>' +
+                '<div class="page-title">Instrumentos de pago</div>' +
+                '<div class="page-subtitle">Captura bancaria · fuentes de pago, transacciones y conciliación</div>' +
+              '</div></div>' +
+              gearHtml() + modeToggle() + '</div>';
+      html += '<div id="ip-companies"></div>';
+
+      if (state.mode === 'empty') {
+        html += '<div class="empty-state"><div class="icon">▢</div><div class="title">Sin datos</div>' +
+                '<div>Activa <b>Demo</b> para ver datos de muestra' + (IP_REAL_ENABLED ? ', o <b>Real</b> para consultar captura bancaria (solo lectura).' : '. <span class="mono">(Real pendiente de checklist de seguridad)</span>') + '</div></div></div>';
+        container.innerHTML = html; wireHead(); return;
+      }
+      if (state.mode === 'demo') html += '<div class="demo-banner"><b>DEMO</b> · datos ficticios de muestra, no provienen de Odoo.</div>';
+
+      if (state.loading) { html += '<div class="loader" style="padding:30px;text-align:center;color:var(--steel)">Cargando…</div></div>'; container.innerHTML = html; wireHead(); return; }
+      if (state.error)   { html += '<div class="empty-state"><div class="icon">⚠</div><div class="title">Error</div><div class="mono">' + esc(state.error) + '</div></div></div>'; container.innerHTML = html; wireHead(); return; }
+
+      html += '<h2>Fuentes de pago — FTS MEX</h2><div class="srclist" id="ip-srcMEX"></div>';
+      html += '<h2>Fuentes de pago — FTS USA</h2><div class="srclist" id="ip-srcUSA"></div>';
+
+      html += '<h2>Transacciones</h2><div class="panel">' + filtersHtml() +
+              '<div class="selbanner" id="ip-selbanner"></div>' +
+              '<div id="ip-tblwrap"></div>' +
+              '<div class="tfoot"><span id="ip-aggs"></span><span class="pager" id="ip-pager"></span></div></div>';
+
+      html += '<h2>Semáforo de conciliación — Admin</h2><div class="sem"><div class="title">Control de conciliación por journal</div>' +
+              '<div id="ip-semrows"></div>' +
+              '<div class="semnote">Verde = 100% conciliado y residual $0 · Amarillo ≥ 90% · Rojo &lt; 90% o residual &gt; ' + money(RESIDUAL_UMBRAL_MXN) + '. El KPI incluye backlog histórico hasta su limpieza (Fase 2).</div></div>';
+
+      html += '<h2>Últimas corridas de captura</h2><div class="panel"><table class="runs">' +
+              '<thead><tr><th>Run</th><th>Origen</th><th>Rango</th><th>Nuevas</th><th>Dup.</th><th>Rech.</th><th>Status</th></tr></thead>' +
+              '<tbody id="ip-runsbody"></tbody></table></div>';
+
+      html += '<div class="ip-toast" id="ip-toast"></div>';
+      html += '</div>';
+      container.innerHTML = html;
+
+      wireHead();
+      wireFilters();
+      renderSources();
+      renderRuns();
+      buildColMenu();
+      paintTable();
+    }
+
+    // ── head: gear + mode toggle + company selector ──
+    function gearHtml() {
+      return '<div class="ip-gearwrap"><button class="gear" id="ip-gear" title="Agregar fuente de pago">⚙</button>' +
+        '<div class="setmenu" id="ip-setmenu"><div class="mt">Agregar fuente de pago</div>' +
+        '<label>Empresa</label><select id="ip-nfEmp"><option>FTS MEX (Servicios FTS)</option><option>FTS USA (FTS LLC)</option></select>' +
+        '<label>Nombre de la cuenta</label><input id="ip-nfNom" placeholder="ej. Banorte Empresarial MXN">' +
+        '<label>Método de sync</label><select id="ip-nfMet"><option>MCP / API nativa</option><option>CAMT.053 / archivo banco</option><option>Plaid / agregador</option><option>CSV por correo (IMAP)</option><option>Extensión portal</option><option>Manual</option></select>' +
+        '<button class="ip-btn" id="ip-addsrc">Agregar (demo)</button></div></div>';
+    }
+    function modeToggle() {
+      function b(m, lbl) {
+        var dis = (m === 'real' && !IP_REAL_ENABLED);
+        return '<button data-mode="' + m + '"' + (state.mode === m ? ' class="active"' : '') +
+          (dis ? ' disabled title="Pendiente checklist de seguridad"' : '') + '>' + lbl + '</button>';
+      }
+      return '<div class="mode-toggle" id="ip-mode">' + b('empty', 'Vacío') + b('demo', 'Demo') + b('real', 'Real') + '</div>';
+    }
+    function wireHead() {
+      var el = q('#ip-companies');
+      if (el && window.FinCompanySelector) window.FinCompanySelector.mount(el, { onChange: function () {
+        if (state.mode === 'empty') return;
+        if (state.mode === 'real') { load(); } else { renderSources(); paintTable(); }
+      } });
+      qa('#ip-mode button').forEach(function (b) {
+        b.addEventListener('click', function () {
+          if (b.disabled) return;
+          window.FinState.setMode(MODULE_ID, b.getAttribute('data-mode'));
+        });
+      });
+      var gear = q('#ip-gear'), setmenu = q('#ip-setmenu');
+      if (gear && setmenu) {
+        gear.addEventListener('click', function (e) { e.stopPropagation(); setmenu.classList.toggle('open'); });
+        document.addEventListener('click', function docClose(ev) {
+          if (!document.body.contains(container)) { document.removeEventListener('click', docClose); return; }
+          if (!ev.target.closest || !ev.target.closest('.ip-gearwrap')) setmenu.classList.remove('open');
+        });
+        var add = q('#ip-addsrc');
+        if (add) add.addEventListener('click', addSource);
+      }
+    }
+
+    function addSource() {
+      var emp = q('#ip-nfEmp').value, nom = q('#ip-nfNom').value || 'Nueva cuenta', met = q('#ip-nfMet').value;
+      state.sources.push({ id: 'n' + state.sources.length, co: emp.indexOf('USA') >= 0 ? 6 : 1, pais: emp.indexOf('USA') >= 0 ? 'USA' : 'MEX', nm: nom, jt: 'sin journal', met: met.split(' ')[0], st: 'ok', last: '—', kpi: '—', movHoy: 0, movMes: 0, run: 'Pendiente de primer sync' });
+      renderSources(); q('#ip-setmenu').classList.remove('open');
+      toast('Fuente <b>' + esc(nom) + '</b> agregada (demo) — configura credenciales para el primer sync');
+    }
+
+    // ── fuentes colapsables ──
+    function srcRow(s) {
+      var chip = s.st === 'ok'
+        ? '<span class="stchip ok">● SYNC OK · ' + esc(s.last) + '</span>'
+        : s.st === 'off'
+          ? '<span class="stchip off">○ SIN CONFIGURAR</span>'
+          : '<span class="stchip err">▲ SYNC ERROR · ' + esc(s.last) + '</span><span class="wdbadge">WATCHDOG <button data-atender="' + esc(s.id) + '">Atender</button></span>';
+      var jeevesExtra = s.main ? (
+        '<div class="synced"><span class="pulse"></span>' +
+        '<span>Próximo sync en <b class="ip-countdown" style="font-family:var(--ip-mono)">—</b></span>' +
+        '<span class="schChip" title="Horario de captura">' + esc(state.cron && state.cron.label || DEFAULT_CRON.label) + '</span></div>') : '';
+      var btn = s.st === 'off' ? '' : (s.main
+        ? '<button class="ip-btn ip-btnrun"><span class="spin"></span><span class="ip-btntxt">Sync Now</span></button>'
+        : '<button class="ip-btn" data-demosync="' + esc(s.id) + '">Sync Now</button>');
+      var body = s.st === 'off'
+        ? '<div class="meta">Fuente no configurada — pendiente de credenciales / primer sync.</div>'
+        : '<div class="meta">Última captura: <b class="' + (s.main ? 'ip-lastsync' : '') + '">' + esc(s.last) + '</b> · schedule<br>' +
+            'Movimientos hoy: <b>' + esc(s.movHoy) + '</b> · este mes: <b>' + esc(s.movMes) + '</b><br>' +
+            'Último run: <b style="color:' + (s.st === 'ok' ? 'var(--ip-ok)' : 'var(--ip-bad)') + '">' + esc(s.run) + '</b>' +
+            (s.wd ? '<br><span style="color:var(--ip-bad);font-weight:600">⚠ ' + esc(s.wd) + '</span>' : '') + '</div>' +
+          jeevesExtra +
+          '<div class="kpi"><div class="lbl">$ sin conciliar</div><div class="val">' + esc(s.kpi) + '</div>' + (s.note ? '<div class="note">' + esc(s.note) + '</div>' : '') + '</div>' +
+          btn;
+      return '<div class="src" data-src="' + esc(s.id) + '"><div class="srchead" data-toggle="' + esc(s.id) + '">' +
+        '<span class="chev">▶</span><span class="nm">' + esc(s.nm) + '</span><span class="jtag">' + esc(s.jt) + '</span>' +
+        chip + '<span class="sp">' + esc(s.met) + '</span></div><div class="srcbody">' + body + '</div></div>';
+    }
+    function renderSources() {
+      var mex = q('#ip-srcMEX'), usa = q('#ip-srcUSA'); if (!mex || !usa) return;
+      var cos = window.FinState.getCompanies();
+      var pick = function (pais) { return state.sources.filter(function (s) { return s.pais === pais && cos.indexOf(s.co) >= 0; }).map(srcRow).join(''); };
+      mex.innerHTML = pick('MEX') || '<div class="ip-empty" style="padding:14px">Sin fuentes para la empresa seleccionada.</div>';
+      usa.innerHTML = pick('USA') || '<div class="ip-empty" style="padding:14px">Sin fuentes para la empresa seleccionada.</div>';
+      qa('[data-toggle]').forEach(function (h) { h.addEventListener('click', function () { var el = q('[data-src="' + h.getAttribute('data-toggle') + '"]'); if (el) el.classList.toggle('open'); }); });
+      qa('[data-atender]').forEach(function (b) { b.addEventListener('click', function (e) { e.stopPropagation(); toast('Watchdog <b>' + esc(b.getAttribute('data-atender').toUpperCase()) + '</b>: reintentando sync y notificando responsable…'); }); });
+      qa('[data-demosync]').forEach(function (b) { b.addEventListener('click', function (e) { e.stopPropagation(); toast('Sync <b>' + esc(b.getAttribute('data-demosync').toUpperCase()) + '</b> terminado — 0 nuevas · 0 duplicadas'); }); });
+      var run = q('.ip-btnrun');
+      if (run) run.addEventListener('click', function () {
+        run.disabled = true; run.classList.add('busy'); var tx = q('.ip-btntxt'); if (tx) tx.textContent = 'Sincronizando…';
+        setTimeout(function () {
+          if (!document.body.contains(container)) return;
+          run.disabled = false; run.classList.remove('busy'); if (tx) tx.textContent = 'Sync Now';
+          toast('Captura Jeeves terminada — <b>3 nuevas</b> · 2 duplicadas · 0 rechazadas');
+          var rb = q('#ip-runsbody');
+          if (rb) rb.insertAdjacentHTML('afterbegin', '<tr><td>Jeeves manual ' + new Date().toTimeString().slice(0, 5) + '</td><td>manual</td><td>07-14 → 07-18</td><td>3</td><td>2</td><td>0</td><td class="st ok">OK</td></tr>');
+        }, 1600);
+      });
+    }
+
+    // ── filtros + menú de columnas ──
+    function filtersHtml() {
+      var f = state.filters;
+      return '<div class="filters">' +
+        '<select id="ip-fJournal"><option value="">Todos los journals</option>' +
+          '<option value="Jeeves"' + (f.journal === 'Jeeves' ? ' selected' : '') + '>Jeeves (61)</option>' +
+          '<option value="Chase"' + (f.journal === 'Chase' ? ' selected' : '') + '>Chase</option>' +
+          '<option value="BBVA"' + (f.journal === 'BBVA' ? ' selected' : '') + '>BBVA General</option></select>' +
+        '<input type="date" id="ip-fFrom" value="' + esc(f.from) + '">' +
+        '<input type="date" id="ip-fTo" value="' + esc(f.to) + '">' +
+        '<select id="ip-fEstado"><option value="">Estado: todos</option>' +
+          '<option value="ok"' + (f.estado === 'ok' ? ' selected' : '') + '>Conciliadas</option>' +
+          '<option value="pend"' + (f.estado === 'pend' ? ' selected' : '') + '>Sin conciliar</option></select>' +
+        '<input class="grow" type="text" id="ip-fSearch" placeholder="Buscar en TODAS las columnas… (comercio, PO, folio, comprador, analítica)" value="' + esc(f.search) + '">' +
+        '<button class="xlsbtn" id="ip-btnxls" title="Descarga las filas seleccionadas con las columnas visibles">⬇ Excel <span id="ip-xlscount"></span></button>' +
+        '<select id="ip-fPageSize" title="Filas por página">' +
+          [10, 25, 50, 100].map(function (n) { return '<option value="' + n + '"' + (state.pageSize === n ? ' selected' : '') + '>' + n + ' filas</option>'; }).join('') + '</select>' +
+        '<div class="colbtn"><button id="ip-colbtn" title="Columnas">⋮</button>' +
+          '<div class="colmenu" id="ip-colmenu"><div class="mt">Columnas visibles</div>' +
+          '<div class="cact"><a id="ip-colall">Seleccionar todas</a><a id="ip-colnone">Ninguna</a></div>' +
+          '<div id="ip-colchecks"></div></div></div>' +
+        '</div>';
+    }
+    function wireFilters() {
+      var reload = function () {
+        state.filters.journal = q('#ip-fJournal').value;
+        state.filters.estado = q('#ip-fEstado').value;
+        state.filters.from = q('#ip-fFrom').value;
+        state.filters.to = q('#ip-fTo').value;
+        state.filters.search = q('#ip-fSearch').value;
+        state.page = 1;
+        if (state.mode === 'real') { load(); } else { paintTable(); }
+      };
+      ['#ip-fJournal', '#ip-fEstado', '#ip-fFrom', '#ip-fTo'].forEach(function (s) { var el = q(s); if (el) el.addEventListener('change', reload); });
+      var srch = q('#ip-fSearch'); if (srch) srch.addEventListener('input', function () { state.filters.search = srch.value; state.page = 1; paintTable(); });
+      var ps = q('#ip-fPageSize'); if (ps) ps.addEventListener('change', function () { state.pageSize = +ps.value; state.page = 1; paintTable(); });
+      var cb = q('#ip-colbtn'), cm = q('#ip-colmenu');
+      if (cb && cm) {
+        cb.addEventListener('click', function (e) { e.stopPropagation(); cm.classList.toggle('open'); });
+        document.addEventListener('click', function docClose(ev) {
+          if (!document.body.contains(container)) { document.removeEventListener('click', docClose); return; }
+          if (!ev.target.closest || !ev.target.closest('.colbtn')) cm.classList.remove('open');
+        });
+        cm.addEventListener('click', function (e) { e.stopPropagation(); });
+      }
+      var all = q('#ip-colall'), none = q('#ip-colnone');
+      if (all) all.addEventListener('click', function () { COLS.forEach(function (c) { c.vis = true; }); buildColMenu(); paintTable(); });
+      if (none) none.addEventListener('click', function () { COLS.forEach(function (c) { c.vis = false; }); buildColMenu(); paintTable(); });
+      var xls = q('#ip-btnxls'); if (xls) xls.addEventListener('click', exportXls);
+    }
+    function buildColMenu() {
+      var cc = q('#ip-colchecks'); if (!cc) return;
+      cc.innerHTML = COLS.map(function (c, i) { return '<label><input type="checkbox" data-col="' + i + '"' + (c.vis ? ' checked' : '') + '> ' + esc(c.lbl) + '</label>'; }).join('');
+      qa('#ip-colchecks input[data-col]').forEach(function (inp) { inp.addEventListener('change', function () { COLS[+inp.getAttribute('data-col')].vis = inp.checked; paintTable(); }); });
+    }
+
+    // ── tabla (repintado parcial, preserva menús abiertos) ──
+    function paintTable() {
+      var rows = visibleRows();
+      var pages = Math.max(1, Math.ceil(rows.length / state.pageSize));
+      if (state.page > pages) state.page = 1;
+      var slice = rows.slice((state.page - 1) * state.pageSize, state.page * state.pageSize);
+      var vis = COLS.filter(function (c) { return c.vis; });
+      var allSel = rows.length > 0 && rows.every(function (t) { return state.sel[t._id]; });
+
+      var tbl = rows.length ? '<div style="overflow-x:auto"><table><thead><tr>' +
+        '<th class="chk"><input type="checkbox" id="ip-checkall"' + (allSel ? ' checked' : '') + ' title="Seleccionar toda la vista filtrada (' + rows.length + ')"></th>' +
+        vis.map(function (c) { return '<th class="sortable" data-sort="' + c.k + '"' + (c.k === 'amt' ? ' style="text-align:right"' : '') + '>' + esc(c.lbl) + (state.sortK === c.k ? '<span class="sarr">' + (state.sortDir > 0 ? '▲' : '▼') + '</span>' : '') + '</th>'; }).join('') +
+        '</tr></thead><tbody>' +
+        slice.map(function (t) {
+          return '<tr class="' + (state.sel[t._id] ? 'selrow' : '') + '"><td class="chk"><input type="checkbox" data-row="' + t._id + '"' + (state.sel[t._id] ? ' checked' : '') + '></td>' +
+            vis.map(function (c) { return '<td ' + colAttr(c, t) + '>' + c.fmt(t) + '</td>'; }).join('') + '</tr>';
+        }).join('') +
+        '</tbody></table></div>'
+        : '<div class="ip-empty">Sin movimientos con estos filtros. Ajusta el rango o la búsqueda.</div>';
+      var w = q('#ip-tblwrap'); if (w) w.innerHTML = tbl;
+
+      var conc = rows.filter(function (t) { return t.ok; }).length;
+      var resid = rows.reduce(function (a, t) { return a + (t.res || 0); }, 0);
+      var nSel = rows.filter(function (t) { return state.sel[t._id]; }).length;
+      var ag = q('#ip-aggs'); if (ag) ag.textContent = rows.length + ' líneas · ' + conc + ' conciliadas · ' + (rows.length - conc) + ' pendientes · residual ' + money(resid) + (nSel ? ' · ' + nSel + ' seleccionadas' : '');
+
+      var bn = q('#ip-selbanner');
+      if (bn) {
+        if (nSel > 0) {
+          bn.classList.add('show');
+          bn.innerHTML = '<span>Seleccionadas <b>' + nSel + '</b> de <b>' + rows.length + '</b> transacciones de la vista (todas las páginas · ' + pages + ' pág.)</span>' +
+            (nSel < rows.length ? '<a id="ip-selall">Seleccionar las ' + rows.length + '</a>' : '') + '<a id="ip-selnone">Quitar selección</a>';
+          var sa = q('#ip-selall'), sn = q('#ip-selnone');
+          if (sa) sa.addEventListener('click', function () { rows.forEach(function (t) { state.sel[t._id] = true; }); paintTable(); });
+          if (sn) sn.addEventListener('click', function () { rows.forEach(function (t) { delete state.sel[t._id]; }); paintTable(); });
+        } else { bn.classList.remove('show'); bn.innerHTML = ''; }
+      }
+
+      var xls = q('#ip-btnxls'); if (xls) xls.classList.toggle('show', nSel > 0);
+      var xc = q('#ip-xlscount'); if (xc) xc.textContent = nSel ? '(' + nSel + ')' : '';
+
+      var pg = q('#ip-pager');
+      if (pg) {
+        pg.innerHTML = Array.from({ length: pages }, function (_, i) { return '<button class="' + (i + 1 === state.page ? 'on' : '') + '" data-page="' + (i + 1) + '">' + (i + 1) + '</button>'; }).join('');
+        qa('#ip-pager button').forEach(function (b) { b.addEventListener('click', function () { state.page = +b.getAttribute('data-page'); paintTable(); }); });
+      }
+
+      // wiring de la tabla repintada
+      var ca = q('#ip-checkall');
+      if (ca) ca.addEventListener('change', function () { rows.forEach(function (t) { if (ca.checked) state.sel[t._id] = true; else delete state.sel[t._id]; }); paintTable(); });
+      qa('input[data-row]').forEach(function (rc) { rc.addEventListener('change', function () { var id = +rc.getAttribute('data-row'); if (rc.checked) state.sel[id] = true; else delete state.sel[id]; paintTable(); }); });
+      qa('th[data-sort]').forEach(function (th) { th.addEventListener('click', function () { var k = th.getAttribute('data-sort'); if (state.sortK === k) state.sortDir *= -1; else { state.sortK = k; state.sortDir = 1; } paintTable(); }); });
+
+      paintSem();
+    }
+
+    // ── semáforo ──
+    function semColor(pct, res) {
+      if (pct === null) return 'off';
+      if (res > RESIDUAL_UMBRAL_MXN) return 'r';
+      if (pct === 100 && res === 0) return 'g';
+      if (pct >= 90) return 'y';
+      return 'r';
+    }
+    function barc(c) { return c === 'g' ? 'var(--ip-ok)' : c === 'y' ? 'var(--ip-warn)' : 'var(--ip-bad)'; }
+    function paintSem() {
+      var host = q('#ip-semrows'); if (!host) return;
+      var journals = [{ n: 'Jeeves', id: '61' }, { n: 'Chase', id: '73' }, { n: 'BBVA', id: '—' }];
+      var base = state.allRows;   // el semáforo admin evalúa todo el universo cargado, no la vista filtrada
+      var data = journals.map(function (x) {
+        var r = base.filter(function (t) { return t.j === x.n; });
+        var tot = r.length, conc = r.filter(function (t) { return t.ok; }).length, res = r.reduce(function (a, t) { return a + (t.res || 0); }, 0);
+        return { n: x.n, tot: tot, conc: conc, res: res, pct: tot ? Math.round(conc / tot * 100) : null };
+      });
+      var all = { tot: base.length, conc: base.filter(function (t) { return t.ok; }).length, res: base.reduce(function (a, t) { return a + (t.res || 0); }, 0) };
+      all.pct = all.tot ? Math.round(all.conc / all.tot * 100) : null;
+
+      host.innerHTML = data.map(function (d) {
+        var c = semColor(d.pct, d.res);
+        return '<div class="semrow"><span class="jn">' + esc(d.n) + (d.pct === null ? '' : ' <span style="color:#68788a;font-family:var(--ip-mono);font-size:11px">(' + d.conc + '/' + d.tot + ')</span>') + '</span>' +
+          '<div class="bar"><i style="width:' + (d.pct || 0) + '%;background:' + barc(c) + '"></i></div>' +
+          '<span class="pct">' + (d.pct === null ? '—' : d.pct + '%') + '</span>' +
+          '<span class="res">' + (d.pct === null ? '' : money(d.res)) + '</span></div>';
+      }).join('') +
+        '<div class="semrow total"><span class="jn" style="display:flex;align-items:center;gap:10px"><span class="light ' + semColor(all.pct, all.res) + '"></span> TODOS</span>' +
+        '<div class="bar"><i style="width:' + (all.pct || 0) + '%;background:' + barc(semColor(all.pct, all.res)) + '"></i></div>' +
+        '<span class="pct">' + (all.pct === null ? '—' : all.pct + '%') + '</span><span class="res">' + money(all.res) + '</span></div>';
+    }
+
+    // ── corridas ──
+    function renderRuns() {
+      var rb = q('#ip-runsbody'); if (!rb) return;
+      rb.innerHTML = state.runs.map(function (r) {
+        var st = r.status === 'ok' ? 'ok' : 'pend';
+        var cell = function (v) { return (v == null ? '—' : v); };
+        return '<tr><td>' + esc(r.run) + '</td><td>' + esc(r.origen) + '</td><td>' + esc(r.rango) + '</td>' +
+          '<td>' + cell(r.nuevas) + '</td><td>' + cell(r.dup) + '</td><td>' + cell(r.rech) + '</td>' +
+          '<td class="st ' + st + '">' + esc(r.status_label || (r.status === 'ok' ? 'OK' : r.status)) + '</td></tr>';
+      }).join('');
+    }
+
+    // ── export XLSX (columnas visibles × filas seleccionadas) ──
+    function exportXls() {
+      var vis = COLS.filter(function (c) { return c.vis; });
+      var selIds = Object.keys(state.sel).filter(function (k) { return state.sel[k]; });
+      if (!selIds.length) return;
+      if (state.mode === 'real') {
+        // dataset completo desde el server (columnas visibles × selección)
+        window.FinClient.call(EP_DATASET, { companies: window.FinState.getCompanies(), ids: selIds.map(Number), columns: vis.map(function (c) { return c.k; }), filters: txParams() })
+          .then(function (data) { writeXls(data.rows || [], vis); })
+          .catch(function (err) { toast('No se pudo exportar: ' + esc((err && err.msg) || (err && err.code) || 'error')); });
+        return;
+      }
+      var data = visibleRows().filter(function (t) { return state.sel[t._id]; });
+      writeXls(data, vis);
+    }
+    function writeXls(rows, vis) {
+      if (!rows.length) { toast('Nada que exportar'); return; }
+      ensureSheetJS(function (XLSX) {
+        if (!XLSX) { toast('SheetJS no cargó; intenta de nuevo'); return; }
+        var plain = rows.map(function (t) {
+          var o = {};
+          vis.forEach(function (c) { o[c.lbl] = c.k === 'ok' ? (t.ok ? 'CONCILIADA' : 'PENDIENTE') : (t[c.k] == null ? '' : t[c.k]); });
+          return o;
+        });
+        var ws = XLSX.utils.json_to_sheet(plain);
+        ws['!cols'] = vis.map(function (c) { return { wch: c.k === 'ref' ? 45 : c.k === 'ana' ? 24 : 14 }; });
+        var wb = XLSX.utils.book_new();
+        XLSX.utils.book_append_sheet(wb, ws, 'Transacciones');
+        XLSX.writeFile(wb, 'FTS_transacciones_' + new Date().toISOString().slice(0, 10) + '.xlsx');
+      });
+    }
+    function ensureSheetJS(cb) {
+      if (window.XLSX) return cb(window.XLSX);
+      var s = document.createElement('script'); s.src = SHEETJS_CDN;
+      s.onload = function () { cb(window.XLSX); };
+      s.onerror = function () { cb(null); };
+      document.head.appendChild(s);
+    }
+
+    // ── countdown al próximo sync ──
+    function nextSync(now, cron) {
+      var c = new Date(now.getTime());
+      for (var i = 0; i < 10080; i++) {
+        c.setSeconds(0, 0);
+        var dow = c.getDay(), h = c.getHours(), m = c.getMinutes();
+        var habil = cron.days.indexOf(dow) >= 0;
+        var reg = h >= cron.start_hour && h <= cron.regular_end_hour && (m % cron.regular_interval_min === 0);
+        var peak = h === cron.peak_hour && (m % cron.peak_interval_min === 0);
+        var close = h === cron.close_hour && m === 0;
+        if (habil && (reg || peak || close) && c > now) return c;
+        c.setMinutes(c.getMinutes() + 1);
+      }
+      return null;
+    }
+    function fmtDelta(ms) {
+      var s = Math.floor(ms / 1000);
+      if (s >= 3600) { var h = Math.floor(s / 3600); return h + 'h ' + Math.floor(s % 3600 / 60) + 'm'; }
+      return String(Math.floor(s / 60)).padStart(2, '0') + ':' + String(s % 60).padStart(2, '0');
+    }
+    function startCountdown() {
+      if (state.timer) { clearInterval(state.timer); state.timer = null; }
+      var cron = state.cron || DEFAULT_CRON;
+      var target = nextSync(new Date(), cron);
+      state.timer = setInterval(function () {
+        if (!document.body.contains(container)) { clearInterval(state.timer); state.timer = null; return; }
+        var el = q('.ip-countdown'); if (!el) return;
+        var now = new Date();
+        if (!target || target <= now) {
+          var ls = q('.ip-lastsync'); if (ls) ls.textContent = 'hoy ' + now.toTimeString().slice(0, 5);
+          target = nextSync(now, cron);
+        }
+        el.textContent = target ? fmtDelta(target - now) : 'fuera de horario';
+      }, 1000);
+    }
+
+    // ── toast ──
+    function toast(html) {
+      var t = q('#ip-toast'); if (!t) return;
+      t.innerHTML = html; t.style.display = 'block';
+      clearTimeout(t._to); t._to = setTimeout(function () { t.style.display = 'none'; }, 3800);
+    }
+
+    return { mount: mount };
+  }
+
+  window.FinRouter.register(MODULE_ID, {
+    render: function (container) { createView(container).mount(); }
+  });
+})();

--- a/finanzas/manifest.json
+++ b/finanzas/manifest.json
@@ -27,7 +27,7 @@
     { "id": "bills-odoo",            "name": "Bills Odoo",               "block": "B4", "icon": "←", "status": "real-readonly", "webhook": "/fin/bills-odoo" },
     { "id": "facturas-sat-ingresos", "name": "Facturas SAT Ingresos",    "block": "B4", "icon": "⇧", "status": "empty", "webhook": null },
     { "id": "facturas-sat-egresos",  "name": "Facturas SAT Egresos",     "block": "B4", "icon": "⇩", "status": "empty", "webhook": null },
-    { "id": "instrumentos-pago",     "name": "Instrumentos de pago",     "block": "B4", "icon": "◧", "status": "empty", "webhook": null },
+    { "id": "instrumentos-pago",     "name": "Instrumentos de pago",     "block": "B4", "icon": "◧", "status": "real-readonly", "webhook": "/fin/captura-status" },
 
     { "id": "pagos-hub",             "name": "Hub de Pagos",             "block": "B5", "icon": "⊕", "status": "empty", "webhook": null },
     { "id": "sync-sat",              "name": "Sync SAT",                 "block": "B5", "icon": "⟳", "status": "empty", "webhook": null }

--- a/finanzas/version.json
+++ b/finanzas/version.json
@@ -1,7 +1,7 @@
 {
   "module": "finanzas",
-  "version": "0.3.0",
-  "build": "20260609-paso3-facturas",
-  "description": "Paso 3 — módulos Facturas Odoo + Bills Odoo (account.move out/in) con webhook real /fin/facturas-odoo y /fin/bills-odoo. Router + state + company-selector + tabla config-driven (FinFacturas). Modo demo (mock sanitizado) + real (Odoo read-only).",
+  "version": "0.4.0",
+  "build": "20260720-paso6-instrumentos-pago",
+  "description": "Paso 6 — Instrumentos de pago (Bancos): fuentes de pago colapsables, tabla 17 columnas, semáforo de conciliación, countdown al próximo sync y últimas corridas (CBRUN), portado del mockup v7. Modo demo (mock) + real gateado (fin/captura-status/transacciones/dataset) hasta cerrar checklist de seguridad. Paso 3 previo: Facturas Odoo + Bills Odoo.",
   "status": "active"
 }


### PR DESCRIPTION
## Summary
Llena el slot reservado `instrumentos-pago` (B4 · Centro de transacciones) con el contenido del mockup v7 aprobado. **No es pestaña nueva** — se rellena el placeholder existente.

- Fuentes de pago colapsables por país (chip sync, watchdog + Atender, KPI, Sync Now).
- Tabla de 17 columnas: menú ⋮ (8 visibles default), headers ordenables, búsqueda global, paginación 10/25/50/100, selección multi-página estilo Gmail + banner, export XLSX (columnas visibles × filas seleccionadas).
- Semáforo de conciliación por journal + TODOS con umbral $10K.
- Countdown al próximo sync (derivado del cron) + tabla de últimas corridas (CBRUN).

## Decisiones honradas
- Selector de empresa = **FinCompanySelector** (mecanismo único de Finanzas), no se replican los chips del v7.
- Modo **Real cableado pero GATEADO** (`IP_REAL_ENABLED=false`) hasta cerrar el checklist de seguridad. Demo es el default de revisión.
- Columnas transitivas (ana/po/bill/sb/ff/art) → "—" ámbar hasta el motor de Fase 2 (sin tocar el front).

## Seguridad
`docs/finanzas/BANCOS_CHECKLIST_SEGURIDAD.md`. Barrido de secretos en 1,241 commits: **superficie Finanzas/Bancos limpia** (secretos del login nunca commiteados; ningún JSON de workflow con secretos exportado). Aprobados como condición previa al flip de Real: JWT 1–2h + claims `bancos:read` (a) y Cloudflare Access (c). Hallazgo PMO (HMAC hardcodeado) agendado como hardening aparte.

## Test plan
- [x] `node --check` del módulo + validación de JSON (mock/manifest).
- [x] Revisión visual del demo (Artifact) aprobada por Esteban.
- [ ] Verificar deploy de Pages: `/finanzas` carga, Instrumentos de pago en modo demo con Real deshabilitado + tooltip.
- [ ] No-regresión: resto del sidebar Finanzas navega igual.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DA7D53mvCYtuwHZqcgoTvU