### PR TITLE
fix(finanzas): Instrumentos de pago carga en modo demo por default (Real gateado)

### DIFF
--- a/finanzas/index.html
+++ b/finanzas/index.html
@@ -67,7 +67,7 @@
 <script src="js/modules/facturas-core.js?v=0.3.0"></script>
 <script src="js/modules/facturas-odoo.js?v=0.3.0"></script>
 <script src="js/modules/bills-odoo.js?v=0.3.0"></script>
-<script src="js/modules/instrumentos-pago.js?v=0.4.0"></script>
+<script src="js/modules/instrumentos-pago.js?v=0.4.1"></script>
 <script>
 /* ═══ FTS Finanzas — shell (Paso 1: auth + sidebar + empty states) ═══ */
 'use strict';

--- a/finanzas/js/modules/instrumentos-pago.js
+++ b/finanzas/js/modules/instrumentos-pago.js
@@ -76,9 +76,11 @@
     };
 
     function currentMode() {
-      var m = window.FinState ? window.FinState.getMode(MODULE_ID) : 'empty';
-      if (m === 'real' && !IP_REAL_ENABLED) return 'demo';   // coerción: Real gateado
-      return m;
+      var stored = null;
+      try { stored = localStorage.getItem('fts_fin_mode_' + MODULE_ID); } catch (e) { stored = null; }
+      if (stored === 'real') return IP_REAL_ENABLED ? 'real' : 'demo';   // Real gateado → cae a demo
+      if (stored === 'demo' || stored === 'empty') return stored;         // respeta elección explícita del usuario
+      return IP_REAL_ENABLED ? 'empty' : 'demo';   // sin preferencia: demo por default mientras Real esté gateado (deploy de revisión)
     }
 
     var q  = function (s) { return container.querySelector(s); };

--- a/finanzas/version.json
+++ b/finanzas/version.json
@@ -1,7 +1,7 @@
 {
   "module": "finanzas",
-  "version": "0.4.0",
-  "build": "20260720-paso6-instrumentos-pago",
+  "version": "0.4.1",
+  "build": "20260720-paso6b-demo-default",
   "description": "Paso 6 — Instrumentos de pago (Bancos): fuentes de pago colapsables, tabla 17 columnas, semáforo de conciliación, countdown al próximo sync y últimas corridas (CBRUN), portado del mockup v7. Modo demo (mock) + real gateado (fin/captura-status/transacciones/dataset) hasta cerrar checklist de seguridad. Paso 3 previo: Facturas Odoo + Bills Odoo.",
   "status": "active"
 }


### PR DESCRIPTION
## Summary
`currentMode()` devuelve `demo` por default cuando no hay preferencia guardada y `IP_REAL_ENABLED=false` — la vista carga con datos de muestra en vez del empty-state, según lo pedido para la revisión en vivo. Respeta elección explícita del usuario; coerciona `real→demo` mientras esté gateado; cuando se habilite Real el default vuelve a `empty`.

Bump `instrumentos-pago.js?v=0.4.1` + `version.json` build `20260720-paso6b-demo-default`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DA7D53mvCYtuwHZqcgoTvU