### PR TITLE
feat(finanzas): Etapa C — UI de conciliación en Instrumentos de pago

### DIFF
--- a/docs/odoo-captura-bancaria.md
+++ b/docs/odoo-captura-bancaria.md
@@ -1,0 +1,304 @@
+# Odoo — Terreno para la captura bancaria de Jeeves (E0)
+
+> Investigación **solo lectura** vía mcp-server-odoo (UID 2). Fecha: 2026-07-18. Company objetivo: **SERVICIOS FTS (id 1)**.
+> Objetivo E0: mapear dónde y cómo viven hoy los datos antes de construir la captura de movimientos Jeeves como `account.bank.statement.line`.
+>
+> ⚠️ **LEER PRIMERO §0 y §8.** El supuesto de partida ("no existe journal Jeeves, es greenfield") es **incorrecto**: el journal ya existe, ya capturó ~5,410 líneas, y hay un segundo camino contable (vendor bills) para el gasto de gasolina. Hay **riesgo de duplicidad** que exige decisión tuya antes de continuar.
+
+---
+
+## 0. TL;DR — lo que cambia el plan
+
+1. **Ya existe el journal.** `account.journal` **id 61 "Jeeves Tarjeta Credito"** (code `Jeeve`), tipo **bank**, MXN, cuenta default **223 `102.01.007 Jeeves Tarjeta Credito`** (`asset_cash`), suspense **184 `102.01.01 Bank Suspense Account`**, `bank_statements_source = file_import`, ligado a `res.partner.bank` **15 "77648192 - JEEVES"**, `active: true`. → **NO crear un journal nuevo. Reutilizar el 61.**
+2. **Ya capturó movimientos** — pero se murió. 5,410 statement lines: **4,148 en 2023**, **1,247 en 2024**, **15 en 2025** (la última **2025-11-07**), **0 en 2026**. Era captura **manual por file import** (CSV/Excel) que alguien dejó de hacer. El proyecto real = **automatizar ese import** con n8n + API Jeeves, no inventar la capa cruda.
+3. **El gasto de Jeeves tiene un SEGUNDO camino contable hoy:** la gasolina se registra como **Vendor Bills** (journal 2) a la cuenta de gasto **`601.84.01 Otros gastos generales`** (30 bills / ~$16.5k en 2026), con contrapartida **`201.01.01 Proveedores nacionales`** y partner = el comercio real (ej. "OXXO Gas"). **Este es el vector de duplicidad** (§8).
+4. **Los fondeos 2026 desde BBVA NO están en Odoo.** Los montos conocidos (198,757.85 / 301,000 / 243,000 / 181,630.52) devuelven **0 líneas**. Se registraban en 2025 (ver §3) pero en 2026 no hay rastro.
+5. **Dedup: usar el campo NATIVO `unique_import_id`** de `account.bank.statement.line` (mecanismo estándar Odoo anti-duplicado de imports). **No hace falta `x_studio_hash_captura`.**
+6. **El KPI "$ sin conciliar" NO puede ser el saldo de la cuenta suspense 184** — esa cuenta es **compartida** por TODOS los bancos (BBVA, Monex, Jeeves…). Hay que aislarlo (§5.3).
+
+---
+
+## 1. Journals existentes (company 1 · `SERVICIOS FTS`)
+
+`account.journal` relevantes:
+
+| id | Nombre | code | type | Moneda | Cuenta default | Suspense | source |
+|----|--------|------|------|--------|----------------|----------|--------|
+| **61** | **Jeeves Tarjeta Credito** | Jeeve | bank | MXN | **223 · 102.01.007 Jeeves Tarjeta Credito** | 184 · 102.01.01 Bank Suspense | **file_import** |
+| 8 | BBVA General MXN | BBVA | bank | MXN | 38 · 102.01.001 BBVA General MXN | 184 | file_import |
+| 96 | BBVA Nomina | BBVA1 | bank | MXN | 359 · 102.01.00008 | 184 | file_import |
+| 58 | BBVA DORADA FTS | BBVAD | bank | MXN | 217 · 101.01.000002 | 184 | file_import |
+| 75 | BBVA USD | USDMX | bank | USD | 227 · 102.01.00002 | 228 (suspense USD) | file_import |
+| 111 | Monex MXN | BNK6 | bank | MXN | 462 · 102.01.005 | 184 | file_import |
+| 112 | Monex USD | BNK8 | bank | USD | 463 · 102.01.006 | 228 | file_import |
+| 74 | PAYANA | payan | bank | MXN | 316 · 102.01.00006 | 184 | file_import |
+| 20 | Paypal | PAYPA | bank | — | 85 · 102.01.012 | 184 | — |
+| 30 | Stripe | STRIP | bank | — | 126 · 102.01.013 | 184 | — |
+| 103/57/104 | Cash / Alimentos JMZ / Cash Restaurant | — | cash | — | 384/212/388 | 184 | — |
+| 2 | **Vendor Bills** | BILL | purchase | MXN | **32 · 601.84.01 Otros gastos generales** | — | — |
+| 1 | Customer Invoices | INV | sale | MXN | 30 · 401.01.01 | — | — |
+
+- **No existe** ningún journal tipo `credit`. Jeeves está modelado como **bank** (asset), no como pasivo de tarjeta — coherente porque es línea **fondeada** (saldo deudor a favor), no revolvente clásica.
+- **`suspense_account_id = 184` es COMPARTIDO** por casi todos los journals MXN. Consecuencia directa en §5.3 (KPI).
+
+## 2. Cómo entran HOY los gastos de Jeeves a la contabilidad
+
+**Dos caminos paralelos y desincronizados:**
+
+### 2a. Statement lines en journal 61 (la capa cruda que se murió)
+- Import manual de archivo. Volumen: 2023 = 4,148 líneas (−$5.41M), 2024 = 1,247 (−$1.36M), 2025 = **15** (+$580k), 2026 = **0**. Última línea **2025-11-07**.
+- Conciliación: **5,360 conciliadas / 50 sin conciliar** (backlog de suspense pequeño).
+- Ejemplo real (id 29749): fondeo +$318,276.40, partner "jevees", conciliado contra `1.1 BBVA Mexico, 201.01.01 Proveedores nacionales`. Consumos tipo "OXXO PALMAS MONTERREY", partner "GASNGO MEXICO".
+
+### 2b. Vendor Bills para gasolina (el camino vivo en 2026)
+- `account.move` journal 2 (Vendor Bills), líneas "Fondeo Jeeves gasolina". Volumen: 2024 = 4, 2025 = 7, **2026 = 30 (~$16,549.53)**.
+- Estructura de la bill (ej. BILL3049 / move 58493, partner **OXXO Gas** 1816):
+  - Dr `601.84.01 Otros gastos generales` 689.66 (gasto)
+  - Dr `119.01.01 IVA pendiente de pago` 110.34
+  - Cr `201.01.01 Proveedores nacionales` 800.00 (cuenta por pagar)
+- **La contrapartida es `201.01.01 Proveedores nacionales`, NO la cuenta Jeeves 223.** El partner es el comercio real, no "jevees".
+
+> Conclusión: hoy el **gasto** de gasolina Jeeves ya está capitalizado en `601.84.01` vía bills. El resto del consumo de tarjeta (no-gasolina) **no está en ningún lado en 2026** (ni bills ni statement lines).
+
+## 3. Pagos/fondeos a Jeeves desde BBVA
+
+- **2026: NO están en Odoo.** Búsqueda por los 4 montos conocidos (198,757.85 / 301,000 / 243,000 / 181,630.52) → **0 `account.move.line`**. Los egresos BBVA→Jeeves de 2026 no se han registrado (probablemente el statement BBVA 2026 no se ha importado, o el fondeo no se asienta).
+- **2025 sí se registraban** como statement lines en journal 61 con partner "jevees" (1617) o "BBVA México" (1247), payment_ref "Fondeo Jevees"/"Aumento de cuenta", conciliadas contra `201.01.01 Proveedores nacionales` y/o BBVA. Ej.: +$318,276.40 (2025-11-07), +$186,375.86 (2025-09-02), +$82,843.33 (2025-10-01).
+- Partner proxy de Jeeves: **`res.partner` 1617 "jevees"** (nótese el typo), `supplier_rank 24`, sin VAT, no company.
+
+## 4. Plan de cuentas relevante
+
+| id | code | Nombre | account_type | reconcile |
+|----|------|--------|--------------|-----------|
+| 223 | 102.01.007 | **Jeeves Tarjeta Credito** | asset_cash | false |
+| 38 | 102.01.001 | BBVA General MXN | asset_cash | false |
+| 32 | 601.84.01 | Otros gastos generales (gasto default de bills) | expense | false |
+| 17 | 201.01.01 | Proveedores nacionales | (payable) | — |
+| 14 | 119.01.01 | IVA pendiente de pago | — | — |
+| 184 | 102.01.01 | Bank Suspense Account (compartida) | — | — |
+
+- **`3034` NO es una `account.account`** — es una **cuenta analítica** (plan de proyectos, catch-all "Topo Chico"). Vive en `account.analytic.account`, no en el plan contable. Pertenece a la Fase 2 (conciliación analítica), no a esta captura cruda. No la toqué.
+- No hay cuenta "puente/transitoria" con ese nombre; el rol de puente lo cumple la suspense 184.
+
+## 5. Modelo `account.bank.statement.line` en Odoo 19 SaaS
+
+### 5.1 Creación sin statement padre — ✅ CONFIRMADO
+La línea 29749 tiene `statement_id: false` y está posteada/reconciliada. En Odoo 19 las statement lines **existen sin `account.bank.statement` padre**; el statement es solo un agrupador opcional para el cuadre de saldos. → **crear líneas sueltas por JSON-RPC es válido.**
+
+### 5.2 Campos para la captura
+- **Obligatorios de hecho:** `journal_id`, `date`, `payment_ref` (label), `amount` (con signo: negativo=cargo, positivo=abono/fondeo).
+- **Opcionales útiles:** `partner_id`, `partner_name`, `account_number`, `transaction_type`, `narration`/`ref`, `foreign_currency_id`/`amount_currency` (no aplica, todo MXN).
+- **Dedup NATIVO:** **`unique_import_id`** (char). Odoo lo usa para rechazar imports duplicados. **Es el campo correcto para el dedupe — no crear Studio field.** Propuesta de valor: `"jeeves-<transactionId>"` si logramos id estable del API, o `"jeeves-" + SHA256(fecha|monto|tag|last4|destination)` como fallback.
+  - ⚠️ Matiz API: `list_transactions` **no** devuelve el id de transacción; solo `search` lo hace (ids tipo `12029289`). Para el workflow que pagina `list_transactions`, el **hash** es el camino práctico. Evaluar si vale una segunda pasada por `search` para amarrar el id estable.
+- **Studio:** el modelo (heredado de `account.move`) tiene **decenas** de `x_studio_*` legacy (PO, project, evidencia…) — ruido de otros flujos, ninguno sirve de hash. **No añadir `x_studio_hash_captura`; usar `unique_import_id`.**
+
+### 5.3 KPI "$ sin conciliar" — corrección de diseño
+La suspense **184 es compartida** por todos los bancos → su saldo global NO es el "$ sin conciliar de Jeeves". Dos opciones:
+- **(A, recomendada)** Crear una **suspense dedicada** para el journal 61 (ej. `102.01.01.JEEVES Jeeves Suspense`) y apuntar `suspense_account_id` del journal a ella. Entonces el KPI = saldo de esa cuenta, limpio y directo. Cambio de 1 cuenta + 1 campo del journal.
+- **(B)** Dejar la suspense compartida y computar el KPI como **Σ `amount_residual` de las statement lines no conciliadas del journal 61** (o `is_reconciled = false`). Sin tocar cuentas, pero el número se calcula, no se "lee".
+
+## 6. Estructura analítica (solo documentación — Fase 2)
+
+- `account.move.line` usa `analytic_distribution` (jsonb) — el eje proyecto/rubro de Frente A. Documentado en CLAUDE.md §17. En esta captura cruda **no** se toca analítica; las statement lines entran a suspense sin distribución.
+- Cuentas analíticas activas post-limpieza (7 archivadas) — no re-consultado aquí para no ampliar alcance; la conciliación analítica es fase posterior.
+
+## 7. Modelos de conciliación existentes (`account.reconcile.model`)
+
+13 registros, **todos genéricos**: "Create Bill" e "Internal Transfers" (uno por company). **Ninguna regla custom para Jeeves.** No hay automatismo heredado que casar/cuidar. Si en Fase 2 se quiere auto-conciliar statement line ↔ vendor bill de gasolina, se crearía una regla nueva (con cuidado del §8).
+
+---
+
+## 8. ⚠️ RIESGO DE DUPLICIDAD CONTABLE — decisión requerida antes de construir
+
+**El vector:** el gasto de gasolina Jeeves ya se registra como **vendor bill** (Dr `601.84.01` / Cr `201.01.01`, partner = comercio). Si además importamos la **statement line** del mismo cargo de tarjeta y en Fase 2 la posteamos a gasto, el gasto queda **doble**.
+
+**Por qué la captura cruda (ESTA fase) es segura:**
+- La statement line entra a **suspense 184**, sin tocar `601.84.01`. No hay gasto hasta conciliar. → **importar no duplica nada por sí solo.**
+
+**Dónde muerde (Fase 2, a dejar amarrado desde ya):**
+- Para los ~30 cargos de gasolina/2026 que SÍ tienen bill, la conciliación correcta es **statement line ↔ el apunte `201.01.01 Proveedores nacionales` de la bill** (el banco paga la cuenta por pagar). **NO** re-postear a `601.84.01`.
+- Para el consumo NO-gasolina (la mayoría), la statement line no tiene bill → se queda en suspense = **legítimo "$ sin conciliar"**, o se postea directo a la cuenta de gasto/analítica en Fase 2.
+- Los **fondeos** entran positivos, sin bill, y se conciliarán contra el egreso BBVA (cuando ese lado se capture) → hoy inflan el "$ sin conciliar" hasta que exista la contraparte BBVA.
+
+**Riesgo de solape con el histórico:**
+- El journal 61 ya tiene 5,410 líneas hasta 2025-11-07 y **0 en 2026**. Arrancar la carga histórica en **2026-01-01** (default del plan) **no colisiona**. Si algún día se recargan 2023–2025, el `unique_import_id` debe estar poblado o se duplicaría el histórico. Recomendado: **fecha de arranque 2026-01-01** (o 2025-11-08 si se quiere cerrar el hueco), nunca antes.
+
+---
+
+## 9. Propuesta de diseño (para tu visto bueno)
+
+### 9.1 Journal — REUTILIZAR el 61, NO crear uno nuevo
+- Mantener `account.journal` 61 tal cual (bank, MXN, cuenta 223, source file_import).
+- **Único cambio recomendado:** crear **suspense dedicada** `102.01.01.JEEVES` y apuntar `suspense_account_id` del journal 61 a ella (Opción A del §5.3) para que el KPI sea un saldo limpio. Si prefieres cero cambios contables, vamos con Opción B (KPI calculado).
+- **Decisión tuya #1:** ¿reutilizamos 61 (recomendado) o insistes en journal nuevo "Jeeves Crédito"? Un journal nuevo **fragmenta** el histórico y crea DOS saldos Jeeves — no lo recomiendo.
+- **Decisión tuya #2:** ¿suspense dedicada (A) o KPI calculado (B)?
+
+### 9.2 Captura (E1) sobre esa base
+- Dedup por **`unique_import_id`** (nativo), valor `"jeeves-" + SHA256(fecha|monto|tag|last4|destination)`; evaluar segunda pasada `search` para id estable.
+- Arranque **2026-01-01**, traslape 3 días, solo `settled/completed`, paginado `pageSize=100`.
+- Mapeo de labels y signo según el plan (consumo −, devolución +, fondeo +), partner opcional = 1617 "jevees" para fondeos.
+- Validación total-API == filas; abortar sin escribir si difiere.
+
+### 9.3 Duplicidad — regla operativa para Fase 2 (documentar ahora)
+- Statement line de gasolina **concilia contra la bill existente** (`201.01.01`), nunca re-postea `601.84.01`.
+- Ideal: una `account.reconcile.model` que matchee por monto+fecha+partner comercio para las bills de gasolina, dejando el resto en suspense.
+
+### 9.4 Log de corridas — dónde
+- Recomiendo **modelo Odoo simple `x_jeeves_captura_run`** (Studio) o, más ligero, un JSON en el repo/n8n `staticData`. Como el front (Finanzas) ya lee Odoo vía n8n, un modelo Studio pequeño (fecha, nuevas, duplicadas, rechazadas, status, error) es lo más consistente y consultable por el endpoint `status`. **Decisión tuya #3.**
+
+---
+
+## 10. Preguntas abiertas para ti (bloquean el arranque)
+
+1. **¿Reutilizamos journal 61?** (recomendado) o journal nuevo.
+2. **¿Suspense dedicada (A) o KPI calculado (B)?**
+3. **¿El hueco 2025-11-08 → 2025-12-31 se ignora** (arranque 2026-01-01) o lo cerramos?
+4. **Gasolina como vendor bills:** ¿se mantiene ese flujo (y Fase 2 concilia contra él) o se planea migrar la gasolina también a statement lines? (afecta la regla anti-duplicado).
+5. **Fondeos 2026 ausentes en Odoo:** ¿los capturamos como statement lines Jeeves (lado abono) desde ya, aunque el lado BBVA no exista aún? (quedarán en suspense).
+6. **Log de corridas:** modelo Studio Odoo vs. Postgres Railway vs. staticData n8n.
+
+---
+
+## 11. Decisiones tomadas (2026-07-18) + diseño concreto para construir
+
+### 11.1 Decisiones
+1. **Journal:** ✅ **reutilizar el 61** (no crear nuevo). No hay cambio contable que hacer al journal.
+2. **KPI "$ sin conciliar":** ✅ **calculado** (Opción B). No se crea suspense dedicada. El endpoint lo computa como **Σ `amount_residual` de las statement lines del journal 61 con `is_reconciled = false`**. (Hoy: 50 líneas sin conciliar del histórico — ese backlog aparecerá en el KPI hasta que se limpie; anotarlo en el front como "incluye backlog histórico").
+3. **Log de corridas:** ~~modelo Studio~~ → **SUPERSEDED por §14**: `mail.message` en el chatter del journal + `staticData` n8n. **Cero Studio, cero campos, cero F12.**
+
+### 11.2 Log de corridas — CERO Studio: `mail.message` en el chatter del journal (ver §14)
+> **SUPERSEDE al modelo custom `x_captura_bancaria_run`.** No se crea ningún modelo ni campo Studio. El log vive como **nota de chatter (`mail.message`) posteada al propio journal** (`account.journal` **sí tiene chatter** — verificado, `message_ids` existe). n8n `staticData` guarda el cursor operativo. Detalle y justificación en §14.
+- Cada run = 1 `mail.message` en `res_id = <journal>` (61), `model='account.journal'`, `author_id=3` (Esteban; NO 2/OdooBot archivado — lección §18), `subtype_id=2`.
+- Body con marcador machine-readable para el endpoint:
+  `Captura <label> — <origen> — <fecha hora>` + `[[CBRUN]]{"journal_id":61,"desde":"…","hasta":"…","total_api":184,"filas":184,"nuevas":170,"duplicadas":14,"rechazadas":0,"status":"ok"}[[/CBRUN]]`
+- Multi-journal nativo: cada journal loguea en SU chatter (`res_id`). La tabla de corridas del front = `mail.message` de ese `res_id`, orden `date desc`.
+
+### 11.3 Workflow n8n `captura-jeeves` (nodos) — a construir, NO activar
+Triggers:
+- **Schedule** 07:30 CST L–V → en UTC = **13:30 UTC** (⚠️ §18 lección TZ: fijar `settings.timezone` del workflow a mano tras importar).
+- **Webhook POST** `captura-jeeves/run`.
+  - ⚠️ **Refinamiento de seguridad:** el botón vive en el browser → un HMAC con secreto en el front se filtra. Propongo **auth por JWT en el body** (mismo patrón Finanzas, token en body §15), no HMAC-en-browser. El HMAC queda para el hardening server-to-server / cron interno (backlog §9 CLAUDE.md). **Confirmar.**
+
+Cadena:
+1. (Webhook) `Code - Validar JWT` (reusa cripto de facturas/bills).
+2. `Odoo SEARCH última línea` — `account.bank.statement.line`, filterRequest `journal_id=61`, order `date desc`, limit 1, fieldsList `[date]`. Vacío → arranque configurable (default **2026-01-01**).
+3. `Code - fromDate` = últimaFecha − 3 días (traslape); settear `pageSize=100, page=1`.
+4. `HTTP → MCP Jeeves` (JSON-RPC `tools/call` → `list_transactions`, header `x-api-key` desde **credencial n8n cifrada**, nunca hardcode). Paginar en `Code`/loop hasta agotar.
+5. `Code - Validar total` API == filas recibidas → si difiere, **abortar sin escribir** + log `abortado_validacion` + notificar.
+6. `Code - Construir filas`: filtrar `settled/completed`; por fila `unique_import_id = "jeeves-" + sha256(fecha|monto|tag|last4|destination)`; label + signo:
+   - `debit+CARD` → `"[alias ****XXXX] comercio"`, `amount` **negativo**.
+   - `credit+CARD` → `"[DEVOLUCIÓN ****XXXX] comercio"`, `amount` **positivo**.
+   - `credit+DEPOSIT` (source vacío) → `"[FONDEO] Credit Line"`, `amount` **positivo**, `partner_id = 1617` (jevees).
+7. `Odoo SEARCH dedupe`: statement lines del journal 61 con `unique_import_id in [...]` en el rango → `Code` diff → `toInsert[]`.
+8. `Odoo CREATE` (loop) `account.bank.statement.line` — `fieldsToCreateOrUpdate`: `journal_id, date, payment_ref, amount, unique_import_id, partner_id?`. (Sin `operation` = create, per §3.)
+9. `Odoo CREATE mail.message` (chatter del journal) con el resumen: `model='account.journal'`, `res_id=61`, `author_id=3`, `subtype_id=2`, `body` con el marcador `[[CBRUN]]{…}[[/CBRUN]]` (ver §11.2/§14). También persistir el run en n8n `staticData[journal_id]`.
+10. `Respond`/notify.
+
+### 11.4 Endpoint `GET captura-jeeves/status` (JWT en body, patrón Finanzas)
+- `Code - Validar JWT`.
+- `Odoo SEARCH mail.message` `[['model','=','account.journal'],['res_id','=',<journal>],['body','ilike','[[CBRUN]']]`, order `date desc`, limit N → parsear el JSON entre `[[CBRUN]]…[[/CBRUN]]` = historial de corridas (último run + tabla).
+- `Odoo aggregate` statement lines journal 61: `count` del mes en curso, última `date`.
+- `Odoo SEARCH/aggregate` `amount_residual:sum` donde `journal_id=61 & is_reconciled=false` → **KPI "$ sin conciliar"**.
+- Devuelve `{ ultimo_run, resumen, ultima_fecha, sin_conciliar, lineas_mes }`.
+
+### 11.5 Front E2 — pestaña "Bancos" en Finanzas
+- Card por journal (hoy solo Jeeves): nombre, última captura (fecha/hora), movimientos hoy/mes, status último run, **"$ sin conciliar" como número protagonista** (nota: incluye backlog histórico de 50 líneas).
+- Botón **"Capturar ahora"** → POST `captura-jeeves/run` (JWT en body); deshabilitado mientras corre; muestra resumen al terminar.
+- Tabla de últimas corridas (de `x_jeeves_captura_run`).
+- Mismo patrón visual + JWT que el resto de Finanzas. Sin librerías nuevas.
+
+### 11.6 Orden de construcción acordado
+`(journal = no-op, ya existe)` → **modelo log Studio** → **E1 con payload sintético** → **canary 7 días reales** → **carga histórica desde 2026-01-01** → **E2**. No activar workflows (publica Esteban). No merge del front sin revisión.
+
+### 11.7 Respuestas confirmadas (2026-07-18)
+1. **AUTH:** ✅ JWT en body para `captura-jeeves/run` **y** `status` (patrón facturas/bills). HMAC reservado a server-to-server.
+2. **FONDEOS 2026:** ✅ capturarlos como `[FONDEO]` positivos desde ya. Que queden en suspense = evidencia de que falta el lado BBVA.
+3. **GASOLINA:** ✅ se mantiene el flujo de vendor bills. Ver **regla canónica Fase 2** abajo.
+
+### 11.8 ⚠️ REGLA CANÓNICA FASE 2 — conciliación de gasolina (NO borrar)
+> Una statement line de **gasolina** (cargo de tarjeta Jeeves) se concilia **contra el apunte `201.01.01 Proveedores nacionales`** de la vendor bill existente (partner = comercio). **NUNCA se re-postea a `601.84.01`** — el gasto ya está en la bill. Re-postear = doble gasto. La statement line es el lado banco que salda la cuenta por pagar. Migrar gasolina a otro flujo **no está en el plan**.
+
+---
+
+## 12. Ampliación E2 — Vista "Transacciones" + semáforo admin (multi-journal desde diseño)
+
+> Todo esto nace **multi-journal** aunque hoy solo alimente Jeeves (61). Cuando entren BBVA (8/96/58/75), Monex (111/112), Chase (73) → solo se agregan `journal_id`s a la config. **Cero refactor.**
+
+### 12.1 Endpoint `GET captura/transacciones` (JWT en body, patrón Finanzas)
+- Fuente: `account.bank.statement.line` **multi-journal** (config `JOURNALS_BANCOS = [61, ...]`; default hoy `[61]`).
+- **Params:** `journal_id` (uno o `null`=todos los de la config), `date_from`/`date_to`, `estado` (`conciliado`/`sin_conciliar`/`todos`), `search` (texto en `payment_ref`), `page` (50/pág), `order`.
+- **Por línea devuelve:** `date`, `journal_id`(nombre), `payment_ref`, `amount`, `is_reconciled`, `amount_residual`, `partner_id`.
+- **Agregados del filtro activo:** `total_lineas`, `conciliadas`, `sin_conciliar`, `residual_sum`.
+- **Semáforo por journal** (calculado server-side sobre el filtro): `{journal, pct_conciliado, residual, color}` + fila **`TODOS`** con el rollup global.
+  - **Verde** = 100% conciliado **y** residual $0 · **Amarillo** = ≥90% · **Rojo** = <90% **o** residual > umbral (config `RESIDUAL_UMBRAL_MXN`).
+
+### 12.2 Front — sección "Transacciones" dentro de la pestaña Bancos
+- Tabla única **multi-journal** con filtros arriba: selector journal (Todos/Jeeves/…), rango fechas, estado, búsqueda.
+- Fila con status visual: **✓ conciliada** / **● pendiente** (por `is_reconciled`).
+- **Paginación de servidor** (50/pág) — nunca cargar miles de líneas al browser.
+- **Semáforo admin al pie:** por journal (% conciliado + $ residual) + fila resumen **"TODOS LOS JOURNALS"** = señal de admin de que todo está 100% conciliado.
+- Nota visible mientras exista: **"incluye backlog histórico (50 líneas)"**.
+- Mismo patrón visual + JWT que Finanzas. Sin librerías nuevas.
+
+### 12.3 Config multi-journal (una sola fuente)
+`{ JOURNALS_BANCOS: [{id:61, label:'Jeeves'}], RESIDUAL_UMBRAL_MXN: <n>, PAGE_SIZE: 50 }` — agregar bancos = agregar entradas, sin tocar endpoint ni front.
+
+---
+
+## 13. ~~Modelo de log F12~~ — ELIMINADO (ver §14)
+
+**No se crea modelo custom. No hay F12 que correr.** El log de corridas es `mail.message` en el chatter del journal (§11.2) + `staticData` de n8n. Justificación completa en §14.
+
+---
+
+## 14. Investigación: log de corridas SIN Studio (2026-07-18) + VEREDICTO
+
+Disparador: los modelos/campos Studio pueden pegarle a la tarifa de Odoo SaaS (experiencia previa de FTS). Objetivo: log con **cero o mínimos campos Studio**.
+
+### 14.1 Q1 — ¿un `ir.model state='manual'` sube la tarifa de Odoo SaaS?
+- **Odoo Online cobra por PLAN + usuarios, no por customización.** El salto de precio real es **Standard ($24.90/u/mes) → Custom ($37.40/u/mes)**; el plan **Custom** es el que **desbloquea Studio, multi-company y External API**.
+- **FTS YA está en Custom** (opera multi-company {1,6,11,…} y **escribe a Odoo desde n8n = External API**, ambos exclusivos de Custom). → Un modelo manual **NO** genera un nuevo salto de tarifa ni cargo por-modelo; ya está dentro de lo que se paga.
+- **Matiz honesto:** el susto previo de FTS fue casi seguro ese salto **Standard→Custom** al instalar Studio la primera vez (ya hundido). Aun así, la métrica exacta de Odoo SaaS no es 100% transparente y el log de corridas **es telemetría operativa que NO pertenece a la contabilidad** → conviene mantenerlo fuera del modelo de datos contable **por diseño**, no solo por costo. Fuentes: [Odoo Pricing](https://www.odoo.com/pricing), [Standard vs Custom](https://thethinktech.com/blog/odoo-erp-pricing-comparison/), [planes](https://transines.com/odoo-pricing-online-enterprise/).
+
+### 14.2 Q2 — Alternativa A: `account.bank.statement` como contenedor del run
+- Campos libres verificados: **`name`** (char) y **`reference`** (char; hoy guarda el nombre del archivo importado, ej. `jeeves_loc_MXN_20240322.csv`). **NO existe `narration`** en el statement de esta instancia.
+- **Cómo están los 5,410 históricos:** **MIXTO** — **~5,361 dentro de statements** (134 statements tipo "BNK6 Statement 2024-03-25" con `balance_start`/`balance_end_real`, era 2023-2024, creados por el file-import) y **49 sueltos** (`statement_id=false`, el goteo 2025, ej. línea 29749). El file-import nativo crea **un statement por archivo**.
+- **Veredicto A: descartada como store del run.** Agrupar por "run operativo" **contamina la semántica** de `account.bank.statement` (que es período bancario con cuadre de saldos); dejaría statements **desbalanceados** (`statement_valid=false`) = ruido cosmético, y **cambia cómo ve las líneas quien concilia**. Útil solo si quisiéramos cuadre de saldos por corte — no es el caso.
+
+### 14.3 Q3 — Alternativa B: `mail.message` en el chatter (nativo, cero campos) ✅
+- **`account.journal` TIENE chatter** — verificado: `message_ids` existe y responde `[]` en el journal 61.
+- Postear el resumen del run como **nota de chatter** es 100% nativo, **cero campos, cero modelo**, y **consultable** (`search_records('mail.message', …)`). Ya es patrón de la casa (§18: `project/archive-budget-cierre` crea `mail.message` subtype 2, `author_id=3`).
+
+### 14.4 Q4 — Alternativa C: `staticData` de n8n
+- Perfecta para el **cursor operativo** (última fecha capturada por journal) y métricas efímeras. Ya es patrón (§17/§18 idempotencia). Contra: vive dentro de n8n (frágil ante reset del workflow), no es fuente de auditoría durable.
+
+### 14.5 🏆 VEREDICTO — combinación ganadora (prioridad: cero Studio > mínimos > funcionalidad)
+**Statement lines nativas + SUELTAS** (como el patrón 2025, `statement_id=false`) · **log de corridas en `mail.message` del chatter del journal** (durable, consultable, cero Studio) · **`staticData` de n8n como cursor** (velocidad + idempotencia).
+- **Cero modelos custom. Cero campos Studio. Cero F12.**
+- `/status` y la **tabla de corridas** del front se sirven 100%: último run + historial desde `mail.message` (parseando `[[CBRUN]]{…}[[/CBRUN]]`); KPI "$ sin conciliar" y conteos del mes desde agregados de statement lines del journal 61.
+- **Multi-journal nativo**: cada journal loguea en su propio chatter; agregar BBVA/Monex = agregar `journal_id`s a la config, sin tocar el diseño del log.
+- **Por qué no el modelo custom:** aunque técnicamente está incluido en el plan Custom (no sube tarifa), el chatter cumple lo mismo con **menos superficie**, honra "cero Studio", y deja la telemetría fuera del modelo contable. El modelo custom queda como fallback solo si algún día se necesita reporting/filtrado pesado sobre las corridas (BI), no hoy.
+
+---
+
+## 15. Carga histórica 2026 — EJECUTADA (2026-07-21)
+
+Backfill del año completo 2026 del journal 61 (Jeeves), corrida `manual` observada por path schedule. **Éxito.**
+
+### Prerrequisito: hardening del nodo 11 (obligatorio, aplicado antes de cargar)
+`captura-jeeves` nodo `11 - Odoo CREATE statement lines` (`odcreate`) ganó **`onError:"continueRegularOutput"`** (antes ausente → un CREATE fallido tumbaba el batch). Origen del bug: ejecución `41161` (2026-07-20 13:00 UTC) se cayó en el primer `unique_import_id` duplicado, dejando el batch a medias. Con el hardening, un duplicado/colisión se **salta por-item** sin tumbar la corrida. Aplicado vía `update_full` + diff de integridad (solo `odcreate` cambió; SHA-256 de los 7 jsCode intactos).
+
+### Mecánica del disparo (cero código)
+El nodo `4 - Code fromDate` hace `fromDate = MAX(maxDate − traslape, fecha_piso)`. El `fecha_piso` es **tope duro (mínimo)**: protege 2025 pero NO adelanta el arranque. Con `maxDate = 2026-07-17`, flipear solo el piso a 2026-01-01 daba `MAX(07-14, 01-01) = 07-14` (no backfilleaba). **Solución:** en el `2 - Set origen config` se puso `fecha_piso = 2026-01-01` (permanente) **+** `traslape_dias = 210` (temporal) → `cand = 07-17 − 210 = 2025-12-19 < piso` → el `MAX` **clampa a 2026-01-01**. El piso hizo su trabajo (nunca antes de 2026). Tras la corrida, `traslape_dias` **revertido a 3** (incremental normal); `fecha_piso` queda **2026-01-01 permanente** (red de seguridad).
+
+### Resultado (run `42663`, success, 22:15→22:32 UTC ≈ 17 min)
+- **`total_api` = 1779** settled (2026-01-01 → hoy; nodo 6 fetchea `transactionStatuses:['settled']`, 18 páginas de 100). No se movió → sin abort por `total!=filas`.
+- **Journal 61 · 2026 = 1772 líneas** (antes 37). Aritmética: `1779 = 37 dedupeadas + 1735 nuevas + 7 saltadas`. Los **7** colisionaron en `unique_import_id` (colisión intra-lote) y el `onError` del nodo 11 los saltó — el hardening funcionando.
+- **Cero duplicados:** `count = count_distinct(unique_import_id) = 1772`.
+- **min fecha = 2026-01-02** (≥ 2026-01-01). Las **5410 líneas pre-2026 (2023–2025, import NO-Jeeves) intactas.**
+- Distribución mensual: Ene 172 · Feb 254 · Mar 393 · Abr 338 · May 325 · Jun 174 · Jul 116.
+- Desglose de labels estrenados en volumen: **FONDEO 16** (partner **1617** "jevees", montos +), **AJUSTE 16**, **DEVOLUCIÓN ~15** (créditos CARD).
+- **KPI "$ sin conciliar"** (journal 61, `is_reconciled=false`): 1,820 líneas, `sum(amount_residual) = $64,083.88` (net firmado — fondeos + compensan cargos −; es lo que computa `captura-status`).
+
+### Pendiente
+- **Confirmar los 7 saltados**: ¿duplicados reales de Jeeves (benigno) o transacciones distintas con hash colisionado (serían 7 no capturadas)? Revisar el input del hash `unique_import_id` en el nodo `8 - Code Construir filas`.

--- a/docs/receta-conciliacion-rpc.md
+++ b/docs/receta-conciliacion-rpc.md
@@ -247,3 +247,21 @@ Match Oxxo gas de Mateo: línea **31507** (`[Mateo Salazar ****4197] Oxxo` −60
 - **`fin/captura-sugerencias`** (JWT `bancos:read`): las 5 reglas del motor → score → nivel (auto-elegible / sugerida / sin-documento), pre-marcado por cercanía de fecha en sugeridas.
 - **3 cubetas en `captura-status`**: 🔵 en tránsito (pendings vía MCP Jeeves read-only, nunca a Odoo) · 🔴 conciliable pendiente por antigüedad · 🟢 conciliadas hoy (auto vs manual).
 - **Hardening menor de `fin/captura-conciliar`**: envolver los reads en try/catch (hoy solo auth + los 2 writes lo están; un read RPC caído lanza sin respuesta limpia — pero cero write parcial, los reads son antes de los writes).
+
+## 17. Etapa B del motor — B.0 + B.1 en producción, B.2 PENDIENTE (2026-07-23)
+
+### B.0 — rastro del botón (hecho)
+`fin/captura-conciliar` postea al éxito un marcador **`[[CONCFTS]]`{origen:'boton', line_id, bill_aml_id, full_reconcile_id, monto, parcial}** en el chatter del **move del BILL**, **NO-bloqueante** (try/catch → `firma:true/false` en el response; **nunca rechaza una conciliación válida** por un fallo de bitácora). Sirve para clasificar conciliadas-hoy botón vs widget.
+
+### B.1 — `fin/captura-sugerencias` (hecho, INACTIVO, id `43ueZWEXzLyty0LF`)
+JWT `bancos:read`, read-only. Las 5 reglas → **score `0.6·comercio_sim + 0.4·cercanía_fecha`** → nivel:
+- Candidatos = bills abiertos 201.01.01, `|residual|=|monto|±0.01`, fecha `±5d`. Sin candidato → **`sin-documento`**.
+- **`auto-elegible`** solo si **único + score>0.7 + no conflict-pair**. Si ≥2 candidatos → **`sugerida`** con **pre-marcado por cercanía** (FIFO secundario). Texto pobre + monto/fecha/único → `sugerida` (NO descarta; bill puede estar con otra razón social).
+- **`CONFLICT_PAIRS`** editable `[['oxxo','oxxo gas'],['ferreteria','material electrico']]` (crece con cada FP) → capa a `sugerida` (nunca auto). **B SOLO ETIQUETA** — nada auto-concilia hasta D con su gate.
+- Response: `{lineas:[{line_id,comercio,monto,nivel,candidatos:[{bill_aml_id,bill_name,partner,score,banda,pre_marcado,conflicto}]}], pagination}`. Paginado 50/req. **D reusa la lógica interna en lotes, no el HTTP.**
+
+### B.2 — PENDIENTE: 3 cubetas en `fin/captura-status`
+Extender el response con bloque `hoy`: **🔵 en_transito** (pendings Jeeves SSE, key `$env.JEEVES_API_KEY`, **timeout 5s + no-bloqueante**, `disponible:false` si falla, NUNCA tumba el resto) · **🔴 conciliable_pendiente** (buckets de antigüedad hoy/1-3d/+3d de las statement lines sin conciliar) · **🟢 conciliadas_hoy** (v1 `{boton, auto}` desde marcadores `[[CONCFTS]]`; `widget`/`total` = **v2** por el join `full_reconcile.create_date`↔journal 61). `captura-status` NO tiene gate de scope (no agregar). Diseño detallado en memoria `bancos-motor-etapa-b.md`.
+
+### Etapa C (siguiente) — UI en `instrumentos-pago`
+Panel **Hoy** (3 cubetas de captura-status) · sección **En tránsito** (pendings, estilo no-contable gris/itálica, desaparecen al liquidar) · **fila pendiente expandible** → sugerencias de `fin/captura-sugerencias` (score+nivel+pre-marcado) → **botón Conciliar** → `fin/captura-conciliar` (manejo de **éxito full**, **parcial con residuales**, y **rechazo de guard con refresh** de la fila). Branch → PR → revisión visual → merge. ⚠️ **El panel Hoy depende de B.2** — hacer B.2 antes, o el panel Hoy espera esa parte. **Ritual de activación pendiente:** activar B.1 (`43ueZWEXzLyty0LF`) + reactivar los que `update_full` toque, en un solo golpe al cerrar B.2.

--- a/docs/receta-conciliacion-rpc.md
+++ b/docs/receta-conciliacion-rpc.md
@@ -229,3 +229,21 @@ Tras apagar el cron 52, se desenredaron los falsos positivos conocidos (mismo ru
 ## 15. Auto-match nativo — mecanismo confirmado (`ir.cron` 52)
 
 El culpable de los FP fue **`ir.cron` 52 `_cron_try_auto_reconcile_statement_lines`** (diario ~18:40 UTC, OdooBot), NO una `reconcile.model` (las 13 son `trigger:manual`). Evidencia: los partials FP los creó **OdooBot** (uid 1) en la ventana del cron (12728/12729/12730 el 07-19 18:42). Los partials legítimos (ej. BILL3063) los creó un **humano** (uid 25). → Desactivado (§11).
+
+## 16. Etapa A del motor — EN PRODUCCIÓN (2026-07-23)
+
+**El botón de conciliación manual está vivo.**
+
+### A.1 — Login emite `bancos:write`
+`auth/finanzas-login` (**ver:3**, exp 2h): payload `scope = ['bancos:read','bancos:write','facturas:read','bills:read']`. Verificado en el jsCode desplegado (read-back) + token decodificado offline. Único usuario `finanzas` nace autorizado a conciliar (v1 single-user; multiusuario/gate por persona = v2).
+
+### A.2 — `fin/captura-conciliar` (id `PcnlIPWh30l2LrwW`, ACTIVO)
+JWT + scope **`bancos:write`** (403 `SCOPE_INSUFFICIENT` sin él — probado offline). Recibe `{line_id, bill_aml_id}`. Ejecuta la receta §2 (`write([susp],{account_id:17,partner_id:vendor})` + `reconcile([susp, bill_aml])`) con **auto-revert**. Guards **re-validados en el instante del write**: `LINE_YA_CONCILIADA`, `NO_SUSPENSE_UNICA` (descarta línea ya medio-desenredada), `BILL_NO_201`, `BILL_NO_POSTED`, `BILL_YA_CONCILIADO` (concurrencia humana §13), `BILL_SIN_PARTNER`. **NO exige match exacto** (eso es regla del pase automático D, no del botón — el humano puede hacer parciales honestos; `reconcile()` estándar los maneja). Detecta y reporta parcial: `{parcial, residual_linea, residual_bill}`. Respuesta: `{ok:true, full_reconcile_id, bill_name, vendor_id, monto, parcial, residuales, msg}` o `{ok:false, code, msg, http}` (para la UI).
+
+### Caso real verificado (2026-07-23)
+Match Oxxo gas de Mateo: línea **31507** (`[Mateo Salazar ****4197] Oxxo` −600, 2026-03-24, journal 61) ↔ bill_aml **192331** (BILL2490, OXXO Gas partner 1816, 201.01.01, −600, 2026-03-26). Disparado vía runner TMP (mintea JWT `bancos:write` server-side + POST al endpoint; borrado al terminar). Resultado: **FULL reconcile, `full_reconcile 8858`**, `parcial:false`. **Verificación independiente en Odoo:** línea `is_reconciled=true`/residual 0 · BILL2490 `payment_state=paid`/residual 0 · ambas patas unidas en 8858 sobre 201.01.01 · gasto intacto. `ODOO_RPC_KEY` resuelve en vivo. Gate cumplido: A probada con 1 caso real antes de B.
+
+### Pendiente (Etapa B — sesión próxima)
+- **`fin/captura-sugerencias`** (JWT `bancos:read`): las 5 reglas del motor → score → nivel (auto-elegible / sugerida / sin-documento), pre-marcado por cercanía de fecha en sugeridas.
+- **3 cubetas en `captura-status`**: 🔵 en tránsito (pendings vía MCP Jeeves read-only, nunca a Odoo) · 🔴 conciliable pendiente por antigüedad · 🟢 conciliadas hoy (auto vs manual).
+- **Hardening menor de `fin/captura-conciliar`**: envolver los reads en try/catch (hoy solo auth + los 2 writes lo están; un read RPC caído lanza sin respuesta limpia — pero cero write parcial, los reads son antes de los writes).

--- a/finanzas/css/instrumentos-pago.css
+++ b/finanzas/css/instrumentos-pago.css
@@ -138,6 +138,102 @@
 /* ---- corridas ---- */
 .ip-view .runs td{font-family:var(--ip-mono);font-size:12.5px}
 
+/* ═══ Etapa C — conciliación ═══ */
+
+/* ---- panel "Hoy" (3 cubetas) ---- */
+.ip-view .ip-today{display:grid;grid-template-columns:repeat(3,1fr);gap:12px}
+.ip-view .ip-tcard{background:var(--ip-panel);border:1px solid var(--ip-line);border-left-width:4px;border-radius:8px;padding:14px 16px;cursor:pointer;transition:box-shadow .15s,transform .05s}
+.ip-view .ip-tcard:hover{box-shadow:0 3px 12px rgba(0,0,0,.08)}
+.ip-view .ip-tcard:active{transform:translateY(1px)}
+.ip-view .ip-tcard.blue{border-left-color:var(--ip-accent)}
+.ip-view .ip-tcard.red{border-left-color:var(--ip-bad)}
+.ip-view .ip-tcard.green{border-left-color:var(--ip-ok)}
+.ip-view .ip-tcard.active{box-shadow:0 0 0 2px rgba(14,95,216,.28)}
+.ip-view .ip-tcard.red.active{box-shadow:0 0 0 2px rgba(214,59,47,.30)}
+.ip-view .ip-tcard.green.active{box-shadow:0 0 0 2px rgba(18,161,80,.30)}
+.ip-view .ip-tk{font-size:11.5px;text-transform:uppercase;letter-spacing:.6px;color:var(--steel);font-weight:700}
+.ip-view .ip-tn{font-family:var(--ip-mono);font-size:26px;font-weight:600;margin:6px 0 2px;line-height:1.1}
+.ip-view .ip-tcard.blue .ip-tn{color:var(--ip-accent)}
+.ip-view .ip-tcard.red .ip-tn{color:var(--ip-bad)}
+.ip-view .ip-tcard.green .ip-tn{color:var(--ip-ok)}
+.ip-view .ip-tn .ip-tnc{font-size:14px;color:var(--steel);font-weight:400}
+.ip-view .ip-tn.na{font-size:15px;color:var(--steel);font-style:italic;font-weight:400}
+.ip-view .ip-tsub{font-size:11.5px;color:var(--steel)}
+
+/* ---- chevron de expansión en la celda .chk ---- */
+.ip-view td.chk,.ip-view th.chk{width:46px;white-space:nowrap}
+.ip-view .ip-expbtn{border:none;background:transparent;color:var(--steel);cursor:pointer;font-family:var(--ip-mono);font-size:11px;padding:0 3px;transition:transform .18s;line-height:1;vertical-align:middle}
+.ip-view .ip-expbtn:hover{color:var(--ip-accent)}
+.ip-view .ip-expbtn.open{transform:rotate(90deg);color:var(--ip-accent)}
+.ip-view tr.ip-exprow>td{border-bottom-color:transparent}
+.ip-view tr.ip-exprow{background:#f7f9fb}
+
+/* ---- fila-detalle: acordeón de sugerencias ---- */
+.ip-view .ip-acc-row>td{background:#f7f9fb;border-bottom:1px solid var(--ip-line);padding:0}
+.ip-view .ip-acc{padding:14px 18px}
+.ip-view .ip-acc-loading{display:flex;align-items:center;gap:9px;font-size:13px;color:var(--steel)}
+.ip-view .ip-accspin{width:13px;height:13px;border:2px solid var(--ip-line);border-top-color:var(--ip-accent);border-radius:50%;animation:ipsp .7s linear infinite;display:inline-block}
+.ip-view .ip-nivel{display:inline-block;font-family:var(--ip-mono);font-size:11px;font-weight:600;border-radius:12px;padding:3px 11px;margin-bottom:10px}
+.ip-view .ip-nivel.ok{background:#e7f6ed;color:#0d7a3f}
+.ip-view .ip-nivel.warn{background:#fdf3d9;color:#8a6400}
+.ip-view .ip-nivel.gray{background:#eef1f4;color:#5b6875}
+.ip-view .ip-acc-nodoc{font-size:13px;color:var(--steel);line-height:1.6}
+.ip-view .ip-acc-nodoc b{color:var(--ink)}
+
+/* ---- lista de candidatos ---- */
+.ip-view .ip-acc-list{display:flex;flex-direction:column;gap:8px}
+.ip-view .ip-cand{display:flex;align-items:flex-start;gap:11px;background:#fff;border:1px solid var(--ip-line);border-radius:7px;padding:10px 13px;cursor:pointer}
+.ip-view .ip-cand:hover{border-color:#b9c6d6}
+.ip-view .ip-cand.on{border-color:var(--ip-accent);box-shadow:0 0 0 1px var(--ip-accent) inset;background:#f0f6ff}
+.ip-view .ip-cand>input[type=radio]{margin-top:3px;accent-color:var(--ip-accent);cursor:pointer}
+.ip-view .ip-cand-main{flex:1;min-width:0}
+.ip-view .ip-cand-top{display:flex;flex-wrap:wrap;align-items:center;gap:8px;margin-bottom:4px}
+.ip-view .ip-cand-bill{font-family:var(--ip-mono);font-size:12.5px;font-weight:600;color:var(--ink)}
+.ip-view .ip-cand-partner{font-size:13px;color:var(--steel)}
+.ip-view .ip-chip{font-family:var(--ip-mono);font-size:10px;font-weight:700;border-radius:10px;padding:2px 8px;text-transform:uppercase;letter-spacing:.4px}
+.ip-view .ip-chip.pre{background:#e7f6ed;color:#0d7a3f}
+.ip-view .ip-chip.conf{background:#fdf3d9;color:#8a6400}
+.ip-view .ip-cand-sub{display:flex;flex-wrap:wrap;align-items:center;gap:12px;font-size:12px;color:var(--steel)}
+.ip-view .ip-cand-monto{font-family:var(--ip-mono);font-weight:600;color:var(--ink)}
+.ip-view .ip-cand-date{font-family:var(--ip-mono);font-size:11.5px}
+.ip-view .ip-band{font-family:var(--ip-mono);font-size:10.5px;font-weight:600;border-radius:4px;padding:1px 7px;text-transform:uppercase;letter-spacing:.4px}
+.ip-view .ip-band.pleno{background:#e7f6ed;color:#0d7a3f}
+.ip-view .ip-band.sugerida{background:#fdf3d9;color:#8a6400}
+.ip-view .ip-band.baja{background:#fdeae8;color:#b32d22}
+.ip-view .ip-score{display:inline-flex;align-items:center;gap:6px;font-family:var(--ip-mono);font-size:11.5px}
+.ip-view .ip-scorebar{width:56px;height:6px;background:#e3e8ee;border-radius:3px;overflow:hidden}
+.ip-view .ip-scorebar i{display:block;height:100%;border-radius:3px}
+.ip-view .ip-scorebar.g i{background:var(--ip-ok)}
+.ip-view .ip-scorebar.y i{background:var(--ip-warn)}
+.ip-view .ip-scorebar.r i{background:var(--ip-bad)}
+.ip-view .ip-scorenum{color:var(--steel)}
+
+/* ---- acciones + resultado ---- */
+.ip-view .ip-acc-actions{display:flex;align-items:center;gap:12px;margin-top:12px;flex-wrap:wrap}
+.ip-view .ip-acc-conc{background:var(--ip-accent);color:#fff;border:none;border-radius:6px;padding:8px 18px;font-family:inherit;font-weight:600;font-size:13.5px;cursor:pointer}
+.ip-view .ip-acc-conc:disabled{background:#8fa8cc;cursor:not-allowed}
+.ip-view .ip-acc-conc.busy{background:#8fa8cc;cursor:wait}
+.ip-view .ip-acc-hint{font-size:11.5px;color:var(--steel)}
+.ip-view .ip-acc-reload{background:#fff;border:1px solid var(--ip-line);color:var(--ip-accent);border-radius:6px;padding:6px 13px;font-family:inherit;font-weight:600;font-size:12.5px;cursor:pointer}
+.ip-view .ip-acc-reload:hover{border-color:var(--ip-accent)}
+.ip-view .ip-res{font-size:13.5px;font-weight:600;border-radius:6px;padding:10px 13px}
+.ip-view .ip-res.ok{background:#e7f6ed;color:#0d7a3f}
+.ip-view .ip-res.partial{background:#fdf3d9;color:#8a6400}
+.ip-view .ip-res.bad{background:#fdeae8;color:#b32d22}
+.ip-view .ip-res b{font-weight:700}
+.ip-view .ip-mono2{font-family:var(--ip-mono);font-size:12px}
+
+/* ---- sección "En tránsito" (no-contable) ---- */
+.ip-view .ip-itnote{font-size:12px;color:var(--steel);padding:12px 16px;border-bottom:1px solid var(--ip-line);background:#f7f9fb}
+.ip-view .ip-ittbl{width:100%}
+.ip-view .ip-ittbl .ip-itrow td{color:var(--steel);font-style:italic}
+.ip-view .ip-ittbl .ip-itrow td.amt{font-style:normal}
+.ip-view .ip-itbadge{display:inline-block;font-family:var(--ip-mono);font-size:10.5px;font-weight:600;background:#eef1f4;color:#5b6875;border-radius:10px;padding:2px 9px;font-style:normal}
+
+@media(max-width:700px){
+  .ip-view .ip-today{grid-template-columns:1fr}
+}
+
 @media(max-width:700px){
   .ip-view .semrow{grid-template-columns:26px 1fr 70px 110px}
   .ip-view .semrow .jn{font-size:13px}

--- a/finanzas/data/mock/instrumentos-pago.mock.json
+++ b/finanzas/data/mock/instrumentos-pago.mock.json
@@ -29,6 +29,48 @@
     { "run": "Jeeves 2026-07-16 07:30", "origen": "schedule", "rango": "07-12 → 07-16", "nuevas": 11, "dup": 2,  "rech": 0,  "status": "ok",    "status_label": "OK" },
     { "run": "Jeeves 2026-07-15 07:30", "origen": "schedule", "rango": "07-11 → 07-15", "nuevas": null, "dup": null, "rech": null, "status": "abort", "status_label": "ABORTADO (total API ≠ filas)" }
   ],
+  "today": {
+    "en_transito": { "count": 7, "suma": 18450.50, "disponible": true },
+    "conciliable_pendiente": { "hoy": 4, "d1_3": 9, "d3plus": 22, "total": 35, "suma": 88230.10 },
+    "conciliadas_hoy": { "auto": 0, "boton": 3, "widget": 1, "total": 4 }
+  },
+  "intransit": [
+    { "d": "2026-07-18", "ref": "[Primary ****6831] Amazon MX — autorización", "amt": -2340.00, "tarj": "Primary", "comp": "Esteban" },
+    { "d": "2026-07-18", "ref": "[Mateo Salazar ****4197] Uber Eats — hold", "amt": -410.50, "tarj": "Mateo Salazar", "comp": "Mateo Salazar" },
+    { "d": "2026-07-17", "ref": "[Felipe Pérez ****4548] Pemex Estación 4412 — pre-auth", "amt": -1200.00, "tarj": "Felipe Pérez", "comp": "Felipe Pérez" },
+    { "d": "2026-07-17", "ref": "[Chase TDC] Hertz Rental — deposit hold", "amt": -14500.00, "tarj": "Chase TDC", "comp": "Jesús Montalvo" }
+  ],
+  "suggestions": {
+    "1": {
+      "nivel": "auto-elegible",
+      "candidatos": [
+        { "bill_aml_id": 88231, "bill_name": "BILL2951", "partner": "Oxxo Gas Santa Catarina", "partner_id": 4412, "monto_bill": 1580.00, "date_bill": "2026-07-18", "days_diff": 0, "score": 98, "banda": "pleno", "pre_marcado": true, "conflicto": false, "demo_outcome": "full" }
+      ]
+    },
+    "5": {
+      "nivel": "sugerida",
+      "candidatos": [
+        { "bill_aml_id": 87540, "bill_name": "BILL2905", "partner": "VivaAerobus", "partner_id": 2755, "monto_bill": 6874.00, "date_bill": "2026-07-15", "days_diff": 0, "score": 79, "banda": "sugerida", "pre_marcado": true, "conflicto": false, "demo_outcome": "full" },
+        { "bill_aml_id": 87541, "bill_name": "BILL2906", "partner": "VivaAerobus", "partner_id": 2755, "monto_bill": 6900.00, "date_bill": "2026-07-13", "days_diff": 2, "score": 55, "banda": "baja", "pre_marcado": false, "conflicto": false, "demo_outcome": "full" }
+      ]
+    },
+    "8": {
+      "nivel": "sugerida",
+      "candidatos": [
+        { "bill_aml_id": 87720, "bill_name": "BILL2911", "partner": "Hotel City Express Saltillo", "partner_id": 2980, "monto_bill": 3890.00, "date_bill": "2026-07-10", "days_diff": 0, "score": 91, "banda": "pleno", "pre_marcado": true, "conflicto": false, "demo_outcome": "rechazo" }
+      ]
+    },
+    "9": {
+      "nivel": "sugerida",
+      "candidatos": [
+        { "bill_aml_id": 88109, "bill_name": "BILL2929", "partner": "Grainger México", "partner_id": 3301, "monto_bill": 18671.11, "date_bill": "2026-07-08", "days_diff": 0, "score": 84, "banda": "sugerida", "pre_marcado": true, "conflicto": false, "demo_outcome": "parcial", "residual_demo": { "linea": 70.99, "bill": 0 } },
+        { "bill_aml_id": 88110, "bill_name": "BILL2930", "partner": "Grainger México", "partner_id": 3301, "monto_bill": 18742.10, "date_bill": "2026-07-09", "days_diff": 1, "score": 62, "banda": "baja", "pre_marcado": false, "conflicto": true, "demo_outcome": "full" }
+      ]
+    },
+    "0":  { "nivel": "sin-documento", "candidatos": [] },
+    "10": { "nivel": "sin-documento", "candidatos": [] },
+    "11": { "nivel": "sin-documento", "candidatos": [] }
+  },
   "rows": [
     { "company_id": 1, "d": "2026-07-18", "j": "Jeeves", "tipo": "Egreso",   "ref": "[Primary ****6831] Costco Wholesale",               "amt": -714.04,    "mon": "MXN", "tarj": "Primary",       "comp": "Esteban",        "rs": "Servicios FTS", "art": "Consumibles",       "ana": "SO8205-OFICINA",      "po": "",       "bill": "",         "sb": "",       "ff": "",           "tk": "",  "ok": false, "res": 714.04 },
     { "company_id": 1, "d": "2026-07-18", "j": "Jeeves", "tipo": "Egreso",   "ref": "[Mateo Salazar ****4197] Oxxo Gas Santa Catarina", "amt": -1580.00,   "mon": "MXN", "tarj": "Mateo Salazar", "comp": "Mateo Salazar",  "rs": "Servicios FTS", "art": "Gasolina",          "ana": "SO8438-GASOLINA",     "po": "PO6591", "bill": "BILL2951", "sb": "PAGADA", "ff": "A1B2-…-9F3C", "tk": "✓", "ok": false, "res": 1580.00 },

--- a/finanzas/index.html
+++ b/finanzas/index.html
@@ -8,7 +8,7 @@
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
 <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@300;400;500;600;700&family=IBM+Plex+Mono:wght@400;500;600&family=IBM+Plex+Sans+Condensed:wght@500;600;700&display=swap" rel="stylesheet">
 <link rel="stylesheet" href="css/finanzas.css?v=0.1.0">
-<link rel="stylesheet" href="css/instrumentos-pago.css?v=0.4.0">
+<link rel="stylesheet" href="css/instrumentos-pago.css?v=0.5.0">
 </head>
 <body>
 
@@ -67,7 +67,7 @@
 <script src="js/modules/facturas-core.js?v=0.3.0"></script>
 <script src="js/modules/facturas-odoo.js?v=0.3.0"></script>
 <script src="js/modules/bills-odoo.js?v=0.3.0"></script>
-<script src="js/modules/instrumentos-pago.js?v=0.4.1"></script>
+<script src="js/modules/instrumentos-pago.js?v=0.5.0"></script>
 <script>
 /* ═══ FTS Finanzas — shell (Paso 1: auth + sidebar + empty states) ═══ */
 'use strict';

--- a/finanzas/js/modules/instrumentos-pago.js
+++ b/finanzas/js/modules/instrumentos-pago.js
@@ -25,6 +25,8 @@
   // Endpoints reales (contrato construido en la sesión de backend; verificar nombres de
   // campo contra la respuesta viva al des-gatear Real — requiere runner JWT).
   var EP_STATUS = '/fin/captura-status', EP_TX = '/fin/captura-transacciones', EP_DATASET = '/fin/captura-dataset';
+  // Etapa C — motor de conciliación (contrato real; solo se ejercita al des-gatear Real).
+  var EP_SUGERENCIAS = '/fin/captura-sugerencias', EP_CONCILIAR = '/fin/captura-conciliar';
 
   var DEFAULT_CRON = { days: [1, 2, 3, 4, 5], start_hour: 7, regular_end_hour: 16, regular_interval_min: 30, peak_hour: 17, peak_interval_min: 10, close_hour: 18, label: 'L–V 7–18h · 30 min · pico 10 min' };
 
@@ -72,7 +74,13 @@
       pageSize: 100, page: 1,
       sel: {},                 // rowId -> true
       loading: false, error: null,
-      timer: null
+      timer: null,
+      // Etapa C — conciliación
+      today: null,             // panel "Hoy" (3 cubetas)
+      intransit: [],           // movimientos en tránsito (pendings)
+      suggByRow: {},           // demo: sugerencias precargadas del mock, por índice de row
+      expanded: null,          // _id de la ÚNICA fila expandida (acordeón), o null
+      sugg: {}                 // _id -> {loading, cand:{nivel,candidatos}, sel:idx, result, error}
     };
 
     function currentMode() {
@@ -103,7 +111,7 @@
       if (state.mode === 'demo') {
         fetch(MOCK_PATH, { cache: 'no-store' })
           .then(function (r) { return r.json(); })
-          .then(function (data) { ingest(data.rows || [], data.sources || [], data.runs || [], data.cron || DEFAULT_CRON); state.loading = false; render(); afterData(); })
+          .then(function (data) { ingest(data.rows || [], data.sources || [], data.runs || [], data.cron || DEFAULT_CRON, { today: data.today || null, intransit: data.intransit || [], suggByRow: data.suggestions || {} }); state.loading = false; render(); afterData(); })
           .catch(function (e) { state.loading = false; state.error = 'No se pudo cargar el mock: ' + e.message; render(); });
         return;
       }
@@ -114,7 +122,9 @@
         window.FinClient.call(EP_TX, txParams())
       ]).then(function (res) {
         var st = res[0] || {}, tx = res[1] || {};
-        ingest(tx.rows || [], st.sources || [], st.runs || [], st.cron || DEFAULT_CRON);
+        // captura-status.hoy es opcional (B.2 pendiente): si no llega, degrada elegante sin romper.
+        var today = st.hoy || { en_transito: { disponible: false }, conciliable_pendiente: null, conciliadas_hoy: null, _degradado: true };
+        ingest(tx.rows || [], st.sources || [], st.runs || [], st.cron || DEFAULT_CRON, { today: today, intransit: st.intransit || [], suggByRow: {} });
         state.loading = false; render(); afterData();
       }).catch(function (err) {
         state.loading = false;
@@ -131,9 +141,15 @@
         search: f.search || null, limit: 500, offset: 0
       };
     }
-    function ingest(rows, sources, runs, cron) {
+    function ingest(rows, sources, runs, cron, extra) {
       rows.forEach(function (r, i) { r._id = i; });
       state.allRows = rows; state.sources = sources; state.runs = runs; state.cron = cron || DEFAULT_CRON;
+      extra = extra || {};
+      state.today = extra.today || null;
+      state.intransit = extra.intransit || [];
+      state.suggByRow = extra.suggByRow || {};
+      state.expanded = null;   // reset acordeón en cada carga
+      state.sugg = {};         // limpia caché de sugerencias/resultados
     }
     function afterData() { startCountdown(); }
 
@@ -187,9 +203,13 @@
               '<div id="ip-tblwrap"></div>' +
               '<div class="tfoot"><span id="ip-aggs"></span><span class="pager" id="ip-pager"></span></div></div>';
 
+      html += '<h2>Hoy</h2><div class="ip-today" id="ip-today"></div>';
+
       html += '<h2>Semáforo de conciliación — Admin</h2><div class="sem"><div class="title">Control de conciliación por journal</div>' +
               '<div id="ip-semrows"></div>' +
               '<div class="semnote">Verde = 100% conciliado y residual $0 · Amarillo ≥ 90% · Rojo &lt; 90% o residual &gt; ' + money(RESIDUAL_UMBRAL_MXN) + '. El KPI incluye backlog histórico hasta su limpieza (Fase 2).</div></div>';
+
+      html += '<h2>En tránsito</h2><div class="panel" id="ip-intransit"></div>';
 
       html += '<h2>Últimas corridas de captura</h2><div class="panel"><table class="runs">' +
               '<thead><tr><th>Run</th><th>Origen</th><th>Rango</th><th>Nuevas</th><th>Dup.</th><th>Rech.</th><th>Status</th></tr></thead>' +
@@ -203,8 +223,10 @@
       wireFilters();
       renderSources();
       renderRuns();
+      renderIntransit();
       buildColMenu();
       paintTable();
+      paintToday();
     }
 
     // ── head: gear + mode toggle + company selector ──
@@ -374,8 +396,13 @@
         vis.map(function (c) { return '<th class="sortable" data-sort="' + c.k + '"' + (c.k === 'amt' ? ' style="text-align:right"' : '') + '>' + esc(c.lbl) + (state.sortK === c.k ? '<span class="sarr">' + (state.sortDir > 0 ? '▲' : '▼') + '</span>' : '') + '</th>'; }).join('') +
         '</tr></thead><tbody>' +
         slice.map(function (t) {
-          return '<tr class="' + (state.sel[t._id] ? 'selrow' : '') + '"><td class="chk"><input type="checkbox" data-row="' + t._id + '"' + (state.sel[t._id] ? ' checked' : '') + '></td>' +
+          var chev = t.ok ? '' : '<button class="ip-expbtn' + (state.expanded === t._id ? ' open' : '') + '" data-expand="' + t._id + '" title="Sugerencias de conciliación" aria-label="Ver sugerencias">▶</button>';
+          var tr = '<tr class="' + (state.sel[t._id] ? 'selrow' : '') + (state.expanded === t._id ? ' ip-exprow' : '') + '"><td class="chk">' + chev + '<input type="checkbox" data-row="' + t._id + '"' + (state.sel[t._id] ? ' checked' : '') + '></td>' +
             vis.map(function (c) { return '<td ' + colAttr(c, t) + '>' + c.fmt(t) + '</td>'; }).join('') + '</tr>';
+          if (state.expanded === t._id) {
+            tr += '<tr class="ip-acc-row"><td class="ip-acc-cell" colspan="' + (vis.length + 1) + '">' + accordionHtml(t) + '</td></tr>';
+          }
+          return tr;
         }).join('') +
         '</tbody></table></div>'
         : '<div class="ip-empty">Sin movimientos con estos filtros. Ajusta el rango o la búsqueda.</div>';
@@ -413,7 +440,166 @@
       qa('input[data-row]').forEach(function (rc) { rc.addEventListener('change', function () { var id = +rc.getAttribute('data-row'); if (rc.checked) state.sel[id] = true; else delete state.sel[id]; paintTable(); }); });
       qa('th[data-sort]').forEach(function (th) { th.addEventListener('click', function () { var k = th.getAttribute('data-sort'); if (state.sortK === k) state.sortDir *= -1; else { state.sortK = k; state.sortDir = 1; } paintTable(); }); });
 
+      // wiring del acordeón de sugerencias (Etapa C) — solo existe en filas expandidas
+      qa('button[data-expand]').forEach(function (b) { b.addEventListener('click', function (e) { e.stopPropagation(); toggleExpand(+b.getAttribute('data-expand')); }); });
+      qa('input[data-cand]').forEach(function (rc) { rc.addEventListener('change', function () { var id = +rc.getAttribute('data-cand'), idx = +rc.getAttribute('data-idx'); var s = state.sugg[id]; if (s) { s.sel = idx; if (state.expanded === id) paintTable(); } }); });
+      qa('button[data-conc]').forEach(function (b) { b.addEventListener('click', function (e) { e.stopPropagation(); doConciliar(+b.getAttribute('data-conc'), b); }); });
+      qa('button[data-reload]').forEach(function (b) { b.addEventListener('click', function (e) { e.stopPropagation(); var id = +b.getAttribute('data-reload'); delete state.sugg[id]; loadSugg(state.allRows[id]); paintTable(); }); });
+
       paintSem();
+    }
+
+    // ── acordeón de sugerencias + conciliación (Etapa C) ──
+    function defaultSel(list) {
+      if (!list || !list.length) return null;
+      for (var i = 0; i < list.length; i++) { if (list[i].pre_marcado) return i; }
+      return 0;
+    }
+    function toggleExpand(id) {
+      if (state.expanded === id) { state.expanded = null; paintTable(); return; }
+      state.expanded = id;
+      loadSugg(state.allRows[id]);   // lazy: dispara fetch si no está cacheada
+      paintTable();
+    }
+    function loadSugg(row) {
+      if (!row) return;
+      var id = row._id;
+      if (state.sugg[id]) return;                 // cacheada (o cargando / con resultado) → no refetch
+      state.sugg[id] = { loading: true };
+      if (state.mode !== 'real') {
+        // demo: lee del mock (state.suggByRow por índice), simula el "cargando" lazy
+        setTimeout(function () {
+          if (!document.body.contains(container)) return;
+          if (!state.sugg[id] || !state.sugg[id].loading) return;   // colapsada o reemplazada
+          var raw = (state.suggByRow && state.suggByRow[id]) || { nivel: 'sin-documento', candidatos: [] };
+          var cand = { nivel: raw.nivel, candidatos: raw.candidatos || [] };
+          state.sugg[id] = { loading: false, cand: cand, sel: defaultSel(cand.candidatos) };
+          if (state.expanded === id) paintTable();
+        }, 400);
+        return;
+      }
+      // real: contrato fin/captura-sugerencias → tomamos lineas[0]
+      window.FinClient.call(EP_SUGERENCIAS, { companies: window.FinState.getCompanies(), line_ids: [row.id] })
+        .then(function (data) {
+          var l0 = (data && data.lineas && data.lineas[0]) || { nivel: 'sin-documento', candidatos: [] };
+          var cand = { nivel: l0.nivel, candidatos: l0.candidatos || [] };
+          state.sugg[id] = { loading: false, cand: cand, sel: defaultSel(cand.candidatos) };
+          if (state.expanded === id) paintTable();
+        })
+        .catch(function (err) {
+          state.sugg[id] = { loading: false, error: (err && err.msg) || (err && err.code) || 'error' };
+          if (state.expanded === id) paintTable();
+        });
+    }
+    function nivelBadge(nivel) {
+      var map = { 'auto-elegible': ['ok', '● Auto-elegible'], 'sugerida': ['warn', '◐ Sugerida'], 'sin-documento': ['gray', '○ Sin documento'] };
+      var m = map[nivel] || map['sin-documento'];
+      return '<span class="ip-nivel ' + m[0] + '">' + m[1] + '</span>';
+    }
+    function scoreBar(sc) {
+      var v = Math.max(0, Math.min(100, +sc || 0));
+      var cls = v >= 85 ? 'g' : v >= 60 ? 'y' : 'r';
+      return '<span class="ip-score"><span class="ip-scorebar ' + cls + '"><i style="width:' + v + '%"></i></span><span class="ip-scorenum">' + v + '</span></span>';
+    }
+    function candHtml(t, c, i) {
+      var checked = state.sugg[t._id] && state.sugg[t._id].sel === i;
+      var dd = c.days_diff === 0 ? 'mismo día' : (Math.abs(c.days_diff || 0) + 'd');
+      return '<label class="ip-cand' + (checked ? ' on' : '') + '">' +
+        '<input type="radio" name="ip-cand-' + t._id + '" data-cand="' + t._id + '" data-idx="' + i + '"' + (checked ? ' checked' : '') + '>' +
+        '<span class="ip-cand-main">' +
+          '<span class="ip-cand-top"><span class="ip-cand-bill">' + esc(c.bill_name) + '</span>' +
+            '<span class="ip-cand-partner">' + esc(c.partner) + '</span>' +
+            (c.pre_marcado ? '<span class="ip-chip pre">pre-marcado</span>' : '') +
+            (c.conflicto ? '<span class="ip-chip conf">⚠ revisar</span>' : '') + '</span>' +
+          '<span class="ip-cand-sub"><span class="ip-cand-monto">' + money(c.monto_bill) + '</span>' +
+            '<span class="ip-cand-date">' + esc(c.date_bill) + ' · ' + esc(dd) + '</span>' +
+            '<span class="ip-band ' + esc(c.banda) + '">' + esc(c.banda) + '</span>' +
+            scoreBar(c.score) + '</span>' +
+        '</span></label>';
+    }
+    function resultHtml(t, r) {
+      if (r.ok && !r.parcial) {
+        return '<div class="ip-acc"><div class="ip-res ok">✓ Conciliada' + (r.bill_name ? ' · <b>' + esc(r.bill_name) + '</b>' : '') + ' — <span class="ip-mono2">' + esc(r.full_reconcile_id || '') + '</span></div></div>';
+      }
+      if (r.ok && r.parcial) {
+        return '<div class="ip-acc"><div class="ip-res partial">✓ Conciliada PARCIALMENTE — quedan línea <b>' + money(r.residual_linea) + '</b> / bill <b>' + money(r.residual_bill) + '</b></div></div>';
+      }
+      return '<div class="ip-acc"><div class="ip-res bad"><b>' + esc(r.code || 'ERROR') + '</b> — ' + esc(r.msg || 'No se pudo conciliar.') + '</div>' +
+        '<div class="ip-acc-actions"><button class="ip-acc-reload" data-reload="' + t._id + '">↻ Recargar sugerencias</button></div></div>';
+    }
+    function accordionHtml(t) {
+      var s = state.sugg[t._id];
+      if (!s || s.loading) return '<div class="ip-acc"><div class="ip-acc-loading"><span class="ip-accspin"></span> Cargando sugerencias…</div></div>';
+      if (s.result) return resultHtml(t, s.result);
+      if (s.error) return '<div class="ip-acc"><div class="ip-res bad">No se pudieron cargar las sugerencias: ' + esc(s.error) + '</div><div class="ip-acc-actions"><button class="ip-acc-reload" data-reload="' + t._id + '">↻ Reintentar</button></div></div>';
+      var cand = s.cand || { nivel: 'sin-documento', candidatos: [] };
+      var nivel = cand.nivel || 'sin-documento';
+      var list = cand.candidatos || [];
+      if (nivel === 'sin-documento' || !list.length) {
+        return '<div class="ip-acc">' + nivelBadge(nivel) +
+          '<div class="ip-acc-nodoc">Sin bill que conciliar — esta línea va al <b>censo</b> para captura / registro manual.</div></div>';
+      }
+      var chosen = (s.sel != null && list[s.sel]);
+      return '<div class="ip-acc">' + nivelBadge(nivel) +
+        '<div class="ip-acc-list">' + list.map(function (c, i) { return candHtml(t, c, i); }).join('') + '</div>' +
+        '<div class="ip-acc-actions"><button class="ip-acc-conc" data-conc="' + t._id + '"' + (chosen ? '' : ' disabled') + '>Conciliar</button>' +
+          '<span class="ip-acc-hint">Elige el documento y confirma. La conciliación escribe en Odoo (modo real).</span></div></div>';
+    }
+    function demoOutcome(cand) {
+      var o = cand.demo_outcome || 'full';
+      if (o === 'parcial') {
+        var rd = cand.residual_demo || { linea: 0, bill: 0 };
+        return { ok: true, parcial: true, residual_linea: rd.linea, residual_bill: rd.bill, bill_name: cand.bill_name, monto: cand.monto_bill, msg: 'Conciliación parcial (demo).' };
+      }
+      if (o === 'rechazo') {
+        return { ok: false, code: 'BILL_YA_CONCILIADO', msg: 'El bill ya fue conciliado por otra línea (el mundo cambió). Recarga las sugerencias.' };
+      }
+      return { ok: true, parcial: false, full_reconcile_id: 'REC-DEMO-' + cand.bill_aml_id, bill_name: cand.bill_name, monto: cand.monto_bill, msg: 'Conciliada (demo).' };
+    }
+    function doConciliar(id, btn) {
+      var s = state.sugg[id]; if (!s || !s.cand || s.sel == null) return;
+      var cand = s.cand.candidatos[s.sel]; if (!cand) return;
+      if (btn) { btn.disabled = true; btn.classList.add('busy'); btn.textContent = 'Conciliando…'; }
+      var row = state.allRows[id];
+      if (state.mode !== 'real') {
+        setTimeout(function () { if (!document.body.contains(container)) return; applyConcResult(id, demoOutcome(cand)); }, 700);
+        return;
+      }
+      window.FinClient.call(EP_CONCILIAR, { line_id: row.id, bill_aml_id: cand.bill_aml_id })
+        .then(function (r) { applyConcResult(id, r || {}); })
+        .catch(function (err) { applyConcResult(id, { ok: false, code: (err && err.code) || 'ERROR', msg: (err && err.msg) || 'Error al conciliar.' }); });
+    }
+    function applyConcResult(id, r) {
+      var s = state.sugg[id]; if (!s) return;
+      s.result = r;
+      var row = state.allRows[id];
+      if (r.ok && !r.parcial) {
+        if (row) { row.ok = true; row.res = 0; }
+        // baja el panel Hoy: −1 pendiente, +1 conciliada manual (botón)
+        if (state.today) {
+          if (state.today.conciliable_pendiente) state.today.conciliable_pendiente.total = Math.max(0, (state.today.conciliable_pendiente.total || 0) - 1);
+          if (state.today.conciliadas_hoy) { state.today.conciliadas_hoy.boton = (state.today.conciliadas_hoy.boton || 0) + 1; state.today.conciliadas_hoy.total = (state.today.conciliadas_hoy.total || 0) + 1; }
+          paintToday();
+        }
+        paintTable();
+        toast('Conciliada' + (r.bill_name ? ' · <b>' + esc(r.bill_name) + '</b>' : ''));
+        setTimeout(function () {
+          if (!document.body.contains(container)) return;
+          if (state.expanded === id) state.expanded = null;
+          delete state.sugg[id];
+          paintTable();
+        }, 1500);
+        return;
+      }
+      if (r.ok && r.parcial) {
+        if (row) { row.res = (r.residual_linea != null ? r.residual_linea : row.res); row.ok = false; }
+        paintTable();
+        toast('Conciliada parcialmente — residual línea <b>' + money(r.residual_linea) + '</b>');
+        return;
+      }
+      // rechazo: no marca conciliada; el acordeón muestra el error + "Recargar sugerencias"
+      paintTable();
+      toast('<b>' + esc(r.code || 'ERROR') + '</b> — no se concilió');
     }
 
     // ── semáforo ──
@@ -459,6 +645,60 @@
           '<td>' + cell(r.nuevas) + '</td><td>' + cell(r.dup) + '</td><td>' + cell(r.rech) + '</td>' +
           '<td class="st ' + st + '">' + esc(r.status_label || (r.status === 'ok' ? 'OK' : r.status)) + '</td></tr>';
       }).join('');
+    }
+
+    // ── panel "Hoy" (3 cubetas) — Etapa C ──
+    function syncEstadoSelect() { var el = q('#ip-fEstado'); if (el) el.value = state.filters.estado || ''; }
+    function paintToday() {
+      var host = q('#ip-today'); if (!host) return;
+      var td = state.today;
+      if (!td) { host.innerHTML = '<div class="ip-empty" style="padding:14px">Panel del día no disponible.</div>'; return; }
+      var et = td.en_transito || {}, cp = td.conciliable_pendiente || {}, ch = td.conciliadas_hoy || {};
+      var etDisp = et.disponible !== false;
+      var estado = state.filters.estado;
+      var c1 = '<div class="ip-tcard blue" data-today="transito">' +
+        '<div class="ip-tk">🔵 En tránsito</div>' +
+        (etDisp
+          ? '<div class="ip-tn">' + money(et.suma) + ' <span class="ip-tnc">(' + (et.count || 0) + ')</span></div>'
+          : '<div class="ip-tn na">no disponible · reintenta</div>') +
+        '<div class="ip-tsub">pendings, no cuentan</div></div>';
+      var c2 = '<div class="ip-tcard red' + (estado === 'pend' ? ' active' : '') + '" data-today="pend">' +
+        '<div class="ip-tk">🔴 Conciliable pendiente</div>' +
+        '<div class="ip-tn">' + (cp.total || 0) + ' <span class="ip-tnc">líneas</span></div>' +
+        '<div class="ip-tsub">hoy ' + (cp.hoy || 0) + ' · 1-3d ' + (cp.d1_3 || 0) + ' · +3d ' + (cp.d3plus || 0) + ' · ' + money(cp.suma) + '</div></div>';
+      var c3 = '<div class="ip-tcard green' + (estado === 'ok' ? ' active' : '') + '" data-today="ok">' +
+        '<div class="ip-tk">🟢 Conciliadas hoy</div>' +
+        '<div class="ip-tn">' + (ch.total || 0) + '</div>' +
+        '<div class="ip-tsub">auto ' + (ch.auto || 0) + ' · manual ' + ((ch.boton || 0) + (ch.widget || 0)) + '</div></div>';
+      host.innerHTML = c1 + c2 + c3;
+      qa('#ip-today .ip-tcard').forEach(function (card) {
+        card.addEventListener('click', function () {
+          var k = card.getAttribute('data-today');
+          if (k === 'pend' || k === 'ok') {
+            var target = (k === 'pend') ? 'pend' : 'ok';
+            state.filters.estado = (state.filters.estado === target) ? '' : target;   // toggle
+            state.page = 1; syncEstadoSelect(); paintTable(); paintToday();
+          } else {
+            var s = q('#ip-intransit');
+            if (s && s.scrollIntoView) s.scrollIntoView({ behavior: 'smooth', block: 'start' });
+            else toast('Sección <b>En tránsito</b> abajo');
+          }
+        });
+      });
+    }
+
+    // ── sección "En tránsito" (movimientos no liquidados) — Etapa C ──
+    function renderIntransit() {
+      var host = q('#ip-intransit'); if (!host) return;
+      var list = state.intransit || [];
+      if (!list.length) { host.innerHTML = '<div class="ip-empty">Sin movimientos en tránsito.</div>'; return; }
+      host.innerHTML = '<div class="ip-itnote">Movimientos autorizados aún no liquidados — no cuentan en métricas, desaparecen al liquidar.</div>' +
+        '<div style="overflow-x:auto"><table class="ip-ittbl"><thead><tr><th>Fecha</th><th>Descripción</th><th>Tarjeta</th><th>Comprador</th><th style="text-align:right">Monto</th><th>Estado</th></tr></thead><tbody>' +
+        list.map(function (x) {
+          return '<tr class="ip-itrow"><td style="font-family:var(--ip-mono);font-size:12.5px">' + esc(x.d) + '</td><td>' + esc(x.ref) + '</td><td>' + (esc(x.tarj) || '—') + '</td><td>' + (esc(x.comp) || '—') + '</td>' +
+            '<td class="amt ' + ((x.amt || 0) < 0 ? 'neg' : 'pos') + '">' + money(x.amt) + '</td>' +
+            '<td><span class="ip-itbadge">pending · no liquida</span></td></tr>';
+        }).join('') + '</tbody></table></div>';
     }
 
     // ── export XLSX (columnas visibles × filas seleccionadas) ──

--- a/finanzas/version.json
+++ b/finanzas/version.json
@@ -1,7 +1,7 @@
 {
   "module": "finanzas",
-  "version": "0.4.1",
-  "build": "20260720-paso6b-demo-default",
-  "description": "Paso 6 — Instrumentos de pago (Bancos): fuentes de pago colapsables, tabla 17 columnas, semáforo de conciliación, countdown al próximo sync y últimas corridas (CBRUN), portado del mockup v7. Modo demo (mock) + real gateado (fin/captura-status/transacciones/dataset) hasta cerrar checklist de seguridad. Paso 3 previo: Facturas Odoo + Bills Odoo.",
+  "version": "0.5.0",
+  "build": "20260723-etapaC-conciliacion",
+  "description": "Etapa C — motor de conciliación Bancos: panel 'Hoy' (3 cubetas clicables como filtro), acordeón de sugerencias por línea pendiente (fetch lazy, 1 sola fila abierta) con botón Conciliar (full/parcial/rechazo con guard 'recargar sugerencias'), y sección 'En tránsito' (movimientos no liquidados). Endpoints reales fin/captura-sugerencias + fin/captura-conciliar cableados (solo demo ejercitada, Real gateado). Previo Paso 6: fuentes colapsables, tabla 17 columnas, semáforo, corridas.",
   "status": "active"
 }


### PR DESCRIPTION
## Summary
UI de la Etapa C del motor de conciliación en el módulo `instrumentos-pago` (demo aprobado visualmente por Esteban).
- **Panel "Hoy"** (3 cubetas de `captura-status.hoy`, clicables como filtro; degrada si el endpoint no trae `hoy` — B.2 pendiente).
- **Sección "En tránsito"** (pendings no-contables).
- **Acordeón inline lazy** (una fila pendiente a la vez) → sugerencias de `fin/captura-sugerencias` (score/banda/nivel + pre-marcado + conflict-pair).
- **Botón Conciliar** → `fin/captura-conciliar`, render en la fila de los 3 desenlaces: full / parcial (residuales) / rechazo de guard (+ recargar); sin-documento = censo.

## Seguridad
`IP_REAL_ENABLED=false` intacto → Conciliar solo corre en demo (mock). Branch real cableado para el flip futuro.

## Deuda conocida (post-D, no en este PR)
El front solo consume página 1 del endpoint → con miles de pendientes, Real muestra solo las primeras 100. Falta paginación server-side real (pedir page N / iterar `has_more`).

## Test plan
- [x] Revisión visual del demo (Artifact) aprobada por Esteban.
- [x] node --check JS + JSON.parse mock. Sin regresión de paginación (slice/pageSize byte-idénticos).
- [ ] Verificación en Pages: /finanzas → Instrumentos de pago demo con panel Hoy + acordeón + 3 desenlaces.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DA7D53mvCYtuwHZqcgoTvU