### PR TITLE
fix(finanzas/bancos): arregla Real — normaliza cron de captura-status (v0.5.3)

### DIFF
--- a/finanzas/index.html
+++ b/finanzas/index.html
@@ -8,7 +8,7 @@
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
 <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@300;400;500;600;700&family=IBM+Plex+Mono:wght@400;500;600&family=IBM+Plex+Sans+Condensed:wght@500;600;700&display=swap" rel="stylesheet">
 <link rel="stylesheet" href="css/finanzas.css?v=0.1.0">
-<link rel="stylesheet" href="css/instrumentos-pago.css?v=0.5.2">
+<link rel="stylesheet" href="css/instrumentos-pago.css?v=0.5.3">
 </head>
 <body>
 
@@ -67,7 +67,7 @@
 <script src="js/modules/facturas-core.js?v=0.3.0"></script>
 <script src="js/modules/facturas-odoo.js?v=0.3.0"></script>
 <script src="js/modules/bills-odoo.js?v=0.3.0"></script>
-<script src="js/modules/instrumentos-pago.js?v=0.5.2"></script>
+<script src="js/modules/instrumentos-pago.js?v=0.5.3"></script>
 <script>
 /* ═══ FTS Finanzas — shell (Paso 1: auth + sidebar + empty states) ═══ */
 'use strict';

--- a/finanzas/js/modules/instrumentos-pago.js
+++ b/finanzas/js/modules/instrumentos-pago.js
@@ -20,7 +20,7 @@
   var MODULE_ID = 'instrumentos-pago';
   var MOCK_PATH = 'data/mock/instrumentos-pago.mock.json';
   var IP_REAL_ENABLED = true;             // Real HABILITADO en producción (flip 2026-07-23; checklist: JWT ok, Cloudflare diferido)
-  var IP_BUILD = '0.5.2';                 // badge de versión visible (evidencia de qué build está desplegado)
+  var IP_BUILD = '0.5.3';                 // badge de versión visible (evidencia de qué build está desplegado)
   var RESIDUAL_UMBRAL_MXN = 10000;        // coherente con fin/captura-status
   var SHEETJS_CDN = 'https://cdn.sheetjs.com/xlsx-0.20.3/package/dist/xlsx.full.min.js';
   // Endpoints reales (contrato construido en la sesión de backend; verificar nombres de
@@ -30,6 +30,53 @@
   var EP_SUGERENCIAS = '/fin/captura-sugerencias', EP_CONCILIAR = '/fin/captura-conciliar';
 
   var DEFAULT_CRON = { days: [1, 2, 3, 4, 5], start_hour: 7, regular_end_hour: 16, regular_interval_min: 30, peak_hour: 17, peak_interval_min: 10, close_hour: 18, label: 'L–V 7–18h · 30 min · pico 10 min' };
+
+  // ── cron: normaliza a la forma interna {days,start_hour,...}. El mock/DEMO ya la trae; el
+  //    backend real (captura-status) emite {timezone, rules:['min hr dom mon dow', ...]} → se parsea
+  //    a la forma interna para que el countdown no reviente (bug v0.5.2: nextSync leía cron.days de
+  //    un cron sin esa llave → TypeError → toda la carga Real caía al .catch. Fix v0.5.3).
+  function parseCronField(field) {
+    field = String(field);
+    if (field === '*') return null;                 // comodín (cualquier valor)
+    var out = [];
+    field.split(',').forEach(function (part) {
+      var step = 1, base = part, sl = part.split('/');
+      if (sl.length === 2) { base = sl[0]; step = parseInt(sl[1], 10) || 1; }
+      if (base === '*') { for (var i = 0; i <= 59; i += step) out.push(i); return; }
+      var rg = base.split('-');
+      if (rg.length === 2) { for (var j = +rg[0]; j <= +rg[1]; j += step) out.push(j); }
+      else out.push(+base);
+    });
+    return out;
+  }
+  function cronRulesToModel(rules) {
+    var m = { days: [1, 2, 3, 4, 5], start_hour: 7, regular_end_hour: 16, regular_interval_min: 30, peak_hour: 17, peak_interval_min: 10, close_hour: 18, label: '' };
+    var daysSet = null;
+    (rules || []).forEach(function (r) {
+      var f = String(r).trim().split(/\s+/); if (f.length < 5) return;
+      var mins = parseCronField(f[0]), hours = parseCronField(f[1]), dow = parseCronField(f[4]);
+      if (dow) daysSet = dow;
+      var hourIsRange = /-/.test(f[1]);
+      var minMultiple = /[,*\/-]/.test(f[0]);
+      if (hourIsRange && hours && hours.length) {                        // ventana regular
+        m.start_hour = hours[0]; m.regular_end_hour = hours[hours.length - 1];
+        m.regular_interval_min = (mins && mins.length >= 2) ? (mins[1] - mins[0]) : 30;
+      } else if (hours && hours.length === 1 && minMultiple && mins && mins.length >= 2) {  // pico
+        m.peak_hour = hours[0]; m.peak_interval_min = mins[1] - mins[0];
+      } else if (hours && hours.length === 1) {                          // cierre
+        m.close_hour = hours[0];
+      }
+    });
+    if (daysSet) m.days = daysSet;
+    m.label = 'L–V ' + m.start_hour + '–' + m.close_hour + 'h · ' + m.regular_interval_min + ' min · pico ' + m.peak_interval_min + ' min';
+    return m;
+  }
+  function normalizeCron(raw) {
+    if (!raw) return DEFAULT_CRON;
+    if (Array.isArray(raw.days)) return raw;                            // forma interna (mock/DEFAULT)
+    if (Array.isArray(raw.rules)) return cronRulesToModel(raw.rules);   // forma real del backend
+    return DEFAULT_CRON;
+  }
 
   // ── helpers ──
   function esc(s) {
@@ -144,7 +191,7 @@
     }
     function ingest(rows, sources, runs, cron, extra) {
       rows.forEach(function (r, i) { r._id = i; });
-      state.allRows = rows; state.sources = sources; state.runs = runs; state.cron = cron || DEFAULT_CRON;
+      state.allRows = rows; state.sources = sources; state.runs = runs; state.cron = normalizeCron(cron);
       extra = extra || {};
       state.today = extra.today || null;
       state.intransit = extra.intransit || [];
@@ -743,6 +790,7 @@
 
     // ── countdown al próximo sync ──
     function nextSync(now, cron) {
+      if (!cron || !Array.isArray(cron.days)) cron = DEFAULT_CRON;   // guarda dura: nunca lanzar
       var c = new Date(now.getTime());
       for (var i = 0; i < 10080; i++) {
         c.setSeconds(0, 0);

--- a/finanzas/version.json
+++ b/finanzas/version.json
@@ -1,7 +1,7 @@
 {
   "module": "finanzas",
-  "version": "0.5.2",
-  "build": "20260723-flip-real-badge",
-  "description": "Real HABILITADO (flip IP_REAL_ENABLED=true, primera habilitación en prod) + badge de versión visible v0.5.2 + persistencia de modo (1a visita demo, luego recuerda). Etapa C — motor de conciliación Bancos: panel 'Hoy' (3 cubetas clicables como filtro), acordeón de sugerencias por línea pendiente (fetch lazy, 1 sola fila abierta) con botón Conciliar (full/parcial/rechazo con guard 'recargar sugerencias'), y sección 'En tránsito' (movimientos no liquidados). Endpoints reales fin/captura-sugerencias + fin/captura-conciliar cableados (solo demo ejercitada, Real gateado). Previo Paso 6: fuentes colapsables, tabla 17 columnas, semáforo, corridas.",
+  "version": "0.5.3",
+  "build": "20260723-fix-cron-real",
+  "description": "HOTFIX Real: normaliza el cron real de captura-status ({timezone,rules[]}) a la forma interna del countdown — v0.5.2 reventaba en Real porque nextSync leía cron.days de un cron sin esa llave (TypeError → toda la carga caía al .catch → 'Error al consultar el servidor'), pese a que el server devolvía 200 correcto. Guarda dura en nextSync. Real HABILITADO (flip IP_REAL_ENABLED=true) + badge v0.5.3 + persistencia de modo. Etapa C — motor de conciliación Bancos: panel 'Hoy' (3 cubetas clicables como filtro), acordeón de sugerencias por línea pendiente (fetch lazy, 1 sola fila abierta) con botón Conciliar (full/parcial/rechazo con guard 'recargar sugerencias'), y sección 'En tránsito' (movimientos no liquidados). Endpoints reales fin/captura-sugerencias + fin/captura-conciliar cableados (solo demo ejercitada, Real gateado). Previo Paso 6: fuentes colapsables, tabla 17 columnas, semáforo, corridas.",
   "status": "active"
 }


### PR DESCRIPTION
## Causa raíz (con evidencia, NO era HTTP)
El toggle Real fallaba con *"Error al consultar el servidor"* al cargar. Diagnóstico con evidencia dura del servidor:

- **Ejecuciones n8n** de `captura-status` (44741 pre-login @19:24, 44762 post-login @19:28) y `captura-transacciones`: **todas `success`, 200, `_jwt_ok:true`**, scope correcto. El server nunca falló, antes ni después del re-login.
- **curl OPTIONS + POST** a ambos endpoints: `access-control-allow-origin: https://yinyo1.github.io` presente → **CORS OK**. Descartado 401/403/404/500/CORS.

El fallo era un **`TypeError` browser-side**: el backend real emite `cron:{timezone, rules:["0,30 7-16 * * 1-5", …]}`, pero `nextSync()` leía `cron.days.indexOf(...)` → `cron.days` `undefined` → throw dentro del `.then` de `load()` → caía al `.catch`. **Nunca se detectó porque todo el QA de Etapa C fue en DEMO** (el mock trae el cron con la forma interna `{days, start_hour,…}`); Real solo se probó vía runners server-side, jamás renderizado en un browser.

## Fix
- `normalizeCron()` parsea los `rules` cron reales a la forma interna. **Verificado ejecutando**: produce un modelo idéntico a `DEFAULT_CRON` (`days:[1-5]`, 7–16 c/30min, pico 17 c/10min, cierre 18) → el countdown ahora funciona, no solo deja de reventar.
- Guarda dura en `nextSync` (`if (!cron || !Array.isArray(cron.days)) cron = DEFAULT_CRON`) — nunca lanza.
- Demo intacto. Badge **v0.5.3** + `version.json` + `?v=`.

## Test plan
- [x] `node -c` syntax OK
- [x] normalizer probado contra los rules reales → modelo == DEFAULT_CRON
- [ ] Pages sirve v0.5.3 → Esteban confirma badge en URL viva + Real carga sin error (protocolo nuevo)

🤖 Generated with [Claude Code](https://claude.com/claude-code)