### PR TITLE
fix(semaforo): watchdog B — bizDays en hora de Monterrey + banda amarilla

### DIFF
--- a/docs/n8n-workflows/watchdog-semaforo-code-main.js
+++ b/docs/n8n-workflows/watchdog-semaforo-code-main.js
@@ -1,0 +1,64 @@
+let _r = $('HTTP - load config').first().json;
+const cfg = (_r && _r.config) ? _r : JSON.parse(_r.data || _r.body || (typeof _r === 'string' ? _r : JSON.stringify(_r)));
+const C = cfg.config, STG = cfg.stages, MAT = cfg.materiales_overrides || {}, EXCL = cfg.excluidos || [];
+const SEQ = {1:0,2:1,5:2,3:3,7:4,13:8,8:9,4:10,6:11};
+const COM = C.comercial_whitelist_partner_ids || [], WD = C.watchdog_author_partner_id;
+const FF = cfg.integridad.fecha_fin_field_id, FS = cfg.integridad.stage_field_id;
+const AP = C.ap_confirmacion || {};
+// --- TZ ----------------------------------------------------------------------
+// Toda la aritmetica de dias opera en hora de MONTERREY (UTC-6, sin DST desde 2022).
+// El contenedor n8n corre en UTC (medido 2026-08-09: reconstruyendo el snapshot 2026-07-24,
+// solo offset 0 lo reproduce 23/23; -4h/-5h/-6h dan 10/23). settings.timezone del workflow
+// NO aplica a getHours()/setDate() de un Code node, por eso se normaliza a mano.
+const TZO = (C.tz_offset_hours != null ? C.tz_offset_hours : -6);
+function mtyWall(ds){ if(!ds) return null; const s=String(ds);
+  const iso = s.replace(' ','T') + (/([Zz]|[+-]\d\d:?\d\d)$/.test(s) ? '' : 'Z');
+  const t = Date.parse(iso); if(isNaN(t)) return null;
+  return new Date(t + TZO*3600000); }
+function dayStart(d){ const x=new Date(d); x.setHours(0,0,0,0); return x; }
+const today = mtyWall($('Set - hoy').first().json.hoy);
+const todayDay = dayStart(today);
+const m2o = v => Array.isArray(v)?v[0]:v;
+const isWE = x => x.getDay()===6 || x.getDay()===0;
+function nextBizDay(d){ const x=dayStart(d); do { x.setDate(x.getDate()+1); } while(C.excluir_findes && isWE(x)); return x; }
+// Dias habiles TRANSCURRIDOS desde el dia de la nota: hoy=0, ayer habil=1, viernes->lunes=1.
+// Granularidad de DIA -> el resultado NO depende de la hora de captura.
+// (business_day_start_hour / business_day_cutoff_hour quedan sin uso.)
+function bizDays(ds){ const w=mtyWall(ds); if(!w) return null;
+  let c=nextBizDay(w), n=0; while(c <= todayDay){ n++; c=nextBizDay(c); } return n; }
+function lastBy(node, filt){ const m={}; for(const it of $(node).all()){ const r=it.json; if(filt && !filt(r)) continue;
+  const rid=r.res_id; if(!m[rid] || new Date(r.date) > new Date(m[rid].date)) m[rid]=r; } return m; }
+const lastStageMsg = lastBy('Odoo - getAll msg94');
+const lastComment = lastBy('Odoo - getAll msgComment', r => m2o(r.author_id) !== WD);
+const matSO = {}; for(const it of $('Odoo - getAll SO').all()){ matSO[it.json.id] = (C.materiales_values||[]).includes(it.json.x_studio_product_type); }
+const termDays = {}; for(const it of $('Odoo - getAll termlines').all()){ const t=m2o(it.json.payment_id); termDays[t]=Math.max(termDays[t]||0, Number(it.json.nb_days)||0); }
+const partnerTerm = {}; for(const it of $('Odoo - getAll partners').all()){ partnerTerm[it.json.id] = it.json.property_payment_term_id ? m2o(it.json.property_payment_term_id) : null; }
+const trkByMsg = {}; for(const it of $('Odoo - getAll trackingVals').all()){ trkByMsg[m2o(it.json.mail_message_id)] = it.json; }
+const flagsByProj = {}; function addFlag(rid,f){ (flagsByProj[rid]=flagsByProj[rid]||[]).push(f); }
+for(const it of $('Odoo - getAll trackedMsgs').all()){ const m=it.json; const t=trkByMsg[m.id]; if(!t) continue; const au=m2o(m.author_id); const aun=Array.isArray(m.author_id)?m.author_id[1]:''; const fid=m2o(t.field_id);
+  if(fid===FF && t.old_value_datetime && !COM.includes(au)) addFlag(m.res_id,{tipo:'fecha_fin', detalle:'Fecha fin movida por '+aun+' (no Comercial)', fecha:m.date});
+  if(fid===FS && SEQ[t.new_value_integer]!=null && SEQ[t.old_value_integer]!=null && SEQ[t.new_value_integer] < SEQ[t.old_value_integer]) addFlag(m.res_id,{tipo:'stage_atras', detalle:'Stage regresado '+t.old_value_char+' -> '+t.new_value_char+' por '+aun, fecha:m.date}); }
+const attMime = {}; for(const it of $('Odoo - getAll attachments').all()){ attMime[it.json.id]= it.json.mimetype||''; }
+function norm(s){ return String(s||'').replace(/<[^>]*>/g,' ').normalize('NFD').replace(/[\u0300-\u036f]/g,'').toLowerCase(); }
+const apTpl = norm(AP.template);
+const apOk = {};
+for(const it of $('Odoo - getAll msgComment').all()){ const m=it.json; if(apTpl && norm(m.body).includes(apTpl)){ const hasImg=(m.attachment_ids||[]).some(a=>(attMime[a]||'').startsWith('image/')); if(!AP.requiere_imagen || hasImg) apOk[m.res_id]=true; } }
+function colorOf(d,r){ if(d==null||r==null) return 'verde'; if(d>=r) return 'rojo'; if(d>=Math.max(r-1,1)) return 'amarillo'; return 'verde'; }
+function rojoCredito(p){ const t=partnerTerm[m2o(p.partner_id)]; const d=(t&&termDays[t]!=null)?termDays[t]:C.credit_fallback_days; return d + C.credit_extra_days; }
+const ORD={verde:0,amarillo:1,rojo:2}; const out=[];
+for(const it of $('Odoo - getAll projects').all()){ const p=it.json; const sid=m2o(p.stage_id); if(sid==null||EXCL.includes(sid)) continue; const sc=STG[String(sid)]; if(!sc) continue;
+  const esMat = p.sale_order_id ? !!matSO[m2o(p.sale_order_id)] : false;
+  const ls=lastStageMsg[p.id]; const diasEnStage = ls?bizDays(ls.date):(p.create_date?bizDays(p.create_date):null);
+  const lc=lastComment[p.id]; const diasSinSeg = lc?bizDays(lc.date):(p.create_date?bizDays(p.create_date):null);
+  const oEn = (esMat && MAT[sid] && MAT[sid].en_stage) ? MAT[sid].en_stage : sc.en_stage;
+  const oSeg = (esMat && MAT[sid] && MAT[sid].sin_seguimiento) ? MAT[sid].sin_seguimiento : sc.sin_seguimiento;
+  let colA;
+  if(oEn.modo==='due_date'){ if(!p.date){ colA=colorOf(diasEnStage, C.in_progress_fallback_dias); } else { const due=new Date(p.date); const ama=new Date(due.getTime()-(C.in_progress_amarillo_dias_habiles||3)*86400000); colA = today>=due?'rojo':(today>=ama?'amarillo':'verde'); } }
+  else if(oEn.modo==='credito'){ colA=colorOf(diasEnStage, rojoCredito(p)); }
+  else { colA=colorOf(diasEnStage, oEn.rojo_dias); }
+  let colB; if(oSeg.modo==='credito'){ colB=colorOf(diasSinSeg, rojoCredito(p)); } else { colB=colorOf(diasSinSeg, oSeg.rojo_dias); }
+  let col = ORD[colA]>=ORD[colB]?colA:colB;
+  if(p.last_update_status==='off_track') col='rojo'; else if(p.last_update_status==='at_risk' && col==='verde') col='amarillo';
+  if((AP.aplica_stages||[]).includes(sid) && !apOk[p.id]) addFlag(p.id,{tipo:'ap_sin_confirmacion', detalle:'En plazo de credito SIN confirmacion AP documentada (falta log note + pantallazo)'});
+  out.push({ json:{ id:p.id, name:p.name, stage_id:sid, stage:sc.label, grupo:sc.grupo, cliente: p.partner_id?p.partner_id[1]:'', es_materiales:esMat, dias_en_stage:diasEnStage, dias_sin_seguimiento:diasSinSeg, color_a:colA, color_b:colB, color:col, banderas: flagsByProj[p.id]||[], link_odoo:'https://serviciosfts.odoo.com/web#id='+p.id+'&model=project.project&view_type=form' } }); }
+return out;

--- a/shared/operaciones/sla_stages.json
+++ b/shared/operaciones/sla_stages.json
@@ -1,9 +1,10 @@
 {
   "_meta": {
     "doc": "docs/operaciones/SEMAFORO_WATCHDOG.md",
-    "descripcion": "Config del semáforo/watchdog operativo. Umbrales por stage (project.project.stage_id) para 2 métricas: A=tiempo en stage (chatter subtype 94), B=tiempo sin seguimiento (chatter comment no-bot). 🟡 = amarillo_pct del 🔴. Días = HÁBILES (excluye sáb/dom). Todo read-only en Odoo salvo el log note al chatter.",
-    "version": "1.0",
-    "fecha": "2026-06-17"
+    "descripcion": "Config del semáforo/watchdog operativo. Umbrales por stage (project.project.stage_id) para 2 métricas: A=tiempo en stage (chatter subtype 94), B=tiempo sin seguimiento (chatter comment no-bot). 🟡 = max(🔴 - 1, 1). Días = HÁBILES (excluye sáb/dom) contados en hora de Monterrey. Todo read-only en Odoo salvo el log note al chatter.",
+    "version": "1.1",
+    "fecha": "2026-08-09",
+    "_cambios_v1_1": "bizDays reescrito: días hábiles TRANSCURRIDOS desde la nota (hoy=0, ayer hábil=1), con granularidad de día en hora de Monterrey. Antes contaba el día de la nota Y el día en curso, y operaba en la TZ del contenedor (UTC), lo que hacía que una nota de ayer 07:26 CST leyera '2d' y saliera roja al día siguiente. Umbrales SIN recalibrar todavía — cambiaron de significado."
   },
   "config": {
     "alert_recipient_default": "estebandelacruz@fts.mx",
@@ -20,10 +21,13 @@
     "in_progress_fallback_dias": 30,
     "credit_fallback_days": 30,
     "credit_extra_days": 7,
-    "business_day_start_hour": 8,
-    "business_day_cutoff_hour": 17,
+    "tz_offset_hours": -6,
+    "_tz_offset_hours": "Hora de Monterrey. El contenedor n8n corre en UTC (medido 2026-08-09: reconstruyendo el snapshot 2026-07-24, solo offset 0 lo reproduce 23/23; -4h/-5h/-6h dan 10/23). settings.timezone del workflow NO aplica a getHours()/setDate() de un Code node, por eso Code - MAIN normaliza a mano con este offset. Monterrey NO tiene DST desde el decreto de oct-2022 (no es municipio fronterizo), así que un offset fijo es exacto. Si México reinstala DST, este es el único campo a tocar.",
     "excluir_findes": true,
     "festivos_mx": [],
+    "_deprecado_v1_1": "business_day_start_hour, business_day_cutoff_hour y amarillo_pct ya NO se usan. Los dos primeros murieron al volverse bizDays granular por día (el resultado ya no depende de la hora de captura). amarillo_pct se reemplazó por max(rojo-1,1) porque 0.9 colapsaba el amarillo sobre el rojo con cualquier rojo_dias<=2. Se dejan las llaves para no romper lectores externos.",
+    "business_day_start_hour": 8,
+    "business_day_cutoff_hour": 17,
     "amarillo_pct": 0.9,
     "in_progress_amarillo_dias_habiles": 3,
     "ap_confirmacion": {


### PR DESCRIPTION
## Contexto

El semáforo B (falta de seguimiento) marcaba **rojo al día siguiente** de que Felipe pusiera la log note. Doce proyectos mostraban todos exactamente `2d`.

El diagnóstico previo descartó las 4 hipótesis obvias: **las notas SÍ eran visibles** al watchdog (`message_type='comment'`, autor 12, modelo `project.project` — todo dentro del filtro). El bug estaba en el conteo.

## Qué se arregla

### 1. `bizDays` contaba de más (off-by-two)

El loop arrancaba en el timestamp crudo de la nota y contaba **el día de la propia nota Y el día en curso**. Una nota de ayer 07:26 CST leía `2d` a las 8:00 de la mañana siguiente.

Reescrito a **días hábiles transcurridos desde el día de la nota**, con granularidad de día:

| caso | antes | ahora |
|---|---|---|
| nota de hoy | 1d | **0d** |
| nota de ayer hábil | 2d | **1d** |
| nota del viernes, run del lunes | 2d | **1d** |

El resultado **ya no depende de la hora de captura** — antes, publicar a las 07:26 CST (justo antes del run de las 8:00) costaba un día extra frente a publicar a las 08:30.

### 2. La aritmética corría en UTC, no en hora de Monterrey

`settings.timezone: "Etc/UTC"` gobierna el Schedule y `$now`, pero **no** `getHours()`/`setDate()` de un Code node — ésos usan la TZ del proceso.

**Medición** (no inferencia): se reconstruyeron los 23 proyectos del snapshot `2026-07-24` con su última nota real de Odoo y se recomputó bajo varios offsets.

```
UTC (Etc/UTC)           offset   0h  ->  23/23  REPRODUCE EL SNAPSHOT
America/New_York (EDT)  offset  -4h  ->  10/23
CDT generico            offset  -5h  ->  10/23
America/Monterrey (CST) offset  -6h  ->  10/23
Europe/Madrid (CEST)    offset  +2h  ->  18/23
```

El par que fija la frontera: proyecto **2304** (última nota 23-jul **14:13:49Z**) dio **1d**, mientras **343** (23-jul **13:28:12Z**) dio **2d** — mismo día, 45 min de diferencia. Eso acota el offset a `(−32 min, +13.6 min)`.

Consecuencias que esto tenía:
- `business_day_cutoff_hour: 17` se evaluaba a **11:00 CST**, no 17:00 CST
- `business_day_start_hour: 8` = **02:00 CST**
- `isWE()`: el sábado empezaba el viernes 18:00 CST y el lunes empezaba el domingo 18:00 CST

Ahora todo opera en hora de Monterrey vía el campo nuevo `tz_offset_hours: -6`. Se eligió offset fijo sobre Luxon porque **Monterrey no tiene DST desde el decreto de oct-2022** (no es municipio fronterizo), así que el offset es exacto, no depende de que el sandbox de n8n exponga el global `DateTime`, y es 100% testeable en frío. Si México reinstala DST, es el único campo a tocar.

### 3. Banda amarilla colapsada

`amarillo_pct: 0.9` daba `round(2 * 0.9) = 2` — **amarillo y rojo eran el mismo número** para `rojo_dias <= 2`. El semáforo saltaba de verde a rojo sin avisar nunca. Reemplazado por `max(rojo - 1, 1)`.

| rojo_dias | banda amarilla antes | ahora |
|---|---|---|
| 1 | ninguna | ninguna (sin margen posible) |
| 2 | **ninguna** | **1d** |
| 7 | 1d | 1d |
| 30 | 3d | 1d |
| 37 | 4d | 1d |

⚠️ Para umbrales grandes la banda **se estrecha** (30d pasa de 3d a 1d de aviso). Entra en la recalibración.

## Lo que NO se tocó

- **Umbrales**: a propósito. Cambiaron de significado con el conteo nuevo; se recalibran con datos después de un run limpio.
- **`watchdog_author_partner_id`**: se queda en `2`. Ver issue separado abajo.
- **Rama `due_date` del semáforo A**: la comparación es algebraicamente idéntica con el run de las 8:00 (ambos frames comparan contra medianoche del día objetivo, y el run cae muy después en cualquiera de los dos).

## Validación

Harness en frío contra datos reales de Odoo (23 proyectos del snapshot `2026-07-24`, última nota de cada uno leída de `mail.message`):

```
A) Sanity: el codigo VIEJO reproduce el snapshot
   deltas: 23/23   colores_B: 23/23     -> el harness es fiel a produccion

B) VIEJO vs NUEVO (umbral fijo, 14 proy)
   12 rojo->amarillo, 2 sin cambio, 0 rojo->verde
   credito (9 proy): sin cambio de color

C) Los timestamps del diagnostico
   nota 23-jul 13:26:33Z -> run vie 24-jul :  viejo 2d (rojo) -> NUEVO 1d (amarillo)
   nota 27-jul 13:20:08Z -> run mar 28-jul :  viejo 2d (rojo) -> NUEVO 1d (amarillo)

D) Independencia de la hora de captura (misma nota, run vie 24-jul)
   06:30Z (00:30 CST) -> viejo 2d | NUEVO 1d
   13:26Z (07:26 CST) -> viejo 2d | NUEVO 1d
   16:59Z (10:59 CST) -> viejo 1d | NUEVO 1d
   17:01Z (11:01 CST) -> viejo 1d | NUEVO 1d
   23:50Z (17:50 CST) -> viejo 1d | NUEVO 1d

E) Semantica objetivo: 5/5 casos correctos
```

Y el **jsCode exacto a desplegar fue EJECUTADO** con stubs de los nodos n8n (no sólo `node -c`): corre sin error y da **23/23** en `color_b`.

Nota: los 12 falsos rojos pasan a **amarillo**, no a verde — con `rojo_dias: 2` en stage 2, escribir cada 2 días sigue siendo un aviso. El proyecto 213 (10 días reales sin nota) **sigue rojo**, que es lo correcto: el fix quita los falsos positivos sin tapar los atrasos reales.

## ⚠️ La mitad n8n NO está aplicada

El API de esta instancia rechaza el update por MCP con `request/body must NOT have additional properties` (quirk documentado en `CLAUDE.md` §17). El `validateOnly` pasa porque valida del lado del MCP; el rechazo ocurre al mandar el body real.

Verificado que el intento fallido **no dejó nada a medias**: `updatedAt` sigue en `2026-06-19T18:47:04.363Z` y `active: true`.

**Acción manual requerida (Esteban):** pegar `docs/n8n-workflows/watchdog-semaforo-code-main.js` en el nodo **`Code - MAIN`** del workflow `ops/watchdog-semaforo` (`29eaGe2wkS98lRMU`) desde la UI. El archivo es byte-idéntico a lo verificado, sin cabecera añadida.

Después del pegado, **confirmar que `active` sigue en `true`** — es un Schedule y una desactivación silenciosa no se nota hasta que nadie recibe el correo.

### Orden de despliegue

Ambas mitades son **tolerantes**, así que no hay riesgo de trabón:
- config sin el workflow nuevo → `tz_offset_hours` es una llave sin leer
- workflow nuevo sin la config mergeada → cae al default `-6` del propio código

## Issue separado (no implementado aquí)

`project/archive-budget-cierre` (`RW7KnoeEzYLvavI0`) escribe sus log notes con `message_type='comment'`; debería escribirlas con `'notification'`, como ya hace el nodo `Odoo - CREATE log note` del propio watchdog. Eso excluiría las notas de bot del semáforo **sin filtrar por autor**.

Por qué importa: `watchdog_author_partner_id` apunta a `2` pero el watchdog escribe como autor `3`. Alinearlo a `3` parecía el arreglo obvio, pero **partner 3 es identidad compartida** — Esteban humano *y* al menos dos workflows. Filtrar por autor no puede distinguirlos, y `WD=3` mataría las notas genuinas de Esteban como seguimiento válido. Evidencia de notas de bot con autor 3:

```
msg 2902717 | proy 2338 | 2026-06-26T04:00:52Z | comment | author 3
msg 2901481 | proy 2298 | 2026-06-24T04:00:53Z | comment | author 3
msg 2899984 | proy 2327 | 2026-06-19T04:00:53Z | comment | author 3
body: "Cierre definitivo: stage En plazo de credito, AR=0 y AP=0. ..."
```

## Test plan

- [ ] Pegar el jsCode en `Code - MAIN` desde la UI de n8n
- [ ] Read-back: `active` sigue en `true` y `triggerCount` en `1`
- [ ] Mergear este PR para que `sla_stages.json` v1.1 quede en `main` (el workflow lo lee de raw main en vivo)
- [ ] Primer run limpio (lunes 8:00 CST) → revisar el snapshot y el correo
- [ ] Recalibrar umbrales con ese run

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CNUkfof8V6it1ZC1zFYiH7