### PR TITLE
feat(semaforo): recalibracion B a politica de captura diaria (Mundo A)

### DIFF
--- a/docs/n8n-workflows/watchdog-semaforo-code-buildemail.js
+++ b/docs/n8n-workflows/watchdog-semaforo-code-buildemail.js
@@ -1,0 +1,115 @@
+
+const _cf = $('HTTP - load config').first().json;
+const cfg = (_cf && _cf.config) ? _cf : JSON.parse(_cf.data || _cf.body || (typeof _cf==='string'?_cf:JSON.stringify(_cf)));
+const C = cfg.config;
+const OBSH = (cfg.observacion||{}).hasta;
+const rows = $('Code - MAIN').all().map(i=>i.json);
+const hoy = $('Set - hoy').first().json.hoy;
+const today = new Date(hoy);
+const fechaStr = hoy.slice(0,10);
+const MES_EN = ['Jan','Feb','Mar','Apr','May','Jun','Jul','Aug','Sep','Oct','Nov','Dec'];
+const fb = fechaStr.slice(8,10)+'/'+MES_EN[parseInt(fechaStr.slice(5,7),10)-1]+'/'+fechaStr.slice(0,4);
+// DOS semaforos independientes: A = estancamiento en stage (color_a), B = falta de seguimiento (color_b).
+const cntBy = (a,key) => ({ total:a.length, V:a.filter(r=>r[key]==='verde').length, A:a.filter(r=>r[key]==='amarillo').length, R:a.filter(r=>r[key]==='rojo').length });
+const aAll = cntBy(rows,'color_a'), bAll = cntBy(rows,'color_b');
+const sd = $getWorkflowStaticData('global');
+sd.history = (sd.history||[]).filter(h=>h.fecha!==fechaStr);
+sd.history.push({ fecha:fechaStr, total:rows.length, aV:aAll.V,aA:aAll.A,aR:aAll.R, bV:bAll.V,bA:bAll.A,bR:bAll.R });
+sd.history = sd.history.slice(-45);
+const criticosG = rows.filter(r=>r.color_a==='rojo' && r.color_b==='rojo');
+const critKey = criticosG.map(r=>r.id).sort((a,b)=>a-b).join(',');
+const prevIds = new Set(sd.lastCritIds||[]);
+const cambio = critKey !== (sd.lastCritKey||'');
+sd.lastCritKey = critKey; sd.lastCritIds = criticosG.map(r=>r.id);
+function mondayOf(d){ const x=new Date(d); const g=(x.getDay()+6)%7; x.setDate(x.getDate()-g); x.setHours(0,0,0,0); return x; }
+const lunes = mondayOf(today);
+const semana = sd.history.filter(h=> new Date(h.fecha) >= lunes);
+function pctV(list,vKey){ if(!list.length) return 0; const s=list.reduce((a,h)=>a+(h.total?(h[vKey]/h.total):0),0); return Math.round(s/list.length*100); }
+const aPctNow = rows.length?Math.round(aAll.V/rows.length*100):0;
+const bPctNow = rows.length?Math.round(bAll.V/rows.length*100):0;
+let kpiSem;
+if (semana.length < 4) { kpiSem = { modo:'simple', aPct:aPctNow, bPct:bPctNow, dias:semana.length }; }
+else { kpiSem = { modo:'promedio', aPct:pctV(semana,'aV'), bPct:pctV(semana,'bV'), dias:semana.length }; }
+const kpiTxt = kpiSem.modo==='simple' ? ('arranque, dia '+kpiSem.dias) : ('promedio '+kpiSem.dias+' dias');
+const mesD = sd.history.filter(h=>(h.fecha||'').slice(0,7)===fechaStr.slice(0,7));
+const kpiMes = mesD.length ? { a:pctV(mesD,'aV'), b:pctV(mesD,'bV') } : { a:aPctNow, b:bPctNow };
+const dow = today.getDay(); const dom = today.getDate();
+const esLunes = dow===1; const esInicioMes = dom<=3 && dow>=1 && dow<=5;
+const esc = v => Array.from(String(v==null?'':v)).map(function(ch){ var cp=ch.codePointAt(0); if(ch==='&')return '&amp;'; if(ch==='<')return '&lt;'; if(ch==='>')return '&gt;'; if(ch==='"')return '&quot;'; return cp>127?('&#'+cp+';'):ch; }).join('');
+const escN = (v,n) => { const s=String(v==null?'':v); return esc(s.length>(n||60) ? s.slice(0,(n||60))+'...' : s); };
+const lnk = r => '<a href="'+r.link_odoo+'">abrir</a>';
+const dE = r => (r.dias_en_stage==null?'?':r.dias_en_stage);
+const dS = r => (r.dias_sin_seguimiento==null?'?':r.dias_sin_seguimiento);
+// Un proyecto que nunca tuvo nota valida NO se puede leer igual que uno que tuvo
+// seguimiento y lo perdio: el delta viene de create_date, y hay que decirlo.
+const txtNota = r => r.sin_nota_valida
+  ? '&#9888; <b>sin ninguna nota valida desde creacion</b> ('+dS(r)+'d)'
+  : 'sin nota <b>'+dS(r)+'d</b>';
+const ACC_DOBLE = '&#8627; Avanza de stage <b>Y</b> pon una Log note';
+const ACC_ESTANC = '&#8627; Avanza de stage o documenta por que sigue aqui (Log note)';
+const ACC_NOTA = '&#8627; Pon una Log note en el chatter del proyecto';
+const ACC_SINAV = '&#8627; La nota se esta repitiendo: documenta que CAMBIO o mueve el stage';
+function secSinAvance(arr){ if(!arr.length) return '<p style="color:#888">- ninguno -</p>';
+  arr=arr.slice().sort((x,y)=>(y.racha_nota||0)-(x.racha_nota||0));
+  let h='<ul style="font-size:13px;margin:4px 0;padding-left:18px">';
+  for(const r of arr){ h+='<li style="margin-bottom:7px"><b>'+escN(r.name)+'</b> ('+escN(r.cliente,40)+') &middot; '+esc(r.stage)+
+    '<br>&#128260; <b>'+(r.racha_nota||0)+' notas seguidas practicamente iguales</b> &middot; en stage <b>'+dE(r)+'d</b> &middot; '+lnk(r)+
+    '<br><span style="color:#8e24aa">'+ACC_SINAV+'</span></li>'; } return h+'</ul>'; }
+function secObserv(arr){ if(!arr.length) return '<p style="color:#888">- ninguno -</p>';
+  arr=arr.slice().sort((x,y)=>(y.dias_sin_seguimiento||0)-(x.dias_sin_seguimiento||0));
+  let h='<ul style="font-size:13px;margin:4px 0;padding-left:18px">';
+  for(const r of arr){ const cn=r.color_b_nuevo; const ic = cn==='rojo'?'&#128308;':(cn==='amarillo'?'&#128993;':'&#128994;');
+    h+='<li style="margin-bottom:5px">'+ic+' <b>'+escN(r.name)+'</b> ('+escN(r.cliente,40)+') &middot; '+txtNota(r)+' &middot; '+lnk(r)+'</li>'; }
+  return h+'</ul>'; }
+function semLine(icon,label,c){ return '<p style="margin:3px 0">'+icon+' <b>'+label+':</b> &#128994; '+c.V+' verde &middot; &#128993; '+c.A+' amarillo &middot; &#128308; '+c.R+' rojo</p>'; }
+function secCrit(arr){ if(!arr.length) return '<p style="color:#888">- ninguno -</p>'; arr=arr.slice().sort((x,y)=>((y.dias_en_stage||0)+(y.dias_sin_seguimiento||0))-((x.dias_en_stage||0)+(x.dias_sin_seguimiento||0))); let h='<ul style="font-size:13px;margin:4px 0;padding-left:18px">'; for(const r of arr){ const nv=prevIds.has(r.id)?'':' &#128640;'; h+='<li style="margin-bottom:7px"><b>'+escN(r.name)+'</b>'+nv+' ('+escN(r.cliente,40)+') &middot; '+esc(r.stage)+'<br>&#128308; en stage <b>'+dE(r)+'d</b> &middot; &#128308; '+txtNota(r)+' &middot; '+lnk(r)+'<br><span style="color:#c62828">'+ACC_DOBLE+'</span></li>'; } return h+'</ul>'; }
+function secEstanc(arr){ if(!arr.length) return '<p style="color:#888">- ninguno -</p>'; arr=arr.slice().sort((x,y)=>(y.dias_en_stage||0)-(x.dias_en_stage||0)); let h='<ul style="font-size:13px;margin:4px 0;padding-left:18px">'; for(const r of arr){ h+='<li style="margin-bottom:5px"><b>'+escN(r.name)+'</b> ('+escN(r.cliente,40)+') &middot; '+esc(r.stage)+' &middot; &#128308; en stage <b>'+dE(r)+'d</b> &middot; '+lnk(r)+'<br><span style="color:#1565c0">'+ACC_ESTANC+'</span></li>'; } return h+'</ul>'; }
+function secNota(arr){ if(!arr.length) return '<p style="color:#888">- ninguno -</p>'; arr=arr.slice().sort((x,y)=>(y.dias_sin_seguimiento||0)-(x.dias_sin_seguimiento||0)); let h='<ul style="font-size:13px;margin:4px 0;padding-left:18px">'; for(const r of arr){ h+='<li style="margin-bottom:5px"><b>'+escN(r.name)+'</b> ('+escN(r.cliente,40)+') &middot; '+esc(r.stage)+' &middot; &#128308; '+txtNota(r)+' &middot; '+lnk(r)+'<br><span style="color:#b35900">'+ACC_NOTA+'</span></li>'; } return h+'</ul>'; }
+function secAmar(arr){ if(!arr.length) return '<p style="color:#888">- ninguno -</p>'; let h='<ul style="font-size:13px;margin:4px 0;padding-left:18px">'; for(const r of arr){ const p=[]; if(r.color_a==='amarillo') p.push('estancamiento '+dE(r)+'d'); if(r.color_b==='amarillo') p.push('seguimiento '+dS(r)+'d'); h+='<li>&#128993; '+escN(r.name)+' ('+escN(r.cliente,40)+') &middot; acercandose: '+p.join(' + ')+' &middot; '+lnk(r)+'</li>'; } return h+'</ul>'; }
+function listaFlags(arr){ if(!arr.length) return '<p style="color:#888">- sin banderas -</p>'; let h='<ul style="font-size:13px;margin:4px 0;padding-left:18px">'; for(const r of arr){ for(const f of (r.banderas||[])){ h+='<li>&#128681; '+escN(r.name)+': '+esc(f.detalle)+'</li>'; } } return h+'</ul>'; }
+function buildMsg(subset, grupoLabel, to){
+  const aC=cntBy(subset,'color_a'), bC=cntBy(subset,'color_b');
+  const crit=subset.filter(r=>r.color_a==='rojo'&&r.color_b==='rojo');
+  const soloEst=subset.filter(r=>r.color_a==='rojo'&&r.color_b!=='rojo');
+  const soloNota=subset.filter(r=>r.color_b==='rojo'&&r.color_a!=='rojo');
+  const amar=subset.filter(r=>(r.color_a==='amarillo'||r.color_b==='amarillo')&&r.color_a!=='rojo'&&r.color_b!=='rojo');
+  const flg=subset.filter(r=>(r.banderas||[]).length>0);
+  const sinAv=subset.filter(r=>r.sin_avance);
+  const obs=subset.filter(r=>r.en_observacion);
+  let html='<meta charset="utf-8"><div style="font-family:Arial,sans-serif;color:#222;font-size:14px">';
+  html+='<h2 style="color:#0078D4;margin:0">Semaforo '+esc(grupoLabel)+' - '+fb+'</h2>';
+  html+='<div style="background:#f4f6f8;border-radius:8px;padding:8px 12px;margin:8px 0">';
+  html+='<p style="margin:0 0 4px"><b>'+subset.length+' proyectos totales</b> '+(cambio?'':'<span style="color:#888">(sin cambios en criticos desde ayer)</span>')+'</p>';
+  html+=semLine('&#128309;','ESTANCAMIENTO EN STAGE',aC);
+  html+=semLine('&#128221;','FALTA DE SEGUIMIENTO',bC);
+  html+='</div>';
+  html+='<h3 style="color:#c62828;margin:14px 0 4px">&#128308;&#128308; CRITICOS - doble rojo (atorado Y sin seguimiento) ['+crit.length+']</h3>'+secCrit(crit);
+  html+='<h3 style="color:#8e24aa;margin:14px 0 4px">&#128260; SEGUIMIENTO SIN AVANCE (la nota se repite) ['+sinAv.length+']</h3>'+secSinAvance(sinAv);
+  html+='<h3 style="color:#1565c0;margin:14px 0 4px">&#128309; SOLO ESTANCADOS (mucho tiempo en stage) ['+soloEst.length+']</h3>'+secEstanc(soloEst);
+  html+='<h3 style="color:#b35900;margin:14px 0 4px">&#128221; SOLO SIN SEGUIMIENTO (falta Log note) ['+soloNota.length+']</h3>'+secNota(soloNota);
+  html+='<h3 style="margin:14px 0 4px">&#128993; AMARILLOS - preventivo ['+amar.length+']</h3>'+secAmar(amar);
+  if(obs.length){ html+='<div style="border:1px dashed #b35900;border-radius:8px;padding:8px 12px;margin:14px 0;background:#fff8f0">';
+    html+='<h3 style="color:#b35900;margin:0 0 4px">&#128300; NUEVO CRITERIO - EN OBSERVACION ['+obs.length+']</h3>';
+    html+='<p style="margin:0 0 6px;font-size:12px;color:#666">Estos proyectos se evaluarian asi con la regla de nota diaria. '+
+      'Hoy <b>no</b> cuentan para el KPI ni para los contadores de arriba; siguen puntuando con su criterio anterior'+
+      (OBSH?(' hasta el '+esc(OBSH)):'')+'.</p>';
+    html+=secObserv(obs)+'</div>'; }
+  html+='<h3 style="margin:14px 0 4px">&#128681; INTEGRIDAD / posible manipulacion</h3>'+listaFlags(flg);
+  if(esLunes){ html+='<hr><p>&#128202; <b>KPI semanal</b> ('+kpiTxt+'): estancamiento <b>'+kpiSem.aPct+'%</b> verde &middot; seguimiento <b>'+kpiSem.bPct+'%</b> verde (meta &ge;90%)</p>'; }
+  if(esInicioMes){ html+='<p>&#128197; <b>Cierre mensual</b> (mes en curso): estancamiento <b>'+kpiMes.a+'%</b> &middot; seguimiento <b>'+kpiMes.b+'%</b> verde</p>'; }
+  html+='</div>';
+  const E=String.fromCodePoint;
+  const subj='[Semaforo '+grupoLabel+'] '+fb+' - '+E(128308)+E(128308)+' '+crit.length+' criticos '+E(183)+' '+E(128309)+' '+soloEst.length+' estancados '+E(183)+' '+E(128221)+' '+soloNota.length+' sin nota';
+  const toList = Array.isArray(to) ? to : String(to).split(',').map(s=>s.trim()).filter(Boolean);
+  return { message:{ subject:subj, body:{ contentType:'HTML', content:html }, toRecipients: toList.map(a=>({ emailAddress:{ address:a } })) }, saveToSentItems:true };
+}
+const out=[];
+const redir = C.redirect_todo_a;
+if (redir) {
+  // PRUEBA DE VESTIDO: 2 correos por grupo (contenido separado, como produccion) pero destinatario
+  // FORZADO a redir. Esta rama NUNCA lee recipients_por_grupo -> imposible que llegue a las listas reales.
+  // BORRAR redirect_todo_a del config para el go-live.
+  for(const g of ['Operaciones','Admin']){ const sub=rows.filter(r=>r.grupo===g); out.push({ json: buildMsg(sub, g, redir) }); }
+} else if (C.modo_prueba){ out.push({ json: buildMsg(rows, 'Operaciones + Admin', C.alert_recipient_default) }); }
+else { for(const g of ['Operaciones','Admin']){ const sub=rows.filter(r=>r.grupo===g); const to=(C.recipients_por_grupo||{})[g]||C.alert_recipient_default; out.push({ json: buildMsg(sub, g, to) }); } }
+return out;

--- a/docs/n8n-workflows/watchdog-semaforo-code-main.js
+++ b/docs/n8n-workflows/watchdog-semaforo-code-main.js
@@ -5,6 +5,14 @@ const SEQ = {1:0,2:1,5:2,3:3,7:4,13:8,8:9,4:10,6:11};
 const COM = C.comercial_whitelist_partner_ids || [], WD = C.watchdog_author_partner_id;
 const FF = cfg.integridad.fecha_fin_field_id, FS = cfg.integridad.stage_field_id;
 const AP = C.ap_confirmacion || {};
+const OBS = cfg.observacion || {};
+const NR = cfg.nota_repetida || {};
+const SIMIL = (NR.umbral_similitud != null) ? NR.umbral_similitud : 0.85;
+const RACHA_MIN = (NR.racha_minima != null) ? NR.racha_minima : 2;
+const SA = cfg.sin_avance || {};
+const SA_DIAS = (SA.dias_en_stage_min != null) ? SA.dias_en_stage_min : 60;
+const HOLD_ST = (cfg.banderas && cfg.banderas.hold_sin_fecha_stages) || [];
+const hoyISO = String($('Set - hoy').first().json.hoy || '').slice(0,10);
 // --- TZ ----------------------------------------------------------------------
 // Toda la aritmetica de dias opera en hora de MONTERREY (UTC-6, sin DST desde 2022).
 // El contenedor n8n corre en UTC (medido 2026-08-09: reconstruyendo el snapshot 2026-07-24,
@@ -29,7 +37,30 @@ function bizDays(ds){ const w=mtyWall(ds); if(!w) return null;
 function lastBy(node, filt){ const m={}; for(const it of $(node).all()){ const r=it.json; if(filt && !filt(r)) continue;
   const rid=r.res_id; if(!m[rid] || new Date(r.date) > new Date(m[rid].date)) m[rid]=r; } return m; }
 const lastStageMsg = lastBy('Odoo - getAll msg94');
-const lastComment = lastBy('Odoo - getAll msgComment', r => m2o(r.author_id) !== WD);
+// --- Notas: normalizacion, GUARD de vacias, y deteccion de repetidas --------
+// Una nota cuyo body normalizado queda vacio NO es seguimiento valido: no entra al
+// calculo del semaforo B ni a la comparacion de similitud. Levanta bandera nota_vacia.
+function normNota(h){ return String(h==null?'':h)
+  .replace(/<[^>]*>/g,' ').replace(/&nbsp;/gi,' ').replace(/&amp;/gi,'&')
+  .normalize('NFD').replace(/[\u0300-\u036f]/g,'')
+  .toLowerCase().replace(/\s+/g,' ').trim(); }
+function bigr(s){ const g=new Set(); for(let i=0;i<s.length-1;i++) g.add(s.slice(i,i+2)); return g; }
+function simil(a,b){ if(a===b) return 1; if(!a.length||!b.length) return 0;
+  const A=bigr(a), B=bigr(b); let x=0; for(const k of A) if(B.has(k)) x++;
+  return (2*x)/(A.size+B.size); }
+const notasProj = {}, vaciasProj = {};
+for(const it of $('Odoo - getAll msgComment').all()){ const m=it.json;
+  if(m==null || m.res_id==null) continue;
+  if(m2o(m.author_id) === WD) continue;
+  const t = normNota(m.body);
+  if(!t){ vaciasProj[m.res_id] = (vaciasProj[m.res_id]||0)+1; continue; }
+  (notasProj[m.res_id] = notasProj[m.res_id]||[]).push({ date:m.date, t }); }
+const lastComment = {}, rachaProj = {};
+for(const k of Object.keys(notasProj)){
+  const arr = notasProj[k].sort((a,b)=> new Date(a.date) - new Date(b.date));
+  lastComment[k] = arr[arr.length-1];
+  let r=1; for(let i=arr.length-1; i>0; i--){ if(simil(arr[i].t, arr[i-1].t) >= SIMIL) r++; else break; }
+  rachaProj[k] = r; }
 const matSO = {}; for(const it of $('Odoo - getAll SO').all()){ matSO[it.json.id] = (C.materiales_values||[]).includes(it.json.x_studio_product_type); }
 const termDays = {}; for(const it of $('Odoo - getAll termlines').all()){ const t=m2o(it.json.payment_id); termDays[t]=Math.max(termDays[t]||0, Number(it.json.nb_days)||0); }
 const partnerTerm = {}; for(const it of $('Odoo - getAll partners').all()){ partnerTerm[it.json.id] = it.json.property_payment_term_id ? m2o(it.json.property_payment_term_id) : null; }
@@ -49,16 +80,33 @@ const ORD={verde:0,amarillo:1,rojo:2}; const out=[];
 for(const it of $('Odoo - getAll projects').all()){ const p=it.json; const sid=m2o(p.stage_id); if(sid==null||EXCL.includes(sid)) continue; const sc=STG[String(sid)]; if(!sc) continue;
   const esMat = p.sale_order_id ? !!matSO[m2o(p.sale_order_id)] : false;
   const ls=lastStageMsg[p.id]; const diasEnStage = ls?bizDays(ls.date):(p.create_date?bizDays(p.create_date):null);
-  const lc=lastComment[p.id]; const diasSinSeg = lc?bizDays(lc.date):(p.create_date?bizDays(p.create_date):null);
+  const lc=lastComment[p.id];
+  const sinNotaValida = !lc;   // ninguna nota con contenido -> el delta viene de create_date
+  const diasSinSeg = lc?bizDays(lc.date):(p.create_date?bizDays(p.create_date):null);
   const oEn = (esMat && MAT[sid] && MAT[sid].en_stage) ? MAT[sid].en_stage : sc.en_stage;
   const oSeg = (esMat && MAT[sid] && MAT[sid].sin_seguimiento) ? MAT[sid].sin_seguimiento : sc.sin_seguimiento;
   let colA;
   if(oEn.modo==='due_date'){ if(!p.date){ colA=colorOf(diasEnStage, C.in_progress_fallback_dias); } else { const due=new Date(p.date); const ama=new Date(due.getTime()-(C.in_progress_amarillo_dias_habiles||3)*86400000); colA = today>=due?'rojo':(today>=ama?'amarillo':'verde'); } }
   else if(oEn.modo==='credito'){ colA=colorOf(diasEnStage, rojoCredito(p)); }
   else { colA=colorOf(diasEnStage, oEn.rojo_dias); }
-  let colB; if(oSeg.modo==='credito'){ colB=colorOf(diasSinSeg, rojoCredito(p)); } else { colB=colorOf(diasSinSeg, oSeg.rojo_dias); }
+  // colB con el criterio VIGENTE del stage (ya uniformado a la regla diaria)
+  const evalSeg = o => (o.modo==='credito') ? colorOf(diasSinSeg, rojoCredito(p)) : colorOf(diasSinSeg, o.rojo_dias);
+  const colBNuevo = evalSeg(oSeg);
+  // OBSERVACION: mientras dure, el stage sigue puntuando con su criterio PREVIO en
+  // bloques/contadores/KPI; el veredicto nuevo viaja aparte para la seccion dedicada.
+  const enObs = (OBS.stages||[]).includes(sid) && (!OBS.hasta || hoyISO <= OBS.hasta);
+  const oPrev = enObs ? ((OBS.sin_seguimiento_previo||{})[String(sid)] || oSeg) : oSeg;
+  let colB = enObs ? evalSeg(oPrev) : colBNuevo;
   let col = ORD[colA]>=ORD[colB]?colA:colB;
   if(p.last_update_status==='off_track') col='rojo'; else if(p.last_update_status==='at_risk' && col==='verde') col='amarillo';
   if((AP.aplica_stages||[]).includes(sid) && !apOk[p.id]) addFlag(p.id,{tipo:'ap_sin_confirmacion', detalle:'En plazo de credito SIN confirmacion AP documentada (falta log note + pantallazo)'});
-  out.push({ json:{ id:p.id, name:p.name, stage_id:sid, stage:sc.label, grupo:sc.grupo, cliente: p.partner_id?p.partner_id[1]:'', es_materiales:esMat, dias_en_stage:diasEnStage, dias_sin_seguimiento:diasSinSeg, color_a:colA, color_b:colB, color:col, banderas: flagsByProj[p.id]||[], link_odoo:'https://serviciosfts.odoo.com/web#id='+p.id+'&model=project.project&view_type=form' } }); }
+  if(vaciasProj[p.id]) addFlag(p.id,{tipo:'nota_vacia', detalle:vaciasProj[p.id]+' log note(s) sin contenido en el chatter - no cuentan como seguimiento'});
+  if(HOLD_ST.includes(sid)){ const fr=p.date;
+    if(!fr) addFlag(p.id,{tipo:'hold_sin_fecha_vigente', detalle:'En Hold SIN fecha de reactivacion capturada'});
+    else if(String(fr) < hoyISO) addFlag(p.id,{tipo:'hold_sin_fecha_vigente', detalle:'En Hold con fecha de reactivacion VENCIDA ('+fr+')'}); }
+  // SEGUIMIENTO SIN AVANCE: nota repetida sostenida sobre un proyecto que no avanza.
+  // Las notas vacias ya fueron descartadas arriba, asi que no pueden disparar esto.
+  const racha = rachaProj[p.id] || 0;
+  const sinAvance = (racha >= RACHA_MIN) && ((diasEnStage != null && diasEnStage > SA_DIAS) || colA !== 'verde');
+  out.push({ json:{ id:p.id, name:p.name, stage_id:sid, stage:sc.label, grupo:sc.grupo, cliente: p.partner_id?p.partner_id[1]:'', es_materiales:esMat, dias_en_stage:diasEnStage, dias_sin_seguimiento:diasSinSeg, color_a:colA, color_b:colB, color:col, banderas: flagsByProj[p.id]||[], sin_nota_valida:sinNotaValida, racha_nota:(rachaProj[p.id]||0), sin_avance:sinAvance, en_observacion:enObs, color_b_nuevo:colBNuevo, link_odoo:'https://serviciosfts.odoo.com/web#id='+p.id+'&model=project.project&view_type=form' } }); }
 return out;

--- a/shared/operaciones/sla_stages.json
+++ b/shared/operaciones/sla_stages.json
@@ -2,8 +2,9 @@
   "_meta": {
     "doc": "docs/operaciones/SEMAFORO_WATCHDOG.md",
     "descripcion": "Config del semáforo/watchdog operativo. Umbrales por stage (project.project.stage_id) para 2 métricas: A=tiempo en stage (chatter subtype 94), B=tiempo sin seguimiento (chatter comment no-bot). 🟡 = max(🔴 - 1, 1). Días = HÁBILES (excluye sáb/dom) contados en hora de Monterrey. Todo read-only en Odoo salvo el log note al chatter.",
-    "version": "1.1",
+    "version": "1.2",
     "fecha": "2026-08-09",
+    "_cambios_v1_2": "Recalibración a política de captura DIARIA (Mundo A: el run se queda a las 8:00 CST). Semáforo B uniformado a rojo_dias=2 / amarillo=1 en TODOS los stages activos — a las 8:00, 1d significa 'escribió el día hábil anterior y aún no hoy' (normal para quien cumple) y solo 2d es un día hábil perdido; con rojo_dias=1 el semáforo marcaba rojo a gente que sí cumplía (caso real: proy 241, 09-ago). Stage 13 entra en observación hasta 2026-08-24 (ver bloque 'observacion'). Nuevos: guard de nota vacía, detección de nota repetida, bloque SEGUIMIENTO SIN AVANCE y bandera hold_sin_fecha_vigente.",
     "_cambios_v1_1": "bizDays reescrito: días hábiles TRANSCURRIDOS desde la nota (hoy=0, ayer hábil=1), con granularidad de día en hora de Monterrey. Antes contaba el día de la nota Y el día en curso, y operaba en la TZ del contenedor (UTC), lo que hacía que una nota de ayer 07:26 CST leyera '2d' y saliera roja al día siguiente. Umbrales SIN recalibrar todavía — cambiaron de significado."
   },
   "config": {
@@ -42,7 +43,7 @@
     "1": {
       "label": "To Do", "grupo": "Operaciones",
       "en_stage": { "modo": "fijo", "rojo_dias": 1 },
-      "sin_seguimiento": { "modo": "fijo", "rojo_dias": 1 }
+      "sin_seguimiento": { "modo": "fijo", "rojo_dias": 2 }
     },
     "2": {
       "label": "In Progress", "grupo": "Operaciones",
@@ -52,22 +53,22 @@
     "5": {
       "label": "Hold", "grupo": "Operaciones",
       "en_stage": { "modo": "fijo", "rojo_dias": 30 },
-      "sin_seguimiento": { "modo": "fijo", "rojo_dias": 7 }
+      "sin_seguimiento": { "modo": "fijo", "rojo_dias": 2 }
     },
     "3": {
       "label": "Done Operations", "grupo": "Admin",
       "en_stage": { "modo": "fijo", "rojo_dias": 2 },
-      "sin_seguimiento": { "modo": "fijo", "rojo_dias": 1 }
+      "sin_seguimiento": { "modo": "fijo", "rojo_dias": 2 }
     },
     "7": {
       "label": "Admin - In progress", "grupo": "Admin",
       "en_stage": { "modo": "fijo", "rojo_dias": 14 },
-      "sin_seguimiento": { "modo": "fijo", "rojo_dias": 1 }
+      "sin_seguimiento": { "modo": "fijo", "rojo_dias": 2 }
     },
     "13": {
       "label": "En plazo de credito", "grupo": "Admin",
       "en_stage": { "modo": "credito" },
-      "sin_seguimiento": { "modo": "credito" }
+      "sin_seguimiento": { "modo": "fijo", "rojo_dias": 2 }
     }
   },
   "materiales_overrides": {
@@ -77,6 +78,26 @@
   },
   "excluidos": [8, 4, 6],
   "_excluidos_labels": { "8": "Complete TOTAL (Gera)", "4": "Canceled", "6": "Templates" },
+  "observacion": {
+    "_descripcion": "Stages cuyo criterio de seguimiento acaba de cambiar. Mientras dure, siguen puntuando en bloques, contadores y KPI con su criterio PREVIO (sin_seguimiento_previo); su veredicto con el criterio NUEVO aparece SOLO en la sección '🔬 NUEVO CRITERIO — EN OBSERVACIÓN' del correo. Al pasar la fecha 'hasta', la excepción caduca sola y el stage entra al régimen normal sin tocar nada.",
+    "stages": [13],
+    "hasta": "2026-08-24",
+    "sin_seguimiento_previo": { "13": { "modo": "credito" } }
+  },
+  "nota_repetida": {
+    "_descripcion": "Detección de copy-paste en el chatter. Compara cada nota contra la anterior del mismo proyecto: texto normalizado idéntico, o coeficiente de Dice sobre bigramas de caracteres >= umbral_similitud. Usa el campo 'body' que YA viene en 'Odoo - getAll msgComment' → cero consultas extra a Odoo. Las notas vacías se descartan ANTES de comparar. Medición 10-jul→09-ago: 43 de 195 notas (25%) caerían en la regla; racha máxima 10 (proy 2356).",
+    "umbral_similitud": 0.85,
+    "racha_minima": 2
+  },
+  "sin_avance": {
+    "_descripcion": "Bloque 'SEGUIMIENTO SIN AVANCE': racha de notas repetidas >= nota_repetida.racha_minima Y (dias_en_stage > dias_en_stage_min O color_a != verde). NO se gatea solo por color_a a propósito: en stage 2, color_a depende de project.date, que suele estar desfasado — SO11492 llevaba 165 días en stage con 8 notas idénticas seguidas y color_a VERDE porque su fecha compromiso aún no vencía.",
+    "dias_en_stage_min": 60
+  },
+  "banderas": {
+    "hold_sin_fecha_stages": [5],
+    "_hold_sin_fecha_vigente": "Levanta bandera si un proyecto en estos stages tiene project.date vacío o vencido. 'date' es la fecha comprometida de reactivación; la bandera solo sirve si el proceso la mantiene al mover a Hold. Caso 09-ago: proy 213 con fecha vencida el 30-jul y 244 días en Hold; proy 2352 con fecha 31-ago pero su propia nota decía 'se reanudan en diciembre 2026' — ninguna automatización caza esa contradicción.",
+    "_nota_vacia": "Levanta bandera si el proyecto tiene log notes cuyo body normalizado queda vacío. Esas notas NO cuentan como seguimiento válido. Caso 09-ago: proy 2345 salía verde con 22d teniendo sus DOS únicas notas de toda su historia vacías; con el guard pasa a 39d desde create_date."
+  },
   "integridad": {
     "fecha_fin_field_id": 24700,
     "stage_field_id": 24714,


### PR DESCRIPTION
## Decisión: Mundo A

El run se queda a las **8:00 CST** y los umbrales se alinean a esa hora.

A las 8:00, `1d` significa *"escribió el día hábil anterior y aún no hoy"* — el estado normal de alguien que cumple. Solo `2d` es un día hábil perdido. Con `rojo_dias: 1` el semáforo marcaba rojo a gente que sí cumplía: caso real el 09-ago, el proyecto **241** salió rojo con su última nota del jueves 6-ago.

## Cambios

**1. Semáforo B uniformado a `rojo_dias: 2` / amarillo `max(rojo-1,1) = 1`** en stages 1, 3, 5 y 7. Stage 2 ya estaba correcto.

**2. Stage 13 también a 2/1, pero en observación hasta `2026-08-24`.** Sigue puntuando en bloques, contadores y KPI con su criterio previo (crédito); su veredicto diario aparece solo en la sección "NUEVO CRITERIO — EN OBSERVACIÓN" del correo. La excepción **caduca sola por fecha**.

**3. Detección de nota repetida.** Texto normalizado idéntico, o coeficiente de Dice sobre bigramas >= 0.85 contra la nota anterior del mismo proyecto. Usa el `body` que **ya viene** en `Odoo - getAll msgComment` → cero consultas extra a Odoo.

Medición sobre el corpus real 10-jul → 09-ago (195 notas, 21 proyectos):

    proy   notas  identicas  casi-id  % repetido
    2356     14        10        1       79%
    506      14         7        0       50%
    2349     14         5        1       43%
    212      14         5        0       36%
    TOTAL: 39 identicas + 4 casi-identicas = 43 de 174 comparaciones (25%)

**4. Bloque nuevo "SEGUIMIENTO SIN AVANCE"**, arriba junto a CRÍTICOS. Racha >= 2 **Y** (>60d en stage **O** `color_a != verde`).

No se gatea solo por `color_a` a propósito: **SO11492 (506) llevaba 165 días en stage con 8 notas idénticas seguidas y `color_a` verde**, porque su `project.date` es 30-sep y aún no vence. Un gate por color_a lo habría perdido. Backtest sobre los 20 snapshots reales: gate-por-colorA = 4 disparos / 2 proyectos; el criterio elegido = 32 / 6.

**5. Bandera `hold_sin_fecha_vigente`** — stage 5 con `project.date` vacío o vencido. Hoy dispara en **213**: 244 días en Hold, fecha vencida el 30-jul, `last_update_status` en `on_track` y sus propias notas diciendo que probablemente se cancele.

**6. Guard de nota vacía, ANTES de la lógica de repetición.** Un body que normaliza a cadena vacía no cuenta como seguimiento válido, no entra a la comparación de similitud, y levanta bandera `nota_vacia`.

Hallazgo que lo motivó: **el proyecto 2345 salía VERDE con 22d teniendo sus dos únicas notas de toda su historia vacías**. Con el guard cae al fallback `create_date` y queda en **39d rojo**. Sin el guard, además, el bloque nuevo lo habría etiquetado como "nota repetida" cuando el problema real es que están vacías.

**7. Fallback a `create_date` visible en el correo.** Cuando un proyecto no tiene ninguna nota válida, el correo dice **"sin ninguna nota válida desde creación (Nd)"** en vez de solo el número. 2345 no se puede leer igual que un proyecto que sí tuvo seguimiento y lo perdió.

## Proyección del run del lunes 10-ago

Escenario pesimista (nadie captura antes del run):

    Operaciones B: 0 verde, 13 amarillo, 2 rojo
    Operaciones A: 11 verde, 0 amarillo, 4 rojo
    Admin B: 5 verde, 1 amarillo, 3 rojo
    Admin A: 2 verde, 0 amarillo, 7 rojo
    Seccion observacion (stage 13, 7): 0 verde, 0 amarillo, 7 rojo
      101=28d, 160=4d, 2305=15d, 2327=37d, 2345=39d, 2353=14d, 2357=19d
    CRITICOS: 213, 241, 2327, 2345, 2352
    SIN AVANCE: 212, 2356
    Banderas nuevas: hold_sin_fecha_vigente=213 / nota_vacia=2345

Los 13 amarillos de Operaciones son el estado *"escribió el viernes, aún no escribe el lunes a las 8"* — exactamente la banda que se diseñó. Escenario realista, si Felipe captura 07:20-07:40 como los lunes 03-ago y 27-jul: Operaciones pasa a **14 verde / 0 amarillo / 1 rojo**. **213 no se evapora**: es Hold y recibe ~2 notas al mes.

## Validación

- **Harness en frío** contra los 20 snapshots reales commiteados: **24/24** deltas reproducidos.
- **`newMain.js` EJECUTADO** con stubs de los 11 nodos (no solo `node -c`): **24/24** filas coinciden con la proyección en delta, `color_b`, `sin_avance` y `sin_nota_valida`.
- **`newEmail.js` EJECUTADO**: genera los 2 correos. Operaciones → 2 críticos, bloque SIN AVANCE presente, sin sección de observación (correcto, stage 13 es todo Admin). Admin → 3 críticos, sección de observación presente, texto de fallback presente.
- Los 13 parches se aplicaron con `assert count == 1` por anchor: si alguno no matcheaba, abortaba en vez de escribir basura.

## La mitad n8n NO está aplicada

El API de esta instancia rechaza el PUT por MCP con `request/body must NOT have additional properties` (quirk `CLAUDE.md` §17). Se sondeó con el parche más pequeño y compatible hacia atrás; rechazado igual. **No se forzó `update_full`.**

Verificado que el intento no dejó nada a medias: `updatedAt` sigue en `2026-08-09T23:12:49.704Z` y `active` en `true`.

**Acción manual requerida (Esteban)** — pegar desde la UI de n8n en `ops/watchdog-semaforo` (`29eaGe2wkS98lRMU`):

1. `docs/n8n-workflows/watchdog-semaforo-code-buildemail.js` → nodo **`Code - buildEmail`**
2. `docs/n8n-workflows/watchdog-semaforo-code-main.js` → nodo **`Code - MAIN`**

**Ese orden.** `buildEmail` es la mitad tolerante: si se pega primero y `Code - MAIN` aún no emite los campos nuevos, los bloques nuevos renderizan "- ninguno -" y el resto del correo sale igual. Al revés no: `Code - MAIN` emitiría los umbrales nuevos sin las secciones que los explican.

Después del pegado, confirmar que **`active` sigue en `true`**.

### Orden de despliegue config vs workflow

Ambas mitades son tolerantes, no hay riesgo de trabón. Recomendado igual: mergear este PR y pegar el mismo día.

## Fuera de alcance, documentado

**Issue A — nota vacía en origen.** Una nota vacía hoy pone el semáforo B en verde. El guard lo corrige **en el cálculo**, pero Odoo sigue permitiendo guardar un log note vacío. Evaluar validación en origen.

**Issue B — `watchdog_author_partner_id`.** Sigue en `2`. Ya documentado en PR #111: `project/archive-budget-cierre` (`RW7KnoeEzYLvavI0`) escribe sus log notes con `message_type='comment'` y debería usar `'notification'`, como ya hace el nodo `Odoo - CREATE log note` del propio watchdog. Eso excluiría las notas de bot sin filtrar por autor — necesario porque partner 3 es identidad compartida (Esteban humano y al menos dos workflows).

**Issue C — `materiales_overrides` sin uniformar.** Su override de stage 1 sigue en `rojo_dias: 1`, lo que reintroduciría la misma incoherencia en cuanto aparezca un proyecto MRO en stage 1. Hoy hay **0 proyectos con `es_materiales=true`**, así que está dormido. No se tocó por estar fuera del alcance especificado.

## Test plan

- [ ] Pegar `Code - buildEmail`, luego `Code - MAIN`, desde la UI
- [ ] Read-back: `active` en `true`, `triggerCount` en `1`
- [ ] Verificar `data.nodes` **y** `data.activeVersion.nodes` (la versión publicada es la que corre)
- [ ] sha256 de ambos nodos contra el blob commiteado con `git show`, **no** la copia de trabajo (con `core.autocrlf=true` el working tree queda en CRLF y el sha no cuadra)
- [ ] Mergear para que `sla_stages.json` v1.2 quede en `main`
- [ ] Run del lunes 10-ago: contrastar contra la proyección de arriba
- [ ] 24-ago: confirmar que la observación de stage 13 caducó sola

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CNUkfof8V6it1ZC1zFYiH7
