### PR TITLE
chore(semaforo): respaldo del jsCode vivo PRE-v1.2 (punto de rollback)

### DIFF
--- a/docs/n8n-workflows/_backup/2026-08-09-buildemail-PRE-v12.js
+++ b/docs/n8n-workflows/_backup/2026-08-09-buildemail-PRE-v12.js
@@ -1,0 +1,87 @@
+
+const _cf = $('HTTP - load config').first().json;
+const cfg = (_cf && _cf.config) ? _cf : JSON.parse(_cf.data || _cf.body || (typeof _cf==='string'?_cf:JSON.stringify(_cf)));
+const C = cfg.config;
+const rows = $('Code - MAIN').all().map(i=>i.json);
+const hoy = $('Set - hoy').first().json.hoy;
+const today = new Date(hoy);
+const fechaStr = hoy.slice(0,10);
+const MES_EN = ['Jan','Feb','Mar','Apr','May','Jun','Jul','Aug','Sep','Oct','Nov','Dec'];
+const fb = fechaStr.slice(8,10)+'/'+MES_EN[parseInt(fechaStr.slice(5,7),10)-1]+'/'+fechaStr.slice(0,4);
+// DOS semaforos independientes: A = estancamiento en stage (color_a), B = falta de seguimiento (color_b).
+const cntBy = (a,key) => ({ total:a.length, V:a.filter(r=>r[key]==='verde').length, A:a.filter(r=>r[key]==='amarillo').length, R:a.filter(r=>r[key]==='rojo').length });
+const aAll = cntBy(rows,'color_a'), bAll = cntBy(rows,'color_b');
+const sd = $getWorkflowStaticData('global');
+sd.history = (sd.history||[]).filter(h=>h.fecha!==fechaStr);
+sd.history.push({ fecha:fechaStr, total:rows.length, aV:aAll.V,aA:aAll.A,aR:aAll.R, bV:bAll.V,bA:bAll.A,bR:bAll.R });
+sd.history = sd.history.slice(-45);
+const criticosG = rows.filter(r=>r.color_a==='rojo' && r.color_b==='rojo');
+const critKey = criticosG.map(r=>r.id).sort((a,b)=>a-b).join(',');
+const prevIds = new Set(sd.lastCritIds||[]);
+const cambio = critKey !== (sd.lastCritKey||'');
+sd.lastCritKey = critKey; sd.lastCritIds = criticosG.map(r=>r.id);
+function mondayOf(d){ const x=new Date(d); const g=(x.getDay()+6)%7; x.setDate(x.getDate()-g); x.setHours(0,0,0,0); return x; }
+const lunes = mondayOf(today);
+const semana = sd.history.filter(h=> new Date(h.fecha) >= lunes);
+function pctV(list,vKey){ if(!list.length) return 0; const s=list.reduce((a,h)=>a+(h.total?(h[vKey]/h.total):0),0); return Math.round(s/list.length*100); }
+const aPctNow = rows.length?Math.round(aAll.V/rows.length*100):0;
+const bPctNow = rows.length?Math.round(bAll.V/rows.length*100):0;
+let kpiSem;
+if (semana.length < 4) { kpiSem = { modo:'simple', aPct:aPctNow, bPct:bPctNow, dias:semana.length }; }
+else { kpiSem = { modo:'promedio', aPct:pctV(semana,'aV'), bPct:pctV(semana,'bV'), dias:semana.length }; }
+const kpiTxt = kpiSem.modo==='simple' ? ('arranque, dia '+kpiSem.dias) : ('promedio '+kpiSem.dias+' dias');
+const mesD = sd.history.filter(h=>(h.fecha||'').slice(0,7)===fechaStr.slice(0,7));
+const kpiMes = mesD.length ? { a:pctV(mesD,'aV'), b:pctV(mesD,'bV') } : { a:aPctNow, b:bPctNow };
+const dow = today.getDay(); const dom = today.getDate();
+const esLunes = dow===1; const esInicioMes = dom<=3 && dow>=1 && dow<=5;
+const esc = v => Array.from(String(v==null?'':v)).map(function(ch){ var cp=ch.codePointAt(0); if(ch==='&')return '&amp;'; if(ch==='<')return '&lt;'; if(ch==='>')return '&gt;'; if(ch==='"')return '&quot;'; return cp>127?('&#'+cp+';'):ch; }).join('');
+const escN = (v,n) => { const s=String(v==null?'':v); return esc(s.length>(n||60) ? s.slice(0,(n||60))+'...' : s); };
+const lnk = r => '<a href="'+r.link_odoo+'">abrir</a>';
+const dE = r => (r.dias_en_stage==null?'?':r.dias_en_stage);
+const dS = r => (r.dias_sin_seguimiento==null?'?':r.dias_sin_seguimiento);
+const ACC_DOBLE = '&#8627; Avanza de stage <b>Y</b> pon una Log note';
+const ACC_ESTANC = '&#8627; Avanza de stage o documenta por que sigue aqui (Log note)';
+const ACC_NOTA = '&#8627; Pon una Log note en el chatter del proyecto';
+function semLine(icon,label,c){ return '<p style="margin:3px 0">'+icon+' <b>'+label+':</b> &#128994; '+c.V+' verde &middot; &#128993; '+c.A+' amarillo &middot; &#128308; '+c.R+' rojo</p>'; }
+function secCrit(arr){ if(!arr.length) return '<p style="color:#888">- ninguno -</p>'; arr=arr.slice().sort((x,y)=>((y.dias_en_stage||0)+(y.dias_sin_seguimiento||0))-((x.dias_en_stage||0)+(x.dias_sin_seguimiento||0))); let h='<ul style="font-size:13px;margin:4px 0;padding-left:18px">'; for(const r of arr){ const nv=prevIds.has(r.id)?'':' &#128640;'; h+='<li style="margin-bottom:7px"><b>'+escN(r.name)+'</b>'+nv+' ('+escN(r.cliente,40)+') &middot; '+esc(r.stage)+'<br>&#128308; en stage <b>'+dE(r)+'d</b> &middot; &#128308; sin nota <b>'+dS(r)+'d</b> &middot; '+lnk(r)+'<br><span style="color:#c62828">'+ACC_DOBLE+'</span></li>'; } return h+'</ul>'; }
+function secEstanc(arr){ if(!arr.length) return '<p style="color:#888">- ninguno -</p>'; arr=arr.slice().sort((x,y)=>(y.dias_en_stage||0)-(x.dias_en_stage||0)); let h='<ul style="font-size:13px;margin:4px 0;padding-left:18px">'; for(const r of arr){ h+='<li style="margin-bottom:5px"><b>'+escN(r.name)+'</b> ('+escN(r.cliente,40)+') &middot; '+esc(r.stage)+' &middot; &#128308; en stage <b>'+dE(r)+'d</b> &middot; '+lnk(r)+'<br><span style="color:#1565c0">'+ACC_ESTANC+'</span></li>'; } return h+'</ul>'; }
+function secNota(arr){ if(!arr.length) return '<p style="color:#888">- ninguno -</p>'; arr=arr.slice().sort((x,y)=>(y.dias_sin_seguimiento||0)-(x.dias_sin_seguimiento||0)); let h='<ul style="font-size:13px;margin:4px 0;padding-left:18px">'; for(const r of arr){ h+='<li style="margin-bottom:5px"><b>'+escN(r.name)+'</b> ('+escN(r.cliente,40)+') &middot; '+esc(r.stage)+' &middot; &#128308; sin nota <b>'+dS(r)+'d</b> &middot; '+lnk(r)+'<br><span style="color:#b35900">'+ACC_NOTA+'</span></li>'; } return h+'</ul>'; }
+function secAmar(arr){ if(!arr.length) return '<p style="color:#888">- ninguno -</p>'; let h='<ul style="font-size:13px;margin:4px 0;padding-left:18px">'; for(const r of arr){ const p=[]; if(r.color_a==='amarillo') p.push('estancamiento '+dE(r)+'d'); if(r.color_b==='amarillo') p.push('seguimiento '+dS(r)+'d'); h+='<li>&#128993; '+escN(r.name)+' ('+escN(r.cliente,40)+') &middot; acercandose: '+p.join(' + ')+' &middot; '+lnk(r)+'</li>'; } return h+'</ul>'; }
+function listaFlags(arr){ if(!arr.length) return '<p style="color:#888">- sin banderas -</p>'; let h='<ul style="font-size:13px;margin:4px 0;padding-left:18px">'; for(const r of arr){ for(const f of (r.banderas||[])){ h+='<li>&#128681; '+escN(r.name)+': '+esc(f.detalle)+'</li>'; } } return h+'</ul>'; }
+function buildMsg(subset, grupoLabel, to){
+  const aC=cntBy(subset,'color_a'), bC=cntBy(subset,'color_b');
+  const crit=subset.filter(r=>r.color_a==='rojo'&&r.color_b==='rojo');
+  const soloEst=subset.filter(r=>r.color_a==='rojo'&&r.color_b!=='rojo');
+  const soloNota=subset.filter(r=>r.color_b==='rojo'&&r.color_a!=='rojo');
+  const amar=subset.filter(r=>(r.color_a==='amarillo'||r.color_b==='amarillo')&&r.color_a!=='rojo'&&r.color_b!=='rojo');
+  const flg=subset.filter(r=>(r.banderas||[]).length>0);
+  let html='<meta charset="utf-8"><div style="font-family:Arial,sans-serif;color:#222;font-size:14px">';
+  html+='<h2 style="color:#0078D4;margin:0">Semaforo '+esc(grupoLabel)+' - '+fb+'</h2>';
+  html+='<div style="background:#f4f6f8;border-radius:8px;padding:8px 12px;margin:8px 0">';
+  html+='<p style="margin:0 0 4px"><b>'+subset.length+' proyectos totales</b> '+(cambio?'':'<span style="color:#888">(sin cambios en criticos desde ayer)</span>')+'</p>';
+  html+=semLine('&#128309;','ESTANCAMIENTO EN STAGE',aC);
+  html+=semLine('&#128221;','FALTA DE SEGUIMIENTO',bC);
+  html+='</div>';
+  html+='<h3 style="color:#c62828;margin:14px 0 4px">&#128308;&#128308; CRITICOS - doble rojo (atorado Y sin seguimiento) ['+crit.length+']</h3>'+secCrit(crit);
+  html+='<h3 style="color:#1565c0;margin:14px 0 4px">&#128309; SOLO ESTANCADOS (mucho tiempo en stage) ['+soloEst.length+']</h3>'+secEstanc(soloEst);
+  html+='<h3 style="color:#b35900;margin:14px 0 4px">&#128221; SOLO SIN SEGUIMIENTO (falta Log note) ['+soloNota.length+']</h3>'+secNota(soloNota);
+  html+='<h3 style="margin:14px 0 4px">&#128993; AMARILLOS - preventivo ['+amar.length+']</h3>'+secAmar(amar);
+  html+='<h3 style="margin:14px 0 4px">&#128681; INTEGRIDAD / posible manipulacion</h3>'+listaFlags(flg);
+  if(esLunes){ html+='<hr><p>&#128202; <b>KPI semanal</b> ('+kpiTxt+'): estancamiento <b>'+kpiSem.aPct+'%</b> verde &middot; seguimiento <b>'+kpiSem.bPct+'%</b> verde (meta &ge;90%)</p>'; }
+  if(esInicioMes){ html+='<p>&#128197; <b>Cierre mensual</b> (mes en curso): estancamiento <b>'+kpiMes.a+'%</b> &middot; seguimiento <b>'+kpiMes.b+'%</b> verde</p>'; }
+  html+='</div>';
+  const E=String.fromCodePoint;
+  const subj='[Semaforo '+grupoLabel+'] '+fb+' - '+E(128308)+E(128308)+' '+crit.length+' criticos '+E(183)+' '+E(128309)+' '+soloEst.length+' estancados '+E(183)+' '+E(128221)+' '+soloNota.length+' sin nota';
+  const toList = Array.isArray(to) ? to : String(to).split(',').map(s=>s.trim()).filter(Boolean);
+  return { message:{ subject:subj, body:{ contentType:'HTML', content:html }, toRecipients: toList.map(a=>({ emailAddress:{ address:a } })) }, saveToSentItems:true };
+}
+const out=[];
+const redir = C.redirect_todo_a;
+if (redir) {
+  // PRUEBA DE VESTIDO: 2 correos por grupo (contenido separado, como produccion) pero destinatario
+  // FORZADO a redir. Esta rama NUNCA lee recipients_por_grupo -> imposible que llegue a las listas reales.
+  // BORRAR redirect_todo_a del config para el go-live.
+  for(const g of ['Operaciones','Admin']){ const sub=rows.filter(r=>r.grupo===g); out.push({ json: buildMsg(sub, g, redir) }); }
+} else if (C.modo_prueba){ out.push({ json: buildMsg(rows, 'Operaciones + Admin', C.alert_recipient_default) }); }
+else { for(const g of ['Operaciones','Admin']){ const sub=rows.filter(r=>r.grupo===g); const to=(C.recipients_por_grupo||{})[g]||C.alert_recipient_default; out.push({ json: buildMsg(sub, g, to) }); } }
+return out;

--- a/docs/n8n-workflows/_backup/2026-08-09-main-PRE-v12.js
+++ b/docs/n8n-workflows/_backup/2026-08-09-main-PRE-v12.js
@@ -1,0 +1,64 @@
+let _r = $('HTTP - load config').first().json;
+const cfg = (_r && _r.config) ? _r : JSON.parse(_r.data || _r.body || (typeof _r === 'string' ? _r : JSON.stringify(_r)));
+const C = cfg.config, STG = cfg.stages, MAT = cfg.materiales_overrides || {}, EXCL = cfg.excluidos || [];
+const SEQ = {1:0,2:1,5:2,3:3,7:4,13:8,8:9,4:10,6:11};
+const COM = C.comercial_whitelist_partner_ids || [], WD = C.watchdog_author_partner_id;
+const FF = cfg.integridad.fecha_fin_field_id, FS = cfg.integridad.stage_field_id;
+const AP = C.ap_confirmacion || {};
+// --- TZ ----------------------------------------------------------------------
+// Toda la aritmetica de dias opera en hora de MONTERREY (UTC-6, sin DST desde 2022).
+// El contenedor n8n corre en UTC (medido 2026-08-09: reconstruyendo el snapshot 2026-07-24,
+// solo offset 0 lo reproduce 23/23; -4h/-5h/-6h dan 10/23). settings.timezone del workflow
+// NO aplica a getHours()/setDate() de un Code node, por eso se normaliza a mano.
+const TZO = (C.tz_offset_hours != null ? C.tz_offset_hours : -6);
+function mtyWall(ds){ if(!ds) return null; const s=String(ds);
+  const iso = s.replace(' ','T') + (/([Zz]|[+-]\d\d:?\d\d)$/.test(s) ? '' : 'Z');
+  const t = Date.parse(iso); if(isNaN(t)) return null;
+  return new Date(t + TZO*3600000); }
+function dayStart(d){ const x=new Date(d); x.setHours(0,0,0,0); return x; }
+const today = mtyWall($('Set - hoy').first().json.hoy);
+const todayDay = dayStart(today);
+const m2o = v => Array.isArray(v)?v[0]:v;
+const isWE = x => x.getDay()===6 || x.getDay()===0;
+function nextBizDay(d){ const x=dayStart(d); do { x.setDate(x.getDate()+1); } while(C.excluir_findes && isWE(x)); return x; }
+// Dias habiles TRANSCURRIDOS desde el dia de la nota: hoy=0, ayer habil=1, viernes->lunes=1.
+// Granularidad de DIA -> el resultado NO depende de la hora de captura.
+// (business_day_start_hour / business_day_cutoff_hour quedan sin uso.)
+function bizDays(ds){ const w=mtyWall(ds); if(!w) return null;
+  let c=nextBizDay(w), n=0; while(c <= todayDay){ n++; c=nextBizDay(c); } return n; }
+function lastBy(node, filt){ const m={}; for(const it of $(node).all()){ const r=it.json; if(filt && !filt(r)) continue;
+  const rid=r.res_id; if(!m[rid] || new Date(r.date) > new Date(m[rid].date)) m[rid]=r; } return m; }
+const lastStageMsg = lastBy('Odoo - getAll msg94');
+const lastComment = lastBy('Odoo - getAll msgComment', r => m2o(r.author_id) !== WD);
+const matSO = {}; for(const it of $('Odoo - getAll SO').all()){ matSO[it.json.id] = (C.materiales_values||[]).includes(it.json.x_studio_product_type); }
+const termDays = {}; for(const it of $('Odoo - getAll termlines').all()){ const t=m2o(it.json.payment_id); termDays[t]=Math.max(termDays[t]||0, Number(it.json.nb_days)||0); }
+const partnerTerm = {}; for(const it of $('Odoo - getAll partners').all()){ partnerTerm[it.json.id] = it.json.property_payment_term_id ? m2o(it.json.property_payment_term_id) : null; }
+const trkByMsg = {}; for(const it of $('Odoo - getAll trackingVals').all()){ trkByMsg[m2o(it.json.mail_message_id)] = it.json; }
+const flagsByProj = {}; function addFlag(rid,f){ (flagsByProj[rid]=flagsByProj[rid]||[]).push(f); }
+for(const it of $('Odoo - getAll trackedMsgs').all()){ const m=it.json; const t=trkByMsg[m.id]; if(!t) continue; const au=m2o(m.author_id); const aun=Array.isArray(m.author_id)?m.author_id[1]:''; const fid=m2o(t.field_id);
+  if(fid===FF && t.old_value_datetime && !COM.includes(au)) addFlag(m.res_id,{tipo:'fecha_fin', detalle:'Fecha fin movida por '+aun+' (no Comercial)', fecha:m.date});
+  if(fid===FS && SEQ[t.new_value_integer]!=null && SEQ[t.old_value_integer]!=null && SEQ[t.new_value_integer] < SEQ[t.old_value_integer]) addFlag(m.res_id,{tipo:'stage_atras', detalle:'Stage regresado '+t.old_value_char+' -> '+t.new_value_char+' por '+aun, fecha:m.date}); }
+const attMime = {}; for(const it of $('Odoo - getAll attachments').all()){ attMime[it.json.id]= it.json.mimetype||''; }
+function norm(s){ return String(s||'').replace(/<[^>]*>/g,' ').normalize('NFD').replace(/[\u0300-\u036f]/g,'').toLowerCase(); }
+const apTpl = norm(AP.template);
+const apOk = {};
+for(const it of $('Odoo - getAll msgComment').all()){ const m=it.json; if(apTpl && norm(m.body).includes(apTpl)){ const hasImg=(m.attachment_ids||[]).some(a=>(attMime[a]||'').startsWith('image/')); if(!AP.requiere_imagen || hasImg) apOk[m.res_id]=true; } }
+function colorOf(d,r){ if(d==null||r==null) return 'verde'; if(d>=r) return 'rojo'; if(d>=Math.max(r-1,1)) return 'amarillo'; return 'verde'; }
+function rojoCredito(p){ const t=partnerTerm[m2o(p.partner_id)]; const d=(t&&termDays[t]!=null)?termDays[t]:C.credit_fallback_days; return d + C.credit_extra_days; }
+const ORD={verde:0,amarillo:1,rojo:2}; const out=[];
+for(const it of $('Odoo - getAll projects').all()){ const p=it.json; const sid=m2o(p.stage_id); if(sid==null||EXCL.includes(sid)) continue; const sc=STG[String(sid)]; if(!sc) continue;
+  const esMat = p.sale_order_id ? !!matSO[m2o(p.sale_order_id)] : false;
+  const ls=lastStageMsg[p.id]; const diasEnStage = ls?bizDays(ls.date):(p.create_date?bizDays(p.create_date):null);
+  const lc=lastComment[p.id]; const diasSinSeg = lc?bizDays(lc.date):(p.create_date?bizDays(p.create_date):null);
+  const oEn = (esMat && MAT[sid] && MAT[sid].en_stage) ? MAT[sid].en_stage : sc.en_stage;
+  const oSeg = (esMat && MAT[sid] && MAT[sid].sin_seguimiento) ? MAT[sid].sin_seguimiento : sc.sin_seguimiento;
+  let colA;
+  if(oEn.modo==='due_date'){ if(!p.date){ colA=colorOf(diasEnStage, C.in_progress_fallback_dias); } else { const due=new Date(p.date); const ama=new Date(due.getTime()-(C.in_progress_amarillo_dias_habiles||3)*86400000); colA = today>=due?'rojo':(today>=ama?'amarillo':'verde'); } }
+  else if(oEn.modo==='credito'){ colA=colorOf(diasEnStage, rojoCredito(p)); }
+  else { colA=colorOf(diasEnStage, oEn.rojo_dias); }
+  let colB; if(oSeg.modo==='credito'){ colB=colorOf(diasSinSeg, rojoCredito(p)); } else { colB=colorOf(diasSinSeg, oSeg.rojo_dias); }
+  let col = ORD[colA]>=ORD[colB]?colA:colB;
+  if(p.last_update_status==='off_track') col='rojo'; else if(p.last_update_status==='at_risk' && col==='verde') col='amarillo';
+  if((AP.aplica_stages||[]).includes(sid) && !apOk[p.id]) addFlag(p.id,{tipo:'ap_sin_confirmacion', detalle:'En plazo de credito SIN confirmacion AP documentada (falta log note + pantallazo)'});
+  out.push({ json:{ id:p.id, name:p.name, stage_id:sid, stage:sc.label, grupo:sc.grupo, cliente: p.partner_id?p.partner_id[1]:'', es_materiales:esMat, dias_en_stage:diasEnStage, dias_sin_seguimiento:diasSinSeg, color_a:colA, color_b:colB, color:col, banderas: flagsByProj[p.id]||[], link_odoo:'https://serviciosfts.odoo.com/web#id='+p.id+'&model=project.project&view_type=form' } }); }
+return out;

--- a/docs/n8n-workflows/_backup/README.md
+++ b/docs/n8n-workflows/_backup/README.md
@@ -1,0 +1,17 @@
+Respaldo del jsCode VIVO de ops/watchdog-semaforo (29eaGe2wkS98lRMU) inmediatamente ANTES de
+aplicar la recalibracion v1.2 (PR #112). Este es el punto de rollback.
+
+Lectura en vivo por MCP: updatedAt 2026-08-09T23:12:49.704Z | active true | 29 nodos.
+Verificado que data.nodes y data.activeVersion.nodes coincidian (la version publicada era la misma).
+
+  2026-08-09-buildemail-PRE-v12.js   nodo 'Code - buildEmail'   9473 bytes
+     sha256 4c41682572c036602f8f23d62ac168538f489821be549fb7c711f65b67262d17
+
+  2026-08-09-main-PRE-v12.js         nodo 'Code - MAIN'         6747 bytes
+     sha256 6c8a1e43ac9340789ac65063a6508e066dbf7bec672e0fd06873cdb3f9ab813b
+
+Los sha256 son sobre el contenido con finales de linea LF, tal como viaja en n8n.
+OJO en Windows: verificar con 'git show <ref>:<path>', NO contra la copia de trabajo
+(core.autocrlf=true la convierte a CRLF y el sha no cuadra).
+
+Para revertir: pegar cada archivo en su nodo desde la UI de n8n y confirmar active=true.

--- a/docs/n8n-workflows/_backup/README.md
+++ b/docs/n8n-workflows/_backup/README.md
@@ -15,3 +15,51 @@ OJO en Windows: verificar con 'git show <ref>:<path>', NO contra la copia de tra
 (core.autocrlf=true la convierte a CRLF y el sha no cuadra).
 
 Para revertir: pegar cada archivo en su nodo desde la UI de n8n y confirmar active=true.
+
+
+-------------------------------------------------------------------------------
+DOS TRAMPAS AL VERIFICAR UN SHA CONTRA UN NODO DE n8n
+-------------------------------------------------------------------------------
+
+Ambas producen un sha que no cuadra sin que haya drift real. Verificadas en el
+despliegue del 2026-08-10 (PR #112).
+
+
+1) CRLF en la copia de trabajo (Windows, core.autocrlf=true)
+
+   Git convierte el archivo a CRLF al hacer checkout, asi que la copia de trabajo
+   NUNCA cuadra contra n8n, que guarda LF. El blob commiteado si cuadra.
+
+   MAL : sha256sum docs/n8n-workflows/<archivo>.js
+   BIEN: git show origin/main:docs/n8n-workflows/<archivo>.js | sha256sum
+
+   Caso real: el archivo de Code - MAIN dio 2ee919f7... en el working tree y
+   6c8a1e43... en el blob. El segundo es el que coincide con n8n.
+
+
+2) El editor de n8n RECORTA el salto de linea final al guardar
+
+   Un archivo de texto normal termina en \n. Al pegarlo en un nodo Code y
+   guardar, n8n descarta ese ultimo \n. El nodo queda con 1 byte menos que el
+   archivo del repo y el sha256 difiere, aunque el contenido sea identico.
+
+   Caso real (Code - buildEmail, 2026-08-10):
+     blob en origin/main : 11857 bytes  0f9562b1d728c47c410c6124e4ddc214c72934d6049ee4256a18bac06a55cb25
+     nodo en n8n         : 11856 bytes  812f2c571ad2e9e9ce63d70b6fe302d56b1b5bbba2437b8ba8aa851ed7e34dfe
+     blob[:-1]           : 11856 bytes  812f2c571ad2e9e9ce63d70b6fe302d56b1b5bbba2437b8ba8aa851ed7e34dfe  <- cuadra
+
+   Las 115 lineas de contenido eran identicas; la unica diferencia era la linea
+   116, vacia, del final del archivo.
+
+   Se decidio DEJARLO ASI y documentar la excepcion, en vez de quitar el salto
+   final del archivo del repo. Al verificar, comparar tambien contra blob[:-1]
+   antes de declarar drift.
+
+   Nota: Code - MAIN cuadro exacto porque su archivo no termina en \n. La
+   diferencia entre los dos archivos es solo como quedaron escritos, no algo
+   sistematico de n8n.
+
+
+REGLA: un sha que no cuadra no se asume ni se ignora. Se explica. Comparar linea
+a linea antes de concluir que hay drift; en los dos casos de arriba el contenido
+era identico y la diferencia estaba fuera del codigo.


### PR DESCRIPTION
Snapshot del jsCode que corre hoy en `ops/watchdog-semaforo` (`29eaGe2wkS98lRMU`), tomado en vivo por MCP justo antes de aplicar la recalibracion del PR #112. Es el punto de rollback.

Lectura en vivo: `updatedAt 2026-08-09T23:12:49.704Z`, `active true`, 29 nodos. Verificado que `data.nodes` y `data.activeVersion.nodes` coincidian, asi que el respaldo es de lo que realmente ejecuta.

| archivo | nodo | bytes | sha256 |
|---|---|---|---|
| `2026-08-09-buildemail-PRE-v12.js` | `Code - buildEmail` | 9473 | `4c41682572c036602f8f23d62ac168538f489821be549fb7c711f65b67262d17` |
| `2026-08-09-main-PRE-v12.js` | `Code - MAIN` | 6747 | `6c8a1e43ac9340789ac65063a6508e066dbf7bec672e0fd06873cdb3f9ab813b` |

Los sha son sobre contenido LF, tal como viaja en n8n. En Windows verificar con `git show <ref>:<path>`, **no** contra la copia de trabajo: con `core.autocrlf=true` el working tree queda en CRLF y el sha no cuadra.

Para revertir: pegar cada archivo en su nodo desde la UI de n8n y confirmar `active=true`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CNUkfof8V6it1ZC1zFYiH7