### PR TITLE
feat(comercial/machote) V1.20: el PDF de la cotización se trae de Odoo, y el envío real queda construido

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -305,6 +305,12 @@ Pendiente F4: usar este mapeo al guardar planes operativos.
 - ⚠️ **Un `create` que devuelve id NO prueba que los campos se guardaron (regla dura, 2026-08-17).** Odoo acepta el `create`, devuelve el id, y **descarta en silencio** los campos que no puede escribir — `readonly`, computados, o de funcionalidad reestructurada. **Releer el campo después de crear, igual que se hace el read-back de un workflow tras un PUT.** **Origen:** el proceso que sembró los alias creó 15 `account.reconcile.model` con `mapped_partner_id`; los 15 ids volvieron bien y el reporte dijo "15 creados", pero **las 15 quedaron con `mapped_partner_id: false`** porque ese campo es `readonly:true`. Reglas con nombre de alias, sin partner, inservibles — y peor, con apariencia de trabajo hecho. Es la misma lección que el `200` que no prueba la escritura (§8) y que el `success:true` que no prueba el `active` (§3), en una superficie nueva: **el ORM.**
 - ⚠️ **El historial de ejecuciones NO prueba ausencia de corridas (regla dura, 2026-08-17).** Los workflows de alta frecuencia llevan `saveDataSuccessExecution: 'none'` **por diseño** (`captura-jeeves` corre ~27 veces/día; guardarlas llenaría la base). En esos, `n8n_executions` solo muestra los **errores** guardados, así que la "última ejecución" que reporta puede ser de hace días aunque el workflow esté corriendo cada 30 min. **Evidencia válida de que corrió:** el **chatter** (`CBRUN` se escribe siempre) o el **`create_date` de las líneas** que insertó. **Origen:** se leyó `captura-jeeves` con última ejecución del 12-ago y se declaró un incidente de captura muerta; las líneas tenían `create_date 2026-08-14 13:00 UTC` (07:00 CST del viernes) y el sistema estaba sano. **Y segundo error del mismo caso:** los Schedule corren **L–V en CST**; antes de concluir que "hoy no ha corrido", convertir la hora actual a CST (UTC−6) y verificar que el día hábil ya empezó — 05:38 UTC del lunes son las 23:38 CST del **domingo**.
 - ⚠️ **Al leer ejecuciones de n8n, filtrar por nodos de LÓGICA; NUNCA pedir el output de un nodo que materializa un secreto (regla dura, 2026-08-17).** `n8n_executions` con `mode:filtered` devuelve el output del nodo **en claro**, así que pedir un nodo `Set` que resuelve `$env.X` trae la credencial al contexto de la sesión. **Origen:** al depurar el runner TMP de cruce Excel↔Odoo se pidió `nodeNames:["Cruce","Set secreto RPC"]` y el segundo devolvió la `ODOO_RPC_KEY` de producción en texto plano — hubo que rotarla. La intención era ver por qué fallaba el nodo de lógica; el nodo de secreto no aportaba nada al diagnóstico. **Regla operativa:** listar en `nodeNames` solo los nodos que se están depurando, y ante la duda usar `mode:preview` (da estructura y tamaños, no valores). Es el mismo criterio que ya aplicamos a la API key de n8n, que se lee a una variable de shell y nunca se imprime.
+- 🔴 **El filtro `nodeNames` NO protege en la ruta de ERROR: si un nodo truena, n8n devuelve su ENTRADA (regla dura, 2026-09-08).** Cuando una ejecución falla, el payload trae `nodeExecutionStack`, y ahí va el **input** del nodo que falló — **aunque se haya filtrado por `nodeNames` pidiendo otro nodo**. Si ese nodo colgaba de un `Set` que resuelve `$env.X`, su input ES el secreto, en claro. **Origen:** ejecución `90281` del 8-sep-2026: se pidió el output de un nodo de lógica, el nodo de Postgres de al lado falló, y `SUITE_JWT_SECRET` de producción acabó en el transcript de la sesión — **con el filtro de §9 puesto**. Hubo que rotarla. La regla de arriba se cumplió y no bastó: sólo cubre el camino feliz.
+  **Las dos defensas, y son de DISEÑO, no de lectura:**
+  1. **Ningún nodo que pueda lanzar debe tener como entrada directa un nodo que materializa un secreto.** El nodo que consume el `Set` va **entero en `try/catch`** y devuelve el fallo como DATO (`{ok:false, error:'FALLO_X'}`), sin tocar el item de entrada. Un nodo que no lanza no produce payload de error.
+  2. **Poner el `Set` del secreto lo más tarde posible** en la cadena, y que el primer nodo que lo consume devuelva un objeto NUEVO — así el secreto no viaja aguas abajo.
+  ⚠️ **`onError: continueRegularOutput` NO sirve aquí: es peor.** Pasa el input del nodo que falló hacia adelante, o sea manda el secreto río abajo, posiblemente hasta la respuesta. Sirve para nodos que NO ven secretos (un HTTP externo, por ejemplo).
+  Aplicado en `comercial/cotizacion` (`dahVXA1NyF1AXfc4`): `Code - Verificar` y `Code - Preparar` van los dos en `try/catch` total, con el porqué escrito en el propio nodo.
 - Webhook secrets HMAC: pendientes de implementar (Bloque A pending).
 - **Pendiente HMAC (B4 Carga MO, 2026-07-06):** los webhooks nuevos `planeacion/horas-dia` (lectura) y `planeacion/confirmar-horas` (UPDATE hr.attendance) heredan el modelo sin secreto. `confirmar-horas` **escribe a producción** (`x_studio_manager_approval` + `x_studio_sales_order_2`) → priorizar HMAC/token cuando se aborde el hardening de webhooks. Gate actual: solo frontend (auth Felipe/master).
 
@@ -878,6 +884,27 @@ podían ver, porque `psql` lee del disco y nunca pasa por n8n. El `.sql` era cor
 (`$rol$`, `$motivo$`). Y para datos de usuario —el texto de un machote puede traer `$$`—
 **parámetros de consulta (`$1`, `$2`), nunca SQL concatenado**: aparte de inyección, es lo
 único que garantiza que el contenido llegue intacto. Detalle en `db/README.md` regla 4.
+
+⚠️ **Corrección de ALCANCE, medida el 8-sep-2026 (ejecuciones `90310` y `90312`).** El
+mecanismo tal como está escrito arriba —«todo lo que viaje por una expresión de n8n pasa
+por un `String.replace` y ahí `$$` se colapsa»— **no se reprodujo**. Se probó con
+`A$$B $1 C $& D $` + "`" + ` E $' F $<x> G` (los cinco patrones de reemplazo de JavaScript, más
+`$<n>`) por un nodo `Set`, de dos formas:
+
+| forma | resultado |
+|---|---|
+| la expresión ES todo el valor: `={{ $json.raro }}` | **idéntico**, 31/31 caracteres |
+| la expresión va incrustada: `=PRE {{ $json.raro }} POST` | **idéntico**, 40/40 caracteres |
+| dentro de `={{ JSON.stringify($json.sobre) }}` y parseado del otro lado | **idéntico** |
+
+O sea: **la ruta `Set` → expresión no colapsa nada**, ni entera ni incrustada. El incidente
+del `.sql` fue real y el archivo era correcto, pero **la causa que se escribió no es la
+que se midió**, así que sigue sin identificarse: pudo estar en el nodo de Postgres, en el
+armado del SQL, o en otro tramo del camino. **La regla operativa se queda tal cual**
+(etiquetas con nombre y parámetros de consulta son buena práctica por su cuenta), pero
+**no se puede citar el mecanismo como si estuviera probado**, y quien vuelva a toparse con
+esto tiene que medir SU tramo, no dar por hecho éste. Es la misma exigencia de §8:
+verificado = ejecutado y observado — que vale igual para las reglas que escribimos nosotros.
 
 ### 11. Un `[]` de un endpoint nuevo no prueba que la consulta sirva
 Una lista vacía se ve idéntica cuando la consulta funciona y no hay filas, y cuando la

--- a/comercial/machote/css/machote.css
+++ b/comercial/machote/css/machote.css
@@ -913,6 +913,12 @@ th .hint { font-weight: 400; text-transform: none; opacity: .75; }
  * no existe. Ámbar, no rojo. */
 .envio.parado { border: 1px solid #e6c98a; background: #fffaf0; }
 .envio.parado p { margin: 4px 0 0; }
+/* Verde SÓLO cuando el servidor confirmó. Nunca al apretar el botón: es
+   justo el color que en el kiosko hizo creer a la gente que había checado
+   salida sin haberlo hecho (CLAUDE.md hallazgo #15). */
+.envio.ok { border: 1px solid #a7d3a7; background: #f3fbf3; }
+.envio.ok p { margin: 4px 0 0; }
+.envio .nota { opacity: .7; }
 
 @media (max-width: 720px) {
   .or-grid { grid-template-columns: 1fr 1fr; }

--- a/comercial/machote/index.html
+++ b/comercial/machote/index.html
@@ -42,6 +42,7 @@
 <script src="js/historial.js"></script>
 <script src="js/franja-sync.js"></script>
 <script src="js/control.js"></script>
+<script src="js/cotizacion.js"></script>
 <script src="js/orden.js"></script>
 <script src="js/app.js"></script>
 </body>

--- a/comercial/machote/js/almacen.js
+++ b/comercial/machote/js/almacen.js
@@ -467,6 +467,18 @@
     });
   }
 
+  /** El id que el SERVIDOR le puso a este machote, o null si nunca ha subido.
+   *
+   *  Existe porque el navegador y el servidor nombran la misma cotización de
+   *  dos maneras: aquí es `id_local` ('M-1757…', único por navegador), allá
+   *  es un uuid. Todo lo que le pregunte algo del machote al servidor
+   *  —historial, PDF, envío— necesita el uuid, y `null` es una respuesta
+   *  legítima que significa «todavía no llega allá», no un error. */
+  function idServidor(idLocal) {
+    var meta = leerSync()[idLocal];
+    return (meta && meta.machote_id) ? meta.machote_id : null;
+  }
+
   /** El historial completo de un machote, del servidor. Para la pantalla de
    *  versiones: la caché del navegador sólo tiene la última. */
   function historial(idLocal) {
@@ -558,6 +570,7 @@
     bajar: bajar,
     empujar: empujar,
     historial: historial,
+    idServidor: idServidor,
 
     pendientes: pendientes,
     estadoServidor: estadoServidor,

--- a/comercial/machote/js/app.js
+++ b/comercial/machote/js/app.js
@@ -40,7 +40,7 @@
    * 2026-09-03 (por instrucción de Esteban), pero lleva el suyo aparte y va en
    * V1.00. Planeación sigue en `2.4.1` y el kiosko sólo con cadena de build;
    * a esos no se propaga. */
-  const VERSION = 'V1.19';
+  const VERSION = 'V1.20';
   const $  = (s, r) => (r || document).querySelector(s);
   const $$ = (s, r) => Array.prototype.slice.call((r || document).querySelectorAll(s));
   const clon = (x) => JSON.parse(JSON.stringify(x));

--- a/comercial/machote/js/cotizacion.js
+++ b/comercial/machote/js/cotizacion.js
@@ -1,0 +1,141 @@
+/* ═══ Machote · el PDF de la orden, traído de Odoo ═══════════════════════
+ *
+ * Habla con el webhook `comercial/cotizacion`. Dos modos, un endpoint:
+ *   · 'pdf'    → devuelve el documento que Odoo le genera al cliente.
+ *   · 'enviar' → lo manda por correo con ese mismo PDF adjunto.
+ *
+ * ── POR QUÉ EL PDF LO TRAE EL SERVIDOR Y NO EL NAVEGADOR ────────────────
+ * Odoo publica el PDF de una orden en un enlace de portal que lleva un
+ * `access_token`. Ese token es una LLAVE DE CAPACIDAD: quien lo tenga ve la
+ * orden completa sin necesidad de entrar a Odoo. Si el navegador armara el
+ * enlace, la llave quedaría en el historial, en el portapapeles y en
+ * cualquier captura de pantalla. Por eso el servidor baja los bytes y
+ * devuelve los bytes; aquí nunca se ve el token.
+ *
+ * ── EL CAMPO QUE LIGA LAS DOS COSAS ─────────────────────────────────────
+ * `comercial.machote.odoo_so_id` (migración 003). Es una referencia externa
+ * SIN llave foránea, a propósito: el día que un dominio salga de Odoo, el
+ * machote no queda apuntando a un id que dejó de existir.
+ * Vacío significa que la cotización todavía no se volvió orden en Odoo, y
+ * ese es el estado NORMAL de un machote recién capturado. La pantalla tiene
+ * que DECIRLO, no fallar: el servidor contesta `SIN_ORDEN` con su frase, y
+ * aquí se pinta tal cual.
+ */
+(function (G) {
+  'use strict';
+
+  var BASE = 'https://primary-production-5c3c.up.railway.app/webhook';
+  var URL_COTIZACION = BASE + '/comercial/cotizacion';
+  /* Más generoso que los otros endpoints (12 s): esta llamada entra a Odoo,
+   * le pide renderizar un PDF y se lo trae. En la prueba tardó ~6 s; un
+   * documento largo o un Odoo ocupado tardan más, y cortar a los 12 s
+   * convertiría una lentitud normal en un error. */
+  var TIMEOUT_MS = 45000;
+
+  function postear(cuerpo) {
+    var ctrl = (typeof AbortController === 'function') ? new AbortController() : null;
+    var corta = null;
+    var opciones = {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      // El token va en el CUERPO, no en Authorization: el header dispara un
+      // preflight CORS que el webhook de n8n no contesta (CLAUDE.md §15 #5).
+      body: JSON.stringify(cuerpo)
+    };
+    if (ctrl) opciones.signal = ctrl.signal;
+    if (ctrl) corta = setTimeout(function () { ctrl.abort(); }, TIMEOUT_MS);
+
+    return fetch(URL_COTIZACION, opciones)
+      .then(function (r) { return r.json().catch(function () { return null; }); })
+      .then(function (d) {
+        if (corta) clearTimeout(corta);
+        if (!d || typeof d !== 'object') {
+          return { ok: false, error: 'RESPUESTA_ILEGIBLE',
+            mensaje: 'El servidor contestó algo que no se entiende.' };
+        }
+        return d;
+      })
+      .catch(function (e) {
+        if (corta) clearTimeout(corta);
+        /* Se resuelve, no se rechaza: quien llama decide cómo degradar, y
+         * ninguna pantalla del machote debe romperse porque el servidor no
+         * contestó. Lo capturado sigue en el navegador. */
+        return { ok: false, error: 'SIN_RED',
+          mensaje: 'No se pudo hablar con el servidor: ' +
+                   String((e && e.message) || e).slice(0, 90) };
+      });
+  }
+
+  /* Traduce el «de qué cotización» a lo que el servidor entiende, y ataja
+   * antes de gastar una llamada los dos casos que ya se saben aquí. */
+  function referencia(m) {
+    var S = G.SuiteAuth;
+    var token = S && S.getToken && S.getToken();
+    if (!token) {
+      return { error: 'SIN_SESION',
+        mensaje: 'No hay sesión. Vuelve a entrar para traer el documento.' };
+    }
+    var A = G.MachoteAlmacen;
+    var idServidor = (A && A.idServidor) ? A.idServidor(m && m.id) : null;
+    if (!idServidor) {
+      return { error: 'NUNCA_SUBIDO',
+        mensaje: 'Este machote todavía no llega al servidor, así que el servidor ' +
+                 'no sabe de qué cotización le estás hablando. Súbelo primero.' };
+    }
+    return { token: token, machote_id: idServidor };
+  }
+
+  /** Trae el PDF. Resuelve SIEMPRE con `{ok:true, archivo, orden}` o
+   *  `{ok:false, error, mensaje}`. `SIN_ORDEN` no es una falla del sistema:
+   *  es la respuesta correcta a un machote que todavía no es orden. */
+  function pdf(m) {
+    var ref = referencia(m);
+    if (ref.error) return Promise.resolve({ ok: false, error: ref.error, mensaje: ref.mensaje });
+    return postear({ token: ref.token, modo: 'pdf', machote_id: ref.machote_id });
+  }
+
+  /** Manda la cotización. `para`, `asunto` y `cuerpo` los edita el vendedor.
+   *  ⚠ El servidor tiene un candado: mientras esté en modo prueba sólo acepta
+   *  sales@fts.mx y contesta `DESTINO_NO_PERMITIDO` a cualquier otro. */
+  function enviar(m, para, asunto, cuerpo) {
+    var ref = referencia(m);
+    if (ref.error) return Promise.resolve({ ok: false, error: ref.error, mensaje: ref.mensaje });
+    return postear({ token: ref.token, modo: 'enviar', machote_id: ref.machote_id,
+      para: para || '', asunto: asunto || '', cuerpo: cuerpo || '' });
+  }
+
+  /** Convierte el base64 que llegó en un archivo y lo baja.
+   *
+   *  Devuelve true/false en vez de no devolver nada: quien llama tiene que
+   *  poder decir «no se pudo bajar» en la pantalla. Que el servidor haya
+   *  contestado bien no significa que el navegador haya podido guardar el
+   *  archivo — es la misma regla de siempre, sólo que un paso más adelante. */
+  function bajar(archivo) {
+    if (!archivo || typeof archivo.base64 !== 'string') return false;
+    try {
+      var bin = atob(archivo.base64);
+      var bytes = new Uint8Array(bin.length);
+      for (var i = 0; i < bin.length; i++) bytes[i] = bin.charCodeAt(i);
+      var url = URL.createObjectURL(new Blob([bytes], { type: 'application/pdf' }));
+      var a = document.createElement('a');
+      a.href = url;
+      a.download = archivo.nombre || 'cotizacion.pdf';
+      document.body.appendChild(a);
+      a.click();
+      document.body.removeChild(a);
+      // Se suelta después: revocar de inmediato cancela la descarga en algunos
+      // navegadores, que todavía no han leído el blob cuando vuelve el click.
+      setTimeout(function () { URL.revokeObjectURL(url); }, 60000);
+      return true;
+    } catch (e) {
+      return false;
+    }
+  }
+
+  G.MachoteCotizacion = {
+    pdf: pdf,
+    enviar: enviar,
+    bajar: bajar,
+    _url: URL_COTIZACION
+  };
+})(window);

--- a/comercial/machote/js/orden.js
+++ b/comercial/machote/js/orden.js
@@ -401,24 +401,32 @@
 
     cascaron(
       '<div class="or-cab">' +
-        '<div><h3>Mandarla al cliente <span class="chip demo">demostración</span></h3>' +
+        /* El chip decía "demostración" a secas y ya es media mentira: el paso 1
+         * baja un PDF de verdad de Odoo. Un cartel de "esto es de mentiras"
+         * encima de algo que sí funciona es tan malo como el contrario —
+         * enseña a no creerle a los carteles. Se acota a lo que sigue en
+         * obra, que es el envío. */
+        '<div><h3>Mandarla al cliente <span class="chip demo">envío pendiente</span></h3>' +
         '<div class="tiny nota">' + esc(m.nombre) + ' · ' + mx(total, p.moneda) + ' ' + esc(p.moneda) + '</div></div>' +
         '<button class="btn fantasma" id="or-x">Cerrar</button>' +
       '</div>' +
 
-      '<div class="aviso"><strong>No se manda ningún correo desde aquí.</strong> ' +
-      'Ni de prueba. Lo que se ve es el camino y, sobre todo, dónde se atora.</div>' +
+      '<div class="aviso"><strong>De esta pantalla no sale ningún correo todavía.</strong> ' +
+      'El PDF sí es real —lo trae de Odoo—. El envío ya está construido y probado ' +
+      'del lado del servidor, pero su webhook está apagado y con candado de prueba.</div>' +
 
       /* El indicador del correo. Se dice el estado REAL y el porqué: un
        * "no vinculado" sin explicación manda al vendedor a buscar un ajuste
        * que no existe. */
       '<div class="corr ' + (cor.vinculado ? 'ok' : 'pend') + '">' +
         '<div class="corr-t"><strong>' +
-          (cor.vinculado ? 'Tu correo está vinculado' : 'Tu correo NO está vinculado') +
+          (cor.vinculado ? 'Tu correo está vinculado' : 'Sale de la casilla común, no de la tuya') +
         '</strong></div>' +
-        '<p class="tiny">Hoy la suite sólo puede mandar como <code>' + esc(cor.buzon_unico) +
-        '</code>. ' + esc(cor.motivo) + ' Mandar como tú exige <strong>permisos nuevos en ' +
-        'Azure que todavía no existen</strong> — no es código, es una decisión.</p>' +
+        '<p class="tiny">Esteban eligió el <strong>camino A</strong> el 8-sep: el correo sale ' +
+        'de <code>' + esc(cor.buzon_unico) + '</code> y tu dirección va en <strong>«responder ' +
+        'a»</strong>, así que el cliente te contesta a ti. ' + esc(cor.motivo) + ' ' +
+        'Mandar <em>como</em> tú queda para después: exige permisos nuevos en Azure, y eso ' +
+        'no es código sino una decisión.</p>' +
         '<div class="corr-bs">' +
           '<button class="btn fantasma f-min" id="or-vincular">Vincular mi correo</button>' +
           '<button class="btn fantasma f-min" id="or-caminos">¿Qué hace falta?</button>' +
@@ -430,9 +438,19 @@
       '<div class="or-pasos">' +
         '<div class="paso"><span class="np">1</span><div>' +
           '<strong>Bajarla en PDF</strong>' +
-          '<p class="tiny">Abre la cotización lista para imprimir; desde ahí, ' +
-          '«Guardar como PDF». No es un botón de mentiras: eso sí funciona hoy.</p>' +
-          '<button class="btn fantasma f-min" id="or-pdf">Ver la cotización para imprimir</button>' +
+          /* Dos botones que hacen cosas DISTINTAS, y la diferencia importa:
+           * el de la izquierda arma aquí una hoja con lo capturado; el de la
+           * derecha trae el documento que Odoo le genera al cliente —el
+           * mismo, byte por byte, que vería si le mandaran el enlace—. El
+           * segundo sólo existe cuando la cotización ya es orden en Odoo. */
+          '<p class="tiny">De aquí sale una hoja armada con lo capturado. ' +
+          'El PDF <strong>oficial</strong> lo genera Odoo, y ése sólo existe ' +
+          'cuando la cotización ya se volvió orden allá.</p>' +
+          '<div class="corr-bs">' +
+            '<button class="btn fantasma f-min" id="or-pdf">Ver la cotización para imprimir</button>' +
+            '<button class="btn fantasma f-min" id="or-pdf-odoo">Traer el PDF de Odoo</button>' +
+          '</div>' +
+          '<div id="or-pdf-estado"></div>' +
         '</div></div>' +
         '<div class="paso"><span class="np">2</span><div>' +
           '<strong>Mandarla y marcarla como enviada</strong>' +
@@ -478,6 +496,79 @@
         '</div>';
     };
 
+    /* ── El PDF de Odoo. Esto SÍ es real ──────────────────────────────────
+     * Llama a `comercial/cotizacion`, que baja el documento de Odoo y lo
+     * devuelve. Los tres desenlaces se pintan distinto a propósito:
+     *
+     *   · bajado      → el archivo se guarda y se dice de qué orden salió.
+     *   · SIN_ORDEN   → NO es una falla. Es un machote que todavía no es
+     *                   orden en Odoo, que es el estado normal mientras se
+     *                   cotiza. Se explica en vez de enseñar un error rojo.
+     *   · lo demás    → el mensaje del servidor, tal cual. Inventar aquí una
+     *                   frase amable escondería la causa.
+     *
+     * Y el éxito se pinta DESPUÉS de que el servidor contesta, nunca al
+     * apretar (CLAUDE.md hallazgo #15). */
+    document.getElementById('or-pdf-odoo').onclick = function () {
+      var b = this, caja = document.getElementById('or-pdf-estado');
+      var Q = window.MachoteCotizacion;
+      if (!Q) {
+        caja.innerHTML = '<div class="envio parado tiny">No cargó el módulo que habla ' +
+          'con el servidor. Recarga la página.</div>';
+        return;
+      }
+      /* El modal es alto y a 380 px la respuesta cae justo en el borde de
+       * abajo: se aprieta el botón y no se ve qué contestó. Se lleva a la
+       * vista SIEMPRE —al pedir y al contestar—, que es más barato que
+       * rediseñar el modal y arregla el caso que se vio en la captura. */
+      function verla() {
+        try { caja.scrollIntoView({ block: 'nearest', behavior: 'smooth' }); } catch (e) {}
+      }
+      b.disabled = true; b.textContent = 'Trayendo…';
+      caja.innerHTML = '<div class="envio esperando tiny">Pidiéndole el documento a Odoo…</div>';
+      verla();
+
+      Q.pdf(_st.machote).then(function (r) {
+        b.disabled = false; b.textContent = 'Traer el PDF de Odoo';
+
+        if (r && r.ok === true && r.archivo) {
+          var guardado = Q.bajar(r.archivo);
+          var o = r.orden || {};
+          caja.innerHTML = guardado
+            ? ('<div class="envio ok tiny"><strong>Bajado de Odoo.</strong> ' +
+               esc(r.archivo.nombre) + ' · ' + Math.round((r.archivo.bytes || 0) / 1024) + ' KB' +
+               (o.nombre ? (' · orden ' + esc(o.nombre)) : '') +
+               (o.cliente ? (' · ' + esc(o.cliente)) : '') + '</div>')
+            : ('<div class="envio parado tiny"><strong>Llegó, pero el navegador no ' +
+               'pudo guardarlo.</strong> Revisa si está bloqueando descargas.</div>');
+          verla();
+          return;
+        }
+
+        var err = (r && r.error) || 'FALLO';
+        var msg = (r && r.mensaje) || 'No se pudo traer el documento.';
+
+        if (err === 'SIN_ORDEN') {
+          caja.innerHTML = '<div class="envio parado tiny">' +
+            '<strong>Todavía no hay PDF que traer.</strong>' +
+            '<p class="tiny">' + esc(msg) + ' El documento oficial lo genera Odoo a ' +
+            'partir de la orden; mientras la cotización viva sólo aquí, no existe. ' +
+            'Usa la hoja para imprimir de al lado.</p></div>';
+          verla();
+          return;
+        }
+        if (err === 'NUNCA_SUBIDO') {
+          caja.innerHTML = '<div class="envio parado tiny">' +
+            '<strong>Falta subirlo.</strong><p class="tiny">' + esc(msg) + '</p></div>';
+          verla();
+          return;
+        }
+        caja.innerHTML = '<div class="envio parado tiny"><strong>No se pudo.</strong> ' +
+          esc(msg) + ' <span class="nota">(' + esc(err) + ')</span></div>';
+        verla();
+      });
+    };
+
     /* El envío. Cuatro estados y el tercero NUNCA llega solo: llega cuando el
      * servidor contesta. Aquí no hay servidor, así que se queda en el segundo
      * y lo dice. Eso ES la demostración. */
@@ -490,13 +581,15 @@
         caja.innerHTML =
           '<div class="envio parado">' +
           '<strong>Aquí se para, y a propósito.</strong>' +
-          '<p class="tiny">No hay a quién preguntarle: el webhook de envío no existe y ' +
-          'el permiso de correo tampoco. La cotización <strong>sigue sin marcarse como ' +
-          'enviada</strong> — que es exactamente lo correcto, porque no se envió.</p>' +
-          '<p class="tiny">Cuando exista, el orden es: el servidor manda → Graph ' +
-          'contesta <code>202</code> con el id del mensaje → el servidor escribe la marca ' +
-          'y la devuelve → la pantalla la pinta <strong>releyendo</strong>, no recordando ' +
-          'que se apretó el botón.</p>' +
+          '<p class="tiny">El webhook <code>comercial/cotizacion</code> ya existe y ya mandó ' +
+          'un correo de verdad: Graph contestó <code>202</code> con el PDF adjunto. Pero ' +
+          '<strong>nace apagado</strong> —lo enciende Esteban— y trae un candado que sólo ' +
+          'deja mandar a <code>sales@fts.mx</code>. Por eso este botón todavía no lo llama.</p>' +
+          '<p class="tiny">La cotización <strong>sigue sin marcarse como enviada</strong>, y eso ' +
+          'es lo correcto: no se envió. Cuando se encienda, el orden es el servidor manda → ' +
+          'Graph contesta <code>202</code> → el servidor escribe la marca → la pantalla la pinta ' +
+          '<strong>releyendo</strong>, no recordando que se apretó el botón. Escribir la marca ' +
+          'es lo único que falta, y falta porque nadie ha decidido si va también a Odoo.</p>' +
           '</div>';
       }, 900);
     };

--- a/comercial/machote/tests/pruebas-navegador.js
+++ b/comercial/machote/tests/pruebas-navegador.js
@@ -2961,8 +2961,13 @@ let ok = 0, mal = 0;
       await q.click('#btnOrden'); await q.waitForTimeout(400);
       await q.click('#or-siguiente'); await q.waitForTimeout(400);
       const t = (await q.textContent('.corr')).replace(/\s+/g, ' ');
-      if (!/NO está vinculado/.test(t)) throw new Error('no dice el estado: ' + t.slice(0, 120));
+      /* Cambió la copia el 8-sep al elegirse el camino A: ya no es "no está
+       * vinculado" (que sonaba a ajuste pendiente del usuario) sino de dónde
+       * sale el correo y a quién le contesta el cliente. Lo que la prueba
+       * exige es lo mismo de antes: el estado, el buzón, y qué falta. */
+      if (!/no de la tuya|NO está vinculado/.test(t)) throw new Error('no dice el estado: ' + t.slice(0, 120));
       if (!/sales@fts\.mx/.test(t)) throw new Error('no dice cuál es el único buzón');
+      if (!/responder a/i.test(t)) throw new Error('no dice que el cliente le contesta al vendedor');
       if (!/Azure/.test(t)) throw new Error('no dice qué falta');
       // Y "Vincular" no puede fingir que vinculó.
       await q.click('#or-vincular'); await q.waitForTimeout(250);
@@ -3016,6 +3021,76 @@ let ok = 0, mal = 0;
       console.log('    sin costos internos · sellada como demostración');
       await hoja.close();
     } finally { await ctx.close(); }
+  });
+
+  /* ══ El PDF de Odoo (V1.20) ═══════════════════════════════════════════ */
+
+  await paso('el PDF de Odoo: el navegador NUNCA arma el enlace de portal', async () => {
+    /* El `access_token` de una orden es una LLAVE DE CAPACIDAD: quien lo tenga
+     * ve la orden completa sin entrar a Odoo. Si el enlace se armara aquí,
+     * la llave acabaría en el historial, en el portapapeles y en cualquier
+     * captura de pantalla. El servidor baja los bytes y devuelve los bytes.
+     *
+     * Es una prueba ESTÁTICA a propósito: el día que alguien "simplifique"
+     * llamando a Odoo desde el navegador, esto truena aunque la pantalla se
+     * vea igual — que es justo cuando no se nota. */
+    const src = fs.readFileSync(path.resolve(__dirname, '..', 'js', 'cotizacion.js'), 'utf8');
+    const cuerpo = src.replace(/\/\*[\s\S]*?\*\//g, '').replace(/^\s*\/\/.*$/gm, '');
+    for (const prohibido of ['access_token', 'serviciosfts.odoo.com', '/my/orders']) {
+      if (cuerpo.indexOf(prohibido) >= 0)
+        throw new Error('el módulo del navegador toca Odoo directo: ' + prohibido);
+    }
+    if (cuerpo.indexOf('/comercial/cotizacion') < 0)
+      throw new Error('no llama al webhook que debe');
+    console.log('    ni access_token ni el dominio de Odoo en el código del navegador');
+  });
+
+  await paso('el PDF de Odoo: sin haber subido el machote lo DICE, no truena', async () => {
+    /* El caso normal del primer día: la cotización vive sólo aquí, así que el
+     * servidor no sabe de qué le hablan. Tiene que explicarlo antes de gastar
+     * una llamada, y sin pintar un error rojo — no hay nada roto. */
+    const q = await cdPagina(['comercial:read']);
+    try {
+      await q.goto(BASE); await q.waitForTimeout(900);
+      const href = await q.$eval('.fila a.item', a => a.getAttribute('href'));
+      await q.goto(BASE + href); await q.waitForTimeout(900);
+      const antes = await q.evaluate(() => JSON.stringify(window.MachoteAlmacen.leerLocal()));
+
+      await q.click('#btnOrden'); await q.waitForTimeout(400);
+      await q.click('#or-siguiente'); await q.waitForTimeout(400);
+      if (!(await q.$('#or-pdf-odoo'))) throw new Error('no existe el botón de traer el PDF');
+      await q.click('#or-pdf-odoo'); await q.waitForTimeout(700);
+
+      const t = (await q.textContent('#or-pdf-estado')).replace(/\s+/g, ' ');
+      if (!/Falta subirlo|todavía no llega al servidor/i.test(t))
+        throw new Error('no explica por qué no puede: ' + t.slice(0, 140));
+      if (/Bajado de Odoo/i.test(t))
+        throw new Error('dijo que bajó un PDF que nunca pidió');
+
+      /* Y no puede haber guardado nada: traer un documento es una LECTURA. */
+      const despues = await q.evaluate(() => JSON.stringify(window.MachoteAlmacen.leerLocal()));
+      if (antes !== despues) throw new Error('se guardó algo al pedir el PDF');
+      console.log('    lo explica, no finge, y no escribió nada');
+    } finally { await q.close(); }
+  });
+
+  await paso('el PDF de Odoo: el botón cabe y se toca a 380 px', async () => {
+    const q = await cdPagina(['comercial:read']);
+    try {
+      await q.setViewportSize({ width: 380, height: 780 });
+      await q.goto(BASE); await q.waitForTimeout(900);
+      const href = await q.$eval('.fila a.item', a => a.getAttribute('href'));
+      await q.goto(BASE + href); await q.waitForTimeout(900);
+      await q.click('#btnOrden'); await q.waitForTimeout(400);
+      await q.click('#or-siguiente'); await q.waitForTimeout(400);
+      const c = await q.$eval('#or-pdf-odoo', el => {
+        const r = el.getBoundingClientRect();
+        return { alto: Math.round(r.height), der: Math.round(r.right) };
+      });
+      if (c.alto < 40) throw new Error('mide ' + c.alto + ' px de alto, menos de los 40 del módulo');
+      if (c.der > 380) throw new Error('se sale de la pantalla: llega a x=' + c.der);
+      console.log('    ' + c.alto + ' px de alto, dentro de la pantalla');
+    } finally { await q.close(); }
   });
 
   await paso('sin errores de consola propios del prototipo', async () => {

--- a/comercial/machote/version.json
+++ b/comercial/machote/version.json
@@ -1,10 +1,15 @@
 {
-  "version": "V1.19",
-  "fecha": "2026-09-07",
+  "version": "V1.20",
+  "fecha": "2026-09-08",
   "modulo": "comercial/machote",
   "ambito": "El CONTADOR es solo de este modulo. finanzas tambien usa V1.xx desde el 2026-09-03 (instruccion directa de Esteban, corrige el \"no propagar\" del issue #148) pero lleva su propio contador y va en V1.00. operaciones/planeacion sigue en 2.4.1, kiosk y confirmar-horas solo con cadena de build, y siete modulos con un 1.0.0 puesto una vez: a esos no se propaga.",
   "esquema": "V<mayor>.<menor de dos digitos>. Un incremento de 0.01 por cada merge a main. Al pasar de .99 sube el mayor y el menor vuelve a 00.",
   "historial": [
+    {
+      "version": "V1.20",
+      "pr": null,
+      "nota": "El PDF oficial de la cotizacion se trae de Odoo. Boton 'Traer el PDF de Odoo' en la pantalla de envio: el servidor le pide a Odoo el documento que le genera al cliente -el mismo, byte por byte, que veria si le mandaran el enlace de portal- y devuelve el archivo. La llave de ese enlace (access_token) NUNCA baja al navegador: quien la tenga ve la orden sin entrar a Odoo, asi que los bytes los baja el servidor. Cuando la cotizacion todavia no es orden en Odoo no hay PDF que traer, y la pantalla lo DICE en ambar y manda a la hoja para imprimir, en vez de enseñar un error: ese es el estado normal mientras se cotiza. El campo que liga las dos cosas es machote.odoo_so_id. Ademas el envio real por correo quedo construido y probado del lado del servidor -sale de sales@fts.mx con el vendedor en 'responder a', decision de Esteban- pero su webhook nace apagado y con candado que solo deja mandar a sales@fts.mx, y la marca de enviada sigue SIN escribirse: la dispara la confirmacion de Graph, nunca el clic, y falta decidir si tambien va a Odoo"
+    },
     {
       "version": "V1.19",
       "pr": null,

--- a/docs/comercial/ALMACEN.md
+++ b/docs/comercial/ALMACEN.md
@@ -326,21 +326,34 @@ y «déjame leer lo tuyo».
 La suma la hace Postgres con un `group by dueno`; el navegador no podría calcularla porque
 sólo conoce lo suyo.
 
-### El permiso que hoy no tiene nadie
+### El permiso, y dónde vive de verdad
 
-`comercial:admin` no está en ninguna fila de `suite_usuarios`. Fue a propósito: **primero
-la puerta, después la llave**. Mientras tanto la pantalla no es un callejón — dice qué
-falta y enseña, marcado como demostración, cómo se va a ver.
+`comercial:admin` nació sin dueño a propósito: **primero la puerta, después la llave**.
+Mientras tanto la pantalla no era un callejón — decía qué faltaba y enseñaba, marcado como
+demostración, cómo se iba a ver.
 
-Dárselo a Esteban es un campo:
+> ⚠️ **Corrección (8-sep-2026).** Aquí decía que el permiso se daba con
+> `UPDATE comercial.suite_usuario SET scopes = …`. **Esa tabla no existe** — no la crea
+> ninguna migración, y el SQL nunca se ejecutó. Los usuarios de la suite **no viven en
+> Postgres**: viven en una *Data Table* de n8n llamada `suite_usuarios`
+> (`YWCP0KoVmgxX2RzL`, proyecto `eWfPdSbGqqG91Eja`), que es de donde `auth/suite-login` las
+> lee. La columna `scopes` es **una cadena separada por comas**, no un arreglo de Postgres.
 
-```sql
-UPDATE comercial.suite_usuario
-   SET scopes = scopes || '{comercial:admin}'
- WHERE actor = '‹el usuario de Esteban›';
-```
+Dárselo sigue siendo un campo, pero se edita en la Data Table:
 
-No va en una migración porque es un **permiso**, no una estructura.
+| columna | antes | después |
+|---|---|---|
+| `scopes` de `esteban.delacruz` | `comercial:read` | `comercial:read,comercial:admin` |
+
+El MCP de n8n **no tiene herramienta para editar una fila** de una Data Table (sólo crear y
+leer), así que el cambio se hace desde la UI de n8n o con un workflow que use el nodo
+`Data Table` (`resource: row`, `operation: update`, que además trae `dryRun`).
+
+**Aplicado el 8-sep-2026, sólo a Esteban** (`updatedAt 2026-09-08T03:20:44Z`, leído de vuelta).
+Los otros siete usuarios siguen sin `comercial:admin`.
+
+No va en una migración porque es un **permiso**, no una estructura — y porque la estructura
+está en otro sistema.
 
 ### Verificado en vivo contra la base real (7-sep-2026)
 

--- a/docs/comercial/ORDEN-CONTRATO.md
+++ b/docs/comercial/ORDEN-CONTRATO.md
@@ -76,6 +76,43 @@ La prueba `cascarón: la cotización para imprimir NO lleva costos internos` vig
 ningún costo se cuele en la hoja del cliente. Es la peor falla posible de esta pantalla y
 no la cazaría ninguna revisión de «se ve bien».
 
+### La salvedad: cuando el cliente pide desglose para armar su PO
+
+Esteban aprobó la línea por sección **con una condición** (8-sep-2026): hay clientes que
+exigen desglose para poder armar su orden de compra, así que tiene que poder **abrirse UNA
+sección a detalle cuando el cliente lo pida** — sin que sea lo normal, y sin que eso
+exponga precios de compra.
+
+Las dos cosas parecen reñidas y no lo están, porque **desglose y costo no son lo mismo**.
+El renglón que el cliente necesita para su PO es *«Tablero de control 480 V · 1 pieza ·
+$X»*; el precio de compra es lo que a FTS le costó ese tablero. Lo que hoy vive en el
+machote es el costo, y el precio de venta del renglón **no está capturado en ningún lado**:
+sólo existe el precio de la sección.
+
+Propuesta —**no está construido, y no debería construirse sin que Esteban confirme el
+punto 2**:
+
+1. **Una casilla por sección, apagada por omisión**, en la pantalla de pasar a orden:
+   *«Desglosar esta sección en la orden»*. Apagada por omisión es lo que hace que siga
+   siendo la excepción; una preferencia global se volvería la costumbre en dos semanas.
+   Que sea **por sección y no por cotización** es justo lo que pidió Esteban: se abre la
+   que el cliente necesita, no todas.
+2. **El precio de cada renglón sale a prorrata del costo dentro de su sección** — la misma
+   regla con la que el motor ya reparte el precio entre secciones
+   (`calcular(m).secciones[i].precio`), un nivel más abajo. Tiene una consecuencia que hay
+   que decir en voz alta: **el margen queda implícito, uniforme dentro de la sección**. Un
+   cliente que compare el precio unitario contra su propia referencia de mercado puede
+   deducir por dónde anda el margen. No es el costo, pero tampoco es opaco. *Ésta es la
+   decisión que falta, y es de negocio, no técnica.*
+3. **La suma de los renglones desglosados tiene que dar exactamente el precio de la
+   sección.** Con una prueba que lo vigile, del mismo tipo que la de V1.16 —invariante, no
+   número esperado—: es la única forma de que abrir el desglose no cambie el total.
+4. **El costo nunca sale.** Ni `costo`, ni `costoMo`, ni `costoMat`, ni la tarifa de mano de
+   obra, ni el multiplicador. La prueba que ya existe (`NO lleva costos internos`) se
+   extiende al caso desglosado, que es donde de verdad puede colarse.
+
+Coste estimado: ~2 h, la mitad en la prueba. **Pendiente de la decisión del punto 2.**
+
 ---
 
 ## El cuerpo
@@ -140,24 +177,35 @@ de Odoo tal cual).
 
 ---
 
-## El envío al cliente — el tapón real
+## El envío al cliente — CAMINO A, construido y probado (8-sep-2026)
 
-El cascarón tiene una segunda pantalla (**Mandarla al cliente**) y ahí está el bloqueo
-que ningún código resuelve:
+Esteban eligió el **camino A**. Lo demás de esta sección queda como estaba porque la
+disyuntiva sigue viva para más adelante.
 
-**La aplicación de Microsoft Graph que ya usa la suite (`n8n-mail-sender`) tiene una
-Application Access Policy que la limita a UN buzón: `sales@fts.mx`.** Mandar como
-Montalvo o como Ricardo exige permisos nuevos en Azure que hoy no existen.
+**El correo sale de `sales@fts.mx` con el vendedor en «responder a».** El cliente le
+contesta a quien debe; el remitente no es la persona. Cero cambios en Azure. Mandar *como*
+cada vendedor (camino B: ampliar la Application Access Policy, o `Mail.Send` delegado con
+autorización de cada quien) queda para cuando Esteban quiera pagar ese permiso — es dar
+permiso de mandar correo **en nombre de una persona**, y no se pide a la ligera.
 
-Dos caminos, y hay que elegir uno antes de construir:
+El correo del vendedor se resuelve **en el servidor**, no en la pantalla:
+`token.empleado_id` → `hr.employee.work_email`. Va firmado dentro del token, así que nadie
+puede poner el correo de otro como suyo mandando un cuerpo distinto. Si el empleado no
+tiene `work_email` en Odoo, el endpoint **no falla**: manda sin «responder a» y devuelve el
+aviso de que la respuesta llegaría a la casilla común.
 
-- **A · Desde el buzón de siempre.** Sale de `sales@fts.mx` con el vendedor en «responder
-  a». Cero cambios en Azure. El cliente le contesta a quien debe, pero el remitente no es
-  la persona.
-- **B · Como cada vendedor.** Ampliar la Application Access Policy a los buzones de
-  comercial, o dar `Mail.Send` delegado y que cada quien autorice su cuenta. Requiere a
-  Esteban en Azure. Es lo que se ve natural, y también es dar permiso de mandar correo en
-  nombre de una persona.
+### El candado de pruebas
+
+Mientras `MODO_PRUEBA` esté en `true` dentro de `Code - Preparar`, el endpoint **sólo
+acepta `sales@fts.mx`** y contesta `DESTINO_NO_PERMITIDO` a cualquier otro destinatario.
+El candado vive en el **servidor**, no en la pantalla, porque la pantalla se salta con un
+`fetch` a mano. Abrirlo es un cambio deliberado de una línea, con nombre, que se ve en el
+diff.
+
+Probado en vivo el 8-sep (ejecución `90414`): correo a `sales@fts.mx`, PDF de 204 KB
+adjunto, Graph contestó **`202`**, «responder a» = `estebandelacruz@fts.mx`. Y el candado
+probado por el lado que importa (ejecución `90412`): un destinatario inventado de cliente
+devolvió `DESTINO_NO_PERMITIDO` **sin mandar nada**.
 
 ### La regla que gobierna la marca de «enviada»
 
@@ -185,6 +233,62 @@ machote guardado antes y después de apretar y exige que no haya cambiado.
 
 ## Lo que sí funciona hoy
 
-**Bajar la cotización en PDF.** El botón abre una hoja lista para imprimir, y desde ahí
+**La hoja para imprimir.** El botón abre una hoja lista para imprimir, y desde ahí
 «Guardar como PDF» del navegador. No depende de ningún permiso ni de ninguna librería, y
 la hoja lleva sello de DEMOSTRACIÓN mientras no haya folio de Odoo.
+
+**El PDF oficial de Odoo.** Botón *«Traer el PDF de Odoo»* → webhook
+`comercial/cotizacion` en modo `pdf` → el documento que Odoo le genera al cliente, bajado
+como archivo. Es el mismo, byte por byte, que vería el cliente si le mandaran el enlace de
+portal.
+
+### Cómo se baja, y los dos caminos que NO sirven
+
+Se midieron tres el 8-sep-2026:
+
+| camino | resultado |
+|---|---|
+| `POST /web/session/authenticate` con la llave de API | **`Access Denied`** (ejec. `90300`). Las llaves de API de Odoo valen para JSON-RPC, **no** para el login web. |
+| `ir.actions.report.render_qweb_pdf` por RPC | **no existe** en este Odoo; el privado `_render_qweb_pdf` lo rechaza: *«Private methods … cannot be called remotely»*. |
+| **enlace de portal**: `GET /my/orders/<id>?access_token=…&report_type=pdf&download=true` | **200 · `application/pdf` · `%PDF-`** (ejec. `90304`, SO11498). ✅ |
+
+**El `access_token` es una llave de capacidad**: quien la tenga ve la orden completa sin
+entrar a Odoo. Por eso el servidor baja los bytes y devuelve los bytes; **el navegador
+nunca ve el token**. Si el enlace se armara en el navegador, la llave quedaría en el
+historial, en el portapapeles y en cualquier captura de pantalla.
+
+### El campo que liga el machote con la orden
+
+**`comercial.machote.odoo_so_id`** (migración `003_machote.sql`). Es una referencia externa
+**sin llave foránea**, a propósito: el día que un dominio salga de Odoo, el machote no queda
+apuntando a un id que dejó de existir.
+
+**Y cuando está vacío, no hay PDF que traer.** Ése es el estado *normal* de un machote
+recién capturado, no un error: la cotización todavía no se volvió orden en Odoo, así que el
+documento oficial no existe. El endpoint contesta `SIN_ORDEN` con su frase y la pantalla la
+pinta en ámbar —no en rojo— y manda a la hoja para imprimir. Probado (ejec. `90405`).
+
+Los otros desenlaces, todos probados el 8-sep:
+
+| situación | respuesta | ejec. |
+|---|---|---|
+| orden real | `ok` + PDF 204 KB, `%PDF-` | `90404` |
+| machote sin `odoo_so_id` | `SIN_ORDEN` | `90405` |
+| machote **de otra persona** (existe) | `MACHOTE_NO_ENCONTRADO` | `90406` |
+| token vencido | `TOKEN_EXPIRADO` | `90407` |
+| sin `comercial:read` | `SCOPE_INSUFICIENTE` | `90408` |
+| token basura | `TOKEN_MALFORMADO` | `90409` |
+| sin decir cuál | `FALTA_QUE_COTIZACION` | `90410` |
+| orden inexistente | `ORDEN_NO_ENCONTRADA` | `90411` |
+
+El renglón de `TOKEN_EXPIRADO` vale doble, por la misma razón que en `ALMACEN.md`: la
+cripto tuvo que viajar por el MCP como texto, y un solo carácter cambiado habría dado
+`FIRMA_INVALIDA`. Que diga `TOKEN_EXPIRADO` prueba que el HMAC calcula bien.
+
+**El machote de otra persona** se probó contra una fila que **sí existe** — un uuid
+inventado habría dado el mismo `MACHOTE_NO_ENCONTRADO` sin probar nada. Se contestan igual
+a propósito: distinguirlos convertiría el endpoint en un oráculo que confirma qué ids
+existen.
+
+> **El endpoint nace INACTIVO.** Lo enciende Esteban en la UI de n8n. Mientras tanto los
+> botones de la pantalla que lo llaman contestan que no hay servidor — que es la verdad.

--- a/docs/n8n-workflows/fase0/jwt-verify.js
+++ b/docs/n8n-workflows/fase0/jwt-verify.js
@@ -84,6 +84,13 @@ function verifyJWT(token, secret, scopeRequerido) {
   if (scopeRequerido && scopes.indexOf(scopeRequerido) < 0) {
     return { ok:false, error:'SCOPE_INSUFICIENTE', requerido:scopeRequerido, tiene:scopes };
   }
-  return { ok:true, actor: payload.sub || payload.username || null, scopes: scopes, exp: payload.exp };
+  /* `nombre` y `empleado_id` vienen FIRMADOS dentro del token (auth/suite-login los
+   * mete en el payload). Se devuelven aquí para que ningún endpoint tenga que
+   * volver a leerlos de una tabla —ni, peor, aceptarlos del cuerpo de la petición,
+   * que es como alguien pondría el correo de otro como suyo. */
+  return { ok:true, actor: payload.sub || payload.username || null,
+    nombre: payload.nombre || null,
+    empleado_id: (typeof payload.empleado_id === 'number') ? payload.empleado_id : null,
+    scopes: scopes, exp: payload.exp };
 }
 module.exports = { sha256Bytes, hmacSha256, b64urlFromBytes, verifyJWT, strBytes };


### PR DESCRIPTION
Issue #140 · sesión 3.

> ⚠️ **Este PR cambió de contenido.** Nació como la documentación de la sesión 0 (`ROADMAP`, `AUDITORIA-2026-08`, `PROPUESTA-1.0`) y traía escrito *«no mergear todavía»*. El entorno remoto de esta sesión asigna esta misma rama (`claude/comercial-sesion-0-nudc9g`) como rama de trabajo, así que se reinició desde `main` y ahora lleva el trabajo de la sesión 3.
>
> **No se perdió nada, verificado antes de reescribir la rama** (punta anterior: `9b9b42e`):
> | archivo | rama vieja vs `main` |
> |---|---|
> | `docs/comercial/AUDITORIA-2026-08.md` | idéntico |
> | `docs/comercial/PROPUESTA-1.0.md` | idéntico |
> | `docs/comercial/ROADMAP.md` | `main` es **superset**: +43 líneas (§5.1 Decisiones 29-ago, §5.2 identidad) |
>
> Los tres documentos ya estaban en `main` por otra vía, así que el PR estaba superado. Si prefieres que la sesión 3 vaya en un PR propio, ciérralo y lo reabro desde otra rama.

---

## Qué hace

**El botón «Traer el PDF de Odoo»** baja el documento **oficial** —el mismo, byte por byte, que Odoo le enseña al cliente si le mandan el enlace de portal— en vez de la hoja armada aquí, que sigue existiendo al lado.

**Lo trae el servidor, no el navegador**, y eso no es un detalle de implementación: el enlace de portal lleva un `access_token` que es una **llave de capacidad** — quien la tenga ve la orden completa sin entrar a Odoo. Si el enlace se armara en el navegador, la llave acabaría en el historial, en el portapapeles y en cualquier captura de pantalla. Hay una prueba **estática** que lo vigila: si algún día alguien «simplifica» llamando a Odoo desde el navegador, truena aunque la pantalla se vea igual.

**Cuando el machote todavía no tiene orden en Odoo no hay PDF que traer, y la pantalla lo dice** en ámbar y manda a la hoja para imprimir. Ése es el estado *normal* mientras se cotiza, no un error. El campo que liga las dos cosas es `comercial.machote.odoo_so_id` (migración `003`), una referencia externa **sin llave foránea** a propósito.

## Los tres caminos, medidos antes de elegir

| camino | resultado |
|---|---|
| `POST /web/session/authenticate` con la llave de API | **`Access Denied`** — esas llaves valen para JSON-RPC, no para el login web (ejec. `90300`) |
| `render_qweb_pdf` por RPC | **no existe** en este Odoo; el privado lo rechaza («Private methods … cannot be called remotely») |
| **enlace de portal** `?access_token=…&report_type=pdf&download=true` | **200 · `application/pdf` · `%PDF-`** ✅ (ejec. `90304`, SO11498) |

## El envío por correo

Construido y **probado en vivo**: sale de `sales@fts.mx` con el vendedor en «responder a» (**camino A**, decisión de Esteban). El correo del vendedor se resuelve en el servidor desde el `empleado_id` que viene **firmado dentro del token**, nunca del cuerpo — si viniera del cuerpo, cualquiera podría poner el correo de otro como suyo.

Ejecución `90414`: Graph contestó **`202`**, PDF de 204 KB adjunto, `responder_a: estebandelacruz@fts.mx`.

Su webhook **nace apagado** y trae un candado *de servidor* que sólo deja mandar a `sales@fts.mx` — probado por el lado que importa: un destinatario de cliente devolvió `DESTINO_NO_PERMITIDO` **sin mandar nada** (ejec. `90412`). El candado no está en la pantalla porque la pantalla se salta con un `fetch` a mano.

**La marca de enviada sigue sin escribirse.** La dispara la confirmación de Graph, nunca el clic — y falta decidir si va también a Odoo. Queda declarada como contrato pendiente (`marca_enviada.aplicada: false`, `procede: true`), no simulada.

## Correcciones de cosas que decían falsedades

- La pantalla afirmaba que *«el webhook de envío no existe y el permiso de correo tampoco»*. Las dos mitades ya son falsas.
- `docs/comercial/ALMACEN.md` documentaba `UPDATE comercial.suite_usuario …` — **esa tabla no existe** y ese SQL nunca se ejecutó; los usuarios viven en una Data Table de n8n.
- `CLAUDE.md` §20 #10 explicaba un mecanismo de colapso de `$$` en expresiones de n8n que, **medido**, no se reproduce (ejec. `90310` y `90312`: `$$`, `$1`, `$&`, `` $` ``, `$'` y `$<x>` sobreviven enteros, en expresión completa y embebida). La regla operativa se queda; el mecanismo queda marcado como no probado.

## Dos cosas que salieron de MIRAR las capturas, no del diff

1. A 380 px la respuesta del botón caía en el borde de abajo del modal: se apretaba y no se veía qué contestó.
2. El título decía **«demostración»** encima de un botón que ya funciona de verdad. Un cartel de «esto es de mentiras» sobre algo real enseña a no creerle a los carteles.

## Plan de prueba

- [x] **145 pruebas en verde**, 0 fallidas (142 + 3 nuevas), sin errores de consola propios
- [x] 380 px y 1280 px **mirados en captura**, cero `pageerror`
- [x] 11/11 casos del endpoint contra Odoo real (ejecuciones `90404`–`90414`)
- [x] El machote **de otra persona** probado contra una fila que sí existe → `MACHOTE_NO_ENCONTRADO`
- [x] `TOKEN_EXPIRADO` y no `FIRMA_INVALIDA` — la criptografía viajó como texto por el MCP y calcula bien
- [ ] `fetch` desde el navegador real con CORS — **no se puede probar aquí**: el contenedor no tiene salida HTTP (proxy `403 a CONNECT`)

## Workflow

`comercial/cotizacion` (`dahVXA1NyF1AXfc4`), 12 nodos, **INACTIVO**. Lo enciende Esteban.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013Qzhio6K8R23HXHnJ2RJ64