### PR TITLE
comercial(machote): la pantalla como el libro, y operable en teléfono

### DIFF
--- a/comercial/machote/README.md
+++ b/comercial/machote/README.md
@@ -45,6 +45,23 @@ reparte entre secciones **a prorrata del costo**. Por eso mover un multiplicador
 en ese escenario no cambia el precio: sólo cambia el reparto. Es una propiedad
 del machote, no un error, y hay una prueba que la fija.
 
+## La pantalla
+
+La hoja se dibuja con la retícula del machote: pestañas por hoja, el bloque de
+`Costos desglosados` y la tabla de márgenes arriba, `COSTO MANO DE OBRA` con sus
+diez renglones fijos en tres grupos, y `COSTO MATERIALES Y SERVICIOS` con sus
+trece columnas. La hoja `DESGLOSE COTIZACIÓN` trae los tres escenarios, el
+`RESUMEN BUDGET`, las diez ranuras de sección, el `BUDGET ODOO` y la tabla de
+comisiones.
+
+**En teléfono la retícula desaparece.** Catorce columnas con el pulgar no se
+capturan: cada renglón se vuelve una tarjeta con sus campos etiquetados, los
+renglones de mano de obra en cero se pliegan detrás de un interruptor que dice
+cuántos hay, y nada de lo que se toca mide menos de 44 px. En pantalla ancha
+vuelve a ser la retícula completa. Hay pruebas para las dos formas.
+
+Reproducir el Excel en un teléfono habría sido fidelidad mal entendida.
+
 ## Cómo correr las pruebas
 
 ```bash
@@ -53,6 +70,11 @@ node comercial/machote/tests/pruebas-navegador.js
 ```
 
 Corren contra el archivo local, sin servidor, a 380 px y a 1280 px.
+
+⚠️ **No instales `@playwright/cli` en este repo sin fijar la versión.** Arrastra
+un `playwright-core` de prerelease cuyo protocolo no habla con el Chromium del
+contenedor de Claude Code: el navegador arranca y nunca contesta, y el fallo se
+ve como un cuelgue sin mensaje.
 
 Cuatro fallos que encontraron estas pruebas y que leer el código no habría
 encontrado:
@@ -64,6 +86,11 @@ encontrado:
 3. Un `<input>` sin `flex` usa su ancho intrínseco (~177 px). Dos en la misma
    fila desbordaban la pantalla del reparto de comisiones.
 4. La fila de mano de obra desbordaba 7 px por no dejar encoger los campos.
+5. `shared/fts-styles.css` define `.btn{width:100%}` para el kiosko. En la barra
+   fija eso hacía que "Revisar" se comiera el ancho entero y el precio quedara
+   en **cero px**: la pantalla se veía bien y el dato no estaba.
+6. `td[colspan]{display:none}` ocultaba también los títulos de grupo de las
+   tarjetas, que son justo lo que las ordena.
 
 ## Lo que falta para que esto deje de ser prototipo
 

--- a/comercial/machote/css/machote.css
+++ b/comercial/machote/css/machote.css
@@ -1,263 +1,303 @@
-/* ═══ Machote · estilos ═══
- * Extiende shared/fts-styles.css. Solo lo que el sistema de la suite no trae.
+/* ═══ Machote · la hoja ═══
  *
- * NOTA DE DISEÑO: la suite fija .scr a max-width 520px (mobile-first, centrado
- * en escritorio). El machote es la excepción: sus tablas de BOM no caben en
- * 520px sin volverse ilegibles. Aquí .scr crece en escritorio y se queda en
- * 520 para las pantallas de decisión (aprobación del AM), que sí son de bolsillo.
+ * Dos modos, un solo marcado:
+ *   ≥720 px  la retícula del Excel, con desplazamiento horizontal.
+ *   <720 px  cada renglón se vuelve una TARJETA con sus campos etiquetados.
+ *
+ * La retícula de catorce columnas es correcta en una laptop e inservible con
+ * el pulgar. Reproducir el Excel en un teléfono sería fidelidad mal entendida.
  */
 
-.scr { max-width: 520px; }
-@media (min-width: 760px) {
-  .scr.ancho { max-width: 920px; }
+:root {
+  --tinta: #1c1c1c;
+  --suave: #6b6b6b;
+  --linea: #dcdcdc;
+  --linea2: #ececec;
+  --fondo: #ffffff;
+  --papel: #f6f7f8;
+  --cab: #eef1f4;
+  --acento: #0969da;
+  --verde: #1a7f37;
+  --ambar: #9a6700;
+  --rojo: #cf222e;
+  --toque: 44px;   /* altura mínima de cualquier cosa que se toque */
 }
 
-/* ── Layout base ── */
-.pad { padding: 14px; display: flex; flex-direction: column; gap: 12px; }
-.pad.tight { gap: 8px; }
+/* ── Base ─────────────────────────────────────────────────────────────── */
+.scr { background: var(--fondo); color: var(--tinta); }
+.pad { padding: 14px; }
+.mono { font-variant-numeric: tabular-nums; font-feature-settings: "tnum"; }
+.tiny { font-size: 12px; color: var(--suave); line-height: 1.45; }
+.nota { color: var(--suave); line-height: 1.45; margin: 6px 0; font-size: 12px; }
+.oc { display: inline-block; font-size: 10px; font-weight: 700; padding: 2px 7px;
+      border-radius: 5px; background: var(--papel); color: var(--suave); white-space: nowrap; }
+.grow { flex: 1 1 auto; min-width: 0; }
+.right { text-align: right; flex-shrink: 0; }
 .row { display: flex; gap: 8px; align-items: center; }
-.row.wrap { flex-wrap: wrap; }
-.grow { flex: 1; min-width: 0; }
-.right { margin-left: auto; }
-.mono { font-variant-numeric: tabular-nums; }
-.tiny { font-size: 11px; color: var(--muted2); }
-.hide { display: none !important; }
+.n-ok { color: var(--verde); } .n-warn { color: var(--ambar); } .n-bad { color: var(--rojo); }
+h2 { font-size: 19px; margin: 4px 0 10px; }
+h3 { font-size: 15px; margin: 16px 0 8px; }
+h4 { font-size: 14px; margin: 0 0 8px; }
 
-h2.sec-t { font-size: 15px; font-weight: 700; margin: 4px 0 0; }
-h3.sub-t { font-size: 12px; font-weight: 700; color: var(--muted2); text-transform: uppercase;
-           letter-spacing: .6px; margin: 10px 0 2px; }
+/* ── Lista ────────────────────────────────────────────────────────────── */
+.item { display: flex; gap: 10px; align-items: center; padding: 12px;
+        border: 1px solid var(--linea); border-radius: 10px; margin-bottom: 8px;
+        text-decoration: none; color: inherit; background: var(--fondo); }
+.item:active { background: var(--papel); }
+.chip { display: inline-block; color: #fff; font-size: 10px; font-weight: 700;
+        padding: 2px 8px; border-radius: 20px; }
+.aviso { border: 1px solid var(--linea); border-left: 3px solid var(--acento);
+         background: var(--papel); padding: 10px 12px; border-radius: 8px;
+         margin: 10px 0; font-size: 13px; line-height: 1.5; }
+.aviso.bad { border-left-color: var(--rojo); }
+.aviso.ok  { border-left-color: var(--verde); }
+.vacio, .vacio2 { color: var(--suave); font-size: 13px; padding: 14px; text-align: center; }
+.wg { border: 1px solid var(--linea); border-radius: 10px; padding: 12px; margin-bottom: 12px; }
+.wg.bad  { border-left: 3px solid var(--rojo); }
+.wg.warn { border-left: 3px solid var(--ambar); }
+.wg.info { border-left: 3px solid var(--acento); }
+.kpi { display: flex; gap: 8px; margin-bottom: 12px; }
+.kpi > div { flex: 1; border: 1px solid var(--linea); border-radius: 10px; padding: 10px;
+             display: flex; flex-direction: column; gap: 2px; }
+.kpi strong { font-size: 17px; }
+.tot { display: flex; justify-content: space-between; gap: 10px; padding: 5px 0;
+       border-bottom: 1px solid var(--linea2); font-size: 13px; }
+.tot:last-child { border-bottom: 0; }
+.tot .lb { color: var(--suave); }
 
-/* ── Chips de estado ── */
-.chip { font-size: 10px; font-weight: 800; letter-spacing: .4px; padding: 3px 9px; border-radius: 20px;
-        border: 1px solid var(--border); background: var(--d3); color: var(--muted2); white-space: nowrap; }
-.chip.verde { background: #eaf6ea; border-color: #b9e0b9; color: var(--green); }
-.chip.ambar { background: #fff6e5; border-color: #f0d49b; color: #9a6700; }
-.chip.rojo  { background: #fdecec; border-color: #f2bcbc; color: var(--red); }
-.chip.azul  { background: #e8f2fc; border-color: #b6d7f5; color: var(--blue); }
-.chip.gris  { background: var(--d3); }
+/* ── Pestañas de hoja ─────────────────────────────────────────────────── */
+.libro { padding: 0 0 12px; }
+.hojas { display: flex; gap: 2px; overflow-x: auto; padding: 8px 10px 0;
+         border-bottom: 1px solid var(--linea); background: var(--papel);
+         -webkit-overflow-scrolling: touch; scrollbar-width: thin; }
+.pestana { flex: 0 0 auto; border: 1px solid var(--linea); border-bottom: 0;
+           background: var(--cab); color: var(--suave);
+           padding: 9px 13px; font-size: 12px; font-weight: 600;
+           border-radius: 7px 7px 0 0; cursor: pointer; white-space: nowrap;
+           min-height: var(--toque); }
+.pestana.on { background: var(--fondo); color: var(--tinta); border-bottom: 1px solid var(--fondo);
+              margin-bottom: -1px; }
+.pestana.mas { font-size: 17px; padding: 6px 14px; font-weight: 400; }
 
-/* ── Tarjetas de lista ── */
-.item { background: var(--d2); border: 1px solid var(--border); border-radius: 12px; padding: 13px 14px;
-        display: flex; flex-direction: column; gap: 7px; cursor: pointer; transition: all .15s;
-        text-align: left; width: 100%; font-family: inherit; font-size: inherit; color: inherit; }
-.item:active { transform: scale(.99); border-color: var(--o); }
-.item .t1 { display: flex; align-items: flex-start; gap: 8px; }
-.item .nm { font-weight: 700; font-size: 14px; line-height: 1.3; }
-.item .cl { font-size: 12px; color: var(--muted2); }
-.item .t2 { display: flex; gap: 14px; align-items: baseline; font-size: 12px; color: var(--muted2); }
-.item .t2 b { color: var(--text); font-size: 13px; }
+/* ── Bloques de encabezado ────────────────────────────────────────────── */
+.cab, .desg-top { display: flex; flex-wrap: wrap; gap: 12px; padding: 12px; }
+.blk { flex: 1 1 320px; min-width: 0; }
+.et2 { font-size: 11px; font-weight: 700; letter-spacing: .04em; color: var(--suave);
+       text-transform: uppercase; margin-bottom: 6px; }
+.escs { display: flex; gap: 6px; flex-wrap: wrap; }
+.escbtn { flex: 1 1 auto; min-height: var(--toque); border: 1px solid var(--linea);
+          background: var(--fondo); border-radius: 8px; font-size: 12px; font-weight: 700;
+          padding: 10px 12px; cursor: pointer; color: var(--suave); }
+.escbtn.on { border-color: var(--acento); color: var(--acento); background: #f0f6ff;
+             box-shadow: inset 0 0 0 1px var(--acento); }
 
-/* ── Formularios ── */
-.f { display: flex; flex-direction: column; gap: 4px; }
-.f > label { font-size: 11px; font-weight: 700; color: var(--muted2); }
-.f input, .f select, .f textarea {
-  width: 100%; padding: 9px 10px; font-size: 14px; font-family: inherit; color: var(--text);
-  background: var(--d2); border: 1px solid var(--border); border-radius: 8px; }
-.f input:focus, .f select:focus, .f textarea:focus { outline: 2px solid var(--o); outline-offset: -1px; border-color: var(--o); }
-.f textarea { resize: vertical; min-height: 70px; line-height: 1.5; }
-.f input.num { text-align: right; font-variant-numeric: tabular-nums; }
-.f input.err, .f select.err { border-color: var(--red); background: #fff8f8; }
-.fgrid { display: grid; grid-template-columns: 1fr 1fr; gap: 10px; }
-.fgrid.c3 { grid-template-columns: 1fr 1fr 1fr; }
-@media (max-width: 420px) { .fgrid.c3 { grid-template-columns: 1fr 1fr; } }
+table.hoja2 { width: 100%; border-collapse: collapse; font-size: 13px; }
+table.hoja2 th { background: var(--cab); text-align: left; font-size: 11px;
+                 padding: 7px 8px; border: 1px solid var(--linea); }
+table.hoja2 td { padding: 5px 8px; border: 1px solid var(--linea2); }
+table.hoja2 td.et { color: var(--suave); }
+table.hoja2 td.vl { text-align: right; white-space: nowrap; }
 
-/* ── Renglones de BOM y MO ── */
-.lin { border: 1px solid var(--border); border-radius: 10px; padding: 10px; background: var(--d2);
-       display: flex; flex-direction: column; gap: 8px; }
-.lin + .lin { margin-top: 8px; }
-.lin .lin-hd { display: flex; align-items: center; gap: 8px; }
-.lin .lin-hd .idx { font-size: 10px; font-weight: 800; color: var(--muted); flex-shrink: 0;
-                    width: 20px; text-align: center; }
-.lin .lin-tot { font-weight: 700; font-size: 13px; font-variant-numeric: tabular-nums; white-space: nowrap; }
-.lin .lin-tot.nd { color: var(--red); font-weight: 800; font-size: 11px; }
-.del { background: none; border: none; color: var(--muted); font-size: 17px; cursor: pointer;
-       padding: 2px 4px; line-height: 1; flex-shrink: 0; }
-.del:hover { color: var(--red); }
+.nomsec { display: flex; align-items: center; gap: 10px; flex-wrap: wrap;
+          padding: 0 12px 12px; }
+.nomsec .et { font-size: 11px; font-weight: 700; color: var(--suave); letter-spacing: .04em; }
+.nomsec .cel.nombre { flex: 1 1 200px; font-weight: 700; font-size: 15px; }
 
-/* ── Origen del precio ── */
-.oc { font-size: 10px; font-weight: 700; padding: 2px 7px; border-radius: 5px; white-space: nowrap; }
-.oc.alta    { background: #eaf6ea; color: var(--green); }
-.oc.media   { background: #fff6e5; color: #9a6700; }
-.oc.baja    { background: #fdeee5; color: #b34700; }
-.oc.ninguna { background: #fdecec; color: var(--red); }
+.secc-tit { background: var(--cab); font-size: 11px; font-weight: 700; letter-spacing: .05em;
+            padding: 9px 12px; border-top: 1px solid var(--linea);
+            border-bottom: 1px solid var(--linea); margin-top: 6px; }
 
-/* ── Totales ── */
-.tot { display: flex; justify-content: space-between; align-items: baseline; padding: 6px 0;
-       font-size: 13px; gap: 12px; }
-.tot + .tot { border-top: 1px dashed var(--border); }
-.tot .lb { color: var(--muted2); }
-.tot .vl { font-weight: 700; font-variant-numeric: tabular-nums; white-space: nowrap; }
-.tot.big { font-size: 15px; padding: 10px 0; }
-.tot.big .vl { font-size: 17px; font-weight: 800; }
-.tot.pos .vl { color: var(--green); }
-.tot.neg .vl { color: var(--red); }
+/* ── Retícula ─────────────────────────────────────────────────────────── */
+.scroll { overflow-x: auto; -webkit-overflow-scrolling: touch; }
+table.rejilla { border-collapse: collapse; font-size: 12.5px; width: 100%; }
+table.rejilla th { background: var(--cab); color: var(--suave); font-size: 10px;
+                   font-weight: 700; letter-spacing: .03em; text-align: left;
+                   padding: 7px 6px; border: 1px solid var(--linea); white-space: nowrap; }
+table.rejilla td { padding: 2px 4px; border: 1px solid var(--linea2); vertical-align: middle; }
+table.rejilla tr.grupo td { background: var(--papel); font-weight: 700; font-size: 11px;
+                            color: var(--suave); padding: 6px 8px; }
+table.rejilla tr.total td { background: var(--papel); font-weight: 700; }
+table.rejilla tr.vacia td { color: #b9b9b9; }
+table.rejilla td.vl { text-align: right; white-space: nowrap; }
+table.rejilla td.fuerte { font-weight: 700; }
+table.rejilla td.ro { color: var(--suave); }
+table.rejilla td.rotulo { font-weight: 600; white-space: nowrap; }
+table.rejilla td.acc { text-align: center; }
+table.rejilla .pctcol { color: var(--suave); text-align: right; }
+.x { border: 0; background: transparent; color: var(--rojo); font-size: 16px;
+     cursor: pointer; min-height: var(--toque); min-width: var(--toque); }
 
-/* ── Barra fija de totales (siempre visible mientras se captura) ── */
-.fija { position: sticky; bottom: 0; z-index: 40; background: rgba(255,255,255,.97);
-        backdrop-filter: blur(8px); border-top: 1px solid var(--border);
-        padding: 9px 14px; display: flex; align-items: center; gap: 12px;
-        box-shadow: 0 -2px 10px rgba(0,0,0,.05); }
-.fija .b { display: flex; flex-direction: column; line-height: 1.25; }
-.fija .b span { font-size: 9px; font-weight: 700; color: var(--muted); letter-spacing: .4px; }
-.fija .b b { font-size: 14px; font-variant-numeric: tabular-nums; }
-.fija .mg b { font-size: 18px; font-weight: 800; }
-.fija .mg.ok b { color: var(--green); }
-.fija .mg.warn b { color: #9a6700; }
-.fija .mg.bad b { color: var(--red); }
+/* ── Celdas editables ─────────────────────────────────────────────────── */
+.cel { border: 1px solid transparent; background: transparent; font: inherit;
+       color: inherit; padding: 7px 5px; border-radius: 5px; width: 100%;
+       box-sizing: border-box; min-width: 0; }
+.cel:hover { border-color: var(--linea); }
+.cel:focus { outline: 0; border-color: var(--acento); background: #fff;
+             box-shadow: 0 0 0 2px rgba(9,105,218,.15); }
+.cel.num { text-align: right; font-variant-numeric: tabular-nums; }
+.cel.pisado { background: #fff8e5; border-color: #e6c200; }
+select.cel { -webkit-appearance: none; appearance: none; padding-right: 16px;
+             background-image: linear-gradient(45deg, transparent 50%, var(--suave) 50%),
+                               linear-gradient(135deg, var(--suave) 50%, transparent 50%);
+             background-position: right 6px center, right 2px center;
+             background-size: 4px 4px, 4px 4px; background-repeat: no-repeat; }
+.w60 { width: 60px } .w70 { width: 70px } .w80 { width: 80px }
+.w90 { width: 90px } .w110 { width: 110px } .w130 { width: 130px }
+.cel.desc { min-width: 190px; }
 
-/* ── KPI grande (aprobación) ── */
-.kpi { text-align: center; padding: 20px 14px; }
-.kpi .n { font-size: 54px; font-weight: 800; line-height: 1; font-variant-numeric: tabular-nums; letter-spacing: -1px; }
-.kpi .n.ok { color: var(--green); } .kpi .n.warn { color: #9a6700; } .kpi .n.bad { color: var(--red); }
-.kpi .l { font-size: 12px; color: var(--muted2); margin-top: 6px; }
-.kpi .sub { font-size: 13px; color: var(--muted2); margin-top: 10px; font-variant-numeric: tabular-nums; }
+/* ── Botones y barra fija ─────────────────────────────────────────────── */
+.btn { display: inline-flex; align-items: center; justify-content: center;
+       min-height: var(--toque); padding: 10px 16px; border: 1px solid var(--linea);
+       border-radius: 9px; background: var(--fondo); color: var(--tinta);
+       font-size: 13px; font-weight: 600; cursor: pointer; text-decoration: none; }
+.btn:active { background: var(--papel); }
+.btn[disabled] { opacity: .45; cursor: not-allowed; }
+.btn.del { color: var(--rojo); border-color: #f0c8cc; }
+.btnrow { display: flex; gap: 8px; align-items: center; flex-wrap: wrap; padding: 10px 12px; }
+#fija { position: sticky; bottom: 0; z-index: 5; }
+.fija { display: flex; gap: 10px; align-items: center; padding: 10px 12px;
+        border-top: 1px solid var(--linea); background: var(--fondo);
+        box-shadow: 0 -3px 12px rgba(0,0,0,.06);
+        padding-bottom: calc(10px + env(safe-area-inset-bottom)); }
+.fija .mono { font-size: 15px; font-weight: 700; }
+textarea { width: 100%; box-sizing: border-box; border: 1px solid var(--linea);
+           border-radius: 8px; padding: 9px; font: inherit; }
+.toast { position: fixed; left: 50%; bottom: 78px; transform: translate(-50%, 12px);
+         background: #222; color: #fff; padding: 10px 16px; border-radius: 20px;
+         font-size: 13px; opacity: 0; transition: .25s; z-index: 50; }
+.toast.on { opacity: 1; transform: translate(-50%, 0); }
 
-/* ── Hallazgos del revisador ── */
-.hz { border-left: 4px solid var(--border); background: var(--d2); border: 1px solid var(--border);
-      border-left-width: 4px; border-radius: 10px; padding: 11px 13px; }
-.hz.dura   { border-left-color: var(--red); }
-.hz.blanda { border-left-color: #e8a33d; }
-.hz.info   { border-left-color: var(--blue); }
-.hz .hz-t { font-weight: 700; font-size: 13px; display: flex; gap: 7px; align-items: flex-start; }
-.hz .hz-d { font-size: 12px; color: var(--muted2); margin-top: 4px; line-height: 1.5; }
-.hz ul { margin: 7px 0 0 16px; padding: 0; }
-.hz li { font-size: 12px; color: var(--muted2); margin-bottom: 3px; line-height: 1.45; }
-.hz .hz-a { font-size: 10px; color: var(--muted); text-transform: uppercase; letter-spacing: .5px;
-            font-weight: 700; margin-bottom: 3px; }
+/* ══ Teléfono: la retícula se vuelve tarjetas ═════════════════════════ */
+@media (max-width: 720px) {
+  .cab, .desg-top { padding: 10px; gap: 10px; }
+  .blk { flex: 1 1 100%; }
+  .escbtn { flex: 1 1 100%; }
 
-/* ── Simulador ── */
-.sim-out { display: grid; grid-template-columns: 1fr 1fr; gap: 10px; }
-.sim-box { background: var(--d3); border: 1px solid var(--border); border-radius: 10px; padding: 12px; text-align: center; }
-.sim-box .n { font-size: 22px; font-weight: 800; font-variant-numeric: tabular-nums; }
-.sim-box .l { font-size: 10px; color: var(--muted2); text-transform: uppercase; letter-spacing: .5px; margin-top: 3px; }
-input[type=range] { width: 100%; accent-color: var(--o); height: 26px; }
+  /* Las tablas de captura dejan de ser tablas. */
+  table.rejilla.tarjetas, table.rejilla.tarjetas tbody,
+  table.rejilla.tarjetas tr, table.rejilla.tarjetas td { display: block; width: auto; }
+  table.rejilla.tarjetas thead { display: none; }
+  table.rejilla.tarjetas { border: 0; }
+  table.rejilla.tarjetas tr { border: 1px solid var(--linea); border-radius: 10px;
+                              margin: 8px 10px; padding: 4px 10px 8px; background: var(--fondo); }
+  table.rejilla.tarjetas tr.grupo { border: 0; background: transparent; margin: 14px 10px 2px;
+                                    padding: 0; }
+  table.rejilla.tarjetas tr.grupo td { background: transparent; padding: 0;
+                                       font-size: 11px; letter-spacing: .06em; }
+  table.rejilla.tarjetas tr.total { background: var(--papel); }
+  table.rejilla.tarjetas td { border: 0; border-bottom: 1px solid var(--linea2);
+                              display: flex; align-items: center; gap: 10px;
+                              padding: 4px 0; min-height: var(--toque); }
+  table.rejilla.tarjetas td:last-child { border-bottom: 0; }
+  table.rejilla.tarjetas td::before { content: attr(data-l); flex: 0 0 42%;
+                                      font-size: 11px; color: var(--suave);
+                                      text-transform: none; }
+  table.rejilla.tarjetas td.vl { justify-content: space-between; }
+  /* El nombre del renglón encabeza la tarjeta, sin etiqueta. */
+  table.rejilla.tarjetas td.rotulo { font-size: 14px; font-weight: 700;
+                                     border-bottom: 1px solid var(--linea);
+                                     padding: 8px 0 6px; }
+  table.rejilla.tarjetas td.rotulo::before { content: none; }
+  table.rejilla.tarjetas td.solo-ancho { display: none; }
+  table.rejilla.tarjetas td:empty { display: none; }
+  /* Ojo: `td[colspan]` a secas también ocultaba el título de grupo, que es
+     justo lo que ordena la tarjeta. Se ocultan sólo los rellenos. */
+  table.rejilla.tarjetas tr.total td[colspan] { display: none; }
+  table.rejilla.tarjetas tr:not(.grupo):not(.total) td[colspan] { display: none; }
+  table.rejilla.tarjetas .cel { text-align: left; }
+  table.rejilla.tarjetas .cel.num { text-align: right; }
+  table.rejilla.tarjetas .w60, table.rejilla.tarjetas .w70, table.rejilla.tarjetas .w80,
+  table.rejilla.tarjetas .w90, table.rejilla.tarjetas .w110, table.rejilla.tarjetas .w130,
+  table.rejilla.tarjetas .cel.desc { width: auto; min-width: 0; flex: 1 1 auto; }
+  table.rejilla.tarjetas .cel { border: 1px solid var(--linea); background: #fff;
+                                min-height: var(--toque); padding: 10px 8px; }
+  table.rejilla.tarjetas td.acc { justify-content: flex-end; }
+  table.rejilla.tarjetas .x { font-size: 13px; min-width: 0; padding: 0 10px;
+                              border: 1px solid #f0c8cc; border-radius: 8px; }
 
-/* ── Widgets ── */
-.wg { border: 1px dashed var(--border); border-radius: 10px; padding: 11px; background: var(--d3); }
-.wg .wg-t { font-weight: 700; font-size: 12px; }
-.wg .wg-f { font-size: 10px; color: var(--muted); font-style: italic; margin-top: 2px; }
-.wg .wg-r { font-size: 20px; font-weight: 800; font-variant-numeric: tabular-nums; }
+  /* Las tablas de sólo lectura siguen siendo tablas, con arrastre lateral. */
+  .scroll { padding-bottom: 2px; }
+  table.rejilla.ancha, table.rejilla.estrecha { min-width: 640px; }
+  table.rejilla.estrecha { min-width: 0; width: 100%; }
 
-/* ── Pasos de la simulación de confirmación ── */
-.pasos { display: flex; flex-direction: column; gap: 0; }
-.paso { display: flex; gap: 11px; align-items: flex-start; padding: 9px 0; }
-.paso .mk { width: 22px; height: 22px; border-radius: 50%; border: 2px solid var(--border);
-            flex-shrink: 0; display: flex; align-items: center; justify-content: center;
-            font-size: 11px; font-weight: 800; background: var(--d2); color: var(--muted);
-            transition: all .3s; }
-.paso.run .mk { border-color: var(--o); color: var(--o); animation: pulso 1s infinite; }
-.paso.ok .mk  { border-color: var(--green); background: var(--green); color: #fff; }
-.paso .px { flex: 1; min-width: 0; }
-.paso .pt { font-size: 13px; font-weight: 600; }
-.paso.wait .pt { color: var(--muted); }
-.paso .pr { font-size: 11px; color: var(--green); margin-top: 2px; font-variant-numeric: tabular-nums; }
-@keyframes pulso { 0%,100% { opacity: 1 } 50% { opacity: .35 } }
-
-/* ── Avisos ── */
-.aviso { border-radius: 10px; padding: 11px 13px; font-size: 12.5px; line-height: 1.5; }
-.aviso.rojo  { background: #fdecec; border: 1px solid #f2bcbc; color: #8d2226; }
-.aviso.ambar { background: #fff6e5; border: 1px solid #f0d49b; color: #7a5200; }
-.aviso.verde { background: #eaf6ea; border: 1px solid #b9e0b9; color: #0b5e0b; }
-.aviso.azul  { background: #e8f2fc; border: 1px solid #b6d7f5; color: #0b4f86; }
-.aviso b { font-weight: 700; }
-
-.vacio { text-align: center; padding: 26px 14px; color: var(--muted); font-size: 13px; }
-.btn.sm { width: auto; padding: 8px 14px; font-size: 12px; border-radius: 7px; }
-.btn.mini { width: auto; padding: 6px 11px; font-size: 11px; border-radius: 6px; }
-.btnrow { display: flex; gap: 8px; }
-.btnrow .btn { flex: 1; }
-
-/* ── Pasada 1 · renglones plegables ──
-   Con 16 partidas por sección, ver los 7 campos de cada una hacía la pantalla
-   un muro. Cerrado se lee de un vistazo; abierto se edita. */
-button.lin { cursor: pointer; font-family: inherit; font-size: inherit; color: inherit; text-align: left;
-             width: 100%; box-sizing: border-box; }
-.lin.cerrada { padding: 9px 10px; }
-.lin.cerrada:active { background: var(--d3); }
-.lin.cerrada .lin-hd { align-items: center; gap: 9px; }
-.lin.cerrada .cd { font-size: 13px; font-weight: 600; line-height: 1.3;
-                   overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
-.lin.cerrada .cm { font-size: 11px; color: var(--muted2); margin-top: 2px;
-                   overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
-.lin.cerrada.mal { border-color: #f2bcbc; background: #fffafa; }
-.lin.abierta { border-color: var(--o); box-shadow: 0 0 0 2px rgba(216,59,1,.10); }
-.chev { color: var(--muted); font-size: 18px; flex-shrink: 0; line-height: 1; }
-
-/* El monto nunca se encoge: es el dato que el analista viene a leer.
-   Lo que se recorta es la descripción, que ya tiene su elipsis. */
-.lin .lin-tot { flex-shrink: 0; }
-.lin.cerrada .lin-tot { font-size: 12.5px; }
-.lin.cerrada .lin-hd > .grow { min-width: 0; flex: 1 1 auto; }
-@media (max-width: 400px) { .lin.cerrada .lin-tot { font-size: 12px; } }
-
-/* ── Pasada 2 · el costo incompleto se ve incompleto ── */
-.fija .b b.inc { color: #9a6700; }
-.fija .b span { white-space: nowrap; }
-/* Un botón deshabilitado no debe seguir pareciendo la acción principal:
-   en un teléfono se toca antes de leer por qué no se puede. */
-.btn[disabled], .btn:disabled {
-  background: var(--d4) !important; color: var(--muted) !important;
-  border: 1px solid var(--border) !important; opacity: 1 !important; cursor: not-allowed; }
-.btn[disabled]:active { transform: none; }
-
-/* ── Pasada 3 · el siguiente paso, siempre a la vista ── */
-.prox { display: flex; align-items: center; gap: 10px; padding: 10px 14px;
-        background: #fff6e5; border-bottom: 1px solid #f0d49b; }
-.prox.ok { background: #eaf6ea; border-bottom-color: #b9e0b9; }
-.prox .pl { font-size: 9px; font-weight: 800; letter-spacing: .6px; color: #9a6700; }
-.prox.ok .pl { color: var(--green); }
-.prox .pd { font-size: 13px; font-weight: 600; line-height: 1.3; margin-top: 1px; }
-.prox .btn { flex-shrink: 0; }
-
-/* La topbar vive dentro de .scr: en escritorio comparte su ancho en vez de
-   abarcar toda la ventana mientras el contenido va centrado. */
-.scr > .topbar { border-left: 1px solid var(--border); border-right: 1px solid var(--border); }
-@media (max-width: 560px) { .scr > .topbar { border-left: 0; border-right: 0; } }
-.scr { background: var(--dark); }
-
-/* ── Renglón de mano de obra ────────────────────────────────────────────
- * Tres campos numéricos, una etiqueta y un total en la misma línea. A 380 px
- * la suma de anchos mínimos desbordaba 7 px: los campos necesitan poder
- * encogerse (min-width:0) y no sumar padding al ancho. */
-.row.lin-mo { gap: 6px; margin: 2px 0; }
-.row.lin-mo > .grow { min-width: 0; flex: 1 1 auto; overflow: hidden; text-overflow: ellipsis; }
-.row.lin-mo input {
-  flex: 0 1 54px; min-width: 0; width: 54px; box-sizing: border-box;
-  padding: 6px; font-size: 13px; text-align: right;
-  border: 1px solid var(--border, #d8d8d8); border-radius: 6px;
-  font-variant-numeric: tabular-nums;
-}
-.row.lin-mo .lin-tot { flex: 0 0 auto; min-width: 60px; text-align: right; }
-
-/* Ninguna fila de la estación debe poder empujar el ancho del documento. */
-.wg .row { max-width: 100%; }
-.wg .row > input, .wg .row > select { min-width: 0; box-sizing: border-box; }
-
-@media (max-width: 400px) {
-  .row.lin-mo input { flex-basis: 44px; width: 44px; padding: 6px 3px; font-size: 12px; }
-  .row.lin-mo .lin-tot { min-width: 50px; font-size: 11.5px; }
-  .row.lin-mo > .grow { font-size: 11.5px; }
+  .pestana { font-size: 11.5px; padding: 9px 11px; }
+  .nomsec { padding: 0 10px 10px; }
+  .kpi { flex-wrap: wrap; }
+  .kpi > div { flex: 1 1 45%; }
 }
 
-/* ── Filas de reparto de comisiones ─────────────────────────────────────
- * Un <input> sin flex usa su ancho intrínseco (~177 px por el size=20 que
- * traen por omisión). Dos de ellos en la misma fila empujaban el documento a
- * 859 px dentro de una ventana de 380. Se les fija base y se les deja encoger. */
-.wg .row > input { flex: 1 1 auto; min-width: 0; box-sizing: border-box; }
-.wg .row > input.num { flex: 0 1 82px; width: 82px; text-align: right; font-variant-numeric: tabular-nums; }
-.wg .row > .lin-tot { flex: 0 0 auto; min-width: 64px; text-align: right; }
+/* En pantallas anchas la retícula puede respirar. */
+@media (min-width: 721px) {
+  table.rejilla { min-width: 100%; }
+  table.rejilla.tarjetas { min-width: 900px; }
+}
 
-/* Los campos de la rejilla no deben poder crecer más que su columna. */
-.fgrid { min-width: 0; }
-.fgrid > .f { min-width: 0; }
-.fgrid > .f input, .fgrid > .f select, .fgrid > .f textarea { max-width: 100%; box-sizing: border-box; }
-.f .chip { white-space: nowrap; }
+/* ── Objetivos tocables ───────────────────────────────────────────────────
+ * Nada que se toque debe medir menos de 44 px de alto. Incluye la flecha de
+ * volver de la barra superior, que vive en shared/fts-styles.css y llega a
+ * 24 px: se corrige aquí porque esta pantalla se usa en obra, con guantes. */
+.tb-back { min-height: var(--toque); min-width: var(--toque);
+           display: inline-flex; align-items: center; justify-content: center; }
+.cel, select.cel { min-height: var(--toque); }
+input[type=checkbox] { width: 22px; height: 22px; }
+label.row { min-height: var(--toque); }
+@media (max-width: 720px) {
+  .cel, select.cel, .btn, .escbtn, .pestana { min-height: var(--toque); }
+}
 
-/* Última defensa: una etiqueta larga sin espacios no debe empujar la página. */
-.pad { min-width: 0; }
-.wg { min-width: 0; overflow-wrap: anywhere; }
+/* ── Renglones de mano de obra en cero ────────────────────────────────────
+ * El Excel siempre muestra los doce. En una laptop eso está bien; en un
+ * teléfono son doce tarjetas de las cuales siete suelen ir vacías, y el
+ * capturista pierde de vista lo que sí llenó. Se pliegan, con un interruptor
+ * que dice cuántas hay para que nadie crea que desaparecieron. */
+.verVacios { float: right; font-weight: 400; font-size: 11px; color: var(--suave);
+             display: inline-flex; align-items: center; gap: 6px; letter-spacing: 0;
+             text-transform: none; cursor: pointer; }
+.verVacios input { width: 16px; height: 16px; }
+@media (max-width: 720px) {
+  table.rejilla.tarjetas:not(.verVacios) tr.enCero { display: none; }
+}
 
-/* .oc es una PASTILLA (nowrap). Las notas explicativas largas necesitan su
- * propia clase: usar .oc para un párrafo empujaba el documento a 859 px en
- * una ventana de 380. */
-.nota { color: #6b6b6b; line-height: 1.45; margin: 2px 0 8px; }
+/* ── Ajustes de teléfono medidos en pantalla, no supuestos ────────────────
+ * La barra se partía en dos renglones ("$1,794,303 MXN ·" / "40%") y crecía a
+ * 101 px, que en un teléfono es una franja. Y las tablas de encabezado traían
+ * el espaciado de escritorio: once renglones antes de llegar a la captura. */
+@media (max-width: 720px) {
+  .fija { padding: 8px 10px; padding-bottom: calc(8px + env(safe-area-inset-bottom)); }
+  .fija .mono { font-size: 14px; white-space: nowrap; overflow: hidden;
+                text-overflow: ellipsis; }
+  .fija .tiny { white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+  .fija .btn { padding: 10px 14px; flex: 0 0 auto; }
+
+  table.hoja2 { font-size: 12.5px; }
+  table.hoja2 th { padding: 6px 8px; }
+  table.hoja2 td { padding: 3px 8px; }
+  table.hoja2 td.et { line-height: 1.3; }
+  table.hoja2 .cel { padding: 6px 8px; }
+}
+
+/* ── Ancho de la hoja ─────────────────────────────────────────────────────
+ * `shared/fts-styles.css` fija `.scr` en 520 px, que es lo correcto para las
+ * pantallas de kiosko y de perfil. Para una hoja de cálculo es lo contrario
+ * de lo que se necesita: en una laptop de 1280 px el machote quedaba metido
+ * en una columna de 520 y no se veía la retícula, que es todo el punto.
+ * Se ensancha SOLO en este módulo. */
+.scr { max-width: 1500px; }
+@media (max-width: 720px) { .scr { max-width: 100%; } }
+
+/* ── Proporciones en pantalla ancha ───────────────────────────────────────
+ * Con el contenedor ensanchado, los botones que antes cabían justos pasaron a
+ * ocupar la fila entera: "Eliminar sección" quedaba como una franja roja de
+ * 1400 px y "Revisar" como una barra. Un botón destructivo del ancho de la
+ * pantalla es además una invitación al clic accidental. */
+/* `shared/fts-styles.css` define `.btn{width:100%}` para el kiosko, donde los
+ * botones son de dedo y ocupan la fila. Aquí eso hacía que "Revisar" se comiera
+ * la barra entera y el precio quedara en cero de ancho. */
+.nomsec .btn.del { margin-left: auto; flex: 0 0 auto; width: auto;
+                   font-size: 12px; padding: 8px 12px; }
+.fija .btn { flex: 0 0 auto; width: auto; min-width: 110px; }
+.fija .grow { flex: 1 1 auto; min-width: 0; }
+.btnrow .btn { width: auto; }
+
+/* En escritorio no se pliega nada, así que el interruptor no viene al caso. */
+@media (min-width: 721px) { .verVacios { display: none; } }

--- a/comercial/machote/js/app.js
+++ b/comercial/machote/js/app.js
@@ -1,13 +1,15 @@
-/* ═══ Machote · vistas y ruteo ═══
+/* ═══ Machote · la hoja ═══
  *
- * Reescrito el 2026-09-03 sobre la estructura REAL del machote.
- * Ninguna vista calcula: todo número sale de MachoteCalc.
+ * Reescrito el 2026-09-03 para que la pantalla se parezca al libro de Excel
+ * en vez de a un formulario. La retícula de abajo es la del machote real,
+ * verificada en cinco cotizaciones de 2026 (SO11737, SO11738, SO11790,
+ * SO11836 y el USD de calbee): mismos encabezados, mismas doce filas de mano
+ * de obra, mismos bloques y en el mismo orden.
  *
- * Rutas:  #/            lista
- *         #/m/:id       estación 2.0 — armar el machote
- *         #/rev/:id     revisador
- *         #/orden/:id   estación 3.0 — confirmar la orden
- *         #/ap/:id      aprobación
+ * Ninguna vista calcula. Todo número sale de MachoteCalc.
+ *
+ * Rutas:  #/  lista · #/m/:id  el libro · #/rev/:id  revisión
+ *         #/orden/:id  cierre de orden · #/ap/:id  aprobación
  */
 (function (G) {
   'use strict';
@@ -18,25 +20,29 @@
   const clon = (x) => JSON.parse(JSON.stringify(x));
 
   const ST = {
+    verVacios: false,
     machotes: clon(D.MACHOTES),
     ordenes:  clon(D.ORDENES),
-    handoff: {}, confirmadas: {}, aprobaciones: {},
-    tab: 'diag', abiertos: {}, simMargen: null
+    handoff: {}, confirmadas: {},
+    hoja: 'desglose', simMargen: null
   };
 
   const esc = (s) => String(s === null || s === undefined ? '' : s)
     .replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;').replace(/"/g, '&quot;');
-  const mx  = (x, mon) => (x === null || x === undefined || !isFinite(x))
-    ? '—' : '$' + Math.round(x).toLocaleString('es-MX') + (mon ? ' ' + mon : '');
-  const pc  = (x) => (x === null || x === undefined || !isFinite(x)) ? '—' : (x * 100).toFixed(1).replace(/\.0$/, '') + '%';
-  const nn  = (x) => (x === null || x === undefined || x === '') ? '' : x;
+
+  /** El formato del machote: $ con separador de miles y sin decimales.
+   *  Un vacío se pinta como " $-  ", igual que en la hoja. */
+  const mx = (x) => (x === null || x === undefined || !isFinite(x)) ? '—'
+    : (Math.round(x) === 0 ? '$-' : '$' + Math.round(x).toLocaleString('es-MX'));
+  const mx2 = (x) => (x === null || x === undefined || !isFinite(x)) ? '—'
+    : '$' + x.toLocaleString('es-MX', { minimumFractionDigits: 2, maximumFractionDigits: 2 });
+  const pc = (x) => (x === null || x === undefined || !isFinite(x)) ? '—'
+    : (x * 100).toFixed(2).replace(/\.00$/, '') + '%';
+  const nn = (x) => (x === null || x === undefined || x === '') ? '' : x;
 
   const mach  = (id) => ST.machotes.find(m => m.id === id);
   const orden = (id) => ST.ordenes.find(o => o.id === id);
-
-  /** Estado de handoff creado al vuelo: si se crea sólo al pintar, todo lo que
-   *  se escriba antes del primer repintado se pierde en silencio. */
-  const hoff = (id) => ST.handoff[id] || (ST.handoff[id] = { entregables: {}, notas: '' });
+  const hoff  = (id) => ST.handoff[id] || (ST.handoff[id] = { entregables: {}, notas: '' });
 
   function toast(txt) {
     const d = document.createElement('div');
@@ -45,15 +51,28 @@
     setTimeout(() => { d.classList.remove('on'); setTimeout(() => d.remove(), 300); }, 2200);
   }
 
-  /** Escribe en el estado por ruta. Formas admitidas:
-   *   "margenes.materiales"          campo simple anidado
-   *   "s:<sid>:partidas:<i>:pu"      renglón de sección por índice
-   *   "eq:venta:<i>:pct"             integrante de un reparto */
+  /* ── Celdas ──────────────────────────────────────────────────────────
+   * Una celda es un input sin bordes hasta que se enfoca, para que la tabla
+   * se lea como una hoja y no como un formulario. */
+  const cel = (path, val, cls, ph) =>
+    '<input class="cel ' + (cls || '') + '" data-cel="' + path + '" value="' + esc(nn(val)) + '"' +
+    (ph ? ' placeholder="' + esc(ph) + '"' : '') + '>';
+  const celNum = (path, val, cls, ph) =>
+    '<input class="cel num ' + (cls || '') + '" type="number" step="any" data-cel="' + path + '" data-num' +
+    ' value="' + esc(nn(val)) + '"' + (ph ? ' placeholder="' + esc(ph) + '"' : '') + '>';
+  const celSel = (path, val, ops) =>
+    '<select class="cel" data-cel="' + path + '">' +
+    ops.map(o => '<option value="' + esc(o) + '"' + (o === val ? ' selected' : '') + '>' + esc(o || '—') + '</option>').join('') +
+    '</select>';
+
+  /** Escribe por ruta. `s:<sid>:mo:<i>:campo` · `s:<sid>:partidas:<i>:campo`
+   *  `eq:<venta|ops|cli>:<i>:campo` · `nom:<sid>` · o campo anidado. */
   function setPath(m, path, val) {
     const p = path.split(':');
+    if (p[0] === 'nom') { const s = m.secciones.find(x => x.id === p[1]); if (s) s.nombre = val; return; }
     if (p[0] === 's') {
       const s = m.secciones.find(x => x.id === p[1]); if (!s) return;
-      const arr = p[2] === 'partidas' ? s.partidas : s.mo;
+      const arr = p[2] === 'mo' ? s.mo : s.partidas;
       const l = arr[parseInt(p[3], 10)]; if (!l) return;
       l[p[4]] = val; return;
     }
@@ -68,10 +87,9 @@
     o[parts[parts.length - 1]] = val;
   }
 
-  /* ── Ruteo ──────────────────────────────────────────────────────────── */
+  /* ── Ruteo ───────────────────────────────────────────────────────────── */
   function render() {
-    const h = location.hash || '#/';
-    const p = h.replace(/^#\//, '').split('/');
+    const p = (location.hash || '#/').replace(/^#\//, '').split('/');
     if (p[0] === '')      return vHome();
     if (p[0] === 'm')     return vMachote(p[1]);
     if (p[0] === 'rev')   return vRevision(p[1]);
@@ -86,7 +104,11 @@
   }
   window.addEventListener('hashchange', render);
 
-  /* ── Lista ──────────────────────────────────────────────────────────── */
+  const nivelMargen = (mg) => mg === null ? 'warn'
+    : mg < R.UMBRALES.margen_minimo_duro ? 'bad'
+    : mg < R.UMBRALES.margen_minimo_blando ? 'warn' : 'ok';
+
+  /* ── Lista ───────────────────────────────────────────────────────────── */
   function vHome() {
     top('Machote y órdenes', 'Comercial · prototipo', 'DEMO', null);
     $('#fija').innerHTML = '';
@@ -94,364 +116,388 @@
 
     const filas = ST.machotes.map(m => {
       const rev = R.revisar(m), c = rev.calc;
-      const nivel = c.costoIncompleto ? 'warn' : nivelMargen(c.margen);
       return '<a class="item" href="#/m/' + m.id + '">' +
         '<div class="grow"><strong>' + esc(m.nombre) + '</strong>' +
         '<div class="tiny">' + esc(m.cliente) + (m.so ? ' · ' + esc(m.so) : '') + ' · ' + m.id + '</div></div>' +
         '<div class="right"><span class="chip" style="background:' + est[m.estado].color + '">' + est[m.estado].label + '</span>' +
-        '<div class="tiny mono n-' + nivel + '">' + mx(c.precio, m.moneda) + ' · ' + pc(c.margen) +
-        (c.costoIncompleto ? '*' : '') + '</div>' +
+        '<div class="tiny mono n-' + (c.costoIncompleto ? 'warn' : nivelMargen(c.margen)) + '">' +
+        mx(c.precio) + ' · ' + pc(c.margen) + (c.costoIncompleto ? '*' : '') + '</div>' +
         '<div class="tiny">' + (rev.duras.length ? '⛔ ' + rev.duras.length + ' duras' : '✓ sin duras') + '</div></div></a>';
     }).join('');
 
-    const ords = ST.ordenes.map(o => {
-      const listo = !!ST.confirmadas[o.id];
-      return '<a class="item" href="#/orden/' + o.id + '">' +
-        '<div class="grow"><strong>' + esc(o.nombre) + '</strong>' +
-        '<div class="tiny">' + esc(o.cliente) + ' · ' + esc(o.so) + '</div></div>' +
-        '<div class="right"><div class="mono">' + mx(o.monto, o.moneda) + '</div>' +
-        '<div class="tiny">' + (listo ? '✓ confirmada' : 'pendiente de confirmar') + '</div></div></a>';
-    }).join('');
+    const ords = ST.ordenes.map(o =>
+      '<a class="item" href="#/orden/' + o.id + '">' +
+      '<div class="grow"><strong>' + esc(o.nombre) + '</strong>' +
+      '<div class="tiny">' + esc(o.cliente) + ' · ' + esc(o.so) + '</div></div>' +
+      '<div class="right"><div class="mono">' + mx(o.monto) + ' ' + esc(o.moneda) + '</div>' +
+      '<div class="tiny">' + (ST.confirmadas[o.id] ? '✓ confirmada' : 'pendiente') + '</div></div></a>').join('');
 
     $('#vista').innerHTML =
-      '<div class="pad"><div class="aviso">Prototipo con datos demo. El motor de precio reproduce el machote real ' +
-      '(<code>docs/comercial/MACHOTE-ESTRUCTURA-REAL.md</code>); los datos de abajo son inventados.</div>' +
-      '<h3>Estación 2.0 · armar el machote</h3>' + filas +
+      '<div class="pad"><div class="aviso">La retícula reproduce el machote real de FTS, verificada en cinco cotizaciones de 2026. ' +
+      'Los datos de las cotizaciones de abajo son demo.</div>' +
+      '<h3>Estación 2.0 · armar la cotización</h3>' + filas +
       '<h3 style="margin-top:22px">Estación 3.0 · confirmar la orden</h3>' + ords + '</div>';
   }
 
-  const nivelMargen = (mg) => mg === null ? 'warn'
-    : mg < R.UMBRALES.margen_minimo_duro ? 'bad'
-    : mg < R.UMBRALES.margen_minimo_blando ? 'warn' : 'ok';
-
-  /* ── Estación 2.0 ───────────────────────────────────────────────────── */
-  const TABS = [
-    { id: 'diag', label: 'Diagnóstico' },
-    { id: 'secc', label: 'Secciones' },
-    { id: 'gen',  label: 'Márgenes' },
-    { id: 'com',  label: 'Comisiones' },
-    { id: 'sim',  label: 'Precio' }
-  ];
-
+  /* ── El libro ────────────────────────────────────────────────────────── */
   function vMachote(id) {
     const m = mach(id); if (!m) { location.hash = '#/'; return; }
-    top(m.cliente, m.id + ' · ' + D.ESTADOS[m.estado].label, 'MACHOTE', '#/');
+    // Al cambiar de cotización se vuelve al DESGLOSE: arrastrar la hoja
+    // abierta de la anterior deja al analista en una sección que no pidió.
+    if (ST.libroAbierto !== id) { ST.hoja = 'desglose'; ST.libroAbierto = id; }
+    const c = C.calcular(m);
+    top(m.cliente, m.id + (m.so ? ' · ' + m.so : ''), 'MACHOTE', '#/');
+
+    const hojas = [{ id: 'desglose', label: 'DESGLOSE COTIZACIÓN' }]
+      .concat(m.secciones.map(s => ({ id: s.id, label: s.nombre || 'SECCIÓN' })));
+    if (!hojas.some(h => h.id === ST.hoja)) ST.hoja = 'desglose';
+
     $('#vista').innerHTML =
-      '<div class="pad"><h2>' + esc(m.nombre) + '</h2>' +
-      '<div class="pasos" id="tabs">' + TABS.map(t =>
-        '<button class="paso' + (t.id === ST.tab ? ' on' : '') + '" data-tab="' + t.id + '">' + t.label + '</button>').join('') +
-      '</div><div id="pane"></div></div>';
-    $('#tabs').onclick = (e) => {
-      const b = e.target.closest('[data-tab]'); if (!b) return;
-      ST.tab = b.dataset.tab; vMachote(id);
+      '<div class="libro">' +
+      '<div class="hojas" id="hojas">' + hojas.map(h =>
+        '<button class="pestana' + (h.id === ST.hoja ? ' on' : '') + '" data-hoja="' + esc(h.id) + '">' +
+        esc(h.label) + '</button>').join('') +
+        (m.secciones.length < C.MAX_SECCIONES
+          ? '<button class="pestana mas" data-nueva="1" title="Nueva sección">+</button>' : '') +
+      '</div><div id="hoja"></div></div>';
+
+    $('#hojas').onclick = (e) => {
+      const b = e.target.closest('[data-hoja]');
+      if (b) { ST.hoja = b.dataset.hoja; return vMachote(id); }
+      if (e.target.closest('[data-nueva]')) {
+        m.secciones.push({ id: 's-' + Date.now(), nombre: 'SECCION ' + (m.secciones.length + 1), mo: [], partidas: [] });
+        ST.hoja = m.secciones[m.secciones.length - 1].id; return vMachote(id);
+      }
     };
-    pintarPane(m); barraFija(m); enlazar(m);
+    pintarHoja(m);
+    barra(m, c);
   }
 
-  function pintarPane(m) {
+  function pintarHoja(m) {
     const c = C.calcular(m);
-    $('#pane').innerHTML =
-      ST.tab === 'diag' ? paneDiag(m) :
-      ST.tab === 'secc' ? paneSecc(m, c) :
-      ST.tab === 'gen'  ? paneGen(m, c) :
-      ST.tab === 'com'  ? paneCom(m, c) : paneSim(m, c);
+    const s = m.secciones.find(x => x.id === ST.hoja);
+    $('#hoja').innerHTML = s ? hojaSeccion(m, s, c) : hojaDesglose(m, c);
     enlazar(m);
   }
 
-  function paneDiag(m) {
-    const t = D.TIPOS_PROYECTO.find(x => x.id === (m.diagnostico || {}).tipo);
-    const r = (m.diagnostico || {}).respuestas || {};
-    return '<div class="f"><label>Tipo de proyecto</label><select data-bind="diagnostico.tipo">' +
-      '<option value="">— elige —</option>' +
-      D.TIPOS_PROYECTO.map(x => '<option value="' + x.id + '"' + (x.id === (m.diagnostico || {}).tipo ? ' selected' : '') + '>' +
-        x.icono + ' ' + x.label + '</option>').join('') + '</select></div>' +
-      '<div class="aviso tiny">Este cuestionario es un supuesto: el machote de Excel no lo tiene. Cada pregunta apunta a un costo que suele descubrirse en obra.</div>' +
-      (!t ? '<div class="vacio">Elige el tipo para ver las preguntas.</div>' :
-        t.preguntas.map(q =>
-          '<div class="f"><label>' + (q.critica ? '<span class="chip bad">crítica</span> ' : '') + esc(q.texto) + '</label>' +
-          '<input data-bind="diagnostico.respuestas.' + q.id + '" value="' + esc(r[q.id] || '') + '" placeholder="' + esc(q.implica) + '">' +
-          '<div class="tiny">Si no se responde: ' + esc(q.riesgo_si_no) + '</div></div>').join(''));
-  }
+  /* ── Hoja de sección ─────────────────────────────────────────────────── */
+  function hojaSeccion(m, s, c) {
+    const cs = c.secciones.find(x => x.id === s.id) || {};
+    const mg = c.margenes;
 
-  function paneSecc(m, c) {
-    return m.secciones.map((s) => {
-      const cs = c.secciones.find(x => x.id === s.id) || {};
-      return '<div class="wg"><div class="row"><div class="grow">' +
-        '<input data-bind="s-nombre:' + s.id + '" value="' + esc(s.nombre) + '" style="font-weight:600">' +
-        '<div class="tiny mono">costo ' + mx(cs.costo, m.moneda) + ' · venta ' + mx(cs.venta, m.moneda) +
-        ' · ' + Math.round(cs.horas || 0) + ' h-hombre</div></div></div>' +
+    // Bloque de encabezado: las once filas de la izquierda y la tabla de
+    // márgenes de la derecha, tal como están en la hoja.
+    const izq = [
+      ['Mano de obra', mx(cs.costoMo)],
+      ['Materiales y servicio', mx(cs.costoMat)],
+      ['Costos Sumados (Mat, Servicio, Mano de obra)', mx2(cs.costo)],
+      ['', ''],
+      ['Comisiones CLIENTE', mx(cs.venta ? c.escenario.comisionFts * (cs.venta / (c.venta || 1)) : 0)],
+      ['Comisiones FTS', mx(cs.venta ? c.escenario.comisionCliente * (cs.venta / (c.venta || 1)) : 0)],
+      ['Costos totales (Cuanto le cuesta a FTS?)', mx(cs.costo + (c.escenario.comisionFts + c.escenario.comisionCliente) * (cs.venta / (c.venta || 1)))],
+      ['Precio de Venta FTS (Antes de comisiones)', mx(cs.venta)],
+      ['Precio de Venta a cliente (Despues de comisiones)', mx2(cs.esc ? cs.esc.con_utilidad.precio : null)],
+      ['Utilidad', mx2((cs.esc ? cs.esc.con_utilidad.precio : 0) - cs.costo)],
+      ['% Utilidad Obtenido', pc(cs.margenObtenido)]
+    ].map(r => '<tr><td class="et">' + esc(r[0]) + '</td><td class="vl mono">' + r[1] + '</td></tr>').join('');
 
-        '<div class="tiny" style="margin-top:10px"><strong>Mano de obra</strong> · tarifa × personas × horas</div>' +
-        C.GRUPOS.map(g => {
-          const rs = C.ROLES.filter(r => r.grupo === g.id);
-          return '<div class="tiny oc">' + g.label + '</div>' + rs.map(rol => {
-            const i = s.mo.findIndex(l => l.rol === rol.id);
-            const l = i >= 0 ? s.mo[i] : null;
-            const idx = i >= 0 ? i : null;
-            return lineaMo(rol, l, idx, s, m);
-          }).join('');
-        }).join('') +
+    const der = [
+      ['Programador', 'margenes.programador', mg.programador],
+      ['Mano de obra', 'margenes.mano_obra', mg.mano_obra],
+      ['Materiales', 'margenes.materiales', mg.materiales],
+      ['Servicios', 'margenes.servicios', mg.servicios]
+    ].map(r => '<tr><td class="et">' + r[0] + '</td><td>' + celNum(r[1], r[2], 'w70') + '</td></tr>').join('') +
+      '<tr><td class="et">Comision FTS</td><td>' + celNum('comision_fts', m.comision_fts, 'w70') + '</td></tr>' +
+      '<tr><td class="et">Comision CLIENTE</td><td>' + celNum('comision_cliente', m.comision_cliente, 'w70') + '</td></tr>';
 
-        '<div class="tiny" style="margin-top:14px"><strong>Materiales y servicios</strong></div>' +
-        (s.partidas.length ? s.partidas.map((l, j) => lineaPartida(l, s, m, j)).join('')
-                           : '<div class="tiny">Sin partidas.</div>') +
-        '<div class="btnrow"><button class="btn" data-add-part="' + s.id + '">+ partida</button></div>' +
-        '</div>';
-    }).join('') +
-    '<div class="btnrow"><button class="btn" data-add-sec="1"' +
-      (m.secciones.length >= C.MAX_SECCIONES ? ' disabled' : '') + '>+ sección (' +
-      m.secciones.length + '/' + C.MAX_SECCIONES + ')</button></div>';
-  }
+    const cab =
+      '<div class="cab">' +
+      '<div class="blk"><table class="hoja2"><thead><tr><th>Costos desglosados</th><th></th></tr></thead>' +
+      '<tbody>' + izq +
+      '<tr><td class="et">Horas sección</td><td class="vl mono">' + Math.round(cs.horas || 0) + '</td></tr>' +
+      '</tbody></table></div>' +
+      '<div class="blk"><table class="hoja2"><thead><tr><th>Concepto</th><th>Margen de utilidad</th></tr></thead>' +
+      '<tbody>' + der + '</tbody></table>' +
+      '<div class="tiny nota">Horas extras = mano de obra × 2 = <strong>' + mg.extra + '</strong>. No se captura, igual que en el Excel.</div>' +
+      '</div></div>' +
+      '<div class="nomsec"><span class="et">NOMBRE DE SECCIÓN</span>' + cel('nom:' + s.id, s.nombre, 'nombre') +
+      (m.secciones.length > 1 ? '<button class="btn del" data-delsec="' + s.id + '">Eliminar sección</button>' : '') + '</div>';
 
-  function lineaMo(rol, l, idx, s, m) {
-    const mg = C.margenes(m);
-    const mult = mg[rol.mult];
-    const cur = l ? C.costoMo(l, m) : null;
-    const base = 's:' + s.id + ':mo:' + (idx === null ? 'NEW' : idx) + ':';
-    const dis = idx === null ? ' data-mo-new="' + s.id + '|' + rol.id + '"' : '';
-    return '<div class="row lin-mo"' + dis + '>' +
-      '<div class="grow tiny">' + esc(rol.label) + ' <span class="mono oc">×' + mult + '</span></div>' +
-      '<input class="num" type="number" step="any" placeholder="h" title="Horas" ' +
-        (idx === null ? 'data-mo-init="' + s.id + '|' + rol.id + '|qty"' : 'data-num data-bind="' + base + 'qty"') +
-        ' value="' + (l ? nn(l.qty) : '') + '">' +
-      '<input class="num" type="number" step="any" placeholder="pers" title="Personas" ' +
-        (idx === null ? 'data-mo-init="' + s.id + '|' + rol.id + '|personas"' : 'data-num data-bind="' + base + 'personas"') +
-        ' value="' + (l ? nn(l.personas) : '') + '">' +
-      '<input class="num" type="number" step="any" placeholder="tarifa" title="Precio unitario" ' +
-        (idx === null ? 'data-mo-init="' + s.id + '|' + rol.id + '|pu"' : 'data-num-null data-bind="' + base + 'pu"') +
-        ' value="' + (l ? nn(l.pu) : '') + '">' +
-      '<div class="lin-tot mono tiny">' + (cur && cur.costo ? mx(cur.conUtilidad) : '—') + '</div></div>';
-  }
+    // COSTO MANO DE OBRA — los diez renglones siempre presentes, en sus tres grupos.
+    let filasMo = '';
+    C.GRUPOS.forEach(g => {
+      const roles = C.ROLES.filter(r => r.grupo === g.id);
+      // Si todos los renglones del grupo van en cero, su rótulo se pliega con
+      // ellos: un título solo, sin nada debajo, se lee como un error.
+      const grupoVacio = roles.every(rol => {
+        const l = s.mo.find(x => x.rol === rol.id);
+        return !l || !(Number(l.qty) > 0);
+      });
+      filasMo += '<tr class="grupo' + (grupoVacio ? ' enCero' : '') + '"><td colspan="9">' +
+                 esc(g.label) + '</td></tr>';
+      roles.forEach(rol => {
+        let i = s.mo.findIndex(l => l.rol === rol.id);
+        if (i < 0) { s.mo.push({ rol: rol.id, qty: '', personas: 1, pu: rol.pu, moneda: m.moneda }); i = s.mo.length - 1; }
+        const l = s.mo[i], cl = C.costoMo(l, m), p = 's:' + s.id + ':mo:' + i + ':';
+        const vacia = !(Number(l.qty) > 0);
+        filasMo +=
+          '<tr' + (vacia ? ' class="enCero"' : '') + '>' +
+          '<td class="rotulo" data-l="Renglón">' + esc(rol.label) + '</td>' +
+          '<td data-l="QTY (horas)">' + celNum(p + 'qty', l.qty, 'w60') + '</td>' +
+          '<td class="ro solo-ancho" data-l="Unidad">Horas</td>' +
+          '<td data-l="Personas">' + celNum(p + 'personas', l.personas, 'w60') + '</td>' +
+          '<td data-l="Precio unitario">' + celNum(p + 'pu', l.pu, 'w80') + '</td>' +
+          '<td class="vl mono" data-l="Precio total">' + mx(cl.costo) + '</td>' +
+          '<td data-l="Moneda">' + celSel(p + 'moneda', l.moneda, ['MXN', 'USD']) + '</td>' +
+          '<td class="ro mono" data-l="Margen">' + cl.mult + '</td>' +
+          '<td class="vl mono fuerte" data-l="Precio con utilidad">' + mx(cl.conUtilidad) + '</td></tr>';
+      });
+    });
 
-  function lineaPartida(l, s, m, j) {
-    const cur = C.costoPartida(l, m);
-    const p = 's:' + s.id + ':partidas:' + j + ':';
-    const ab = ST.abiertos[s.id + '#' + j];
-    const cab = '<button class="lin" data-open="' + s.id + '#' + j + '">' +
-      '<span class="chev">' + (ab ? '▾' : '▸') + '</span>' +
-      '<span class="grow"><strong>' + esc(l.descripcion || '(sin descripción)') + '</strong>' +
-      '<span class="tiny"> ' + (l.qty || 0) + ' ' + esc(l.unidad || '') +
-      (l.marca ? ' · ' + esc(l.marca) : '') +
-      ' · <span class="' + (cur.sinTipo ? 'n-bad' : '') + '">' + esc(l.tipo || 'sin tipo') + '</span>' +
-      ' ×' + (cur.mult || 0) +
-      (l.link ? ' · <span class="n-ok">con liga</span>' : ' · <span class="n-warn">sin liga</span>') +
-      '</span></span>' +
-      '<span class="lin-tot mono">' + (cur.sinPrecio ? '<span class="n-bad">sin precio</span>' : mx(cur.conUtilidad)) + '</span></button>';
-    if (!ab) return cab;
-    return cab + '<div class="fgrid">' +
-      '<div class="f"><label>Descripción</label><input data-bind="' + p + 'descripcion" value="' + esc(l.descripcion) + '"></div>' +
-      '<div class="f"><label>Tipo</label><select data-bind="' + p + 'tipo">' +
-        '<option value="">— elige —</option>' +
-        C.TIPOS.map(t => '<option' + (t === l.tipo ? ' selected' : '') + '>' + t + '</option>').join('') +
-        '</select><div class="tiny">Elige el multiplicador: Materiales ×' + C.margenes(m).materiales +
-        ', Servicios ×' + C.margenes(m).servicios + '.</div></div>' +
-      '<div class="f"><label>Cantidad</label><input class="num" type="number" step="any" data-num data-bind="' + p + 'qty" value="' + nn(l.qty) + '"></div>' +
-      '<div class="f"><label>Unidad</label><select data-bind="' + p + 'unidad">' +
-        D.UNIDADES.map(u => '<option' + (u === l.unidad ? ' selected' : '') + '>' + u + '</option>').join('') + '</select></div>' +
-      '<div class="f"><label>Marca</label><input data-bind="' + p + 'marca" value="' + esc(l.marca) + '"></div>' +
-      '<div class="f"><label>Modelo</label><input data-bind="' + p + 'modelo" value="' + esc(l.modelo) + '"></div>' +
-      '<div class="f"><label>Precio unitario</label><input class="num" type="number" step="any" data-num-null data-bind="' + p + 'pu" value="' + nn(l.pu) + '">' +
-        '<div class="tiny">Vacío no es cero: se reporta como hueco.</div></div>' +
-      '<div class="f"><label>Moneda</label><select data-bind="' + p + 'moneda">' +
-        ['MXN', 'USD'].map(x => '<option' + (x === l.moneda ? ' selected' : '') + '>' + x + '</option>').join('') + '</select></div>' +
-      '<div class="f grow2"><label>Liga al proveedor</label><input data-bind="' + p + 'link" value="' + esc(l.link) + '" placeholder="https://…">' +
-        '<div class="tiny">Es el respaldo del precio. Sin ella nadie puede reverificarlo después.</div></div>' +
-      '<div class="f grow2"><label>Comentario</label><input data-bind="' + p + 'comentario" value="' + esc(l.comentario) + '"></div>' +
-      '<div class="btnrow"><button class="btn del" data-del="' + s.id + '#' + j + '">Eliminar partida</button></div></div>';
-  }
-
-  function paneGen(m, c) {
-    const mg = c.margenes, base = C.MARGENES_PLANTILLA;
-    const fila = (k, label, nota) => {
-      const fuera = Math.abs(Number(mg[k]) - base[k]) > 0.001;
-      return '<div class="f"><label>' + label + (fuera ? ' <span class="chip warn">≠ plantilla ' + base[k] + '</span>' : '') + '</label>' +
-        '<input class="num" type="number" step="0.1" data-num data-bind="margenes.' + k + '" value="' + mg[k] + '">' +
-        '<div class="tiny">' + nota + '</div></div>';
-    };
-    return '<div class="wg"><h4>Multiplicadores de utilidad</h4>' +
-      '<div class="tiny nota">El precio de cada renglón es su costo × este número. No es un porcentaje.</div>' +
-      '<div class="fgrid">' +
-      fila('programador', 'Programador', 'Igual en los 8 machotes revisados: 4,4.') +
-      fila('mano_obra', 'Mano de obra', 'Igual en los 8 machotes revisados: 2,5.') +
-      fila('materiales', 'Materiales', 'Varía por cotización: se han visto 1,4 · 1,8 · 2,5.') +
-      fila('servicios', 'Servicios', 'Varía por cotización: se han visto 1,5 · 1,7 · 1,8.') +
-      '</div><div class="tot"><span class="lb">Horas extras</span><span class="vl mono">×' + mg.extra +
-      '</span></div><div class="tiny">No se captura: es mano de obra × 2, igual que en el Excel.</div></div>' +
-
-      '<div class="wg"><h4>Comisiones y moneda</h4><div class="fgrid">' +
-      '<div class="f"><label>Comisión FTS</label><input class="num" type="number" step="0.001" data-num data-bind="comision_fts" value="' + m.comision_fts + '"><div class="tiny">Plantilla 0,055. Se cobra sobre el precio con utilidad.</div></div>' +
-      '<div class="f"><label>Comisión cliente</label><input class="num" type="number" step="0.001" data-num data-bind="comision_cliente" value="' + m.comision_cliente + '"><div class="tiny">Va encima de la de FTS, en cascada.</div></div>' +
-      '<div class="f"><label>Moneda del documento</label><select data-bind="moneda">' +
-        ['MXN', 'USD'].map(x => '<option' + (x === m.moneda ? ' selected' : '') + '>' + x + '</option>').join('') + '</select></div>' +
-      '<div class="f"><label>Tipo de cambio</label><input class="num" type="number" step="any" data-num data-bind="tc" value="' + m.tc + '"></div>' +
-      '<div class="f"><label>Factor de protección</label><input class="num" type="number" step="0.01" data-num data-bind="factor_proteccion" value="' + m.factor_proteccion + '">' +
-        '<div class="tiny">TC efectivo ' + C.tcEfectivo(m).toFixed(2) + '. El machote de Excel no convierte: suma monedas distintas.</div></div>' +
-      '</div></div>';
-  }
-
-  function paneCom(m, c) {
-    const eq = (titulo, key, rep, bolsa, nota) =>
-      '<div class="wg"><h4>' + titulo + '</h4><div class="tiny nota">' + nota + '</div>' +
-      '<div class="tot"><span class="lb">Bolsa</span><span class="vl mono">' + mx(bolsa, m.moneda) + '</span></div>' +
-      (m[key] || []).map((it, i) =>
-        '<div class="row"><input class="grow" data-bind="eq:' + rep + ':' + i + ':nombre" value="' + esc(it.nombre) + '">' +
-        '<input class="num" type="number" step="0.05" data-num data-bind="eq:' + rep + ':' + i + ':pct" value="' + it.pct + '">' +
-        '<div class="lin-tot mono tiny">' + mx(bolsa * Number(it.pct), '') + '</div></div>').join('') +
-      '<div class="tot"><span class="lb">Suma de porcentajes</span><span class="vl mono n-' +
-        (Math.abs((m[key] || []).reduce((a, x) => a + Number(x.pct || 0), 0) - 1) < 0.0001 ? 'ok' : 'bad') + '">' +
-        pc((m[key] || []).reduce((a, x) => a + Number(x.pct || 0), 0)) + '</span></div></div>';
-
-    const b = c.budget;
-    return eq('Equipo de venta', 'equipo_venta', 'venta', c.reparto.bolsaVenta, pc(Number(m.reparto.venta)) + ' de la comisión de FTS.') +
-      eq('Equipo de operaciones', 'equipo_operaciones', 'ops', c.reparto.bolsaOps, pc(Number(m.reparto.operaciones)) + ' de la comisión de FTS.') +
-      eq('Lado cliente', 'equipo_cliente', 'cli', c.escenario.comisionCliente, 'Se reparte la comisión de cliente.') +
-      '<div class="wg"><h4>BUDGET ODOO</h4>' +
-      '<div class="tiny nota">Es lo que se capturaría como presupuesto del proyecto. Amarra con los rubros 1171 Ingreso / 1177 Mano de obra / 1176 Materiales que ya crea el workflow al confirmar la SO.</div>' +
-      '<div class="tot"><span class="lb">Ingreso</span><span class="vl mono">' + mx(b.ingreso, m.moneda) + '</span></div>' +
-      '<div class="tot"><span class="lb">Mano de obra</span><span class="vl mono">' + mx(b.manoObra, m.moneda) + '</span></div>' +
-      '<div class="tot"><span class="lb">Materiales y servicios</span><span class="vl mono">' + mx(b.materiales, m.moneda) + '</span></div>' +
-      b.comisiones.filter(l => l.monto).map(l =>
-        '<div class="tot"><span class="lb tiny">' + esc(l.nombre) + '</span><span class="vl mono tiny">' + mx(l.monto, '') + '</span></div>').join('') +
-      '<div class="tot"><span class="lb"><strong>Total</strong></span><span class="vl mono"><strong>' + mx(b.total, m.moneda) + '</strong></span></div>' +
-      '<div class="tot"><span class="lb">¿Coincide con la tabla?</span><span class="vl mono n-' + (b.cuadra ? 'ok' : 'bad') + '">' +
-        (b.cuadra ? 'VERDADERO' : 'FALSO') + '</span></div>' +
-      (b.cuadra ? '' : '<div class="aviso">El machote de Excel muestra este mismo FALSO y aun así deja mandar la cotización. Aquí bloquea.</div>') +
-      '</div>';
-  }
-
-  function paneSim(m, c) {
-    const e = c.escenarios;
-    const card = (id, label, x) =>
-      '<button class="paso' + (m.escenario === id ? ' on' : '') + '" data-esc="' + id + '" style="flex-direction:column;align-items:flex-start">' +
-      '<strong>' + label + '</strong><span class="mono tiny">' + mx(x.precio, '') + '</span>' +
-      '<span class="tiny">margen ' + pc(x.margen) + '</span></button>';
-
-    const sim = ST.simMargen === null ? Number(m.margen_deseado) : ST.simMargen;
-    const pSim = C.precioParaMargen(c.costo, c.pctFts, c.pctCli, sim);
-
-    return '<div class="wg"><h4>Escenario</h4>' +
-      '<div class="pasos" id="escs">' + card('costo', 'Costo', e.costo) +
-        card('con_utilidad', 'Con utilidad', e.con_utilidad) +
-        card('margen_deseado', 'Margen deseado', e.margen_deseado) + '</div>' +
-      '<div class="f"><label>Margen deseado</label><input class="num" type="number" step="0.01" data-num data-bind="margen_deseado" value="' + m.margen_deseado + '"></div>' +
-      '<div class="tot"><span class="lb">Factor_req</span><span class="vl mono">' + (c.factorReq ? c.factorReq.toFixed(6) : '—') + '</span></div>' +
-      '<div class="tiny">Cuántas veces el costo hay que cobrar para llegar al margen, ya con las comisiones dentro.</div></div>' +
-
-      '<div class="wg"><h4>Resumen</h4>' +
-      '<div class="tot"><span class="lb">Costo mano de obra</span><span class="vl mono">' + mx(c.costoMo, m.moneda) + ' · ' + pc(c.pesoMo) + '</span></div>' +
-      '<div class="tot"><span class="lb">Costo materiales y servicios</span><span class="vl mono">' + mx(c.costoMat, m.moneda) + ' · ' + pc(c.pesoMat) + '</span></div>' +
-      '<div class="tot"><span class="lb">Costo total</span><span class="vl mono">' + mx(c.costo, m.moneda) + '</span></div>' +
-      '<div class="tot"><span class="lb">Comisión FTS</span><span class="vl mono">' + mx(c.escenario.comisionFts, m.moneda) + '</span></div>' +
-      '<div class="tot"><span class="lb">Comisión cliente</span><span class="vl mono">' + mx(c.escenario.comisionCliente, m.moneda) + '</span></div>' +
-      '<div class="tot"><span class="lb"><strong>Precio</strong></span><span class="vl mono"><strong>' + mx(c.precio, m.moneda) + '</strong></span></div>' +
-      '<div class="tot"><span class="lb">Utilidad</span><span class="vl mono n-' + nivelMargen(c.margen) + '">' + mx(c.utilidad, m.moneda) + ' · ' + pc(c.margen) + '</span></div>' +
-      '<div class="tot"><span class="lb">Horas proyecto</span><span class="vl mono">' + Math.round(c.horas) + '</span></div>' +
-      (c.costoIncompleto ? '<div class="aviso">Hay ' + c.huecos + ' hueco(s) de captura. El margen de arriba es optimista: lo que falta sólo puede subir el costo.</div>' : '') +
+    const enCero = s.mo.filter(l => !(Number(l.qty) > 0)).length;
+    const tablaMo =
+      '<div class="secc-tit">COSTO MANO DE OBRA' +
+      (enCero ? '<label class="verVacios"><input type="checkbox" id="verVacios"' +
+        (ST.verVacios ? ' checked' : '') + '> ver los ' + enCero + ' en cero</label>' : '') +
       '</div>' +
+      '<div class="scroll"><table class="rejilla tarjetas' + (ST.verVacios ? ' verVacios' : '') + '">' +
+      '<thead><tr><th>DESCRIPCIÓN</th><th>QTY</th><th>UNIDAD</th><th>Personas</th>' +
+      '<th>PRECIO UNITARIO</th><th>PRECIO TOTAL</th><th>MONEDA</th><th>Margen utilidad</th>' +
+      '<th>PRECIO CON UTILIDAD</th></tr></thead><tbody>' + filasMo +
+      '<tr class="total"><td class="rotulo" data-l="">TOTAL</td><td colspan="4"></td>' +
+      '<td class="vl mono" data-l="Costo mano de obra">' + mx(cs.costoMo) +
+      '</td><td colspan="2"></td><td class="vl mono fuerte" data-l="Con utilidad">' + mx(cs.ventaMo) + '</td></tr>' +
+      '</tbody></table></div>';
 
-      '<div class="wg sim-box"><h4>¿Y si quisiera otro margen?</h4>' +
-      '<div class="f"><label>Margen objetivo</label><input class="num" type="number" step="0.01" id="simM" value="' + sim + '"></div>' +
-      '<div class="sim-out mono">Precio necesario: <strong>' + mx(pSim, m.moneda) + '</strong></div>' +
-      '<div class="tiny">No cambia la cotización. Es sólo la cuenta.</div></div>' +
+    // COSTO MATERIALES Y SERVICIOS
+    const filasMat = (s.partidas || []).map((l, j) => {
+      const cl = C.costoPartida(l, m), p = 's:' + s.id + ':partidas:' + j + ':';
+      return '<tr>' +
+        '<td data-l="Descripción">' + cel(p + 'descripcion', l.descripcion, 'desc') + '</td>' +
+        '<td data-l="QTY">' + celNum(p + 'qty', l.qty, 'w60') + '</td>' +
+        '<td data-l="Unidad">' + celSel(p + 'unidad', l.unidad, D.UNIDADES) + '</td>' +
+        '<td data-l="Tipo">' + celSel(p + 'tipo', l.tipo, [''].concat(C.TIPOS)) + '</td>' +
+        '<td data-l="Modelo">' + cel(p + 'modelo', l.modelo, 'w110') + '</td>' +
+        '<td data-l="Marca">' + cel(p + 'marca', l.marca, 'w90') + '</td>' +
+        '<td data-l="Precio unitario">' + celNum(p + 'pu', l.pu, 'w90') + '</td>' +
+        '<td data-l="Moneda">' + celSel(p + 'moneda', l.moneda, ['MXN', 'USD']) + '</td>' +
+        '<td class="vl mono' + (cl.sinPrecio ? ' n-bad' : '') + '" data-l="Precio total">' + (cl.sinPrecio ? 'sin precio' : mx(cl.costo)) + '</td>' +
+        '<td data-l="Margen">' + celNum(p + 'margen', l.margen, 'w60' + (cl.pisado ? ' pisado' : ''), String(cl.porTipo || '')) + '</td>' +
+        '<td class="vl mono fuerte" data-l="Precio con utilidad">' + mx(cl.conUtilidad) + '</td>' +
+        '<td data-l="Link">' + cel(p + 'link', l.link, 'w130', 'https://…') + '</td>' +
+        '<td data-l="Comentario">' + cel(p + 'comentario', l.comentario, 'w130') + '</td>' +
+        '<td class="acc"><button class="x" data-del="' + s.id + '#' + j + '" title="Eliminar partida">× eliminar</button></td></tr>';
+    }).join('');
 
-      '<div class="wg"><h4>Por sección</h4>' +
-      c.secciones.map(s => '<div class="tot"><span class="lb">' + esc(s.nombre) + '</span>' +
-        '<span class="vl mono">' + mx(s.precio, '') + ' · ' + pc(s.peso) + ' del costo</span></div>').join('') +
-      '<div class="tiny">En el escenario de margen deseado el precio se reparte a prorrata del costo. El margen es una restricción global, no se fija por sección.</div></div>';
+    const tablaMat =
+      '<div class="secc-tit">COSTO MATERIALES Y SERVICIOS</div>' +
+      '<div class="scroll"><table class="rejilla tarjetas">' +
+      '<thead><tr><th>DESCRIPCIÓN</th><th>QTY</th><th>UNIDAD</th><th>Tipo</th><th>MODELO</th><th>MARCA</th>' +
+      '<th>PRECIO UNITARIO</th><th>MONEDA</th><th>PRECIO TOTAL</th><th>Margen utilidad</th>' +
+      '<th>PRECIO CON UTILIDAD</th><th>Link</th><th>Comentario</th><th></th></tr></thead><tbody>' +
+      (filasMat || '<tr><td colspan="14" class="vacio2">Sin partidas.</td></tr>') +
+      '<tr class="total"><td class="rotulo" data-l="">TOTAL</td><td colspan="7"></td>' +
+      '<td class="vl mono" data-l="Costo materiales">' + mx(cs.costoMat) +
+      '</td><td></td><td class="vl mono fuerte" data-l="Con utilidad">' + mx(cs.ventaMat) + '</td><td colspan="3"></td></tr>' +
+      '</tbody></table></div>' +
+      '<div class="btnrow"><button class="btn" data-add="' + s.id + '">+ partida</button>' +
+      (cs.pisados ? '<span class="tiny n-warn">' + cs.pisados + ' margen(es) pisado(s) a mano en esta sección</span>' : '') +
+      '</div>';
+
+    return cab + tablaMo + tablaMat;
   }
 
-  function barraFija(m) {
-    const rev = R.revisar(m), c = rev.calc;
+  /* ── Hoja DESGLOSE COTIZACIÓN ────────────────────────────────────────── */
+  function hojaDesglose(m, c) {
+    const e = c.escenarios;
+    const escOps = C.ESCENARIOS.map(x =>
+      '<button class="escbtn' + (m.escenario === x.id ? ' on' : '') + '" data-esc="' + x.id + '">' +
+      x.label.toUpperCase() + '</button>').join('');
+
+    const fila = (et, p, cCosto, cUtil, cMd) =>
+      '<tr><td class="et">' + et + '</td><td class="mono pctcol">' + (p || '') + '</td>' +
+      '<td class="vl mono">' + cCosto + '</td><td class="vl mono">' + cUtil + '</td>' +
+      '<td class="vl mono">' + cMd + '</td></tr>';
+
+    const resumen =
+      '<div class="secc-tit">RESUMEN BUDGET</div>' +
+      '<div class="scroll"><table class="rejilla ancha">' +
+      '<thead><tr><th></th><th>%</th><th>COSTO</th><th>CON UTILIDAD</th><th>MARGEN DESEADO</th></tr></thead><tbody>' +
+      fila('MANO DE OBRA', pc(c.pesoMo), mx(c.costoMo), mx(c.ventaMo),
+           mx(e.margen_deseado.precio === null ? null : e.margen_deseado.precio * (c.costo ? c.costoMo / c.costo : 0))) +
+      fila('MATERIALES Y SERVICIOS', pc(c.pesoMat), mx(c.costoMat), mx(c.ventaMat),
+           mx(e.margen_deseado.precio === null ? null : e.margen_deseado.precio * (c.costo ? c.costoMat / c.costo : 0))) +
+      fila('SUMA M. DE OBRA, MATERIALES Y SERV', '', mx(c.costo), mx(c.venta),
+           mx(e.margen_deseado.precio === null ? null : e.margen_deseado.precio - e.margen_deseado.comisionFts - e.margen_deseado.comisionCliente)) +
+      fila('COMISIONES DE FTS', pc(c.pctFts), '', mx(e.con_utilidad.comisionFts), mx(e.margen_deseado.comisionFts)) +
+      fila('COMISIONES DE CLIENTE', pc(c.pctCli), '', mx(e.con_utilidad.comisionCliente), mx(e.margen_deseado.comisionCliente)) +
+      '<tr class="total"><td class="et">PRECIO DE VENTA ANTE DE IMPUESTO</td><td></td>' +
+      '<td class="vl mono">' + mx(e.costo.precio) + '</td><td class="vl mono">' + mx(e.con_utilidad.precio) + '</td>' +
+      '<td class="vl mono">' + mx(e.margen_deseado.precio) + '</td></tr>' +
+      fila('Margen', '', pc(0), pc(e.con_utilidad.margen), pc(e.margen_deseado.margen)) +
+      fila('Utilidad esperada Absoluta', '', mx(0), mx(e.con_utilidad.utilidad), mx(e.margen_deseado.utilidad)) +
+      '</tbody></table></div>';
+
+    const encabezado =
+      '<div class="desg-top">' +
+      '<div class="blk"><div class="et2">ELIGE UN ESCENARIO PARA TU COTIZACIÓN</div>' +
+      '<div class="escs">' + escOps + '</div></div>' +
+      '<div class="blk"><table class="hoja2"><tbody>' +
+      '<tr><td class="et">MARGEN DESEADO</td><td>' + celNum('margen_deseado', m.margen_deseado, 'w80') + '</td></tr>' +
+      '<tr><td class="et">HORAS PROYECTO</td><td class="vl mono">' + Math.round(c.horas) + '</td></tr>' +
+      '<tr><td class="et">Factor_req</td><td class="vl mono">' + (c.factorReq ? c.factorReq.toFixed(9) : '—') + '</td></tr>' +
+      '<tr><td class="et">Moneda</td><td>' + celSel('moneda', m.moneda, ['MXN', 'USD']) + '</td></tr>' +
+      '<tr><td class="et">Tipo de cambio</td><td>' + celNum('tc', m.tc, 'w80') + '</td></tr>' +
+      '</tbody></table></div></div>';
+
+    // RESUMEN por sección: diez ranuras fijas, tres grupos de columnas.
+    let fSec = '';
+    for (let i = 0; i < C.MAX_SECCIONES; i++) {
+      const s = c.secciones[i];
+      const v = s ? s.esc : null;
+      fSec += '<tr' + (s ? '' : ' class="vacia"') + '><td class="mono">' + (i + 1) + '</td>' +
+        '<td class="et">' + esc(s ? s.nombre : 'SECCION ' + (i + 1)) + '</td>' +
+        '<td class="vl mono">' + mx(s ? v.costo.mo : 0) + '</td>' +
+        '<td class="vl mono">' + mx(s ? v.costo.mat : 0) + '</td>' +
+        '<td class="vl mono">' + mx(s ? v.costo.precio : 0) + '</td>' +
+        '<td class="vl mono">' + mx(s ? v.con_utilidad.mo : 0) + '</td>' +
+        '<td class="vl mono">' + mx(s ? v.con_utilidad.mat : 0) + '</td>' +
+        '<td class="vl mono">' + mx(s ? v.con_utilidad.precio : 0) + '</td>' +
+        '<td class="vl mono">' + mx(s ? v.margen_deseado.mo : 0) + '</td>' +
+        '<td class="vl mono">' + mx(s ? v.margen_deseado.mat : 0) + '</td>' +
+        '<td class="vl mono">' + mx(s ? v.margen_deseado.precio : 0) + '</td>' +
+        '<td class="vl mono">' + (s ? Math.round(s.horas) : 0) + '</td></tr>';
+    }
+    const sobra = c.secciones.length > C.MAX_SECCIONES;
+
+    const porSeccion =
+      '<div class="secc-tit">RESUMEN POR SECCIÓN</div>' +
+      '<div class="scroll"><table class="rejilla ancha">' +
+      '<thead><tr><th colspan="2"></th><th colspan="3">COSTO</th><th colspan="3">CON UTILIDAD</th>' +
+      '<th colspan="3">MARGEN DESEADO</th><th></th></tr>' +
+      '<tr><th>SECCIÓN</th><th>SECCION DE COTIZACION</th>' +
+      '<th>MANO DE OBRA</th><th>MATERIALES Y SERV</th><th>COSTOS TOTALES</th>' +
+      '<th>MANO DE OBRA</th><th>MATERIALES Y SERV</th><th>PRECIO DE VENTA</th>' +
+      '<th>MANO DE OBRA</th><th>MATERIALES Y SERV</th><th>PRECIO DE VENTA</th><th>HORAS</th></tr></thead>' +
+      '<tbody>' + fSec +
+      '<tr class="total"><td></td><td class="et">SUMA</td>' +
+      '<td class="vl mono">' + mx(c.costoMo) + '</td><td class="vl mono">' + mx(c.costoMat) + '</td>' +
+      '<td class="vl mono">' + mx(c.costo) + '</td>' +
+      '<td class="vl mono">' + mx(c.ventaMo) + '</td><td class="vl mono">' + mx(c.ventaMat) + '</td>' +
+      '<td class="vl mono">' + mx(e.con_utilidad.precio) + '</td>' +
+      '<td class="vl mono">' + mx(e.margen_deseado.precio === null ? null : e.margen_deseado.precio * (c.costo ? c.costoMo / c.costo : 0)) + '</td>' +
+      '<td class="vl mono">' + mx(e.margen_deseado.precio === null ? null : e.margen_deseado.precio * (c.costo ? c.costoMat / c.costo : 0)) + '</td>' +
+      '<td class="vl mono">' + mx(e.margen_deseado.precio) + '</td>' +
+      '<td class="vl mono">' + Math.round(c.horas) + '</td></tr>' +
+      '</tbody></table></div>' +
+      (sobra ? '<div class="aviso bad">Hay ' + c.secciones.length + ' secciones y la tabla del machote sólo tiene ' +
+        C.MAX_SECCIONES + ' ranuras. Las de más no llegarían al precio.</div>' : '');
+
+    // BUDGET ODOO
+    const b = c.budget;
+    const budget =
+      '<div class="secc-tit">BUDGET ODOO</div>' +
+      '<div class="scroll"><table class="rejilla estrecha"><tbody>' +
+      '<tr><td class="et">INGRESO</td><td class="vl mono">' + mx(b.ingreso) + '</td></tr>' +
+      '<tr><td class="et">MANO DE OBRA</td><td class="vl mono">' + mx(b.manoObra) + '</td></tr>' +
+      '<tr><td class="et">MATERIALES Y SERVICIOS</td><td class="vl mono">' + mx(b.materiales) + '</td></tr>' +
+      b.comisiones.map(l => '<tr><td class="et">' + esc(l.nombre) + '</td><td class="vl mono">' + mx(l.monto) + '</td></tr>').join('') +
+      '<tr class="total"><td class="et">TOTAL (por defecto lo lanza odoo)</td><td class="vl mono">' + mx(b.total) + '</td></tr>' +
+      '<tr><td class="et">COINCIDE CON LA TABLA?</td><td class="vl mono n-' + (b.cuadra ? 'ok' : 'bad') + '">' +
+      (b.cuadra ? 'VERDADERO' : 'FALSO') + '</td></tr>' +
+      '</tbody></table></div>' +
+      (b.cuadra ? '' : '<div class="aviso bad">El machote muestra este mismo FALSO y aun así deja mandar la cotización. Aquí bloquea.</div>');
+
+    // TABLA DE COMISIONES Y BONOS
+    const eq = (titulo, key, rep, bolsa) => {
+      const suma = (m[key] || []).reduce((a, x) => a + Number(x.pct || 0), 0);
+      return '<tr class="grupo"><td colspan="3">' + titulo + ' · bolsa ' + mx(bolsa) + '</td></tr>' +
+        (m[key] || []).map((it, i) =>
+          '<tr><td>' + cel('eq:' + rep + ':' + i + ':nombre', it.nombre, 'desc') + '</td>' +
+          '<td>' + celNum('eq:' + rep + ':' + i + ':pct', it.pct, 'w70') + '</td>' +
+          '<td class="vl mono">' + mx(bolsa * Number(it.pct)) + '</td></tr>').join('') +
+        '<tr class="total"><td class="et">Suma</td><td class="vl mono n-' +
+        (Math.abs(suma - 1) < 0.0001 ? 'ok' : 'bad') + '">' + pc(suma) + '</td><td></td></tr>';
+    };
+    const comisiones =
+      '<div class="secc-tit">TABLA DE COMISIONES Y BONOS</div>' +
+      '<div class="scroll"><table class="rejilla estrecha"><tbody>' +
+      eq('EQUIPO DE VENTA (' + pc(Number(m.reparto.venta)) + ' de la comisión FTS)', 'equipo_venta', 'venta', c.reparto.bolsaVenta) +
+      eq('EQUIPO DE OPERACIONES (' + pc(Number(m.reparto.operaciones)) + ')', 'equipo_operaciones', 'ops', c.reparto.bolsaOps) +
+      eq('LADO CLIENTE', 'equipo_cliente', 'cli', c.escenario.comisionCliente) +
+      '</tbody></table></div>';
+
+    return encabezado + resumen + porSeccion + budget + comisiones;
+  }
+
+  /* ── Barra fija ──────────────────────────────────────────────────────── */
+  function barra(m, c) {
+    const rev = R.revisar(m);
     $('#fija').innerHTML = '<div class="fija"><div class="grow">' +
-      '<div class="mono ' + 'n-' + (c.costoIncompleto ? 'warn' : nivelMargen(c.margen)) + '">' +
-      mx(c.precio, m.moneda) + ' · ' + pc(c.margen) + (c.costoIncompleto ? '*' : '') + '</div>' +
-      '<div class="tiny">' + (rev.duras.length ? '⛔ ' + rev.duras.length + ' duras' : '✓ sin duras') +
-      (rev.blandas.length ? ' · ⚠ ' + rev.blandas.length : '') +
+      '<div class="mono n-' + (c.costoIncompleto ? 'warn' : nivelMargen(c.margen)) + '">' +
+      mx(c.precio) + ' ' + esc(m.moneda) + ' · ' + pc(c.margen) + (c.costoIncompleto ? '*' : '') + '</div>' +
+      '<div class="tiny">' + esc(c.escenario.id.replace('_', ' ')) +
+      (rev.duras.length ? ' · ⛔ ' + rev.duras.length + ' duras' : ' · ✓ sin duras') +
       (c.costoIncompleto ? ' · ' + c.huecos + ' huecos' : '') + '</div></div>' +
       '<a class="btn" href="#/rev/' + m.id + '">Revisar</a></div>';
   }
 
-  /** Reconstruye lo que depende de los números sin repintar el pane entero:
-   *  repintar mientras se teclea mata el foco del campo. */
-  function refrescar(m) { barraFija(m); }
-
-  /* ── Enlace de campos ───────────────────────────────────────────────── */
+  /* ── Enlace de celdas ────────────────────────────────────────────────── */
   function enlazar(m) {
-    $$('[data-bind]').forEach(el => {
-      const ev = el.tagName === 'SELECT' ? 'change' : 'input';
-      el.oninput = el.onchange = () => {
-        const path = el.dataset.bind;
+    $$('[data-cel]').forEach(el => {
+      const esSel = el.tagName === 'SELECT';
+      const aplicar = () => {
         let v = el.value;
-        if (el.hasAttribute('data-num')) v = parseFloat(v) || 0;
-        if (el.hasAttribute('data-num-null')) v = (v === '' ? null : (parseFloat(v) || 0));
-        if (path.indexOf('s-nombre:') === 0) {
-          const s = m.secciones.find(x => x.id === path.split(':')[1]); if (s) s.nombre = v;
-        } else setPath(m, path, v);
-        refrescar(m);
-        if (ev === 'change') pintarPane(m);
+        if (el.hasAttribute('data-num')) v = (v === '' ? null : (parseFloat(v) || 0));
+        setPath(m, el.dataset.cel, v);
       };
+      // Se recalcula al salir del campo, no en cada tecla: repintar la hoja
+      // mientras se escribe mata el foco a media cifra.
+      el.onchange = () => { aplicar(); pintarHoja(m); barra(m, C.calcular(m)); };
+      if (!esSel) el.oninput = () => { aplicar(); barra(m, C.calcular(m)); };
     });
-    // Primer valor en un renglón de mano de obra vacío: lo crea.
-    $$('[data-mo-init]').forEach(el => {
-      el.onchange = () => {
-        const [sid, rolId, campo] = el.dataset.moInit.split('|');
-        const s = m.secciones.find(x => x.id === sid); if (!s) return;
-        const rol = C.ROL[rolId];
-        const l = { rol: rolId, qty: 0, personas: 1, pu: rol.pu, moneda: m.moneda };
-        l[campo] = parseFloat(el.value) || 0;
-        s.mo.push(l); pintarPane(m); refrescar(m);
-      };
+    const vv = $('#verVacios');
+    if (vv) vv.onchange = () => { ST.verVacios = vv.checked; pintarHoja(m); };
+    $$('[data-esc]').forEach(b => b.onclick = () => {
+      m.escenario = b.dataset.esc; pintarHoja(m); barra(m, C.calcular(m));
     });
-    $$('[data-open]').forEach(b => b.onclick = () => {
-      const k = b.dataset.open; ST.abiertos[k] = !ST.abiertos[k]; pintarPane(m);
+    $$('[data-add]').forEach(b => b.onclick = () => {
+      const s = m.secciones.find(x => x.id === b.dataset.add); if (!s) return;
+      s.partidas.push({ qty: 1, unidad: 'Pieza', tipo: 'Materiales', descripcion: '', modelo: '', marca: '',
+                        pu: null, moneda: m.moneda, margen: null, link: '', comentario: '' });
+      pintarHoja(m); barra(m, C.calcular(m));
     });
     $$('[data-del]').forEach(b => b.onclick = () => {
       const [sid, j] = b.dataset.del.split('#');
       const s = m.secciones.find(x => x.id === sid); if (!s) return;
-      s.partidas.splice(parseInt(j, 10), 1); ST.abiertos = {}; pintarPane(m); refrescar(m);
+      s.partidas.splice(parseInt(j, 10), 1); pintarHoja(m); barra(m, C.calcular(m));
     });
-    $$('[data-add-part]').forEach(b => b.onclick = () => {
-      const s = m.secciones.find(x => x.id === b.dataset.addPart); if (!s) return;
-      s.partidas.push({ qty: 1, unidad: 'Pieza', tipo: 'Materiales', descripcion: '', modelo: '', marca: '',
-                        pu: null, moneda: m.moneda, link: '', comentario: '' });
-      ST.abiertos[s.id + '#' + (s.partidas.length - 1)] = true; pintarPane(m); refrescar(m);
+    $$('[data-delsec]').forEach(b => b.onclick = () => {
+      const i = m.secciones.findIndex(x => x.id === b.dataset.delsec);
+      if (i < 0 || m.secciones.length < 2) return;
+      m.secciones.splice(i, 1); ST.hoja = 'desglose'; vMachote(m.id);
     });
-    $$('[data-add-sec]').forEach(b => b.onclick = () => {
-      if (m.secciones.length >= C.MAX_SECCIONES) return;
-      m.secciones.push({ id: 's-' + Date.now(), nombre: 'SECCION ' + (m.secciones.length + 1), partidas: [], mo: [] });
-      pintarPane(m); refrescar(m);
-    });
-    $$('[data-esc]').forEach(b => b.onclick = () => { m.escenario = b.dataset.esc; pintarPane(m); refrescar(m); });
-    const sm = $('#simM');
-    if (sm) sm.oninput = () => {
-      ST.simMargen = parseFloat(sm.value) || 0;
-      const c = C.calcular(m);
-      const out = $('.sim-out');
-      if (out) out.innerHTML = 'Precio necesario: <strong>' +
-        mx(C.precioParaMargen(c.costo, c.pctFts, c.pctCli, ST.simMargen), m.moneda) + '</strong>';
-    };
   }
 
-  /* ── Revisador ──────────────────────────────────────────────────────── */
+  /* ── Revisión ────────────────────────────────────────────────────────── */
   function vRevision(id) {
     const m = mach(id); if (!m) { location.hash = '#/'; return; }
     const rev = R.revisar(m), c = rev.calc;
-    top('Revisión', m.id + ' · ' + esc(m.nombre), 'REVISOR', '#/m/' + id);
+    top('Revisión', m.id + ' · ' + m.nombre, 'REVISOR', '#/m/' + id);
     $('#fija').innerHTML = '<div class="fija"><div class="grow"><div class="tiny">' +
       (rev.puedeConfirmar ? '✓ Se puede mandar' : '⛔ ' + rev.duras.length + ' hallazgo(s) duro(s)') +
-      '</div></div><a class="btn" href="#/m/' + id + '">Volver a editar</a></div>';
+      '</div></div><a class="btn" href="#/m/' + id + '">Volver a la hoja</a></div>';
 
     const bloque = (t, arr, cls) => !arr.length ? '' :
       '<h3 class="' + cls + '">' + t + ' (' + arr.length + ')</h3>' + arr.map(h =>
         '<div class="wg ' + cls + '"><strong>' + esc(h.titulo) + '</strong>' +
-        '<div class="tiny oc">' + esc(h.area) + '</div>' +
-        '<div>' + esc(h.detalle) + '</div>' +
+        '<div class="tiny oc">' + esc(h.area) + '</div><div>' + esc(h.detalle) + '</div>' +
         (h.items.length ? '<ul class="tiny">' + h.items.map(i => '<li>' + esc(i) + '</li>').join('') + '</ul>' : '') +
-        (h.destino ? '<div class="btnrow"><button class="btn" data-goto="' + h.destino.tab + '">Ir a arreglarlo</button></div>' : '') +
+        '<div class="btnrow"><button class="btn" data-goto="' + esc((h.destino && h.destino.tab) || '') + '">Ir a arreglarlo</button></div>' +
         '</div>').join('');
 
     $('#vista').innerHTML = '<div class="pad">' +
-      '<div class="kpi"><div><span class="tiny">Precio</span><strong class="mono">' + mx(c.precio, m.moneda) + '</strong></div>' +
+      '<div class="kpi"><div><span class="tiny">Precio</span><strong class="mono">' + mx(c.precio) + '</strong></div>' +
       '<div><span class="tiny">Margen</span><strong class="mono n-' + nivelMargen(c.margen) + '">' + pc(c.margen) + '</strong></div>' +
       '<div><span class="tiny">Huecos</span><strong class="mono">' + c.huecos + '</strong></div></div>' +
       (rev.total === 0 ? '<div class="vacio">Sin hallazgos.</div>' : '') +
@@ -459,10 +505,14 @@
       bloque('Blandas · advierten', rev.blandas, 'warn') +
       bloque('Observaciones', rev.infos, 'info') + '</div>';
 
-    $$('[data-goto]').forEach(b => b.onclick = () => { ST.tab = b.dataset.goto; location.hash = '#/m/' + id; });
+    $$('[data-goto]').forEach(b => b.onclick = () => {
+      const t = b.dataset.goto;
+      ST.hoja = (t === 'secc' && m.secciones[0]) ? m.secciones[0].id : 'desglose';
+      location.hash = '#/m/' + id;
+    });
   }
 
-  /* ── Estación 3.0 ───────────────────────────────────────────────────── */
+  /* ── Estación 3.0 ────────────────────────────────────────────────────── */
   const ENTREGABLES = [
     { id: 'alcance',   label: 'Alcance escrito y aceptado por el cliente' },
     { id: 'po',        label: 'Orden de compra o correo de autorización' },
@@ -475,34 +525,20 @@
   function vOrden(id) {
     const o = orden(id); if (!o) { location.hash = '#/'; return; }
     const h = hoff(o.id);
-    top('Confirmar orden', o.so + ' · ' + esc(o.cliente), 'ORDEN', '#/');
-    const listo = ENTREGABLES.every(e => h.entregables[e.id]);
-    const ya = !!ST.confirmadas[o.id];
-
+    top('Confirmar orden', o.so + ' · ' + o.cliente, 'ORDEN', '#/');
     $('#vista').innerHTML = '<div class="pad"><h2>' + esc(o.nombre) + '</h2>' +
-      '<div class="tiny">Confirmada el ' + esc(o.fecha_confirmacion) + ' · ' + mx(o.monto, o.moneda) + '</div>' +
-      (ya ? '<div class="aviso ok">Handoff cerrado. Operaciones ya tiene lo que necesita.</div>' : '') +
+      '<div class="tiny">Confirmada el ' + esc(o.fecha_confirmacion) + ' · ' + mx(o.monto) + ' ' + esc(o.moneda) + '</div>' +
+      (ST.confirmadas[o.id] ? '<div class="aviso ok">Handoff cerrado. Operaciones ya tiene lo que necesita.</div>' : '') +
       '<div class="wg"><h4>Qué tiene que quedar antes de soltarla a operaciones</h4>' +
       ENTREGABLES.map(e => '<label class="row"><input type="checkbox" data-ent="' + e.id + '"' +
         (h.entregables[e.id] ? ' checked' : '') + '><span class="grow">' + esc(e.label) + '</span></label>').join('') +
-      '</div>' +
-      '<div class="wg"><h4>Notas para operaciones</h4>' +
-      '<textarea id="notas" rows="4" placeholder="Lo que no cabe en una casilla.">' + esc(h.notas) + '</textarea></div>' +
-      '</div>';
-
+      '</div><div class="wg"><h4>Notas para operaciones</h4>' +
+      '<textarea id="notas" rows="4" placeholder="Lo que no cabe en una casilla.">' + esc(h.notas) + '</textarea></div></div>';
     barraOrden(o, h);
-
-    // Repintar la vista entera en cada palomita arranca el nodo bajo el cursor
-    // (y hacía fallar el click siguiente). Sólo se refresca la barra de abajo.
-    $$('[data-ent]').forEach(cb => cb.onchange = () => {
-      h.entregables[cb.dataset.ent] = cb.checked;
-      barraOrden(o, h);
-    });
+    $$('[data-ent]').forEach(cb => cb.onchange = () => { h.entregables[cb.dataset.ent] = cb.checked; barraOrden(o, h); });
     $('#notas').oninput = (e) => { h.notas = e.target.value; };
   }
 
-  /** Barra de la estación 3.0. Vive aparte para poder refrescarla sin
-   *  reconstruir la lista de casillas. */
   function barraOrden(o, h) {
     const listo = ENTREGABLES.every(e => h.entregables[e.id]);
     const ya = !!ST.confirmadas[o.id];
@@ -515,22 +551,22 @@
     };
   }
 
-  /* ── Aprobación ─────────────────────────────────────────────────────── */
+  /* ── Aprobación ──────────────────────────────────────────────────────── */
   function vAprobar(id) {
     const m = mach(id); if (!m) { location.hash = '#/'; return; }
     const rev = R.revisar(m), c = rev.calc;
     top('Aprobación', m.id, 'DIRECCIÓN', '#/m/' + id);
     $('#fija').innerHTML = '';
     $('#vista').innerHTML = '<div class="pad"><h2>' + esc(m.nombre) + '</h2>' +
-      '<div class="kpi"><div><span class="tiny">Precio</span><strong class="mono">' + mx(c.precio, m.moneda) + '</strong></div>' +
+      '<div class="kpi"><div><span class="tiny">Precio</span><strong class="mono">' + mx(c.precio) + '</strong></div>' +
       '<div><span class="tiny">Margen</span><strong class="mono n-' + nivelMargen(c.margen) + '">' + pc(c.margen) + '</strong></div>' +
       '<div><span class="tiny">Duras</span><strong class="mono">' + rev.duras.length + '</strong></div></div>' +
       '<div class="wg"><h4>Lo que dirección tiene que ver antes de firmar</h4>' +
-      '<div class="tot"><span class="lb">Costo</span><span class="vl mono">' + mx(c.costo, m.moneda) + '</span></div>' +
-      '<div class="tot"><span class="lb">Comisiones</span><span class="vl mono">' + mx(c.escenario.comisionFts + c.escenario.comisionCliente, m.moneda) + '</span></div>' +
-      '<div class="tot"><span class="lb">Utilidad</span><span class="vl mono">' + mx(c.utilidad, m.moneda) + '</span></div>' +
+      '<div class="tot"><span class="lb">Costo</span><span class="vl mono">' + mx(c.costo) + '</span></div>' +
+      '<div class="tot"><span class="lb">Comisiones</span><span class="vl mono">' + mx(c.escenario.comisionFts + c.escenario.comisionCliente) + '</span></div>' +
+      '<div class="tot"><span class="lb">Utilidad</span><span class="vl mono">' + mx(c.utilidad) + '</span></div>' +
       '<div class="tot"><span class="lb">BUDGET ODOO cuadra</span><span class="vl mono n-' + (c.budget.cuadra ? 'ok' : 'bad') + '">' +
-        (c.budget.cuadra ? 'sí' : 'no') + '</span></div></div>' +
+      (c.budget.cuadra ? 'sí' : 'no') + '</span></div></div>' +
       (rev.duras.length ? '<div class="aviso bad">Tiene ' + rev.duras.length + ' hallazgo(s) duro(s). No debería llegar aquí.</div>'
                         : '<div class="aviso ok">Sin hallazgos duros.</div>') + '</div>';
   }

--- a/comercial/machote/js/calc.js
+++ b/comercial/machote/js/calc.js
@@ -15,7 +15,7 @@
   const num = (v) => (typeof v === 'number' && isFinite(v)) ? v : 0;
   const vacio = (v) => v === null || v === undefined || v === '';
 
-  /* ── Los doce renglones fijos de mano de obra ──────────────────────────
+  /* ── Los diez renglones fijos de mano de obra ──────────────────────────
    * Son los del machote, con sus tarifas de plantilla. El capturista pisa la
    * tarifa; los renglones no se agregan ni se quitan.
    * `mult` dice de qué celda de la tabla de márgenes sale el multiplicador. */
@@ -100,20 +100,28 @@
   }
 
   /** Una línea de materiales o servicios. El `tipo` elige el multiplicador:
-   *  es la columna que decide el precio. Sin tipo no hay precio. */
+   *  es la columna que decide el precio. Sin tipo no hay precio.
+   *
+   *  El machote real permite PISAR ese multiplicador renglón por renglón: en
+   *  `SO11737` hay una partida "riel" de $200 marcada como Materiales con
+   *  margen 1,5 escrito encima de la fórmula, que es de donde salían $20 de
+   *  diferencia contra el archivo. Se respeta el valor pisado y se marca. */
   function costoPartida(linea, m) {
     const mg = margenes(m);
     const sinPrecio = vacio(linea.pu);
     const pu = sinPrecio ? 0 : num(linea.pu);
     const costo = aMonedaDoc(pu * num(linea.qty), linea.moneda, m);
     const sinTipo = TIPOS.indexOf(linea.tipo) === -1;
-    const mult = sinTipo ? 0 : num(linea.tipo === 'Materiales' ? mg.materiales : mg.servicios);
-    return { costo, mult, conUtilidad: costo * mult, sinPrecio, sinTipo, sinLink: !linea.link };
+    const porTipo = sinTipo ? 0 : num(linea.tipo === 'Materiales' ? mg.materiales : mg.servicios);
+    const pisado = !vacio(linea.margen) && Math.abs(num(linea.margen) - porTipo) > 0.0001;
+    const mult = pisado ? num(linea.margen) : porTipo;
+    return { costo, mult, porTipo, pisado,
+             conUtilidad: costo * mult, sinPrecio, sinTipo, sinLink: !linea.link };
   }
 
   function totalSeccion(s, m) {
     let costoMoTot = 0, ventaMo = 0, horas = 0, moSinTarifa = 0;
-    let costoMat = 0, ventaMat = 0, sinPrecio = 0, sinTipo = 0, sinLink = 0;
+    let costoMat = 0, ventaMat = 0, sinPrecio = 0, sinTipo = 0, sinLink = 0, pisados = 0;
     const monedas = {};
 
     (s.mo || []).forEach(l => {
@@ -129,6 +137,7 @@
       if (!usada) return;
       if (c.sinPrecio) sinPrecio++;
       if (c.sinTipo) sinTipo++;
+      if (c.pisado) pisados++;
       if (c.sinLink && !vacio(l.pu)) sinLink++;
       if (l.moneda) monedas[l.moneda] = 1;
     });
@@ -137,7 +146,7 @@
       id: s.id, nombre: s.nombre,
       costoMo: costoMoTot, costoMat, costo: costoMoTot + costoMat,
       ventaMo, ventaMat, venta: ventaMo + ventaMat,
-      horas, moSinTarifa, sinPrecio, sinTipo, sinLink,
+      horas, moSinTarifa, sinPrecio, sinTipo, sinLink, pisados,
       monedas: Object.keys(monedas)
     };
   }
@@ -215,13 +224,28 @@
     // sección, no por margen propio de sección. El margen es una restricción
     // global. (DESGLOSE COTIZACION I18/J18.)
     const detalle = secciones.map(s => {
-      const peso = costo > 0 ? s.costo / costo : 0;
-      const precioSec = elegido.precio === null ? null
-        : (elegido.id === 'con_utilidad' ? s.venta + (comFtsCU + comCliCU) * (venta > 0 ? s.venta / venta : 0)
-        : elegido.id === 'costo' ? s.costo
-        : elegido.precio * peso);
+      const peso = costo > 0 ? s.costo / costo : 0;              // peso por COSTO
+      const pesoV = venta > 0 ? s.venta / venta : 0;             // peso por VENTA
+
+      // Los tres escenarios por sección: es la tabla RESUMEN del machote.
+      // Bajo margen deseado el precio se reparte a prorrata del COSTO, y el
+      // reparto entre mano de obra y materiales usa el costo de cada bloque.
+      const pMo  = costo > 0 ? s.costoMo / costo : 0;
+      const pMat = costo > 0 ? s.costoMat / costo : 0;
+      const esc = {
+        costo: { mo: s.costoMo, mat: s.costoMat, precio: s.costo },
+        con_utilidad: {
+          mo: s.ventaMo, mat: s.ventaMat,
+          precio: s.venta + (comFtsCU + comCliCU) * pesoV
+        },
+        margen_deseado: precioMD === null
+          ? { mo: null, mat: null, precio: null }
+          : { mo: precioMD * pMo, mat: precioMD * pMat, precio: precioMD * peso }
+      };
+
+      const precioSec = esc[elegido.id] ? esc[elegido.id].precio : null;
       return Object.assign({}, s, {
-        peso,
+        peso, pesoV, esc,
         precio: precioSec,
         utilidad: precioSec === null ? null : precioSec - s.costo - (elegido.precio > 0 ? (elegido.comisionFts + elegido.comisionCliente) * peso : 0),
         margenObtenido: s.venta > 0 ? (s.venta - s.costo) / s.venta : null
@@ -257,6 +281,7 @@
     const moSinTarifa = secciones.reduce((a, s) => a + s.moSinTarifa, 0);
     const sinTipo     = secciones.reduce((a, s) => a + s.sinTipo, 0);
     const sinLink     = secciones.reduce((a, s) => a + s.sinLink, 0);
+    const pisados     = secciones.reduce((a, s) => a + s.pisados, 0);
     const monedas = {};
     secciones.forEach(s => s.monedas.forEach(x => { monedas[x] = 1; }));
     const mezclaMoneda = Object.keys(monedas).length > 1;
@@ -281,7 +306,7 @@
       pesoMat: costo > 0 ? costoMat / costo : null,
       reparto: { venta: venta_, operaciones: ops_, cliente: cliente_, bolsaVenta, bolsaOps },
       budget,
-      sinPrecio, moSinTarifa, sinTipo, sinLink, mezclaMoneda,
+      sinPrecio, moSinTarifa, sinTipo, sinLink, pisados, mezclaMoneda,
       huecos, costoIncompleto: huecos > 0
     };
   }

--- a/comercial/machote/js/demo.js
+++ b/comercial/machote/js/demo.js
@@ -121,6 +121,11 @@
         ]),
         sec('Instalación en sitio', [
           p(1, 'Servicio', 'Servicios', 'Maniobra con grúa de 20 t', '', 'Subcontratado', 28000, 'MXN', 'https://proveedor.example/gruas'),
+          // REAL — el machote deja pisar el margen renglón por renglón, encima
+          // de la fórmula que lo deriva del Tipo. En SO11737 hay una partida
+          // "riel" de $200 marcada como Materiales con margen 1,5 escrito a
+          // mano: de ahí salían $20 de diferencia contra el archivo.
+          Object.assign(p(4, 'Pieza', 'Materiales', 'Riel de soporte galvanizado', '', 'Unistrut', 200, 'MXN', 'https://proveedor.example/riel'), { margen: 1.5 }),
           p(200, 'Horas', 'Materiales', 'Seguimiento durante instalación', 'Project Manager', '', 200, 'MXN', '')
         ], [
           mo('supervisor_jr', 80, 1),

--- a/comercial/machote/tests/pruebas-navegador.js
+++ b/comercial/machote/tests/pruebas-navegador.js
@@ -13,10 +13,29 @@ const { chromium } = require('playwright');
 const path = require('path');
 const BASE = 'file://' + path.resolve(__dirname, '..', 'index.html');
 
+/* El navegador con el que se corre.
+ *
+ * En una laptop basta `chromium.launch()`. En el contenedor de Claude Code el
+ * binario vive en una ruta fija y NO se puede descargar (cdn.playwright.dev
+ * está fuera de la lista blanca del proxy), así que se apunta a mano.
+ * Se prefiere `headless_shell`, que es lo que Playwright usa de todos modos
+ * para modo headless desde la 1.49.
+ *
+ * Si en tu máquina Playwright ya tiene su navegador, borra `executablePath`
+ * o exporta CHROMIUM_PATH con la ruta que quieras. */
+const fs = require('fs');
+const CANDIDATOS = [
+  process.env.CHROMIUM_PATH,
+  '/opt/pw-browsers/chromium_headless_shell-1194/chrome-linux/headless_shell',
+  '/opt/pw-browsers/chromium'
+].filter(Boolean);
+const EXE = CANDIDATOS.find(x => { try { return fs.statSync(x).isFile(); } catch (e) { return false; } });
+const OPCIONES = EXE ? { executablePath: EXE } : {};
+
 let ok = 0, mal = 0;
 
 (async () => {
-  const b = await chromium.launch({ executablePath: '/opt/pw-browsers/chromium' });
+  const b = await chromium.launch(OPCIONES);
   const errs = [];
   const p = await b.newPage({ viewport: { width: 380, height: 780 } });
   // El contenedor no tiene salida a fonts.googleapis.com, que fts-styles.css
@@ -32,7 +51,20 @@ let ok = 0, mal = 0;
     try { await fn(); console.log('✓', n); ok++; }
     catch (e) { console.log('✗', n, '→', e.message); mal++; }
   };
-  const ir = async (h) => { await p.evaluate(x => { location.hash = x; }, h); await p.waitForTimeout(220); };
+  // Asignar el mismo hash que ya está puesto NO dispara `hashchange`, así que
+  // la vista no se repinta y la prueba mide la pantalla anterior. Se pasa por
+  // '#/' primero para forzar el repintado.
+  const ir = async (h) => {
+    await p.evaluate(() => { location.hash = '#/'; });
+    await p.waitForTimeout(80);
+    await p.evaluate(x => { location.hash = x; }, h);
+    await p.waitForTimeout(260);
+  };
+  // Abre una hoja del libro por su nombre.
+  const hoja = async (nom) => {
+    const b = p.locator('.pestana', { hasText: nom });
+    await b.first().click(); await p.waitForTimeout(240);
+  };
 
   await p.goto(BASE); await p.waitForTimeout(400);
 
@@ -119,86 +151,105 @@ let ok = 0, mal = 0;
     if (Math.abs(r - 1890) > 0.01) throw new Error('costo ' + r);
   });
 
-  // ── Pantallas ────────────────────────────────────────────────────────
+  // ── La hoja ──────────────────────────────────────────────────────────
   await paso('la lista carga con machotes y órdenes', async () => {
     const n = await p.locator('.item').count();
     if (n < 6) throw new Error('pocas tarjetas: ' + n);
-    console.log('   tarjetas:', n);
   });
 
-  await paso('las cinco pestañas de la estación 2.0 pintan', async () => {
+  await paso('el libro abre con sus pestañas de hoja', async () => {
     await ir('#/m/M-1041');
-    for (const t of ['diag', 'secc', 'gen', 'com', 'sim']) {
-      await p.click('[data-tab="' + t + '"]'); await p.waitForTimeout(160);
-      const h = await p.locator('#pane').innerHTML();
-      if (!h || h.length < 60) throw new Error('pestaña vacía: ' + t);
+    const t = await p.locator('.pestana').allTextContents();
+    if (!t[0] || !/DESGLOSE/.test(t[0])) throw new Error('primera pestaña: ' + t[0]);
+    if (t.length < 3) throw new Error('faltan hojas: ' + t.join(' | '));
+    console.log('   hojas:', t.filter(x => x !== '+').join(' · '));
+  });
+
+  await paso('la hoja de sección trae los encabezados del machote', async () => {
+    await ir('#/m/M-1041');
+    await hoja('Suministro');
+    const t = await p.textContent('#hoja');
+    for (const x of ['Costos desglosados', 'Margen de utilidad', 'NOMBRE DE SECCIÓN',
+                     'COSTO MANO DE OBRA', 'COSTO MATERIALES Y SERVICIOS',
+                     'Precio de Venta FTS', 'Horas sección']) {
+      if (t.indexOf(x) < 0) throw new Error('falta: ' + x);
     }
   });
 
-  await paso('bajo CON UTILIDAD, cambiar un multiplicador mueve el precio', async () => {
-    await ir('#/m/M-1041'); await p.click('[data-tab="sim"]'); await p.waitForTimeout(160);
-    await p.click('[data-esc="con_utilidad"]'); await p.waitForTimeout(160);
-    await p.click('[data-tab="gen"]'); await p.waitForTimeout(160);
-    const antes = await p.textContent('.fija .mono');
-    await p.fill('[data-bind="margenes.materiales"]', '3.5');
-    await p.dispatchEvent('[data-bind="margenes.materiales"]', 'input');
-    await p.waitForTimeout(200);
-    const desp = await p.textContent('.fija .mono');
-    if (antes === desp) throw new Error('el precio no se movió: ' + antes);
-    console.log('   ', antes.trim(), '→', desp.trim());
+  await paso('los diez renglones de mano de obra están siempre, en sus tres grupos', async () => {
+    await ir('#/m/M-1041');
+    await hoja('Suministro');
+    const g = await p.locator('#hoja tr.grupo').allTextContents();
+    const esperados = ['Diseño y Programación', 'En Planta', 'Extras'];
+    for (const e of esperados) if (!g.some(x => x.indexOf(e) >= 0)) throw new Error('falta grupo ' + e);
+    const rot = await p.locator('#hoja td.rotulo').allTextContents();
+    const soloMo = rot.filter(x => x !== 'TOTAL');
+    if (soloMo.length !== 10) throw new Error('renglones de MO: ' + soloMo.length);
   });
 
-  // Propiedad real del machote, no un bug: bajo MARGEN DESEADO el precio sale
-  // de costo / (1 - margen - comisiones). Los multiplicadores no entran en esa
-  // cuenta, asi que moverlos NO cambia el precio: solo cambian el escenario
-  // CON UTILIDAD y, con el, el reparto entre secciones. Vale la pena fijarlo
-  // en una prueba porque es lo primero que confunde a quien abre el machote.
-  await paso('bajo MARGEN DESEADO, el multiplicador NO mueve el precio', async () => {
-    await ir('#/m/M-1042'); await p.click('[data-tab="sim"]'); await p.waitForTimeout(160);
-    await p.click('[data-esc="margen_deseado"]'); await p.waitForTimeout(160);
-    await p.click('[data-tab="gen"]'); await p.waitForTimeout(160);
-    const antes = await p.textContent('.fija .mono');
-    await p.fill('[data-bind="margenes.materiales"]', '4.2');
-    await p.dispatchEvent('[data-bind="margenes.materiales"]', 'input');
-    await p.waitForTimeout(200);
-    const desp = await p.textContent('.fija .mono');
-    if (antes !== desp) throw new Error('cambió y no debía: ' + antes + ' → ' + desp);
+  await paso('la hoja DESGLOSE trae los cuatro bloques del machote', async () => {
+    await ir('#/m/M-1041'); await hoja('DESGLOSE');
+    const t = await p.textContent('#hoja');
+    for (const x of ['ELIGE UN ESCENARIO', 'RESUMEN BUDGET', 'RESUMEN POR SECCIÓN',
+                     'BUDGET ODOO', 'TABLA DE COMISIONES Y BONOS', 'Factor_req',
+                     'PRECIO DE VENTA ANTE DE IMPUESTO']) {
+      if (t.indexOf(x) < 0) throw new Error('falta: ' + x);
+    }
   });
 
-  await paso('los tres escenarios dan tres precios distintos', async () => {
-    await ir('#/m/M-1041'); await p.click('[data-tab="sim"]'); await p.waitForTimeout(160);
+  await paso('la tabla por sección tiene las diez ranuras del machote', async () => {
+    await ir('#/m/M-1041'); await hoja('DESGLOSE');
+    const filas = await p.locator('#hoja .rejilla.ancha tbody tr').count();
+    if (filas < 11) throw new Error('filas: ' + filas + ' (10 ranuras + SUMA)');
+  });
+
+  await paso('cambiar el escenario mueve el precio de la barra', async () => {
+    await ir('#/m/M-1041'); await hoja('DESGLOSE');
     const v = [];
     for (const e of ['costo', 'con_utilidad', 'margen_deseado']) {
-      await p.click('[data-esc="' + e + '"]'); await p.waitForTimeout(160);
+      await p.click('[data-esc="' + e + '"]'); await p.waitForTimeout(200);
       v.push((await p.textContent('.fija .mono')).trim());
     }
     if (new Set(v).size !== 3) throw new Error('escenarios iguales: ' + v.join(' | '));
     console.log('   costo', v[0], '· con utilidad', v[1], '· margen deseado', v[2]);
   });
 
+  await paso('editar una celda recalcula', async () => {
+    await ir('#/m/M-1042'); await hoja('DESGLOSE');
+    await p.click('[data-esc="con_utilidad"]'); await p.waitForTimeout(200);
+    await hoja('Adecuación');
+    const antes = await p.textContent('.fija .mono');
+    await p.fill('[data-cel="margenes.materiales"]', '3.2');
+    await p.dispatchEvent('[data-cel="margenes.materiales"]', 'input');
+    await p.waitForTimeout(250);
+    const desp = await p.textContent('.fija .mono');
+    if (antes === desp) throw new Error('no se movió: ' + antes);
+    console.log('   ', antes.trim(), '→', desp.trim());
+  });
+
+  await paso('un margen pisado a mano se marca', async () => {
+    await ir('#/m/M-1041');
+    await hoja('Instalación');
+    const n = await p.locator('#hoja .cel.pisado').count();
+    if (n === 0) throw new Error('no marcó ninguno');
+    console.log('   ', n, 'renglón(es) con el margen escrito encima de la fórmula');
+  });
+
   await paso('el revisador encuentra la partida sin precio', async () => {
     await ir('#/rev/M-1041');
-    const t = await p.textContent('#vista');
-    if (!/Partidas sin precio/.test(t)) throw new Error('no la reportó');
+    if (!/Partidas sin precio/.test(await p.textContent('#vista'))) throw new Error('no la reportó');
   });
 
   await paso('el revisador encuentra el reparto de comisiones descuadrado', async () => {
     await ir('#/rev/M-1044');
     const t = await p.textContent('#vista');
     if (!/no suma 100/.test(t)) throw new Error('no lo reportó');
-    if (!/BUDGET ODOO no cuadra/.test(t)) throw new Error('no reportó el descuadre del budget');
+    if (!/BUDGET ODOO no cuadra/.test(t)) throw new Error('no reportó el descuadre');
   });
 
   await paso('el revisador exige tipo de cambio cuando hay dos monedas', async () => {
     await ir('#/rev/M-1043');
-    const t = await p.textContent('#vista');
-    if (!/no hay tipo de cambio/.test(t)) throw new Error('no lo reportó');
-  });
-
-  await paso('"Ir a arreglarlo" lleva a la pestaña correcta', async () => {
-    await ir('#/rev/M-1043');
-    await p.click('[data-goto]'); await p.waitForTimeout(250);
-    if (!/#\/m\//.test(await p.evaluate(() => location.hash))) throw new Error('no navegó');
+    if (!/no hay tipo de cambio/.test(await p.textContent('#vista'))) throw new Error('no lo reportó');
   });
 
   await paso('la estación 3.0 no deja cerrar el handoff incompleto', async () => {
@@ -208,24 +259,42 @@ let ok = 0, mal = 0;
 
   await paso('marcar todo habilita el cierre, y la marca no se pierde', async () => {
     await ir('#/orden/O-9001');
-    // La vista se repinta en cada cambio, asi que hay que volver a buscar el
-    // pendiente en cada vuelta: guardar los locators de antemano no sirve.
     for (let i = 0; i < 12; i++) {
       const pend = p.locator('[data-ent]:not(:checked)');
       if (await pend.count() === 0) break;
-      await pend.first().check();
-      await p.waitForTimeout(120);
+      await pend.first().check(); await p.waitForTimeout(120);
     }
-    if (await p.locator('[data-ent]:not(:checked)').count()) throw new Error('quedaron casillas sin marcar');
     if (await p.locator('#btnConf').isDisabled()) throw new Error('sigue deshabilitado');
     await p.click('#btnConf'); await p.waitForTimeout(250);
     if (!/Handoff cerrado/.test(await p.textContent('#vista'))) throw new Error('no cerró');
   });
 
-  await paso('la aprobación muestra el cuadre del BUDGET ODOO', async () => {
-    await ir('#/ap/M-1044');
-    const t = await p.textContent('#vista');
-    if (!/BUDGET ODOO cuadra/.test(t)) throw new Error('no lo muestra');
+  await paso('volver al mismo machote conserva la hoja donde ibas', async () => {
+    await ir('#/m/M-1041'); await hoja('Instalación');
+    await ir('#/rev/M-1041');
+    await p.evaluate(() => { location.hash = '#/m/M-1041'; }); await p.waitForTimeout(260);
+    const on = await p.locator('.pestana.on').textContent();
+    if (!/Instalación/.test(on)) throw new Error('cayó en: ' + on);
+  });
+
+  // El precio es lo único que el analista mira sin parar. Que un botón se lo
+  // coma es un fallo silencioso: la pantalla se ve bien y el dato no está.
+  await paso('la barra siempre muestra el precio, no sólo el botón', async () => {
+    for (const [w, h] of [[390, 844], [1440, 900]]) {
+      await p.setViewportSize({ width: w, height: h });
+      await ir('#/m/M-1041');
+      const r = await p.evaluate(() => {
+        const g = document.querySelector('.fija .grow');
+        const b = document.querySelector('.fija .btn');
+        return { ancho: g ? Math.round(g.getBoundingClientRect().width) : -1,
+                 texto: g ? g.textContent.trim().slice(0, 20) : '',
+                 boton: b ? Math.round(b.getBoundingClientRect().width) : -1 };
+      });
+      if (r.ancho < 120) throw new Error('a ' + w + 'px el precio mide ' + r.ancho + 'px de ancho');
+      if (!/\$/.test(r.texto)) throw new Error('a ' + w + 'px no hay precio: ' + r.texto);
+      if (r.boton > w * 0.6) throw new Error('a ' + w + 'px el botón ocupa ' + r.boton + 'px');
+    }
+    await p.setViewportSize({ width: 380, height: 780 });
   });
 
   // ── Diseño ───────────────────────────────────────────────────────────
@@ -235,15 +304,111 @@ let ok = 0, mal = 0;
       const d = await p.evaluate(() => document.documentElement.scrollWidth - document.documentElement.clientWidth);
       if (d > 2) throw new Error(h + ' desborda ' + d + ' px');
     }
+    await ir('#/m/M-1041');
+    await hoja('Suministro');
+    const d = await p.evaluate(() => document.documentElement.scrollWidth - document.documentElement.clientWidth);
+    if (d > 2) throw new Error('la hoja de sección desborda ' + d + ' px');
   });
 
-  await paso('nada desborda a 1280 px', async () => {
+  await paso('en teléfono la captura son tarjetas, no una retícula', async () => {
+    await ir('#/m/M-1041');
+    await hoja('Suministro');
+    const r = await p.evaluate(() => {
+      const td = document.querySelector('.rejilla.tarjetas tbody td');
+      const th = document.querySelector('.rejilla.tarjetas thead');
+      return { disp: td && getComputedStyle(td).display,
+               cabOculta: th ? getComputedStyle(th).display === 'none' : false,
+               rotulo: !!document.querySelector('.rejilla.tarjetas td.rotulo') };
+    });
+    if (r.disp !== 'flex') throw new Error('las celdas no se apilan: ' + r.disp);
+    if (!r.cabOculta) throw new Error('el encabezado de tabla sigue visible');
+    if (!r.rotulo) throw new Error('las tarjetas no traen su rótulo');
+  });
+
+  await paso('cada campo de la tarjeta dice de qué columna es', async () => {
+    await ir('#/m/M-1041');
+    await hoja('Suministro');
+    const sin = await p.evaluate(() => {
+      const out = [];
+      document.querySelectorAll('.rejilla.tarjetas tbody tr:not(.grupo):not(.total) td').forEach(td => {
+        if (getComputedStyle(td).display === 'none') return;
+        if (td.classList.contains('rotulo') || td.classList.contains('acc')) return;
+        if (!td.getAttribute('data-l')) out.push(td.className || '(sin clase)');
+      });
+      return out;
+    });
+    if (sin.length) throw new Error(sin.length + ' celda(s) sin etiqueta: ' + sin.slice(0, 3).join(', '));
+  });
+
+  await paso('todo lo que se toca mide al menos 40 px de alto', async () => {
+    const chico = [];
+    for (const h of ['#/', '#/m/M-1041', '#/orden/O-9002']) {
+      await ir(h);
+      if (h === '#/m/M-1041') { await hoja('Suministro'); }
+      const r = await p.evaluate(() => {
+        const out = [];
+        document.querySelectorAll('button, a.btn, a.item, input:not([type=checkbox]), select, textarea').forEach(el => {
+          const b = el.getBoundingClientRect();
+          if (b.height > 0 && b.height < 40) out.push((el.tagName + '.' + (el.className || '')).slice(0, 40) + ' → ' + Math.round(b.height) + 'px');
+        });
+        return out;
+      });
+      chico.push.apply(chico, r);
+    }
+    if (chico.length) throw new Error(chico.length + ' objetivo(s) chico(s): ' + chico.slice(0, 4).join(' · '));
+  });
+
+  await paso('se puede capturar con el pulgar: escribir en una tarjeta', async () => {
+    await ir('#/m/M-1041');
+    await hoja('Suministro');
+    const campo = p.locator('.rejilla.tarjetas tr:visible [data-cel$=":qty"]').first();
+    await campo.click(); await campo.fill('7'); await campo.blur();
+    await p.waitForTimeout(300);
+    const v = await p.locator('.rejilla.tarjetas tr:visible [data-cel$=":qty"]').first().inputValue();
+    if (v !== '7') throw new Error('no guardó: ' + v);
+  });
+
+  // Los doce renglones del Excel en un teléfono son doce tarjetas, y siete
+  // suelen ir en cero. Se pliegan, pero el interruptor tiene que decir
+  // cuántas hay y devolverlas al instante: si desaparecen sin aviso, el
+  // capturista cree que se le borraron.
+  await paso('los renglones en cero se pliegan y el interruptor los devuelve', async () => {
+    await ir('#/m/M-1041');
+    await hoja('Suministro');
+    const conteo = () => p.locator('.rejilla.tarjetas tr.enCero:visible').count();
+    if (await conteo() !== 0) throw new Error('no se plegaron');
+    const et = await p.textContent('.verVacios');
+    if (!/ver los \d+ en cero/.test(et)) throw new Error('el interruptor no dice cuántas: ' + et);
+    await p.check('#verVacios'); await p.waitForTimeout(300);
+    if (await conteo() === 0) throw new Error('el interruptor no los devolvió');
+    await p.uncheck('#verVacios'); await p.waitForTimeout(300);
+  });
+
+  await paso('en escritorio se ven los diez renglones, como en el Excel', async () => {
+    await p.setViewportSize({ width: 1280, height: 900 });
+    await ir('#/m/M-1041'); await hoja('Suministro');
+    const n = await p.locator('#hoja .rejilla.tarjetas').first()
+      .locator('tbody tr:not(.grupo):not(.total):visible').count();
+    if (n !== 10) throw new Error('renglones de mano de obra visibles: ' + n);
+    await p.setViewportSize({ width: 380, height: 780 });
+  });
+
+  await paso('a 1280 px vuelve a ser retícula, y no desborda', async () => {
     await p.setViewportSize({ width: 1280, height: 900 });
     for (const h of ['#/', '#/m/M-1041', '#/rev/M-1044']) {
       await ir(h);
       const d = await p.evaluate(() => document.documentElement.scrollWidth - document.documentElement.clientWidth);
       if (d > 2) throw new Error(h + ' desborda ' + d + ' px');
     }
+    await ir('#/m/M-1041');
+    await hoja('Suministro');
+    const disp = await p.evaluate(() => {
+      const td = document.querySelector('.rejilla.tarjetas tbody td');
+      return td && getComputedStyle(td).display;
+    });
+    if (disp !== 'table-cell') throw new Error('no volvió a retícula: ' + disp);
+    const d = await p.evaluate(() => document.documentElement.scrollWidth - document.documentElement.clientWidth);
+    if (d > 2) throw new Error('la hoja desborda ' + d + ' px en escritorio');
     await p.setViewportSize({ width: 380, height: 780 });
   });
 

--- a/docs/comercial/MACHOTE-ESTRUCTURA-REAL.md
+++ b/docs/comercial/MACHOTE-ESTRUCTURA-REAL.md
@@ -83,19 +83,19 @@ Comision CLIENTE 0%     (F7, = 'DESGLOSE COTIZACION'!B8)
 **El margen es un MULTIPLICADOR por concepto, no un porcentaje global.** Precio de una
 partida = costo × multiplicador.
 
-Verificado en 8 ejemplares. Lo que **no** varía:
+Verificado en 12 ejemplares, cinco de ellos cotizaciones de 2026 (SO11737, SO11738, SO11790, SO11836 y el USD de calbee). Lo que **no** varía:
 
 | concepto | valor | ejemplares |
 |---|---|---|
-| Programador | **4,4** | 8 de 8 |
-| Mano de obra | **2,5** | 8 de 8 |
-| Horas extras | **mano de obra × 2 = 5,0** (fórmula `=$F$3*2`) | 8 de 8 |
+| Programador | **4,4** | 12 de 12 |
+| Mano de obra | **2,5** | 12 de 12 |
+| Horas extras | **mano de obra × 2 = 5,0** (fórmula `=$F$3*2`) | 12 de 12 |
 
 Lo que **sí** varía por cotización — y por eso son campos, no constantes:
 
 | concepto | valores vistos |
 |---|---|
-| Materiales | 1,4 · **1,8** · 2,5 |
+| Materiales | 1,4 · 1,6 · **1,8** · 2,5 |
 | Servicios | 1,5 · **1,7** · 1,8 |
 | Comisión FTS | 0% · 5% · **5,5%** · 6% |
 | Comisión cliente | 0% · 5% · 5,2% · 5,5% · 10% |
@@ -186,6 +186,39 @@ DIEGO, MONTY, Rissia, RICARDO) con su porcentaje. En la plantilla son 0,25 cada 
 ⚠️ **Defecto real encontrado:** en `Paso de Gato MXN - SO11782.xlsx` los porcentajes de venta
 son 0,20 + 0,15 + 0,05 + 0,70 + 0,15 = **1,25**, y la celda de cuadre dice `FALSO`. El machote
 detecta el descuadre pero no lo impide. Eso es exactamente una regla dura para el revisador.
+
+---
+
+### 2.8 El margen se puede pisar renglón por renglón
+
+La columna `Margen utilidad` de materiales trae la fórmula
+`=IF(Tipo="Materiales", F4, F5)`, pero **es una celda como cualquier otra y la
+gente escribe encima**.
+
+Caso concreto: en `SO11737` la partida **"riel"** de $200, marcada como
+`Materiales` (multiplicador 1,4), tiene **1,5** escrito a mano. De ahí salían
+exactamente $20 de diferencia cuando se reconstruía el archivo suponiendo que
+el Tipo mandaba siempre. Con el margen pisado respetado, el libro cuadra al peso:
+venta de materiales 142,295 · precio con utilidad 305,839 · utilidad 136,070.
+
+El motor respeta el valor pisado **y lo marca**, porque un margen sobrescrito
+en una de cuarenta partidas no lo ve nadie leyendo la hoja.
+
+---
+
+## 2.9 Las ranuras son diez, aunque haya más secciones
+
+La tabla RESUMEN de `DESGLOSE COTIZACION` tiene **diez** filas de sección, y de
+ahí sale el precio. Pero un libro puede tener más hojas de sección: el machote
+USD de calbee de 2026 tiene **once**, más una hoja suelta `Analisis` que no es
+sección.
+
+Las hojas de sección también se renombran al alcance real y ocupan la ranura por
+posición, no por nombre: en ese mismo archivo las ranuras 1 y 2 son `MO` y
+`MATERIALS`. **Una sección más allá de la ranura diez no llega al precio y nada
+lo advierte.**
+
+Conteo de hojas de sección en los cinco machotes de 2026 revisados: 6 · 7 · 9 · 9 · 11.
 
 ---
 


### PR DESCRIPTION
Dos correcciones a lo que se mergeó en #149: la pantalla no se parecía al machote de SharePoint, y en teléfono no era operable.

## La pantalla ahora es la hoja

Lo anterior era un formulario. El machote es una hoja de cálculo, así que ahora la interfaz reproduce su retícula:

- **Pestañas por hoja**, nombradas como en el libro.
- **Hoja de sección**: el bloque `Costos desglosados` y la tabla `Concepto / Margen de utilidad` arriba, `NOMBRE DE SECCIÓN`, `COSTO MANO DE OBRA` con sus diez renglones fijos en los tres grupos (Diseño y Programación · En Planta · Extras), y `COSTO MATERIALES Y SERVICIOS` con sus trece columnas incluyendo `Tipo`, `Link` y `Comentario`.
- **Hoja `DESGLOSE COTIZACIÓN`**: los tres escenarios, `RESUMEN BUDGET`, las diez ranuras de sección con sus tres grupos de columnas, `Factor_req`, `BUDGET ODOO` y `TABLA DE COMISIONES Y BONOS`.

Levantada sobre **cinco cotizaciones de 2026** —SO11737, SO11738, SO11790, SO11836 y el USD de calbee— no sobre una. La retícula es idéntica en las cinco: mismos encabezados, mismos diez renglones, mismos bloques y en el mismo orden.

## En teléfono la retícula desaparece

Catorce columnas con el pulgar no se capturan. Reproducir el Excel en un teléfono habría sido fidelidad mal entendida.

- Cada renglón se vuelve una **tarjeta** con sus campos etiquetados por su columna.
- Los renglones de mano de obra **en cero se pliegan**, detrás de un interruptor que dice cuántos hay — si desaparecieran sin aviso, el capturista creería que se le borraron.
- **Nada de lo que se toca baja de 44 px**, incluida la flecha de volver, que venía a 24 px desde `shared/fts-styles.css`.
- En pantalla ancha vuelve la retícula completa, y el contenedor se ensancha a 1500 px: `.scr` estaba fijo en 520 px, correcto para el kiosko y lo contrario de lo que necesita una hoja.

Hay pruebas para las dos formas.

## Dos hallazgos del acervo que cambian el modelo

**1 · El margen se puede pisar renglón por renglón.** La columna `Margen utilidad` trae la fórmula `=IF(Tipo="Materiales",F4,F5)`, pero es una celda como cualquier otra y la gente escribe encima. En `SO11737` la partida **"riel"** de $200, marcada como `Materiales` (×1,4), tiene **1,5** a mano. De ahí salían exactamente $20 de diferencia al reconstruir el archivo.

Con el valor pisado respetado, SO11737 cuadra **al peso**:

| | motor | archivo |
|---|---|---|
| venta de materiales | 142,295 | 142,295 |
| precio con utilidad | 305,839 | 305,839 |
| utilidad | 136,070 | 136,070 |
| `Factor_req` | 1.730103806 | 1.730103806 |
| sección · margen deseado, mano de obra | 95,279 | 95,279 |
| sección · margen deseado, materiales | 185,492 | 185,492 |

Se respeta **y se marca**, porque un margen sobrescrito en una de cuarenta partidas no lo ve nadie leyendo la hoja.

**2 · Las ranuras son diez aunque el libro tenga más hojas.** El USD de calbee de 2026 tiene **once** secciones y una hoja suelta `Analisis` que no lo es. La sección once no llega al precio y nada lo advierte. Conteo en los cinco de 2026: 6 · 7 · 9 · 9 · 11. Aquí se avisa.

Y la varianza de márgenes se amplía con los nuevos: Materiales 1,4 · 1,6 · 1,8 · 2,5. Programador 4,4 y mano de obra 2,5 siguen invariantes, ahora **12 de 12**.

## Pruebas

**32 en verde.** Cuatro fallos que sólo aparecieron al correrlas y mirar las capturas:

1. `shared/fts-styles.css` define `.btn{width:100%}` para el kiosko. En la barra fija eso hacía que "Revisar" se comiera el ancho entero y el precio quedara en **cero px**. La pantalla se veía bien y el dato no estaba. Hay una prueba que lo fija a 390 y a 1440 px.
2. `td[colspan]{display:none}` ocultaba también los títulos de grupo de las tarjetas, que son justo lo que las ordena.
3. El rótulo de un grupo con todos sus renglones en cero quedaba huérfano.
4. La barra se partía en dos renglones y crecía a 101 px; ahora mide 61.

## Una advertencia para quien siga

⚠️ **No instalar `@playwright/cli` en este repo sin fijar la versión.** Arrastra un `playwright-core` de prerelease cuyo protocolo no habla con el Chromium del contenedor: el navegador arranca y nunca contesta, y el fallo se ve como un cuelgue sin mensaje. Queda anotado en el README y en el #152.

## Alcance

Toca sólo `comercial/machote/` y su documento en `docs/comercial/`. Ningún otro módulo, ningún borrado.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013Qzhio6K8R23HXHnJ2RJ64