### PR TITLE
comercial(machote): versionado V1.00–V1.99 por merge

### DIFF
--- a/comercial/machote/README.md
+++ b/comercial/machote/README.md
@@ -16,28 +16,38 @@ Los **datos** de las cuatro cotizaciones de ejemplo sí son inventados.
 
 ## Versión
 
-El build se ve en pantalla: al pie de la lista y en la barra superior de cada
-cotización. Sirve para una cosa concreta — distinguir *"ya lo cambié"* de
-*"estás viendo el caché"*, que sin esto no se puede sin abrir las herramientas
-de desarrollo.
+**Esquema: `V<mayor>.<menor de dos dígitos>` — un incremento de 0.01 por cada
+merge a `main`.** Al pasar de `.99` sube el mayor y el menor vuelve a `00`:
 
-Convención de `CLAUDE.md` §8: `YYYYMMDD-<modulo>-<hito>`.
+```
+V1.00 · V1.01 · … · V1.99 · V2.00 · V2.01 · …
+```
 
-⚠️ **El build vive en dos lugares y hay que moverlos juntos:** la constante
-`BUILD` en `js/app.js` y `version.json`. Hay una prueba que falla si se
-separan, porque una pantalla que miente sobre su versión es peor que no tener
-indicador.
+Se ve al pie de la lista y en la barra superior de cada cotización. Sirve para
+distinguir *"ya lo cambié"* de *"estás viendo el caché"*, que sin esto no se
+puede sin abrir las herramientas de desarrollo.
+
+### Cómo bumpearla (obligatorio en todo merge)
+
+1. `comercial/machote/version.json` → sube `version` en 0.01 y **antepón** la
+   entrada nueva a `historial` con su número de PR.
+2. `comercial/machote/js/app.js` → la constante `VERSION`, con el mismo valor.
+
+Dos pruebas lo vigilan: una falla si los dos lugares se separan o si el formato
+no calza, y otra si el historial **salta o repite** un número. Una versión que
+salta deja de decir cuántos despliegues van, y una pantalla que miente sobre su
+versión es peor que no tener indicador.
 
 ## Archivos
 
 | archivo | qué es |
 |---|---|
-| `version.json` | El build vigente y su historial. |
+| `version.json` | La versión vigente y su historial. |
 | `js/calc.js` | El motor. Todo número que se ve sale de aquí; ninguna vista calcula. |
 | `js/reglas.js` | 28 reglas en un arreglo de configuración, separadas del motor que las corre. |
 | `js/demo.js` | Datos de ejemplo. Lo que viene del machote real va marcado `REAL`; lo inventado, `SUPUESTO`. |
 | `js/app.js` | Vistas y ruteo. |
-| `tests/pruebas-navegador.js` | 33 pruebas de navegador. |
+| `tests/pruebas-navegador.js` | 34 pruebas de navegador. |
 
 ## Cómo se calcula el precio
 

--- a/comercial/machote/css/machote.css
+++ b/comercial/machote/css/machote.css
@@ -302,14 +302,14 @@ label.row { min-height: var(--toque); }
 /* En escritorio no se pliega nada, así que el interruptor no viene al caso. */
 @media (min-width: 721px) { .verVacios { display: none; } }
 
-/* ── Indicador de build ───────────────────────────────────────────────────
+/* ── Indicador de versión ─────────────────────────────────────────────────
  * Discreto pero siempre visible. Sirve para distinguir "ya lo cambié" de
  * "estás viendo el caché", que sin esto no se puede sin abrir las
  * herramientas de desarrollo. */
-.build { margin: 22px 0 4px; padding-top: 10px; border-top: 1px solid var(--linea2);
+.ver { margin: 22px 0 4px; padding-top: 10px; border-top: 1px solid var(--linea2);
          font-size: 11px; color: var(--suave); text-align: center;
          font-variant-numeric: tabular-nums; }
-.build strong { color: var(--tinta); font-weight: 600; }
+.ver strong { color: var(--tinta); font-weight: 600; }
 
 /* El subtítulo de la barra superior no debe partirse: con el build añadido se
  * iba a dos renglones y empujaba el logotipo. */

--- a/comercial/machote/js/app.js
+++ b/comercial/machote/js/app.js
@@ -16,15 +16,20 @@
 
   const C = G.MachoteCalc, R = G.REGLAS, D = G.DEMO;
 
-  /* Build visible en pantalla.
+  /* Versión visible en pantalla.
    *
-   * Convención de CLAUDE.md §8: `YYYYMMDD-<modulo>-<hito>`. Se bumpea en TODO
-   * cambio que se despliegue, y se mantiene igual al de `version.json`, que es
-   * el que queda en el repo. Sirve para una cosa concreta: abrir la página y
-   * saber de un vistazo si lo que estás viendo es lo último o el caché del
-   * navegador. Sin esto, "ya lo cambié" y "yo no lo veo" no se pueden
-   * distinguir sin abrir las herramientas de desarrollo. */
-  const BUILD = '20260903-machote-3';
+   * Esquema: `V<mayor>.<menor de dos dígitos>`. **Un incremento de 0.01 por
+   * cada merge a `main`.** Al pasar de `.99` sube el mayor y el menor vuelve
+   * a `00` (V1.99 → V2.00).
+   *
+   * Sirve para una cosa concreta: abrir la página y saber de un vistazo si lo
+   * que ves es lo último o el caché del navegador. Sin esto, "ya lo cambié" y
+   * "yo no lo veo" no se distinguen sin abrir las herramientas de desarrollo.
+   *
+   * ⚠️ Vive aquí y en `version.json`, y hay una prueba que falla si se
+   * separan: una pantalla que miente sobre su versión es peor que no tener
+   * indicador. */
+  const VERSION = 'V1.03';
   const $  = (s, r) => (r || document).querySelector(s);
   const $$ = (s, r) => Array.prototype.slice.call((r || document).querySelectorAll(s));
   const clon = (x) => JSON.parse(JSON.stringify(x));
@@ -107,9 +112,9 @@
     if (p[0] === 'ap')    return vAprobar(p[1]);
     location.hash = '#/';
   }
-  function top(t, s, b, back, sinBuild) {
+  function top(t, s, b, back, sinVersion) {
     $('#tbT').textContent = t;
-    $('#tbS').textContent = sinBuild ? s : s + ' · ' + BUILD;
+    $('#tbS').textContent = sinVersion ? s : s + ' · ' + VERSION;
     $('#tbB').textContent = b || 'DEMO';
     $('#btnBack').onclick = () => { if (back) location.hash = back; };
     $('#btnBack').style.visibility = back ? 'visible' : 'hidden';
@@ -149,7 +154,7 @@
       'Los datos de las cotizaciones de abajo son demo.</div>' +
       '<h3>Estación 2.0 · armar la cotización</h3>' + filas +
       '<h3 style="margin-top:22px">Estación 3.0 · confirmar la orden</h3>' + ords +
-      '<div class="build">build <strong>' + BUILD + '</strong></div></div>';
+      '<div class="ver">versión <strong>' + VERSION + '</strong></div></div>';
   }
 
   /* ── El libro ────────────────────────────────────────────────────────── */

--- a/comercial/machote/tests/pruebas-navegador.js
+++ b/comercial/machote/tests/pruebas-navegador.js
@@ -151,25 +151,47 @@ let ok = 0, mal = 0;
     if (Math.abs(r - 1890) > 0.01) throw new Error('costo ' + r);
   });
 
-  // El build se escribe en dos lugares: la constante de app.js y version.json.
-  // Que se separen es el error clásico y deja la pantalla mintiendo sobre qué
-  // versión estás viendo, que es justo para lo que sirve.
-  await paso('el build se ve en pantalla y coincide con version.json', async () => {
+  // La versión se escribe en dos lugares -la constante de app.js y
+  // version.json- y que se separen deja la pantalla mintiendo sobre qué estás
+  // viendo, que es justo para lo que sirve.
+  await paso('la versión se ve en pantalla y coincide con version.json', async () => {
     const ver = JSON.parse(require('fs').readFileSync(
       path.resolve(__dirname, '..', 'version.json'), 'utf8'));
-    if (!/^\d{8}-machote-\d+$/.test(ver.build)) throw new Error('formato: ' + ver.build);
+
+    const m = /^V(\d+)\.(\d{2})$/.exec(ver.version);
+    if (!m) throw new Error('formato inválido: ' + ver.version + ' (se espera V1.00 … V1.99)');
+    if (Number(m[2]) > 99) throw new Error('el menor pasa de 99: ' + ver.version);
 
     await ir('#/');
-    const pie = (await p.textContent('.build') || '').trim();
-    if (pie.indexOf(ver.build) < 0) throw new Error('el pie dice "' + pie + '" y version.json ' + ver.build);
+    const pie = (await p.textContent('.ver') || '').trim();
+    if (pie.indexOf(ver.version) < 0) throw new Error('el pie dice "' + pie + '" y version.json ' + ver.version);
 
     await ir('#/m/M-1041');
     const barra = await p.textContent('#tbS');
-    if (barra.indexOf(ver.build) < 0) throw new Error('la barra superior dice: ' + barra);
+    if (barra.indexOf(ver.version) < 0) throw new Error('la barra superior dice: ' + barra);
+    console.log('   ', ver.version, '· visible en la lista y en la barra');
+  });
 
-    if (!ver.historial || ver.historial[0].build !== ver.build)
-      throw new Error('el historial no encabeza con el build vigente');
-    console.log('   build', ver.build, '· visible en la lista y en la barra');
+  // Un incremento de 0.01 por merge. Sin saltos ni repeticiones: si se salta
+  // un número, la versión deja de decir cuántos despliegues van.
+  await paso('el historial de versiones sube de uno en uno', async () => {
+    const ver = JSON.parse(require('fs').readFileSync(
+      path.resolve(__dirname, '..', 'version.json'), 'utf8'));
+    const h = ver.historial || [];
+    if (!h.length) throw new Error('sin historial');
+    if (h[0].version !== ver.version)
+      throw new Error('el historial encabeza con ' + h[0].version + ' y la vigente es ' + ver.version);
+
+    const aNum = (v) => { const m = /^V(\d+)\.(\d{2})$/.exec(v);
+      if (!m) throw new Error('formato inválido en el historial: ' + v);
+      return Number(m[1]) * 100 + Number(m[2]); };
+
+    for (let i = 0; i < h.length - 1; i++) {
+      const hoy = aNum(h[i].version), antes = aNum(h[i + 1].version);
+      if (hoy - antes !== 1)
+        throw new Error(h[i + 1].version + ' → ' + h[i].version + ' salta ' + (hoy - antes) + ' en vez de 1');
+    }
+    console.log('   ', h.length, 'versiones ·', h[h.length - 1].version, '→', h[0].version);
   });
 
   // ── La hoja ──────────────────────────────────────────────────────────

--- a/comercial/machote/version.json
+++ b/comercial/machote/version.json
@@ -1,11 +1,12 @@
 {
-  "build": "20260903-machote-3",
+  "version": "V1.03",
   "fecha": "2026-09-03",
   "modulo": "comercial/machote",
-  "hito": "Retícula del Excel + operable en teléfono",
+  "esquema": "V<mayor>.<menor de dos dígitos>. Un incremento de 0.01 por cada merge a main. Al pasar de .99 sube el mayor y el menor vuelve a 00.",
   "historial": [
-    { "build": "20260903-machote-3", "nota": "Indicador de build en pantalla" },
-    { "build": "20260903-machote-2", "nota": "La pantalla como el libro; tarjetas en teléfono; margen pisado por renglón; aviso de ranuras (PR #154)" },
-    { "build": "20260903-machote-1", "nota": "Motor reconstruido sobre el machote real de SharePoint (PR #149)" }
+    { "version": "V1.03", "pr": null,  "nota": "Versionado V1.00–V1.99 por merge" },
+    { "version": "V1.02", "pr": 155,   "nota": "Indicador de versión en pantalla" },
+    { "version": "V1.01", "pr": 154,   "nota": "La pantalla como el libro; tarjetas en teléfono; margen pisado por renglón; aviso de ranuras" },
+    { "version": "V1.00", "pr": 149,   "nota": "Motor reconstruido sobre el machote real de SharePoint" }
   ]
 }


### PR DESCRIPTION
Sustituye el build con fecha por un contador de versión.

**Esquema: `V<mayor>.<menor de dos dígitos>` — un incremento de `0.01` por cada merge a `main`.** Al pasar de `.99` sube el mayor y el menor vuelve a `00`:

```
V1.00 · V1.01 · … · V1.99 · V2.00 · V2.01 · …
```

## Aplicado retroactivo

Para que el número diga de verdad cuántos despliegues van:

| versión | PR | qué |
|---|---|---|
| **V1.00** | #149 | Motor reconstruido sobre el machote real de SharePoint |
| **V1.01** | #154 | La pantalla como el libro; tarjetas en teléfono; margen pisado por renglón |
| **V1.02** | #155 | Indicador de versión en pantalla |
| **V1.03** | este | El esquema V1.xx |

## Dónde se ve

Al pie de la lista y en la barra superior de cada cotización: `M-1041 · V1.03`.

## Cómo se bumpea, y qué lo vigila

En **dos** lugares, que hay que mover juntos: `version.json` (subiendo `version` y anteponiendo la entrada al `historial` con su PR) y la constante `VERSION` de `js/app.js`.

Dos pruebas nuevas:

1. **Formato y coincidencia** — falla si el patrón no es `V\d+\.\d{2}`, si el menor pasa de 99, o si los dos lugares se separan.
2. **El historial sube de uno en uno** — falla si salta o repite un número.

Lo segundo importa porque una versión que salta deja de decir cuántos despliegues van, que es justo lo que le pediste que hiciera. Y lo primero porque una pantalla que miente sobre su versión es peor que no tener indicador.

**34 pruebas en verde.**

## Alcance

Sólo `comercial/machote/`. Ningún otro módulo, ningún borrado.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013Qzhio6K8R23HXHnJ2RJ64