### PR TITLE
comercial(machote): acota la convención V1.xx a este módulo

### DIFF
--- a/comercial/machote/README.md
+++ b/comercial/machote/README.md
@@ -27,6 +27,18 @@ Se ve al pie de la lista y en la barra superior de cada cotización. Sirve para
 distinguir *"ya lo cambié"* de *"estás viendo el caché"*, que sin esto no se
 puede sin abrir las herramientas de desarrollo.
 
+⚠️ **El esquema es de este módulo, no de la suite.** El repo tiene otros en uso
+y se decidió no tocarlos:
+
+| módulo | esquema |
+|---|---|
+| `finanzas` | `0.5.36` + cadena de build |
+| `operaciones/planeacion` | `2.4.1` + build |
+| `operaciones/kiosk`, `confirmar-horas` | sólo cadena de build |
+| siete módulos más | `1.0.0` puesto una vez y nunca movido |
+
+No propagues `V1.xx` a ninguno de esos. La decisión está en el issue #148.
+
 ### Cómo bumpearla (obligatorio en todo merge)
 
 1. `comercial/machote/version.json` → sube `version` en 0.01 y **antepón** la

--- a/comercial/machote/js/app.js
+++ b/comercial/machote/js/app.js
@@ -28,8 +28,12 @@
    *
    * ⚠️ Vive aquí y en `version.json`, y hay una prueba que falla si se
    * separan: una pantalla que miente sobre su versión es peor que no tener
-   * indicador. */
-  const VERSION = 'V1.03';
+   * indicador.
+   *
+   * ⚠️ El esquema es de ESTE módulo. El repo tiene otros en uso —finanzas va
+   * en `0.5.36` con cadena de build, planeación en `2.4.1`, el kiosko sólo con
+   * build— y se decidió dejarlos como están. No propagar V1.xx a esos. */
+  const VERSION = 'V1.04';
   const $  = (s, r) => (r || document).querySelector(s);
   const $$ = (s, r) => Array.prototype.slice.call((r || document).querySelectorAll(s));
   const clon = (x) => JSON.parse(JSON.stringify(x));

--- a/comercial/machote/version.json
+++ b/comercial/machote/version.json
@@ -1,12 +1,34 @@
 {
-  "version": "V1.03",
+  "version": "V1.04",
   "fecha": "2026-09-03",
   "modulo": "comercial/machote",
-  "esquema": "V<mayor>.<menor de dos dígitos>. Un incremento de 0.01 por cada merge a main. Al pasar de .99 sube el mayor y el menor vuelve a 00.",
+  "ambito": "SOLO este modulo. El repo tiene otros esquemas en uso -finanzas 0.5.36 + cadena de build, operaciones/planeacion 2.4.1, kiosk y confirmar-horas solo build, y siete modulos con un 1.0.0 puesto una vez y nunca movido-. NO propagar V1.xx a esos: se decidio dejarlos como estan (issue #148).",
+  "esquema": "V<mayor>.<menor de dos digitos>. Un incremento de 0.01 por cada merge a main. Al pasar de .99 sube el mayor y el menor vuelve a 00.",
   "historial": [
-    { "version": "V1.03", "pr": null,  "nota": "Versionado V1.00–V1.99 por merge" },
-    { "version": "V1.02", "pr": 155,   "nota": "Indicador de versión en pantalla" },
-    { "version": "V1.01", "pr": 154,   "nota": "La pantalla como el libro; tarjetas en teléfono; margen pisado por renglón; aviso de ranuras" },
-    { "version": "V1.00", "pr": 149,   "nota": "Motor reconstruido sobre el machote real de SharePoint" }
+    {
+      "version": "V1.04",
+      "pr": null,
+      "nota": "Ambito de la convencion, acotado a este modulo"
+    },
+    {
+      "version": "V1.03",
+      "pr": null,
+      "nota": "Versionado V1.00–V1.99 por merge"
+    },
+    {
+      "version": "V1.02",
+      "pr": 155,
+      "nota": "Indicador de versión en pantalla"
+    },
+    {
+      "version": "V1.01",
+      "pr": 154,
+      "nota": "La pantalla como el libro; tarjetas en teléfono; margen pisado por renglón; aviso de ranuras"
+    },
+    {
+      "version": "V1.00",
+      "pr": 149,
+      "nota": "Motor reconstruido sobre el machote real de SharePoint"
+    }
   ]
 }


### PR DESCRIPTION
Esteban preguntó si habíamos perdido la cuenta del `5.3x`. **No**: ese número es de **finanzas** —bancos va en `0.5.36`, hoy subió 0.5.31→35 en #153— y el machote nació hoy, así que su `V1.00` es su primera versión, no un reinicio.

Lo que sí destapó la pregunta es que el repo tiene **cinco esquemas de versión conviviendo**, y yo acababa de meter el quinto:

| módulo | esquema |
|---|---|
| `finanzas` | `0.5.36` + cadena de build |
| `operaciones/planeacion` | `2.4.1` + build |
| `operaciones/kiosk`, `confirmar-horas` | sólo cadena de build |
| siete módulos más | `1.0.0` puesto una vez y nunca movido |
| `comercial/machote` | **`V1.xx`** ← el nuevo |

## La decisión

`V1.xx` se queda como convención **de este módulo** y los demás **no se tocan**.

Queda escrito en tres lugares para que ninguna sesión futura lo propague ni vuelva a preguntarse de dónde sale el número:

1. **`version.json`** → campo `ambito` nuevo, con la lista de los otros esquemas y el "no propagar".
2. **El comentario de la constante `VERSION`** en `js/app.js`.
3. **El README**, con la tabla de arriba.

Versión: **`V1.04`**.

**34 pruebas en verde.**

## Alcance

Sólo `comercial/machote/`. No toca finanzas, ni operaciones, ni ningún otro `version.json`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013Qzhio6K8R23HXHnJ2RJ64