### PR TITLE
comercial(machote) V1.06: edición estructural y moneda por empresa

### DIFF
--- a/comercial/machote/README.md
+++ b/comercial/machote/README.md
@@ -61,10 +61,10 @@ versión es peor que no tener indicador.
 |---|---|
 | `version.json` | La versión vigente y su historial. |
 | `js/calc.js` | El motor. Todo número que se ve sale de aquí; ninguna vista calcula. |
-| `js/reglas.js` | 28 reglas en un arreglo de configuración, separadas del motor que las corre. |
+| `js/reglas.js` | 30 reglas en un arreglo de configuración, separadas del motor que las corre. |
 | `js/demo.js` | Datos de ejemplo. Lo que viene del machote real va marcado `REAL`; lo inventado, `SUPUESTO`. |
 | `js/app.js` | Vistas y ruteo. |
-| `tests/pruebas-navegador.js` | 42 pruebas de navegador. |
+| `tests/pruebas-navegador.js` | 53 pruebas de navegador. |
 
 ## Cómo se calcula el precio
 
@@ -125,6 +125,43 @@ pierde**: la hoja se renderiza a un nodo suelto, se comparan las celdas `.calc`
 una a una y sólo se copian las que cambiaron. Las que cambiaron parpadean medio
 segundo, y con `prefers-reduced-motion` el parpadeo se cambia por un borde.
 
+## Editar la estructura
+
+El machote real no es una plantilla fija: las secciones **se renombran** al
+alcance de cada obra y los renglones se copian del parecido. La herramienta hace
+lo mismo.
+
+- **Secciones:** renombrar (la pestaña sigue al nombre), duplicar `⧉` — queda al
+  lado como "(copia)" —, reordenar `←` `→`, eliminar `×`.
+- **Renglones de materiales y servicios:** duplicar, subir, bajar, eliminar.
+- **Unidad:** captura libre con catálogo sugerido. Un `<select>` no deja escribir
+  "tramo de 6 m", que es de lo que está lleno el acervo.
+
+**Los renglones de mano de obra no aceptan filas nuevas.** Son exactamente diez
+por sección en los cinco machotes 2026 del acervo (90 = 10×9, 70 = 10×7,
+50 = 10×5). Agregar filas rompería el regreso al Excel.
+
+**Sobre las diez ranuras:** se permite pasar de diez secciones, pero queda
+marcado en tres lados — la pestaña sobrante se pinta distinta, la hoja lo dice, y
+el revisador lo levanta como hallazgo **duro** listando cuáles no llegarían al
+precio. No se bloquea porque el negocio ya lo hace (el USD de calbee 2026 tiene
+once). Lo que se bloquea es el **silencio**, que es lo que hoy cuesta dinero: las
+ranuras se llenan **por posición, no por nombre**, así que mover una sección
+cambia a qué renglón del `RESUMEN` cae.
+
+## Moneda
+
+La cotización nace en la moneda de la **empresa** — Servicios FTS en MXN, FTS
+Full Technology Systems LLC en USD — y la moneda del documento sigue a la empresa
+mientras no se toque a mano. Cada renglón puede ir en otra moneda; ahí sí se
+convierte (el Excel las suma sin convertir, y ese es uno de los hallazgos del
+acervo).
+
+Cuando se convierte hay que decir **de dónde salió el tipo de cambio** — DOF del
+día, Banxico FIX, el del banco, acordado con el cliente, o texto libre. Si no se
+dice, el revisador lo levanta: en tres meses nadie puede reconstruir el precio
+sin ese dato.
+
 ## Cómo correr las pruebas
 
 ```bash
@@ -154,6 +191,10 @@ encontrado:
    en **cero px**: la pantalla se veía bien y el dato no estaba.
 6. `td[colspan]{display:none}` ocultaba también los títulos de grupo de las
    tarjetas, que son justo lo que las ordena.
+7. Repintar el libro desde el `change` del nombre de sección reventaba con
+   *"the node to be removed is no longer a child of this node"*: ese `change`
+   llega **durante el blur** del campo, y el repintado arranca el nodo que el
+   navegador todavía está soltando. La pestaña se corrige en su lugar.
 
 ## Lo que falta para que esto deje de ser prototipo
 

--- a/comercial/machote/css/machote.css
+++ b/comercial/machote/css/machote.css
@@ -379,3 +379,30 @@ label.row { min-height: var(--toque); }
 .leyenda .mu-cel    { border: 1px solid var(--linea); background: var(--fondo); }
 .leyenda .mu-calc   { background: var(--papel); border-left: 2px solid #c8cdd2; }
 .leyenda .mu-pisado { background: #fff8e5; border: 1px solid #d9a800; }
+
+/* ── Acciones de renglón y de sección ─────────────────────────────────────
+ * Botones chicos pero tocables: 44 px de área aunque el glifo sea de 13. */
+.ico { border: 1px solid var(--linea); background: var(--fondo); color: var(--suave);
+       border-radius: 7px; font-size: 13px; line-height: 1; cursor: pointer;
+       min-width: var(--toque); min-height: var(--toque); width: auto;
+       padding: 0 8px; }
+.ico:hover:not([disabled]) { border-color: #b9b9b9; color: var(--tinta); }
+.ico[disabled] { opacity: .3; cursor: not-allowed; }
+.ico.peligro { color: var(--rojo); border-color: #f0c8cc; }
+.accsec { display: inline-flex; gap: 4px; margin-left: auto; flex: 0 0 auto; }
+table.rejilla td.acc { white-space: nowrap; }
+table.rejilla td.acc .ico { min-width: 36px; min-height: 36px; padding: 0 6px; }
+
+/* Una sección fuera de las diez ranuras del machote se marca en su pestaña:
+ * el USD de calbee tiene once y la de más no llega al precio. */
+.pestana.fuera { border-color: var(--rojo); color: var(--rojo); }
+.pestana.fuera::after { content: ' ⚠'; }
+
+@media (max-width: 720px) {
+  /* En tarjeta, las acciones van en una fila propia y con área completa. */
+  table.rejilla.tarjetas td.acc { justify-content: flex-end; gap: 6px;
+                                  padding-top: 8px; }
+  table.rejilla.tarjetas td.acc .ico { min-width: var(--toque); min-height: var(--toque); }
+  .nomsec { align-items: flex-start; }
+  .accsec { margin-left: 0; }
+}

--- a/comercial/machote/js/app.js
+++ b/comercial/machote/js/app.js
@@ -34,7 +34,7 @@
    * 2026-09-03 (por instrucción de Esteban), pero lleva el suyo aparte y va en
    * V1.00. Planeación sigue en `2.4.1` y el kiosko sólo con cadena de build;
    * a esos no se propaga. */
-  const VERSION = 'V1.05';
+  const VERSION = 'V1.06';
   const $  = (s, r) => (r || document).querySelector(s);
   const $$ = (s, r) => Array.prototype.slice.call((r || document).querySelectorAll(s));
   const clon = (x) => JSON.parse(JSON.stringify(x));
@@ -84,6 +84,12 @@
     '<select class="cel" data-cel="' + path + '">' +
     ops.map(o => '<option value="' + esc(o) + '"' + (o === val ? ' selected' : '') + '>' + esc(o || '—') + '</option>').join('') +
     '</select>';
+
+  /** Campo con catálogo sugerido y captura libre. Un `<select>` impide
+   *  escribir "tramo de 6 m", que es de lo que está lleno el acervo. */
+  const celLibre = (path, val, lista, cls) =>
+    '<input class="cel ' + (cls || '') + '" list="' + lista + '" data-cel="' + path + '"' +
+    ' value="' + esc(nn(val)) + '" autocomplete="off">';
 
   /** Escribe por ruta. `s:<sid>:mo:<i>:campo` · `s:<sid>:partidas:<i>:campo`
    *  `eq:<venta|ops|cli>:<i>:campo` · `nom:<sid>` · o campo anidado. */
@@ -177,11 +183,12 @@
 
     $('#vista').innerHTML =
       '<div class="libro">' +
-      '<div class="hojas" id="hojas">' + hojas.map(h =>
-        '<button class="pestana' + (h.id === ST.hoja ? ' on' : '') + '" data-hoja="' + esc(h.id) + '">' +
-        esc(h.label) + '</button>').join('') +
-        (m.secciones.length < C.MAX_SECCIONES
-          ? '<button class="pestana mas" data-nueva="1" title="Nueva sección">+</button>' : '') +
+      '<div class="hojas" id="hojas">' + hojas.map((h, i) =>
+        '<button class="pestana' + (h.id === ST.hoja ? ' on' : '') +
+        (i > C.MAX_SECCIONES ? ' fuera' : '') + '" data-hoja="' + esc(h.id) + '"' +
+        (i > C.MAX_SECCIONES ? ' title="Fuera de las diez ranuras del machote: no llegaría al precio"' : '') +
+        '>' + esc(h.label) + '</button>').join('') +
+        '<button class="pestana mas" data-nueva="1" title="Nueva sección">+</button>' +
       '</div><div id="hoja"></div></div>';
 
     $('#hojas').onclick = (e) => {
@@ -246,6 +253,7 @@
   /* ── Hoja de sección ─────────────────────────────────────────────────── */
   function hojaSeccion(m, s, c) {
     const cs = c.secciones.find(x => x.id === s.id) || {};
+    const idx = m.secciones.findIndex(x => x.id === s.id);
     const mg = c.margenes;
 
     // Bloque de encabezado: las once filas de la izquierda y la tabla de
@@ -284,7 +292,15 @@
       '<div class="tiny nota">Horas extras = mano de obra × 2 = <strong>' + mg.extra + '</strong>. No se captura, igual que en el Excel.</div>' +
       '</div></div>' +
       '<div class="nomsec"><span class="et">NOMBRE DE SECCIÓN</span>' + cel('nom:' + s.id, s.nombre, 'nombre') +
-      (m.secciones.length > 1 ? '<button class="btn del" data-delsec="' + s.id + '">Eliminar sección</button>' : '') + '</div>';
+      '<span class="accsec">' +
+        (idx > 0 ? '<button class="ico" data-movsec="' + s.id + '|-1" title="Mover a la izquierda">←</button>' : '') +
+        (idx < m.secciones.length - 1 ? '<button class="ico" data-movsec="' + s.id + '|1" title="Mover a la derecha">→</button>' : '') +
+        '<button class="ico" data-dupsec="' + s.id + '" title="Duplicar sección">⧉</button>' +
+        (m.secciones.length > 1 ? '<button class="ico peligro" data-delsec="' + s.id + '" title="Eliminar sección">×</button>' : '') +
+      '</span></div>' +
+      '<div class="tiny nota">Sección ' + (idx + 1) + ' de ' + m.secciones.length +
+      (idx >= C.MAX_SECCIONES ? ' · <strong class="n-bad">fuera de las diez ranuras del machote</strong>' : '') +
+      '. Las secciones ocupan la ranura por posición, no por nombre.</div>';
 
     // COSTO MANO DE OBRA — los diez renglones siempre presentes, en sus tres grupos.
     let filasMo = '';
@@ -338,7 +354,7 @@
       return '<tr>' +
         '<td data-l="Descripción">' + cel(p + 'descripcion', l.descripcion, 'desc') + '</td>' +
         '<td data-l="QTY">' + celNum(p + 'qty', l.qty, 'w60') + '</td>' +
-        '<td data-l="Unidad">' + celSel(p + 'unidad', l.unidad, D.UNIDADES) + '</td>' +
+        '<td data-l="Unidad">' + celLibre(p + 'unidad', l.unidad, 'unidades', 'w90') + '</td>' +
         '<td data-l="Tipo">' + celSel(p + 'tipo', l.tipo, [''].concat(C.TIPOS)) + '</td>' +
         '<td data-l="Modelo">' + cel(p + 'modelo', l.modelo, 'w110') + '</td>' +
         '<td data-l="Marca">' + cel(p + 'marca', l.marca, 'w90') + '</td>' +
@@ -351,7 +367,12 @@
         '<td class="vl mono calc fuerte" data-l="Precio con utilidad">' + mx(cl.conUtilidad) + '</td>' +
         '<td data-l="Link">' + cel(p + 'link', l.link, 'w130', 'https://…') + '</td>' +
         '<td data-l="Comentario">' + cel(p + 'comentario', l.comentario, 'w130') + '</td>' +
-        '<td class="acc"><button class="x" data-del="' + s.id + '#' + j + '" title="Eliminar partida">× eliminar</button></td></tr>';
+        '<td class="acc" data-l="">' +
+          '<button class="ico" data-mov="' + s.id + '#' + j + '|-1" title="Subir"' + (j === 0 ? ' disabled' : '') + '>↑</button>' +
+          '<button class="ico" data-mov="' + s.id + '#' + j + '|1" title="Bajar"' + (j === s.partidas.length - 1 ? ' disabled' : '') + '>↓</button>' +
+          '<button class="ico" data-dup="' + s.id + '#' + j + '" title="Duplicar">⧉</button>' +
+          '<button class="ico peligro" data-del="' + s.id + '#' + j + '" title="Eliminar">×</button>' +
+        '</td></tr>';
     }).join('');
 
     const tablaMat =
@@ -369,7 +390,10 @@
       (cs.pisados ? '<span class="tiny n-warn">' + cs.pisados + ' margen(es) pisado(s) a mano en esta sección</span>' : '') +
       '</div>';
 
-    return cab + leyenda() + tablaMo + tablaMat;
+    const listaUnidades = '<datalist id="unidades">' +
+      D.UNIDADES.map(u => '<option value="' + esc(u) + '">').join('') + '</datalist>';
+
+    return listaUnidades + cab + leyenda() + tablaMo + tablaMat;
   }
 
   /* ── Hoja DESGLOSE COTIZACIÓN ────────────────────────────────────────── */
@@ -411,11 +435,24 @@
       '<tr><td class="et">MARGEN DESEADO</td><td>' + celNum('margen_deseado', m.margen_deseado, 'w80') + '</td></tr>' +
       '<tr><td class="et">HORAS PROYECTO</td><td class="vl mono calc">' + Math.round(c.horas) + '</td></tr>' +
       '<tr><td class="et">Factor_req</td><td class="vl mono calc">' + (c.factorReq ? c.factorReq.toFixed(9) : '—') + '</td></tr>' +
-      '<tr><td class="et">Moneda</td><td>' + celSel('moneda', m.moneda, ['MXN', 'USD']) + '</td></tr>' +
+      '<tr><td class="et">Empresa</td><td>' +
+        '<select class="cel" data-cel="empresa_id" data-num>' +
+        C.EMPRESAS.map(e => '<option value="' + e.id + '"' +
+          (Number(m.empresa_id) === e.id ? ' selected' : '') + '>' + esc(e.corto) + '</option>').join('') +
+        '</select></td></tr>' +
+      '<tr><td class="et">Moneda</td><td>' + celSel('moneda', m.moneda, ['MXN', 'USD']) +
+        (m.moneda !== C.monedaPorDefecto(m)
+          ? '<div class="tiny n-warn">' + esc(C.empresaDe(m).corto) + ' factura en ' +
+            C.monedaPorDefecto(m) + '.</div>' : '') + '</td></tr>' +
       '<tr><td class="et">Tipo de cambio</td><td>' + celNum('tc', m.tc, 'w80') + '</td></tr>' +
       '<tr><td class="et">Factor de protección</td><td>' + celNum('factor_proteccion', m.factor_proteccion, 'w80') + '</td></tr>' +
+      '<tr><td class="et">Origen del tipo de cambio</td><td>' +
+        celLibre('tc_fuente', m.tc_fuente, 'fuentes-tc') + '</td></tr>' +
       '<tr><td class="et">TC efectivo</td><td class="vl mono calc">' + C.tcEfectivo(m).toFixed(4) + '</td></tr>' +
       '</tbody></table></div></div>' +
+      '<datalist id="fuentes-tc">' +
+        ['DOF del día', 'Banxico FIX', 'Tipo de cambio del banco', 'Acordado con el cliente']
+          .map(x => '<option value="' + x + '">').join('') + '</datalist>' +
       leyenda();
 
     // RESUMEN por sección: diez ranuras fijas, tres grupos de columnas.
@@ -440,7 +477,7 @@
 
     const porSeccion =
       '<div class="secc-tit">RESUMEN POR SECCIÓN</div>' +
-      '<div class="scroll"><table class="rejilla ancha">' +
+      '<div class="scroll"><table class="rejilla ancha" id="porSeccion">' +
       '<thead><tr><th colspan="2"></th><th colspan="3">COSTO</th><th colspan="3">CON UTILIDAD</th>' +
       '<th colspan="3">MARGEN DESEADO</th><th></th></tr>' +
       '<tr><th>SECCIÓN</th><th>SECCION DE COTIZACION</th>' +
@@ -531,7 +568,25 @@
       };
       // Al salir del campo se repinta -puede haber cambiado la estructura-.
       // Al teclear sólo se refrescan los derivados, que no roba el foco.
-      el.onchange = () => { aplicar(); pintarHoja(m); barra(m, C.calcular(m)); };
+      el.onchange = () => {
+        const antes = el.dataset.cel === 'empresa_id' ? C.monedaPorDefecto(m) : null;
+        const esNombre = el.dataset.cel.indexOf('nom:') === 0;
+        aplicar();
+        // El nombre de la sección vive en la PESTAÑA, que se pinta fuera de la
+        // hoja. Se corrige la pestaña en su lugar, sin repintar el libro: este
+        // `change` llega durante el blur del campo, y repintar de raíz ahí
+        // arranca el nodo que el navegador todavía está soltando -eso reventaba
+        // con "the node to be removed is no longer a child of this node".
+        if (esNombre) {
+          const sid = el.dataset.cel.slice(4);
+          const pes = document.querySelector('.pestana[data-hoja="' + sid + '"]');
+          const sec = m.secciones.find(x => x.id === sid);
+          if (pes && sec) pes.textContent = sec.nombre || 'SECCIÓN';
+        }
+        // La moneda sigue a la empresa mientras no se haya tocado a mano.
+        if (antes !== null && m.moneda === antes) m.moneda = C.monedaPorDefecto(m);
+        pintarHoja(m); barra(m, C.calcular(m));
+      };
       if (!esSel) el.oninput = () => { aplicar(); barra(m, refrescarCalculados(m) || C.calcular(m)); };
     });
     const vv = $('#verVacios');
@@ -545,15 +600,53 @@
                         pu: null, moneda: m.moneda, margen: null, link: '', comentario: '' });
       pintarHoja(m); barra(m, C.calcular(m));
     });
+    const seccionDe = (ref) => {
+      const [sid, j] = ref.split('#');
+      return { s: m.secciones.find(x => x.id === sid), j: parseInt(j, 10) };
+    };
+    const refrescar = () => { pintarHoja(m); barra(m, C.calcular(m)); };
+
     $$('[data-del]').forEach(b => b.onclick = () => {
-      const [sid, j] = b.dataset.del.split('#');
-      const s = m.secciones.find(x => x.id === sid); if (!s) return;
-      s.partidas.splice(parseInt(j, 10), 1); pintarHoja(m); barra(m, C.calcular(m));
+      const { s, j } = seccionDe(b.dataset.del); if (!s) return;
+      s.partidas.splice(j, 1); refrescar();
+    });
+    $$('[data-dup]').forEach(b => b.onclick = () => {
+      const { s, j } = seccionDe(b.dataset.dup); if (!s) return;
+      // Duplicar es como se arma una lista de materiales de verdad: se copia el
+      // renglón parecido y se cambia lo que difiere.
+      s.partidas.splice(j + 1, 0, JSON.parse(JSON.stringify(s.partidas[j])));
+      refrescar();
+    });
+    $$('[data-mov]').forEach(b => b.onclick = () => {
+      const [ref, d] = b.dataset.mov.split('|');
+      const { s, j } = seccionDe(ref); if (!s) return;
+      const k = j + parseInt(d, 10);
+      if (k < 0 || k >= s.partidas.length) return;
+      const t = s.partidas[j]; s.partidas[j] = s.partidas[k]; s.partidas[k] = t;
+      refrescar();
     });
     $$('[data-delsec]').forEach(b => b.onclick = () => {
       const i = m.secciones.findIndex(x => x.id === b.dataset.delsec);
       if (i < 0 || m.secciones.length < 2) return;
       m.secciones.splice(i, 1); ST.hoja = 'desglose'; vMachote(m.id);
+    });
+    $$('[data-dupsec]').forEach(b => b.onclick = () => {
+      const i = m.secciones.findIndex(x => x.id === b.dataset.dupsec); if (i < 0) return;
+      const copia = JSON.parse(JSON.stringify(m.secciones[i]));
+      copia.id = 's-' + Date.now();
+      copia.nombre = (copia.nombre || 'SECCIÓN') + ' (copia)';
+      m.secciones.splice(i + 1, 0, copia);
+      ST.hoja = copia.id; vMachote(m.id);
+    });
+    $$('[data-movsec]').forEach(b => b.onclick = () => {
+      const [sid, d] = b.dataset.movsec.split('|');
+      const i = m.secciones.findIndex(x => x.id === sid);
+      const k = i + parseInt(d, 10);
+      if (i < 0 || k < 0 || k >= m.secciones.length) return;
+      // La ranura la da la POSICIÓN, no el nombre: mover una sección cambia a
+      // qué renglón del RESUMEN va a caer.
+      const t = m.secciones[i]; m.secciones[i] = m.secciones[k]; m.secciones[k] = t;
+      vMachote(m.id);
     });
   }
 

--- a/comercial/machote/js/calc.js
+++ b/comercial/machote/js/calc.js
@@ -50,6 +50,17 @@
   const MAX_SECCIONES = 10;
 
   const TIPOS = ['Materiales', 'Servicios'];
+
+  /* Las dos empresas y su moneda. Verificado contra Odoo: de las 711 órdenes
+   * con machote, 594 son de SERVICIOS FTS (company 1, MXN) y 117 de FTS FULL
+   * TECHNOLOGY SYSTEMS LLC (company 6, USD). La moneda del documento nace de
+   * la empresa; el capturista la puede cambiar, y cada renglón la suya. */
+  const EMPRESAS = [
+    { id: 1, nombre: 'Servicios FTS', corto: 'FTS México', moneda: 'MXN' },
+    { id: 6, nombre: 'FTS Full Technology Systems LLC', corto: 'FTS USA', moneda: 'USD' }
+  ];
+  const empresaDe = (m) => EMPRESAS.find(e => e.id === Number(m && m.empresa_id)) || EMPRESAS[0];
+  const monedaPorDefecto = (m) => empresaDe(m).moneda;
   const ESCENARIOS = [
     { id: 'costo',          label: 'Costo' },
     { id: 'con_utilidad',   label: 'Con utilidad' },
@@ -331,6 +342,7 @@
 
   G.MachoteCalc = {
     ROLES, ROL, GRUPOS, TIPOS, ESCENARIOS, MAX_SECCIONES,
+    EMPRESAS, empresaDe, monedaPorDefecto,
     MARGENES_PLANTILLA, COMISION_FTS_PLANTILLA, MARGEN_DESEADO_PLANTILLA, REPARTO_PLANTILLA,
     tcEfectivo, margenes, costoMo, costoPartida, totalSeccion,
     calcular, precioParaMargen, repartir

--- a/comercial/machote/js/demo.js
+++ b/comercial/machote/js/demo.js
@@ -83,7 +83,8 @@
   ]);
 
   const base = (extra) => Object.assign({
-    moneda: 'MXN', tc: 18.40, factor_proteccion: 0.03,
+    empresa_id: 1,                      // Servicios FTS · MXN
+    moneda: 'MXN', tc: 18.40, factor_proteccion: 0.03, tc_fuente: 'DOF del día',
     margenes: Object.assign({}, C.MARGENES_PLANTILLA),
     comision_fts: C.COMISION_FTS_PLANTILLA,
     comision_cliente: 0,
@@ -159,7 +160,8 @@
       id: 'M-1043', nombre: 'Cooling system for maintenance offices',
       cliente: 'Calbee America Incorporated', so: null, estado: 'borrador',
       analista: 'Analista de propuestas', fecha: '2026-08-30',
-      moneda: 'USD', tc: 0, factor_proteccion: 0,
+      empresa_id: 6,                    // FTS USA · USD
+      moneda: 'USD', tc: 0, factor_proteccion: 0, tc_fuente: '',
       comision_fts: 0.06, comision_cliente: 0.05,
       diagnostico: { tipo: 'suministro', respuestas: { entrega: 'Planta Fayetteville', importado: 'Sí, equipo de EUA' } },
       secciones: [

--- a/comercial/machote/js/reglas.js
+++ b/comercial/machote/js/reglas.js
@@ -295,11 +295,41 @@
         : { detalle: 'No hay ni una partida ni un renglón de mano de obra con importe.' }
     },
     {
+      // MACHOTE — la tabla RESUMEN del Excel tiene diez filas de sección y de
+      // ahí sale el precio. El USD de calbee 2026 tiene ONCE hojas de sección:
+      // la once no llega al precio y el Excel no avisa. La herramienta SÍ deja
+      // pasar de diez -para no impedir lo que el negocio ya hace- pero lo
+      // marca como hallazgo duro, porque es dinero que se pierde en silencio.
       destino: () => ({ tab: 'secc' }),
       id: 'exceso-secciones', severidad: 'dura', area: 'Estructura',
       titulo: 'Más secciones de las que caben en el machote',
       evaluar: (m) => secs(m).length > C.MAX_SECCIONES
-        ? { detalle: 'El machote tiene ' + C.MAX_SECCIONES + ' ranuras fijas de sección y aquí hay ' + secs(m).length + '. No cabría al exportarlo.' }
+        ? { detalle: 'Hay ' + secs(m).length + ' secciones y el machote tiene ' + C.MAX_SECCIONES +
+                     ' ranuras. Las ranuras se llenan por POSICIÓN, así que a partir de la ' +
+                     (C.MAX_SECCIONES + 1) + ' el importe no llega al precio. Reordena o consolida.',
+            items: secs(m).slice(C.MAX_SECCIONES).map((x, i) =>
+              'Ranura ' + (C.MAX_SECCIONES + i + 1) + ': ' + (x.nombre || '(sin nombre)')) }
+        : null
+    },
+    {
+      // Si se convierte de moneda, hay que poder auditar de dónde salió el
+      // tipo de cambio tres meses después.
+      destino: () => ({ tab: 'gen' }),
+      id: 'tc-sin-origen', severidad: 'blanda', area: 'Moneda',
+      titulo: 'Tipo de cambio sin decir de dónde salió',
+      evaluar: (m, c) => (c.mezclaMoneda && Number(m.tc) > 0 && !m.tc_fuente)
+        ? { detalle: 'Se está convirtiendo a ' + Number(m.tc).toFixed(2) +
+                     ' y no dice si es el DOF, el FIX, el del banco o uno acordado. ' +
+                     'En tres meses nadie va a poder reconstruir el precio.' }
+        : null
+    },
+    {
+      destino: () => ({ tab: 'gen' }),
+      id: 'moneda-contra-empresa', severidad: 'info', area: 'Moneda',
+      titulo: 'La moneda no es la de la empresa',
+      evaluar: (m) => (m.moneda && m.moneda !== C.monedaPorDefecto(m))
+        ? { detalle: C.empresaDe(m).corto + ' factura en ' + C.monedaPorDefecto(m) +
+                     ' y esta cotización va en ' + m.moneda + '. Puede ser correcto; confírmalo.' }
         : null
     },
     {

--- a/comercial/machote/tests/pruebas-navegador.js
+++ b/comercial/machote/tests/pruebas-navegador.js
@@ -51,12 +51,25 @@ let ok = 0, mal = 0;
     try { await fn(); console.log('✓', n); ok++; }
     catch (e) { console.log('✗', n, '→', e.message); mal++; }
   };
-  // Asignar el mismo hash que ya está puesto NO dispara `hashchange`, así que
-  // la vista no se repinta y la prueba mide la pantalla anterior. Se pasa por
-  // '#/' primero para forzar el repintado.
+  /* Navegar a una ruta, con el estado LIMPIO.
+   *
+   * El estado vive en memoria y las pruebas de V1.06 mutan de verdad: agregan
+   * renglones, renombran secciones, duplican. Sin recargar, cada prueba hereda
+   * lo que hizo la anterior y los fallos se vuelven cascada — una prueba de
+   * layout terminaba fallando porque otra le había puesto once secciones al
+   * machote. Recargar aísla, y cuesta ~200 ms. */
   const ir = async (h) => {
-    await p.evaluate(() => { location.hash = '#/'; });
-    await p.waitForTimeout(80);
+    await p.goto(BASE);
+    await p.waitForTimeout(220);
+    if (h && h !== '#/') {
+      await p.evaluate(x => { location.hash = x; }, h);
+      await p.waitForTimeout(260);
+    }
+  };
+  /* Navegación SUAVE: cambia de pantalla sin recargar. La necesitan las
+   * pruebas que miden justamente lo que el estado recuerda entre pantallas —
+   * recargar borraría lo que se está midiendo. */
+  const irSuave = async (h) => {
     await p.evaluate(x => { location.hash = x; }, h);
     await p.waitForTimeout(260);
   };
@@ -315,8 +328,8 @@ let ok = 0, mal = 0;
 
   await paso('volver al mismo machote conserva la hoja donde ibas', async () => {
     await ir('#/m/M-1041'); await hoja('Instalación');
-    await ir('#/rev/M-1041');
-    await p.evaluate(() => { location.hash = '#/m/M-1041'; }); await p.waitForTimeout(260);
+    await irSuave('#/rev/M-1041');
+    await irSuave('#/m/M-1041');
     const on = await p.locator('.pestana.on').textContent();
     if (!/Instalación/.test(on)) throw new Error('cayó en: ' + on);
   });
@@ -473,6 +486,153 @@ let ok = 0, mal = 0;
     const desp = await p.textContent('.fija .mono');
     if (antes === desp) throw new Error('cambiarlo no movió el precio: ' + antes);
     console.log('   con tc=18:', antes.trim(), '→ con factor 0.10:', desp.trim());
+  });
+
+  // ══ V1.06 · edición estructural y moneda ═════════════════════════════
+
+  await paso('agregar un renglón mueve el total', async () => {
+    await ir('#/m/M-1042'); await hoja('Adecuación');
+    const antes = await p.textContent('.fija .mono');
+    const n0 = await p.locator('[data-cel$=":descripcion"]').count();
+    await p.click('[data-add]'); await p.waitForTimeout(280);
+    if (await p.locator('[data-cel$=":descripcion"]').count() !== n0 + 1)
+      throw new Error('no se agregó el renglón');
+    // El renglón nace sin precio, así que el total no cambia todavía: lo que
+    // debe cambiar es el conteo de huecos.
+    const pu = p.locator('[data-cel$=":pu"]').last();
+    await pu.fill('5000'); await pu.dispatchEvent('change');
+    await p.waitForTimeout(300);
+    const desp = await p.textContent('.fija .mono');
+    if (antes === desp) throw new Error('el total no se movió: ' + antes);
+    console.log('   ', antes.trim(), '→', desp.trim());
+  });
+
+  await paso('duplicar un renglón lo copia justo debajo', async () => {
+    await ir('#/m/M-1042'); await hoja('Adecuación');
+    const desc0 = await p.locator('[data-cel$=":descripcion"]').first().inputValue();
+    const n0 = await p.locator('[data-cel$=":descripcion"]').count();
+    await p.locator('[data-dup]').first().click(); await p.waitForTimeout(280);
+    const todas = await p.locator('[data-cel$=":descripcion"]').all();
+    if (todas.length !== n0 + 1) throw new Error('no duplicó');
+    if (await todas[1].inputValue() !== desc0)
+      throw new Error('la copia no quedó debajo del original');
+  });
+
+  await paso('subir y bajar reordena los renglones', async () => {
+    await ir('#/m/M-1042'); await hoja('Adecuación');
+    const d = () => p.locator('[data-cel$=":descripcion"]');
+    const a0 = await d().nth(0).inputValue(), a1 = await d().nth(1).inputValue();
+    if (a0 === a1) throw new Error('los dos primeros renglones son iguales, la prueba no distingue');
+    await p.locator('[data-mov$="|1"]').first().click(); await p.waitForTimeout(280);
+    if (await d().nth(0).inputValue() !== a1 || await d().nth(1).inputValue() !== a0)
+      throw new Error('bajar no reordenó');
+    await p.locator('[data-mov$="|-1"]').nth(1).click(); await p.waitForTimeout(280);
+    if (await d().nth(0).inputValue() !== a0) throw new Error('subir no lo regresó');
+  });
+
+  await paso('renombrar una sección persiste en su pestaña', async () => {
+    await ir('#/m/M-1041'); await hoja('Suministro');
+    const campo = p.locator('[data-cel^="nom:"]');
+    await campo.fill('Obra eléctrica en cortina');
+    await campo.dispatchEvent('change'); await p.waitForTimeout(300);
+    const t = await p.locator('.pestana.on').textContent();
+    if (!/Obra eléctrica/.test(t)) throw new Error('la pestaña dice: ' + t);
+    await hoja('DESGLOSE');
+    if ((await p.textContent('#hoja')).indexOf('Obra eléctrica') < 0)
+      throw new Error('no llegó al RESUMEN POR SECCIÓN');
+  });
+
+  await paso('mover una sección cambia su ranura en el RESUMEN', async () => {
+    await ir('#/m/M-1041'); await hoja('DESGLOSE');
+    // OJO: hay dos tablas `.rejilla.ancha` en el DESGLOSE. La ranura vive en la
+    // de RESUMEN POR SECCIÓN, y su segunda celda es el NOMBRE de la sección.
+    const ranura1 = () => p.locator('#porSeccion tbody tr').first().locator('td').nth(1).textContent();
+    const antes = (await ranura1()).trim();
+    await hoja('Suministro');
+    await p.locator('[data-movsec$="|1"]').first().click(); await p.waitForTimeout(320);
+    await hoja('DESGLOSE');
+    const desp = (await ranura1()).trim();
+    if (antes === desp) throw new Error('la ranura 1 no cambió: ' + antes);
+    console.log('   ranura 1:', antes, '→', desp);
+  });
+
+  await paso('duplicar una sección la deja al lado, marcada como copia', async () => {
+    await ir('#/m/M-1041');
+    const n0 = await p.locator('.pestana:not(.mas)').count();
+    await hoja('Suministro');
+    await p.click('[data-dupsec]'); await p.waitForTimeout(320);
+    if (await p.locator('.pestana:not(.mas)').count() !== n0 + 1) throw new Error('no duplicó');
+    const on = await p.locator('.pestana.on').textContent();
+    if (!/copia/.test(on)) throw new Error('la copia no se llama copia: ' + on);
+  });
+
+  // Hallazgo #5: el machote tiene diez ranuras y el USD de calbee tiene once.
+  // La herramienta DEJA pasar de diez -no le voy a impedir al negocio lo que
+  // ya hace- pero lo marca como hallazgo duro, porque el importe de la de más
+  // no llega al precio y el Excel no avisa.
+  await paso('pasar de diez secciones se permite pero bloquea', async () => {
+    await ir('#/m/M-1042');
+    for (let i = 0; i < 12; i++) {
+      if (await p.locator('.pestana:not(.mas)').count() > 11) break;
+      await p.click('[data-nueva]'); await p.waitForTimeout(90);
+    }
+    const n = await p.locator('.pestana:not(.mas)').count();
+    if (n <= 11) throw new Error('no dejó pasar de diez: ' + n);
+    if (await p.locator('.pestana.fuera').count() === 0)
+      throw new Error('no marcó la pestaña de más');
+    await irSuave('#/rev/M-1042');
+    const t = await p.textContent('#vista');
+    if (!/Más secciones de las que caben/.test(t)) throw new Error('el revisador no lo reportó');
+    if (!/ranura por POSICIÓN|por POSICIÓN/.test(t)) throw new Error('no explica por qué importa');
+    console.log('   ', n - 1, 'secciones · marcada y bloqueada');
+  });
+
+  await paso('la unidad admite catálogo y texto libre', async () => {
+    await ir('#/m/M-1042'); await hoja('Adecuación');
+    const u = p.locator('[data-cel$=":unidad"]').first();
+    if (await u.evaluate(e => e.tagName) !== 'INPUT')
+      throw new Error('sigue siendo un select: no deja escribir "tramo de 6 m"');
+    if (!await u.getAttribute('list')) throw new Error('sin catálogo sugerido');
+    await u.fill('tramo de 6 m'); await u.dispatchEvent('change'); await p.waitForTimeout(280);
+    if (await p.locator('[data-cel$=":unidad"]').first().inputValue() !== 'tramo de 6 m')
+      throw new Error('no guardó el texto libre');
+  });
+
+  await paso('cambiar la moneda de un renglón convierte el total', async () => {
+    await ir('#/m/M-1042'); await hoja('Adecuación');
+    const antes = await p.textContent('.fija .mono');
+    // Ojo: los renglones de mano de obra TAMBIÉN tienen moneda, y los que van
+    // en cero están plegados. Hay que apuntar a una partida y que sea visible.
+    const mon = p.locator('[data-cel*=":partidas:"][data-cel$=":moneda"]:visible').first();
+    await mon.selectOption('USD'); await p.waitForTimeout(320);
+    const desp = await p.textContent('.fija .mono');
+    if (antes === desp) throw new Error('no convirtió: ' + antes);
+    const n = parseFloat(antes.replace(/[^0-9.]/g, '')), d = parseFloat(desp.replace(/[^0-9.]/g, ''));
+    if (!(d > n)) throw new Error('un renglón en USD debería subir el total en MXN: ' + antes + ' → ' + desp);
+    console.log('   ', antes.trim(), '→', desp.trim());
+  });
+
+  await paso('la moneda nace de la empresa y avisa si no coincide', async () => {
+    await ir('#/m/M-1041'); await hoja('DESGLOSE');
+    const emp = p.locator('[data-cel="empresa_id"]');
+    if (await emp.count() === 0) throw new Error('no hay selector de empresa');
+    if (await p.locator('[data-cel="moneda"]').inputValue() !== 'MXN')
+      throw new Error('Servicios FTS debería nacer en MXN');
+    await emp.selectOption('6'); await p.waitForTimeout(320);
+    if (await p.locator('[data-cel="moneda"]').inputValue() !== 'USD')
+      throw new Error('al pasar a FTS USA la moneda debió seguir a la empresa');
+    await p.locator('[data-cel="moneda"]').selectOption('MXN'); await p.waitForTimeout(320);
+    if ((await p.textContent('#hoja')).indexOf('factura en USD') < 0)
+      throw new Error('no avisó que la moneda no es la de la empresa');
+  });
+
+  await paso('convertir sin decir de dónde salió el tipo de cambio se advierte', async () => {
+    await ir('#/m/M-1043'); await hoja('DESGLOSE');
+    await p.fill('[data-cel="tc"]', '18');
+    await p.dispatchEvent('[data-cel="tc"]', 'change'); await p.waitForTimeout(300);
+    await irSuave('#/rev/M-1043');
+    if (!/sin decir de dónde salió/.test(await p.textContent('#vista')))
+      throw new Error('no lo advirtió');
   });
 
   // ── Diseño ───────────────────────────────────────────────────────────

--- a/comercial/machote/version.json
+++ b/comercial/machote/version.json
@@ -1,10 +1,15 @@
 {
-  "version": "V1.05",
+  "version": "V1.06",
   "fecha": "2026-09-03",
   "modulo": "comercial/machote",
   "ambito": "El CONTADOR es solo de este modulo. finanzas tambien usa V1.xx desde el 2026-09-03 (instruccion directa de Esteban, corrige el \"no propagar\" del issue #148) pero lleva su propio contador y va en V1.00. operaciones/planeacion sigue en 2.4.1, kiosk y confirmar-horas solo con cadena de build, y siete modulos con un 1.0.0 puesto una vez: a esos no se propaga.",
   "esquema": "V<mayor>.<menor de dos digitos>. Un incremento de 0.01 por cada merge a main. Al pasar de .99 sube el mayor y el menor vuelve a 00.",
   "historial": [
+    {
+      "version": "V1.06",
+      "pr": null,
+      "nota": "Edicion estructural y moneda: renombrar/duplicar/reordenar/eliminar secciones y renglones, unidad libre con catalogo, empresa (FTS Mexico MXN / FTS USA USD) con moneda por renglon, y origen del tipo de cambio declarado"
+    },
     {
       "version": "V1.05",
       "pr": null,


### PR DESCRIPTION
Puntos **C** y **D** del encargo de #148.

## C · Edición estructural

- **Secciones:** renombrar (la pestaña sigue al nombre), duplicar `⧉` — queda al lado como "(copia)" —, reordenar `←` `→`, eliminar `×`.
- **Renglones de materiales y servicios:** duplicar, subir, bajar, eliminar.
- **Unidad:** ya no es un `<select>`. Es captura libre con catálogo sugerido (`<datalist>`), porque el acervo está lleno de "tramo de 6 m".
- Cada hoja de sección dice **"Sección N de M"** y que las ranuras se ocupan **por posición, no por nombre**.

**Decisión explícita sobre las 10 ranuras** (lo que pediste decidir): se **permite** pasar de diez, pero queda marcado en tres lados — la pestaña sobrante se pinta distinta, la hoja lo dice, y el revisador lo levanta como hallazgo **duro** listando qué secciones no llegarían al precio. No se bloquea porque el negocio ya lo hace (el USD de calbee 2026 tiene once); se bloquea el **silencio**, que es lo que hoy cuesta dinero.

**Los renglones de mano de obra NO aceptan filas nuevas.** Son exactamente diez por sección en los cinco machotes 2026 del acervo (90=10×9, 70=10×7, 50=10×5). Agregar filas rompería el regreso al Excel.

## D · Moneda

- Selector de **empresa**: Servicios FTS → MXN, FTS Full Technology Systems LLC → USD. La moneda del documento sigue a la empresa mientras no se toque a mano.
- Moneda **por renglón** (ya existía) más un aviso cuando la moneda del documento no es la de la empresa.
- Campo nuevo **Origen del tipo de cambio** (DOF del día · Banxico FIX · el del banco · acordado con el cliente, y texto libre). Si se convierte y no se dice de dónde salió, el revisador lo levanta: en tres meses nadie puede reconstruir el precio sin ese dato.

## Reglas nuevas del revisador

`exceso-secciones` (ahora **dura**, y explica la ranura por posición) · `tc-sin-origen` (blanda) · `moneda-contra-empresa` (informativa). Total: 30.

## Pruebas

**53 pasaron, 0 fallaron.** Once nuevas, entre ellas las cuatro que nombraste: agregar renglón y que el total cambie, renombrar sección y que persista, cambiar moneda de un renglón y que el total convierta, y las de estructura. Capturas revisadas a **390** y **1440 px**.

Un bug real que encontraron las pruebas: repintar el libro desde el `change` del nombre de sección reventaba con *"the node to be removed is no longer a child of this node"* — ese `change` llega **durante el blur** del campo y el repintado arranca el nodo que el navegador todavía está soltando. La pestaña ahora se corrige en su lugar, sin repintar.

## Versión

`V1.05` → **`V1.06`** en `version.json` y en `app.js`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013Qzhio6K8R23HXHnJ2RJ64