### PR TITLE
finanzas(bancos) V1.01: el error de Chase acusaba a la línea equivocada

### DIFF
--- a/finanzas/js/modules/instrumentos-pago.js
+++ b/finanzas/js/modules/instrumentos-pago.js
@@ -27,7 +27,7 @@
   // comercial/machote y DEBE coincidir con finanzas/version.json — el gate lo verifica, porque
   // una pantalla que dice una versión y un archivo que dice otra deja de ser evidencia de nada.
   // Sustituye a la numeración 0.x.y (última: 0.5.36), conservada en version.json.
-  var IP_BUILD = 'V1.00';
+  var IP_BUILD = 'V1.01';
   var RESIDUAL_UMBRAL_MXN = 10000;        // coherente con fin/captura-status
   var SHEETJS_CDN = 'https://cdn.sheetjs.com/xlsx-0.20.3/package/dist/xlsx.full.min.js';
   // Endpoints reales (contrato construido en la sesión de backend; verificar nombres de
@@ -1372,7 +1372,7 @@
         return '<div class="ip-acc"><div class="ip-res partial">✓ Conciliada PARCIALMENTE — quedan línea <b>' + money(r.residual_linea) + '</b> / bill <b>' + money(r.residual_bill) + '</b></div></div>';
       }
       // Guard humanizado (ej. BILL_NO_201 = cross-company) + código técnico en el detalle.
-      var human = humanConcMsg(r.code, r.msg);
+      var human = humanConcMsg(r.code, r.msg, t);
       // A4 — override del corte. Aparece SOLO cuando el server bloqueó por pre-corte, así que
       // no hay forma de que salga en una línea que no lo necesita: lo gobierna la respuesta,
       // no una condición del cliente que pudiera desincronizarse del guard real.
@@ -1401,12 +1401,37 @@
       return '<div class="ip-acc"><div class="ip-res bad">' + esc(human) + ' <span class="ip-mono2">(' + esc(r.code || 'ERROR') + ')</span></div>' +
         '<div class="ip-acc-actions"><button class="ip-acc-reload" data-reload="' + t._id + '">↻ Recargar sugerencias</button></div></div>';
     }
+    // FTS-USA = company 6. Se acepta el id o la razón social, igual que visibleRows: el endpoint
+    // real manda `rs` sin `company_id`, y el demo al revés.
+    function esUSA(t) { return !!t && (t.company_id === 6 || t.rs === 'FTS LLC'); }
+
     // Traduce códigos de guard del conciliar a lenguaje humano (el código técnico queda en el detalle).
-    function humanConcMsg(code, msg) {
+    function humanConcMsg(code, msg, t) {
+      // NO_SUSPENSE_UNICA en una línea de FTS-USA: el mensaje del server NO aplica.
+      //
+      // El guard cuenta las patas de suspense filtrando por la cuenta 184, que es la de FTS-MX,
+      // y cuando encuentra 0 concluye "no hay exactamente 1" y culpa a la línea de estar «ya
+      // parcialmente desenredada». En una línea de FTS-USA eso es falso: la pata existe, está
+      // intacta, y vive en la 309 —que es la cuenta de suspense de ESA empresa—.
+      //
+      // Comprobado el 2026-09-03 sobre la línea 33235 (BNK2/2026/00382, journal 122, Home Depot
+      // $63.43 del 17-ago): tiene EXACTAMENTE una pata de suspense, en la 309, sin tocar, y aun
+      // así el guard responde NO_SUSPENSE_UNICA. Es P1, no una línea a medio desenredar.
+      //
+      // Se dice sin prometer de más: si algún día el motor abre FTS-USA, este caso deja de
+      // llegar aquí porque la conciliación pasa. Y para FTS-MX el mensaje del server se respeta,
+      // porque ahí "a medio desenredar" sí es la lectura correcta.
+      if (code === 'NO_SUSPENSE_UNICA' && esUSA(t)) {
+        return 'Esta línea es de FTS-USA y su contrapartida está en la cuenta de suspense 309. ' +
+               'El motor todavía busca en la 184, que es la de FTS-MX, así que no la encuentra y ' +
+               'lo reporta como si la línea estuviera a medio desenredar. NO lo está: falta abrir ' +
+               'el motor a esta empresa (P1 del issue #150). El bill no se tocó.';
+      }
       var map = {
         'BILL_NO_201': 'Este bill está cargado a otra empresa/cuenta — caso cross-company, no conciliable desde aquí por ahora.',
         'LINE_YA_CONCILIADA': 'Esta línea ya fue conciliada (el mundo cambió). Recarga las sugerencias.',
-        'BILL_YA_CONCILIADO': 'El bill ya fue conciliado por otra línea. Recarga las sugerencias.'
+        'BILL_YA_CONCILIADO': 'El bill ya fue conciliado por otra línea. Recarga las sugerencias.',
+        'NO_SUSPENSE_UNICA': 'La línea no tiene exactamente una pata de suspense: ya está a medio desenredar. Se resuelve en Odoo, no desde aquí.'
       };
       return map[code] || msg || 'No se pudo conciliar.';
     }

--- a/finanzas/version.json
+++ b/finanzas/version.json
@@ -1,9 +1,14 @@
 {
-  "version": "V1.00",
+  "version": "V1.01",
   "fecha": "2026-09-03",
   "modulo": "finanzas",
   "esquema": "V<mayor>.<menor de dos dígitos>. Un incremento de 0.01 por cada merge a main. Al pasar de .99 sube el mayor y el menor vuelve a 00.",
   "historial": [
+    {
+      "version": "V1.01",
+      "pr": null,
+      "nota": "NO_SUSPENSE_UNICA en FTS-USA deja de acusar a la linea. El guard cuenta patas de suspense filtrando por la cuenta 184 (FTS-MX); en una linea de FTS-USA encuentra 0 y culpa a la linea de estar «ya parcialmente desenredada». Comprobado sobre la linea 33235 (BNK2/2026/00382, journal 122, Home Depot $63.43 del 17-ago): tiene EXACTAMENTE una pata de suspense, intacta, en la 309. Es P1, no una linea a medio desenredar. El panel ahora lo dice, y solo para FTS-USA."
+    },
     {
       "version": "V1.00",
       "pr": null,

--- a/tests/visual-bancos.js
+++ b/tests/visual-bancos.js
@@ -218,6 +218,38 @@ const esDelEntorno = t => /ERR_CONNECTION_RESET|ERR_NAME_NOT_RESOLVED|ERR_BLOCKE
       check('los controles llegan a 40 px de alto táctil', mob.chicos.length === 0, mob.chicos.join(', '));
     }
 
+    // ── NO_SUSPENSE_UNICA sobre una línea de FTS-USA ────────────────────────────────
+    // El server responde «línea ya parcialmente desenredada», y sobre una línea de FTS-USA eso
+    // es FALSO: comprobado en Odoo el 2026-09-03 que la 33235 tiene exactamente una pata de
+    // suspense, intacta, en la 309. El guard cuenta filtrando por la 184 (FTS-MX), encuentra 0,
+    // y culpa a la línea. El panel no debe repetir esa acusación.
+    if (dev.w > 700) {
+      const fila = await p.evaluate(() => {
+        const tr = [...document.querySelectorAll('#ip-tblwrap tbody tr')]
+          .find(t => t.textContent.indexOf('DLO*UBER') >= 0);
+        const b = tr ? tr.querySelector('button[data-expand]') : null;
+        if (b) b.click();
+        return !!b;
+      });
+      if (check('la línea de Chase se puede desplegar', fila)) {
+        await p.waitForSelector('button[data-conc]', { timeout: 5000 }).catch(() => {});
+        await p.evaluate(() => { const b = document.querySelector('button[data-conc]'); if (b) b.click(); });
+        await p.waitForTimeout(400);
+        const txt = (await p.locator('.ip-res.bad').first().textContent().catch(() => '')) || '';
+        console.log('   guard: ' + txt.replace(/\s+/g, ' ').trim().slice(0, 150));
+        check('el guard nombra la cuenta 309 y la 184 (la causa real)',
+          txt.indexOf('309') >= 0 && txt.indexOf('184') >= 0, txt.slice(0, 120));
+        // Se busca el texto EXACTO del server. El panel sí puede usar la palabra para negarla
+        // («lo reporta como si estuviera a medio desenredar. NO lo está»); lo que no puede es
+        // dejar pasar la frase del server como si fuera el diagnóstico.
+        check('el guard NO deja pasar la frase del server («ya parcialmente desenredada»)',
+          txt.indexOf('ya parcialmente desenredada') < 0, txt.slice(0, 120));
+        check('el guard deja ver el código técnico', txt.indexOf('NO_SUSPENSE_UNICA') >= 0, txt.slice(0, 120));
+        await p.evaluate(() => { const b = document.querySelector('button[data-expand]'); if (b) b.click(); });
+        await p.waitForTimeout(200);
+      }
+    }
+
     // Capturas SIN fullPage: lo que se ve de verdad.
     await p.screenshot({ path: path.join(OUT, dev.n + '-1-arriba.png') });
     await p.evaluate(() => { const t = document.querySelector('#ip-tblwrap'); if (t) t.scrollIntoView({ block: 'start' }); });

--- a/tests/visual-harness-bancos.html
+++ b/tests/visual-harness-bancos.html
@@ -149,8 +149,17 @@ window.FinClient = {
         { line_id: 9006, nivel: 'sugerida', candidatos: [
           { bill_aml_id: 111, bill_name: 'BILL3345', partner: 'Proferre', score: 0.91, monto_bill: 340.96,
             banda: 'alta', pre_marcado: true, fecha: '2026-08-27', days_diff: 0 }] },
-        { line_id: 9007, nivel: 'sin-documento', candidatos: [] }
+        { line_id: 9007, nivel: 'sin-documento', candidatos: [] },
+        // 9008 es la linea de Chase (company 6). Existe para reproducir el caso REAL del
+        // 2026-09-03: candidato bueno, y el conciliar responde NO_SUSPENSE_UNICA porque el
+        // motor busca la pata de suspense en la cuenta de la otra empresa.
+        { line_id: 9008, nivel: 'sugerida', candidatos: [
+          { bill_aml_id: 222, bill_name: 'BILL/2026/08/0031', partner: 'HOME DEPOT U.S.A.', score: 0.95,
+            monto_bill: 31.88, banda: 'alta', pre_marcado: true, fecha: '2026-09-01', days_diff: 0 }] }
       ], pagination: { has_more: false } });
+    // Respuesta LITERAL del server sobre una linea de FTS-USA (copiada de produccion).
+    if (ep === '/fin/captura-conciliar') return Promise.resolve({ ok: false, code: 'NO_SUSPENSE_UNICA',
+      msg: 'No hay exactamente 1 pata suspense (línea ya parcialmente desenredada) — manual v2.' });
     if (ep === '/fin/captura-pendings-status') return Promise.resolve({ disponible: false });
     return Promise.resolve({});
   }


### PR DESCRIPTION
## El error

Al intentar conciliar la línea de Chase Cheques del 17‑ago (Home Depot, $63.43) contra `BILL/2026/08/0031`:

> **No hay exactamente 1 pata suspense (línea ya parcialmente desenredada) — manual v2.** `(NO_SUSPENSE_UNICA)`

**Es falso.** Verificado en Odoo antes de tocar nada. La línea es la **33235** (asiento `BNK2/2026/00382`, journal 122, company FTS LLC) y tiene **exactamente una** pata de suspense, intacta:

| cuenta | debe | haber | residual |
|---|---|---|---|
| BUS COMPLETE CHK | | 63.43 | −63.43 |
| **Bank Suspense Account (309, company 6)** | 63.43 | | — |

El guard cuenta las patas **filtrando por la cuenta 184**, que es la suspense de FTS‑MX. En una línea de FTS‑USA encuentra **cero**, concluye *"no hay exactamente 1"* y culpa a la línea de estar a medio desenredar. El mensaje describe un estado de la línea cuando lo que ocurrió es que **se buscó en la cuenta de la otra empresa**. Es P1 del #150.

El bill tampoco tenía nada malo: `BILL/2026/08/0031`, HOME DEPOT U.S.A., **$63.43**, posted, not_paid, company 6, del 18‑ago. Monto exacto, Δ1 día, proveedor idéntico. **Era un par bueno.**

## Qué arregla este PR

No el motor — vive en n8n y sigue cerrado a MCP. Arregla **lo que el panel le dice al operador**:

- Sobre una línea de FTS‑USA, nombra la causa real (309 vs 184), dice que falta abrir el motor a esa empresa, y aclara que **el bill no se tocó**.
- Sobre FTS‑MX se respeta el significado del server —ahí *"a medio desenredar"* sí es la lectura correcta— pero con texto propio en vez de dejarlo caer al crudo. `NO_SUSPENSE_UNICA` ni siquiera estaba en el mapa de mensajes humanos.

## Lo que sigue faltando (server)

```
company 1 → suspense 184, destino 17
company 6 → suspense 309, destino 285
```

Ninguna de las dos cuentas de suspense es `reconcile`, en las dos empresas — por eso la receta reescribe `account_id` a la cuenta por pagar **antes** de reconciliar. O sea que el fix es el mapeo y nada más: no hace falta tocar la receta.

## Verificación

El harness reproduce el caso completo (línea de company 6 + candidato bueno + **la respuesta literal del server**) y tres asserts lo vigilan, incluido uno que falla si la frase del server vuelve a colarse tal cual.

| gate | |
|---|---|
| `tests/gate-instrumentos-pago.js` | 55/55 |
| `tests/visual-bancos.js` | 57/57 |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017aCfYqG8Bi1yMHM5g2xsVb

---
_Generated by [Claude Code](https://claude.ai/code/session_017aCfYqG8Bi1yMHM5g2xsVb)_