### PR TITLE
finanzas(bancos) V1.03: el panel deja de culpar a una causa ya corregida

### DIFF
--- a/finanzas/js/modules/instrumentos-pago.js
+++ b/finanzas/js/modules/instrumentos-pago.js
@@ -27,7 +27,7 @@
   // comercial/machote y DEBE coincidir con finanzas/version.json — el gate lo verifica, porque
   // una pantalla que dice una versión y un archivo que dice otra deja de ser evidencia de nada.
   // Sustituye a la numeración 0.x.y (última: 0.5.36), conservada en version.json.
-  var IP_BUILD = 'V1.02';
+  var IP_BUILD = 'V1.03';
   var RESIDUAL_UMBRAL_MXN = 10000;        // coherente con fin/captura-status
   var SHEETJS_CDN = 'https://cdn.sheetjs.com/xlsx-0.20.3/package/dist/xlsx.full.min.js';
   // Endpoints reales (contrato construido en la sesión de backend; verificar nombres de
@@ -1378,7 +1378,7 @@
         return '<div class="ip-acc"><div class="ip-res partial">✓ Conciliada PARCIALMENTE — quedan línea <b>' + money(r.residual_linea) + '</b> / bill <b>' + money(r.residual_bill) + '</b></div></div>';
       }
       // Guard humanizado (ej. BILL_NO_201 = cross-company) + código técnico en el detalle.
-      var human = humanConcMsg(r.code, r.msg, t);
+      var human = humanConcMsg(r, t);
       // A4 — override del corte. Aparece SOLO cuando el server bloqueó por pre-corte, así que
       // no hay forma de que salga en una línea que no lo necesita: lo gobierna la respuesta,
       // no una condición del cliente que pudiera desincronizarse del guard real.
@@ -1412,32 +1412,41 @@
     function esUSA(t) { return !!t && (t.company_id === 6 || t.rs === 'FTS LLC'); }
 
     // Traduce códigos de guard del conciliar a lenguaje humano (el código técnico queda en el detalle).
-    function humanConcMsg(code, msg, t) {
-      // NO_SUSPENSE_UNICA en una línea de FTS-USA: el mensaje del server NO aplica.
+    // Recibe la RESPUESTA COMPLETA, no solo el código: desde el fix de P1 el server manda campos
+    // estructurados (cuenta_suspense, company_id, encontradas) que dicen más que cualquier texto
+    // que el panel pueda inventar.
+    function humanConcMsg(r, t) {
+      var code = r && r.code, msg = r && r.msg;
+      // NO_SUSPENSE_UNICA — el mensaje bueno depende de QUÉ VERSIÓN DEL MOTOR contestó.
       //
-      // El guard cuenta las patas de suspense filtrando por la cuenta 184, que es la de FTS-MX,
-      // y cuando encuentra 0 concluye "no hay exactamente 1" y culpa a la línea de estar «ya
-      // parcialmente desenredada». En una línea de FTS-USA eso es falso: la pata existe, está
-      // intacta, y vive en la 309 —que es la cuenta de suspense de ESA empresa—.
+      // Hasta el 2026-09-03 el motor contaba las patas de suspense filtrando por la cuenta 184
+      // (FTS-MX). En una línea de FTS-USA encontraba cero y culpaba a la línea de estar «ya
+      // parcialmente desenredada», que era falso: la pata existía, intacta, en la 309.
+      // Comprobado sobre las líneas 33235 y 33121, las dos limpias.
       //
-      // Comprobado el 2026-09-03 sobre la línea 33235 (BNK2/2026/00382, journal 122, Home Depot
-      // $63.43 del 17-ago): tiene EXACTAMENTE una pata de suspense, en la 309, sin tocar, y aun
-      // así el guard responde NO_SUSPENSE_UNICA. Es P1, no una línea a medio desenredar.
+      // Ese motor ya se corrigió: elige el par de cuentas por empresa (1 → 184/17, 6 → 309/285)
+      // y su mensaje ahora dice en qué cuenta buscó y cuántas encontró. Cuando llega ese
+      // mensaje —se reconoce porque trae `cuenta_suspense`— se pasa tal cual: es más preciso
+      // que cualquier explicación de aquí, y repetir la vieja acusaría a una causa ya arreglada.
       //
-      // Se dice sin prometer de más: si algún día el motor abre FTS-USA, este caso deja de
-      // llegar aquí porque la conciliación pasa. Y para FTS-MX el mensaje del server se respeta,
-      // porque ahí "a medio desenredar" sí es la lectura correcta.
-      if (code === 'NO_SUSPENSE_UNICA' && esUSA(t)) {
-        return 'Esta línea es de FTS-USA y su contrapartida está en la cuenta de suspense 309. ' +
-               'El motor todavía busca en la 184, que es la de FTS-MX, así que no la encuentra y ' +
-               'lo reporta como si la línea estuviera a medio desenredar. NO lo está: falta abrir ' +
-               'el motor a esta empresa (P1 del issue #150). El bill no se tocó.';
+      // El texto anterior se queda SOLO como respaldo para el motor viejo. Es la mitad tolerante
+      // (CLAUDE.md §8, regla anti-trabón): el panel entiende las dos respuestas, así que ni un
+      // rollback del workflow ni un caché viejo dejan al operador sin explicación.
+      if (code === 'NO_SUSPENSE_UNICA') {
+        if (r.cuenta_suspense != null) return msg || 'No se encontró exactamente una pata de suspense.';
+        if (esUSA(t)) {
+          return 'Esta línea es de FTS-USA y su contrapartida está en la cuenta de suspense 309. ' +
+                 'El motor que contestó todavía busca en la 184, que es la de FTS-MX, así que no la ' +
+                 'encuentra. Es una respuesta de la versión anterior del workflow. El bill no se tocó.';
+        }
+        return 'La línea no tiene exactamente una pata de suspense: ya está a medio desenredar. Se resuelve en Odoo, no desde aquí.';
       }
       var map = {
         'BILL_NO_201': 'Este bill está cargado a otra empresa/cuenta — caso cross-company, no conciliable desde aquí por ahora.',
+        'BILL_OTRA_EMPRESA': 'El bill y la línea son de empresas distintas. No se concilia cruzado entre compañías.',
+        'EMPRESA_SIN_MAPEO': 'La empresa de esta línea no tiene cuentas de conciliación configuradas en el motor. No se tocó nada.',
         'LINE_YA_CONCILIADA': 'Esta línea ya fue conciliada (el mundo cambió). Recarga las sugerencias.',
-        'BILL_YA_CONCILIADO': 'El bill ya fue conciliado por otra línea. Recarga las sugerencias.',
-        'NO_SUSPENSE_UNICA': 'La línea no tiene exactamente una pata de suspense: ya está a medio desenredar. Se resuelve en Odoo, no desde aquí.'
+        'BILL_YA_CONCILIADO': 'El bill ya fue conciliado por otra línea. Recarga las sugerencias.'
       };
       return map[code] || msg || 'No se pudo conciliar.';
     }

--- a/finanzas/version.json
+++ b/finanzas/version.json
@@ -1,9 +1,14 @@
 {
-  "version": "V1.02",
+  "version": "V1.03",
   "fecha": "2026-09-03",
   "modulo": "finanzas",
   "esquema": "V<mayor>.<menor de dos dígitos>. Un incremento de 0.01 por cada merge a main. Al pasar de .99 sube el mayor y el menor vuelve a 00.",
   "historial": [
+    {
+      "version": "V1.03",
+      "pr": null,
+      "nota": "El motor de conciliacion ya elige las cuentas por empresa (P1 corregido en n8n el 2026-09-03: 1 -> 184/17, 6 -> 309/285), asi que el texto de V1.01 —que culpaba a la cuenta 184— quedo obsoleto el mismo dia. Ahora, cuando la respuesta trae `cuenta_suspense`, el panel pasa el mensaje del server tal cual: dice en que cuenta busco y cuantas patas encontro. La explicacion vieja sobrevive solo como respaldo si contesta el motor anterior (mitad tolerante). Mensajes nuevos para los guards BILL_OTRA_EMPRESA y EMPRESA_SIN_MAPEO."
+    },
     {
       "version": "V1.02",
       "pr": null,

--- a/tests/visual-bancos.js
+++ b/tests/visual-bancos.js
@@ -249,13 +249,14 @@ const esDelEntorno = t => /ERR_CONNECTION_RESET|ERR_NAME_NOT_RESOLVED|ERR_BLOCKE
         await p.waitForTimeout(400);
         const txt = (await p.locator('.ip-res.bad').first().textContent().catch(() => '')) || '';
         console.log('   guard: ' + txt.replace(/\s+/g, ' ').trim().slice(0, 150));
-        check('el guard nombra la cuenta 309 y la 184 (la causa real)',
-          txt.indexOf('309') >= 0 && txt.indexOf('184') >= 0, txt.slice(0, 120));
-        // Se busca el texto EXACTO del server. El panel sí puede usar la palabra para negarla
-        // («lo reporta como si estuviera a medio desenredar. NO lo está»); lo que no puede es
-        // dejar pasar la frase del server como si fuera el diagnóstico.
-        check('el guard NO deja pasar la frase del server («ya parcialmente desenredada»)',
-          txt.indexOf('ya parcialmente desenredada') < 0, txt.slice(0, 120));
+        // Desde el fix de P1 el server dice en qué cuenta buscó y cuántas encontró, y eso es más
+        // preciso que cualquier texto del panel: se pasa tal cual.
+        check('el guard nombra la cuenta de suspense que el motor miró (309)',
+          txt.indexOf('309') >= 0, txt.slice(0, 140));
+        check('el guard dice cuántas patas encontró', /se encontraron 0/i.test(txt), txt.slice(0, 140));
+        // Si el panel cayera al genérico, estaría tirando el detalle del server a la basura.
+        check('el guard NO cae al mensaje genérico',
+          txt.indexOf('No se pudo conciliar') < 0, txt.slice(0, 140));
         check('el guard deja ver el código técnico', txt.indexOf('NO_SUSPENSE_UNICA') >= 0, txt.slice(0, 120));
         await p.evaluate(() => { const b = document.querySelector('button[data-expand]'); if (b) b.click(); });
         await p.waitForTimeout(200);

--- a/tests/visual-harness-bancos.html
+++ b/tests/visual-harness-bancos.html
@@ -157,9 +157,13 @@ window.FinClient = {
           { bill_aml_id: 222, bill_name: 'BILL/2026/08/0031', partner: 'HOME DEPOT U.S.A.', score: 0.95,
             monto_bill: 31.88, banda: 'alta', pre_marcado: true, fecha: '2026-09-01', days_diff: 0 }] }
       ], pagination: { has_more: false } });
-    // Respuesta LITERAL del server sobre una linea de FTS-USA (copiada de produccion).
+    // Respuesta del server DESPUES del fix de P1: ya elige la cuenta por empresa y dice cual
+    // miro y cuantas encontro. Se reconoce por `cuenta_suspense`, y el panel la pasa tal cual.
     if (ep === '/fin/captura-conciliar') return Promise.resolve({ ok: false, code: 'NO_SUSPENSE_UNICA',
-      msg: 'No hay exactamente 1 pata suspense (línea ya parcialmente desenredada) — manual v2.' });
+      cuenta_suspense: 309, company_id: 6, encontradas: 0,
+      msg: 'No hay exactamente 1 pata suspense en la cuenta 309 (empresa 6): se encontraron 0. ' +
+           'Si son 0, la linea puede estar en otra cuenta de suspense; si son 2 o mas, ya esta ' +
+           'parcialmente desenredada — manual v2.' });
     if (ep === '/fin/captura-pendings-status') return Promise.resolve({ disponible: false });
     return Promise.resolve({});
   }


### PR DESCRIPTION
## Contexto: P1 se arregló hoy en el motor

`fin/captura-conciliar` ya elige las cuentas **por empresa** en vez de llevar fijas las de FTS‑MX:

```
company 1 → suspense 184, por pagar 17
company 6 → suspense 309, por pagar 285
```

Publicado y verificado por read‑back (`versionId == activeVersionId == ba5bac91`, `active: true`). El `update` había quedado como **borrador** con el `activeVersionId` viejo — sin el read‑back, el webhook habría seguido corriendo el código anterior.

## Qué arregla este PR

Ese fix dejó obsoleto, el mismo día, el texto que V1.01 puso en el panel:

> *«El motor todavía busca en la **184**, que es la de FTS‑MX…»*

Ya no lo hace. **Arreglar el motor y dejar la pantalla diciendo que sigue roto** es el mismo defecto de coherencia que este módulo lleva corrigiendo toda la tanda, solo que al revés.

El motor corregido responde con campos estructurados —`cuenta_suspense`, `company_id`, `encontradas`— y su mensaje dice en qué cuenta miró y cuántas patas halló. Cuando llega esa forma (se reconoce por `cuenta_suspense`), el panel **la pasa tal cual**: es más precisa que cualquier explicación escrita en el frontend.

La explicación vieja **no se borra**: queda como respaldo para cuando conteste el motor anterior. Es la mitad tolerante de la regla anti‑trabón (§8) — el panel entiende las dos respuestas, así que ni un rollback del workflow ni un caché viejo dejan al operador sin explicación.

De paso, mensajes propios para los dos guards nuevos del motor:

| guard | qué dice |
|---|---|
| `BILL_OTRA_EMPRESA` | el bill y la línea son de compañías distintas — no se concilia cruzado |
| `EMPRESA_SIN_MAPEO` | la empresa no tiene cuentas configuradas; **no se tocó nada** (antes habría caído en silencio al par de FTS‑MX, que era el bug) |

`humanConcMsg` ahora recibe la respuesta completa y no solo el código: los campos que manda el server dicen más que el texto.

## Verificación

| gate | |
|---|---|
| `tests/gate-instrumentos-pago.js` | 55/55 |
| `tests/visual-bancos.js` | 65/65 |

El harness pasa a devolver la respuesta del **motor nuevo**, y los asserts exigen que el panel conserve el detalle (la cuenta mirada y el conteo) en vez de caer al mensaje genérico.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017aCfYqG8Bi1yMHM5g2xsVb

---
_Generated by [Claude Code](https://claude.ai/code/session_017aCfYqG8Bi1yMHM5g2xsVb)_