### PR TITLE
finanzas(bancos) V1.04: separar los dos motores en los textos

### DIFF
--- a/finanzas/js/modules/instrumentos-pago.js
+++ b/finanzas/js/modules/instrumentos-pago.js
@@ -27,7 +27,7 @@
   // comercial/machote y DEBE coincidir con finanzas/version.json — el gate lo verifica, porque
   // una pantalla que dice una versión y un archivo que dice otra deja de ser evidencia de nada.
   // Sustituye a la numeración 0.x.y (última: 0.5.36), conservada en version.json.
-  var IP_BUILD = 'V1.03';
+  var IP_BUILD = 'V1.04';
   var RESIDUAL_UMBRAL_MXN = 10000;        // coherente con fin/captura-status
   var SHEETJS_CDN = 'https://cdn.sheetjs.com/xlsx-0.20.3/package/dist/xlsx.full.min.js';
   // Endpoints reales (contrato construido en la sesión de backend; verificar nombres de
@@ -931,9 +931,13 @@
                        traspaso: 'Traspaso interno', ajuste: 'Ajuste', abono: 'Abono' };
 
     // ── EJE B · CONCILIACIÓN (qué falta hacer) ──
-    // 'noevaluada' es un valor REAL, no un hueco: el motor tiene journal_id 61 fijo, así que las
-    // 473 líneas de Chase nunca se evaluaron. Pintarlas "sin documento" afirmaría que se buscó y
-    // no había — no se buscó. Es la diferencia entre "no hay factura" y "no sabemos".
+    // 'noevaluada' es un valor REAL, no un hueco: el motor de SUGERENCIAS no cubre los journals
+    // de Chase, así que sus líneas nunca se evaluaron. Pintarlas "sin documento" afirmaría que se
+    // buscó y no había — no se buscó. Es la diferencia entre "no hay factura" y "no sabemos".
+    // OJO (2026-09-03): esto ya NO habla del motor de CONCILIAR, que desde hoy cubre las dos
+    // empresas (P1 corregido: cuentas por company_id). Conciliar una línea de Chase funciona;
+    // lo que falta es que alguien le PROPONGA el bill. Son dos workflows distintos y el flag
+    // en_motor solo describe al de sugerencias.
     function enAlcanceMotor(r) {
       var p = (state.porJournal || []).filter(function (x) { return x.journal === r._jid; })[0];
       return p ? p.en_motor !== false : true;   // sin info del server, no se acusa de no-evaluada
@@ -1015,7 +1019,7 @@
         // chevron sale con !t.ok) — ofrecer un botón que siempre falla sería peor que no darlo.
         return '<span class="ip-est tra" title="El apunte de la cuenta 17 recuperó el importe COMPLETO: la conciliación se deshizo entera (lo habitual es que se haya cancelado el bill, pero también pudo desatarse a mano). La línea sigue marcada conciliada en Odoo porque la receta vació la cuenta de suspense y ese flag ya no puede volver atrás. Ojo: NO se puede volver a conciliar desde este panel — el guard la rechaza por ya-conciliada. Hoy se resuelve en Odoo.">⟲ Desconciliada</span> <span class="ip-est-bill">' + money(_rd) + ' abiertos · resolver en Odoo</span>';
       }
-      if (st === 'noevaluada') return '<span class="ip-est nev" title="Fuera del alcance del motor de conciliación (journal_id 61 fijo). No es que no haya factura: no se buscó.">◌ No evaluada</span>';
+      if (st === 'noevaluada') return '<span class="ip-est nev" title="El motor de sugerencias no evalúa este journal todavía, así que no hay bill propuesto. No es que no haya factura: no se buscó. Conciliar SÍ funciona — abre la fila y usa \'buscar bill\'.">◌ No evaluada</span>';
       // Ninguno de los dos va en rojo: no son un error ni trabajo atorado del equipo.
       if (st === 'devolucion_pend') return '<span class="ip-est dev-ret" title="Una devolución no casa contra un bill de proveedor: casa contra una nota de crédito, o reduce el bill original. El motor de sugerencias no la evalúa a propósito.">↩ Devolución</span> <span class="ip-est-bill">pendiente de nota de crédito</span>';
       if (st === 'fondeo_pend')     return '<span class="ip-est fon" title="Abono de la línea de crédito. Su contrapartida es el movimiento del lado BBVA, que aún no se captura en Odoo — por eso queda en suspense.">⊕ Fondeo</span> <span class="ip-est-bill">pendiente del lado BBVA</span>';
@@ -1671,9 +1675,9 @@
 
       // ── B · POST-CORTE. Protagonista, expandido, arriba. ──
       // El desglose POR JOURNAL va primero y el global después, a propósito: el agregado
-      // ATRIBUYE MAL. El motor tiene journal_id 61 fijo, así que 122 y 123 están al 0% por
-      // falta de alcance, no de trabajo. Un 19.6% en grande se lee como "la operación va mal"
-      // cuando lo que dice es "hay dos fuentes sin abrir".
+      // ATRIBUYE MAL. 122 y 123 están casi al 0% porque nadie les propone bills todavía, no
+      // porque el equipo no trabaje. Un porcentaje global en grande se lee como "la operación
+      // va mal" cuando lo que dice es "hay dos fuentes sin sugerencias".
       if (m && m.cumplimiento) {
         var pj = (m.por_journal || []).filter(function (x) { return (x.post_total || 0) > 0; });
         // El foco de la cabecera se calcula SOLO sobre las fuentes con motor (v0.5.37). Antes
@@ -1726,8 +1730,10 @@
             '<div class="bar"><i style="width:' + (p || 0) + '%;background:' + barc(c2) + '"></i></div>' +
             '<div class="s2cn">' + detalle + '</div>' +
             comp.html +
-            (x.en_motor ? '' : '<div class="s2cw">El motor todavía no evalúa este journal: hoy solo cubre Jeeves. ' +
-              'Abrirlo es un cambio en el workflow de conciliación, no en este panel.</div>') +
+            (x.en_motor ? '' : '<div class="s2cw">Lo que falta aquí es el motor de <b>sugerencias</b>: ' +
+              'no propone bills todavía, así que cada línea se busca con <b>buscar bill</b> en su fila. ' +
+              '<b>Conciliar sí funciona</b> — el motor de conciliación ya cubre este journal ' +
+              '(primera línea cerrada el 2026-09-03).</div>') +
             '</div>';
         }).join('');
         html += '<div class="ip-sem2 b">' +

--- a/finanzas/version.json
+++ b/finanzas/version.json
@@ -1,9 +1,14 @@
 {
-  "version": "V1.03",
+  "version": "V1.04",
   "fecha": "2026-09-03",
   "modulo": "finanzas",
   "esquema": "V<mayor>.<menor de dos dígitos>. Un incremento de 0.01 por cada merge a main. Al pasar de .99 sube el mayor y el menor vuelve a 00.",
   "historial": [
+    {
+      "version": "V1.04",
+      "pr": null,
+      "nota": "La nota de las fuentes sin abrir decia \"el motor todavia no evalua este journal\" y eso quedo falso: el 2026-09-03 se concilio la primera linea de FTS-USA (33121 Elliott / BILL/2026/08/0016, full_reconcile 9357). Son DOS motores y el panel los mezclaba: el de CONCILIAR ya cubre las dos empresas; el de SUGERENCIAS todavia no propone bills en Chase. Los textos ahora lo dicen por separado, e indican que conciliar si funciona usando buscar bill."
+    },
     {
       "version": "V1.03",
       "pr": null,


### PR DESCRIPTION
## La nota de Chase dejó de ser cierta

> *«El motor todavía no evalúa este journal: hoy solo cubre Jeeves.»*

Hoy se concilió **la primera línea de FTS‑USA**. Verificado en Odoo:

```
BNK2/2026/00334 · ELLIOTT ELECTRIC SUPPL · 442.86
  Account Payable (285) · residual 0.00 · reconciled sí · full_reconcile 9357
  partner: Elliott Electric Supply, Inc.

BILL/2026/08/0016 → payment_state: paid · amount_residual: 0.00
journal 122: 422 sin conciliar + 1 conciliada   (antes: 423 + 0)
```

## La raíz: el panel hablaba de «el motor» como si fuera uno

Son **dos workflows distintos**, y solo uno cambió:

| workflow | qué hace | Chase |
|---|---|---|
| `fin/captura-conciliar` | el botón **Conciliar** | ✅ ya cubre las dos empresas (fix de P1: cuentas por `company_id`) |
| `fin/captura-sugerencias` | propone el bill al expandir la fila | ❌ sigue sin cubrir los journals de Chase |

El flag `en_motor` que manda el server describe al **segundo**. Eso es lo que la nota tenía que decir y no decía.

## Qué cambia

Los textos van separados: **qué falta** (que alguien proponga el bill — hoy se busca a mano) y **qué sí funciona** (conciliar, con `buscar bill` en la fila). Mismo arreglo en el tooltip del estado `◌ No evaluada`, que además citaba un *«journal_id 61 fijo»* que ya no existe en el motor de conciliar.

Los comentarios del código se corrigieron igual, para que la próxima sesión no vuelva a leer que el motor está clavado en el journal 61.

## Lo que este PR NO hace

**No añade sugerencias a Chase.** Eso vive en `fin/captura-sugerencias` (`43ueZWEXzLyty0LF`), que sigue con `availableInMCP: false`.

Y no basta con que el panel pregunte: hoy `evalSugg()` salta los journals fuera del motor a propósito, y si preguntara antes de que el server sepa contestar, las líneas de Chase pasarían de un honesto *«no evaluada»* a un falso *«sin documento»* — afirmando que se buscó factura y no había. **Primero el server, después el panel** (regla anti‑trabón §8: la mitad tolerante va primero).

## Verificación

| gate | |
|---|---|
| `tests/gate-instrumentos-pago.js` | 55/55 |
| `tests/visual-bancos.js` | 65/65 |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017aCfYqG8Bi1yMHM5g2xsVb

---
_Generated by [Claude Code](https://claude.ai/code/session_017aCfYqG8Bi1yMHM5g2xsVb)_