### PR TITLE
comercial(machote) V1.07: colores del machote, renglón capturado en verde y autoguardado con candado

### DIFF
--- a/comercial/machote/README.md
+++ b/comercial/machote/README.md
@@ -64,7 +64,8 @@ versión es peor que no tener indicador.
 | `js/reglas.js` | 30 reglas en un arreglo de configuración, separadas del motor que las corre. |
 | `js/demo.js` | Datos de ejemplo. Lo que viene del machote real va marcado `REAL`; lo inventado, `SUPUESTO`. |
 | `js/app.js` | Vistas y ruteo. |
-| `tests/pruebas-navegador.js` | 53 pruebas de navegador. |
+| `js/almacen.js` | El autoguardado. UNA pieza entre la pantalla y donde viven los datos. |
+| `tests/pruebas-navegador.js` | 60 pruebas de navegador. |
 
 ## Cómo se calcula el precio
 
@@ -161,6 +162,67 @@ Cuando se convierte hay que decir **de dónde salió el tipo de cambio** — DOF
 día, Banxico FIX, el del banco, acordado con el cliente, o texto libre. Si no se
 dice, el revisador lo levanta: en tres meses nadie puede reconstruir el precio
 sin ese dato.
+
+## Los colores
+
+⚠️ **Son una aproximación, no una medición.** El conector de SharePoint
+devuelve los valores y las fórmulas del libro pero **nada de estilo** — se
+comprobó contra `SO11836`: cero información de relleno. Así que la paleta está
+puesta a ojo con los colores de Office que usan esas plantillas, no leída del
+archivo.
+
+Corregirla es cambiar **ocho variables** al principio de `css/machote.css`
+(`--x-banda`, `--x-cab`, `--x-grupo`, `--x-total`, `--x-fila-ok`…) y nada más:
+ningún color de tabla está escrito en otro lado, y hay una prueba que lo vigila.
+El día que lleguen los colores reales, el cambio es de un minuto.
+
+## El renglón capturado
+
+**Verde = este renglón ya tiene cantidad** (`QTY ≥ 1`). Con diez renglones de
+mano de obra fijos por sección, la mayoría en blanco casi siempre, distinguir de
+un vistazo lo capturado de lo que falta es la diferencia entre revisar una hoja
+y leerla entera.
+
+En teléfono la marca es el **borde** de la tarjeta, no el fondo: un fondo verde
+detrás de catorce campos etiquetados no se lee.
+
+## Autoguardado
+
+No hay botón de guardar, y no debe haberlo. Cada cambio —una cifra, el nombre de
+una sección, agregar un renglón— programa el guardado medio segundo después de
+la última tecla; y al cambiar de pantalla, al cambiar de pestaña del navegador y
+al cerrar, lo pendiente se guarda de inmediato. Un punto de color en la barra
+superior dice en cuál de los tres estados está: **guardado**, **sin guardar**,
+**guardando**.
+
+⚠️ **Hoy guarda en el NAVEGADOR, no en un servidor.** Lo que se captura en una
+laptop no lo ve nadie más, y se pierde si se limpian los datos del sitio. Sirve
+para que el gesto sea real mientras se valida el backend. Todo eso vive detrás
+de `js/almacen.js`, que es **la única pieza que cambia** el día que entre el
+Postgres de la suite (`fts-suite-db`, issue #140) — la pantalla no sabe contra
+qué guarda. Lo que falta para ese salto está listado dentro de ese archivo.
+
+## El flujo, y el candado
+
+```
+En creación  →  En revisión  →  Enviado a Odoo
+                                 ↑ exige orden · congela
+```
+
+El machote **nace sin orden** — casi siempre nace antes que la orden — y por eso
+la SO es opcional mientras se arma. Al enviarlo a Odoo ya no: enviar **es**
+confirmar la venta, y una venta sin orden no existe. Si se intenta, el selector
+se revierte y dice por qué.
+
+Un machote enviado queda **congelado**: los campos se apagan y desaparecen los
+botones de estructura, pero la hoja se sigue viendo — es el documento con el que
+se vendió y hay que poder consultarlo. La banda de estado encabeza **todas** las
+hojas, no sólo el `DESGLOSE`: catorce campos apagados sin decir por qué son
+exactamente el silencio que este módulo persigue.
+
+⚠️ **Enviar todavía NO escribe en Odoo.** La regla vigente del módulo es que
+Odoo sólo se consulta. El estado, el candado y la exigencia de orden ya son
+reales; la escritura espera a que Esteban levante esa regla.
 
 ## Cómo correr las pruebas
 

--- a/comercial/machote/css/machote.css
+++ b/comercial/machote/css/machote.css
@@ -21,6 +21,27 @@
   --ambar: #9a6700;
   --rojo: #cf222e;
   --toque: 44px;   /* altura mínima de cualquier cosa que se toque */
+
+  /* ── Los colores del machote ──────────────────────────────────────────
+   *
+   * ⚠️ APROXIMACIÓN, no medición. El conector de SharePoint devuelve los
+   * valores y las fórmulas del libro pero NADA de estilo -se comprobó contra
+   * `SO11836`: cero información de relleno-, así que estos colores están
+   * puestos a ojo con la paleta de Office que usan esas plantillas, no
+   * leídos del archivo.
+   *
+   * Corregirlos es cambiar ESTAS ocho líneas y nada más: ningún color de
+   * tabla está escrito en otro lado. Si Esteban manda una captura o los
+   * códigos, se sustituyen aquí. */
+  --x-banda:    #1f4e79;   /* banda de bloque: COSTO MANO DE OBRA */
+  --x-banda-tx: #ffffff;
+  --x-cab:      #d9e1f2;   /* encabezado de columna */
+  --x-cab-tx:   #1f3864;
+  --x-grupo:    #ddebf7;   /* rótulo de grupo: Diseño y Programación */
+  --x-total:    #fff2cc;   /* renglones de total */
+  --x-total-bd: #bf8f00;
+  --x-fila-ok:  #e2efda;   /* renglón ya capturado (QTY ≥ 1) */
+  --x-fila-bd:  #70ad47;
 }
 
 /* ── Base ─────────────────────────────────────────────────────────────── */
@@ -405,4 +426,69 @@ table.rejilla td.acc .ico { min-width: 36px; min-height: 36px; padding: 0 6px; }
   table.rejilla.tarjetas td.acc .ico { min-width: var(--toque); min-height: var(--toque); }
   .nomsec { align-items: flex-start; }
   .accsec { margin-left: 0; }
+}
+
+
+/* ── Los colores del machote, aplicados ─────────────────────────────────
+ * Sólo tocan tablas y bandas. Las tres señales de captura contra cálculo
+ * (borde, fondo de papel, barra de fórmula) siguen mandando encima. */
+.secc-tit { background: var(--x-banda); color: var(--x-banda-tx); }
+.secc-tit .verVacios { color: var(--x-banda-tx); opacity: .9; }
+table.rejilla th { background: var(--x-cab); color: var(--x-cab-tx); }
+table.rejilla tr.grupo td { background: var(--x-grupo); color: var(--x-cab-tx); }
+table.rejilla tr.total td { background: var(--x-total); border-top: 2px solid var(--x-total-bd); }
+
+/* ── Renglón capturado ──────────────────────────────────────────────────
+ * Verde = este renglón ya tiene cantidad. Con diez renglones de mano de obra
+ * fijos por sección, distinguir de un vistazo lo capturado de lo que sigue en
+ * blanco es la diferencia entre revisar una hoja y leerla entera.
+ * El verde va en el RENGLÓN; las celdas conservan sus propias señales, que
+ * son las que dicen qué se captura y qué se calcula. */
+table.rejilla tr.capturada > td { background: var(--x-fila-ok); }
+table.rejilla tr.capturada > td.calc { background: #d7e8c8; }
+table.rejilla tr.capturada > td:first-child { box-shadow: inset 3px 0 0 var(--x-fila-bd); }
+
+/* ── Campos apagados por machote congelado ──────────────────────────────
+ * No se esconde la hoja: el documento con el que se vendió hay que poder
+ * consultarlo. Lo que se quita es la posibilidad de cambiarlo. */
+.cel.bloq, .cel:disabled { background: var(--papel); color: var(--suave);
+                           border-style: dashed; cursor: not-allowed; }
+
+/* ── Banda de estado ────────────────────────────────────────────────────*/
+.edo { display: flex; gap: 10px; align-items: center; flex-wrap: wrap;
+       border: 1px solid var(--linea); border-left: 3px solid var(--acento);
+       background: var(--papel); border-radius: 8px; padding: 8px 12px; margin-bottom: 12px; }
+.edo.cerrado { border-left-color: var(--verde); }
+.edo select { min-height: var(--toque); border: 1px solid var(--linea);
+              border-radius: 6px; padding: 0 8px; background: var(--fondo);
+              font-size: 13px; margin-left: 6px; }
+.edo label { display: flex; align-items: center; }
+
+/* ── El pulso del autoguardado ──────────────────────────────────────────
+ * Vive en la topbar porque es el único lugar visible en toda pantalla del
+ * libro. Sin él, "se guarda solo" es una promesa que el usuario tiene que
+ * creer; con él, la ve. */
+.pulso { display: flex; align-items: center; gap: 5px; font-size: 11px;
+         color: var(--suave); white-space: nowrap; margin-right: 8px; }
+.pulso i { width: 8px; height: 8px; border-radius: 50%; background: var(--suave);
+           flex: 0 0 auto; }
+.pulso.p-limpio i, .pulso.p-guardado i { background: var(--verde); }
+.pulso.p-sucio i { background: var(--ambar); }
+.pulso.p-guardando i { background: var(--ambar); animation: latir .7s ease-in-out infinite; }
+.pulso.p-sin-almacen i { background: var(--rojo); }
+.pulso.p-sin-almacen { color: var(--rojo); }
+@keyframes latir { 0%,100% { opacity: 1 } 50% { opacity: .25 } }
+@media (prefers-reduced-motion: reduce) { .pulso.p-guardando i { animation: none } }
+/* En teléfono el texto sobra: el punto de color ya dice lo que hay que saber,
+   y la topbar no tiene ancho para las dos cosas. */
+@media (max-width: 520px) { .pulso span { display: none } }
+
+@media (max-width: 719px) {
+  /* En tarjetas el renglón capturado se marca por su borde, no por el fondo:
+     un fondo verde detrás de catorce campos etiquetados no se lee. */
+  table.rejilla.tarjetas tr.capturada { border-color: var(--x-fila-bd);
+                                        box-shadow: inset 3px 0 0 var(--x-fila-bd); }
+  table.rejilla.tarjetas tr.capturada > td { background: transparent; }
+  table.rejilla.tarjetas tr.capturada > td.calc { background: var(--papel); }
+  table.rejilla.tarjetas tr.capturada > td:first-child { box-shadow: none; }
 }

--- a/comercial/machote/index.html
+++ b/comercial/machote/index.html
@@ -16,6 +16,9 @@
     <button class="tb-back" id="btnBack" aria-label="Volver">&#8249;</button>
     <div class="tb-logo" role="img" aria-label="FTS"></div>
     <div class="tb-info"><strong id="tbT">Machote y órdenes</strong><span id="tbS">Comercial · prototipo</span></div>
+    <!-- El pulso del autoguardado. Va en la topbar a proposito: es el unico
+         lugar que sigue visible en toda pantalla del libro. -->
+    <div class="pulso" id="pulso" title="Autoguardado"><i></i><span id="pulsoTx">—</span></div>
     <div class="tb-badge" id="tbB">DEMO</div>
   </div>
   <main id="vista"></main>
@@ -23,6 +26,7 @@
 </div>
 
 <!-- calc.js primero: demo.js lee de el los roles y los margenes de plantilla. -->
+<script src="js/almacen.js"></script>
 <script src="js/calc.js"></script>
 <script src="js/demo.js"></script>
 <script src="js/reglas.js"></script>

--- a/comercial/machote/js/almacen.js
+++ b/comercial/machote/js/almacen.js
@@ -1,0 +1,84 @@
+/* ═══ Machote · el almacén ═══
+ *
+ * UNA sola pieza entre la pantalla y donde viven los datos. Hoy escribe en el
+ * navegador; mañana escribirá en el Postgres de la suite (`fts-suite-db`,
+ * esquema `comercial`, issue #140) y **esta es la única pieza que cambia** —
+ * la pantalla no sabe contra qué está guardando y no debe saberlo.
+ *
+ * ⚠️ LÍMITE HONESTO DE HOY: `localStorage` es del navegador y del dispositivo.
+ * Lo que Esteban guarde en su laptop NO lo ve el analista en su teléfono, y si
+ * alguien limpia los datos del sitio, se pierde. Sirve para que el gesto de
+ * autoguardado sea REAL mientras se valida el backend, no para operar.
+ *
+ * Lo que falta para mover esto a Postgres, escrito para no re-investigarlo:
+ *   1. `comercial/db/migrations/003_machote.sql` — las tablas.
+ *   2. El workflow `comercial/db-migrate` (DISEÑADO en docs/comercial/ALMACEN.md,
+ *      NO CONSTRUIDO todavía) para aplicarla.
+ *   3. Un humano corre una vez `ALTER ROLE comercial_app WITH LOGIN PASSWORD`
+ *      y crea la credencial Postgres en n8n. La contraseña no pasa por el repo.
+ *   4. Dos webhooks: leer los machotes de la persona, y guardar uno.
+ * Entonces `leer`/`escribir` de aquí abajo cambian de cuerpo, y ya.
+ */
+(function (G) {
+  'use strict';
+
+  var LLAVE = 'fts_machote_v1';
+
+  /* Que exista el objeto no basta: en modo privado de Safari `localStorage`
+   * existe y **tira** al escribir. La única prueba que vale es escribir. */
+  function disponible() {
+    try {
+      var t = '__p' + Date.now();
+      localStorage.setItem(t, '1');
+      localStorage.removeItem(t);
+      return true;
+    } catch (e) { return false; }
+  }
+
+  var VIVO = disponible();
+
+  /** Devuelve lo guardado, o `null` si no hay nada o está corrupto.
+   *  Un JSON roto NO debe tumbar la aplicación: se descarta y se sigue con los
+   *  datos de ejemplo, que es exactamente lo que quiere quien abre la página. */
+  function leer() {
+    if (!VIVO) return null;
+    try {
+      var crudo = localStorage.getItem(LLAVE);
+      if (!crudo) return null;
+      var d = JSON.parse(crudo);
+      if (!d || !Array.isArray(d.machotes)) return null;
+      return d;
+    } catch (e) { return null; }
+  }
+
+  /** Guarda. Devuelve `true` sólo si de verdad quedó.
+   *  Se relee lo escrito a propósito: en este repo ya costó caro dar por bueno
+   *  un `200` que no probaba la escritura (CLAUDE.md §8). Aquí es barato
+   *  comprobarlo, así que se comprueba. */
+  function escribir(datos) {
+    if (!VIVO) return false;
+    try {
+      var payload = JSON.stringify({
+        v: 1,
+        guardado_at: new Date().toISOString(),
+        machotes: datos.machotes,
+        handoff: datos.handoff || {}
+      });
+      localStorage.setItem(LLAVE, payload);
+      return localStorage.getItem(LLAVE) === payload;
+    } catch (e) { return false; }
+  }
+
+  function olvidar() {
+    if (!VIVO) return;
+    try { localStorage.removeItem(LLAVE); } catch (e) { /* nada que hacer */ }
+  }
+
+  G.MachoteAlmacen = {
+    nombre: 'navegador',
+    disponible: function () { return VIVO; },
+    leer: leer,
+    escribir: escribir,
+    olvidar: olvidar
+  };
+})(window);

--- a/comercial/machote/js/app.js
+++ b/comercial/machote/js/app.js
@@ -34,18 +34,80 @@
    * 2026-09-03 (por instrucción de Esteban), pero lleva el suyo aparte y va en
    * V1.00. Planeación sigue en `2.4.1` y el kiosko sólo con cadena de build;
    * a esos no se propaga. */
-  const VERSION = 'V1.06';
+  const VERSION = 'V1.07';
   const $  = (s, r) => (r || document).querySelector(s);
   const $$ = (s, r) => Array.prototype.slice.call((r || document).querySelectorAll(s));
   const clon = (x) => JSON.parse(JSON.stringify(x));
 
+  const A = G.MachoteAlmacen;
+
+  /* Lo guardado manda sobre los datos de ejemplo. Si el almacen esta vacio o
+   * corrupto se arranca con la demo, que es lo que espera quien abre la pagina
+   * por primera vez. */
+  const _guardado = A ? A.leer() : null;
   const ST = {
     verVacios: false,
-    machotes: clon(D.MACHOTES),
+    machotes: _guardado ? _guardado.machotes : clon(D.MACHOTES),
     ordenes:  clon(D.ORDENES),
-    handoff: {}, confirmadas: {},
-    hoja: 'desglose', simMargen: null
+    handoff: _guardado ? (_guardado.handoff || {}) : {},
+    confirmadas: {},
+    hoja: 'desglose', simMargen: null,
+    // 'limpio' | 'sucio' | 'guardando' | 'guardado' | 'sin-almacen'
+    pulso: (A && A.disponible()) ? 'limpio' : 'sin-almacen'
   };
+
+  /* ── Autoguardado ──────────────────────────────────────────────────────
+   *
+   * No hay boton de guardar y no debe haberlo: un capturista que pierde media
+   * hora de trabajo por no haber apretado un boton tiene razon en enojarse.
+   *
+   * El retardo es a proposito. Escribir en cada tecla pelearia con el teclado;
+   * medio segundo despues de la ultima, no. Y en cada salida -cambiar de
+   * pantalla, cambiar de pestaña del navegador, cerrar- se fuerza el guardado
+   * pendiente, que es el momento en que de verdad se pierde el trabajo. */
+  var _reloj = null;
+
+  function pintarPulso() {
+    const el = $('#pulso'), tx = $('#pulsoTx');
+    if (!el || !tx) return;
+    const T = { limpio: 'guardado', sucio: 'sin guardar', guardando: 'guardando…',
+                guardado: 'guardado', 'sin-almacen': 'sin guardar' };
+    el.className = 'pulso p-' + ST.pulso;
+    tx.textContent = T[ST.pulso] || '';
+    el.title = ST.pulso === 'sin-almacen'
+      ? 'Este navegador no deja guardar (modo privado o datos del sitio bloqueados). Lo que captures se pierde al salir.'
+      : 'Se guarda solo, en este navegador. Todavia no viaja a ningun servidor.';
+  }
+
+  /** Guarda ya, sin esperar el retardo. Devuelve si de verdad quedo. */
+  function guardarYa() {
+    if (!A || !A.disponible()) { ST.pulso = 'sin-almacen'; pintarPulso(); return false; }
+    if (_reloj) { clearTimeout(_reloj); _reloj = null; }
+    ST.pulso = 'guardando'; pintarPulso();
+    const ok = A.escribir({ machotes: ST.machotes, handoff: ST.handoff });
+    ST.pulso = ok ? 'guardado' : 'sin-almacen';
+    pintarPulso();
+    return ok;
+  }
+
+  /** Marca sucio y programa el guardado. Es lo que llama toda edicion. */
+  function tocado() {
+    if (!A || !A.disponible()) { ST.pulso = 'sin-almacen'; pintarPulso(); return; }
+    ST.pulso = 'sucio'; pintarPulso();
+    if (_reloj) clearTimeout(_reloj);
+    _reloj = setTimeout(guardarYa, 500);
+  }
+
+  // Las tres salidas por las que se pierde trabajo, cubiertas.
+  window.addEventListener('hashchange', () => { if (ST.pulso === 'sucio') guardarYa(); });
+  window.addEventListener('beforeunload', () => { if (ST.pulso === 'sucio') guardarYa(); });
+  document.addEventListener('visibilitychange', () => {
+    if (document.visibilityState === 'hidden' && ST.pulso === 'sucio') guardarYa();
+  });
+
+  /** Un machote enviado a Odoo ya no se toca: es el documento con el que se
+   *  vendio. Editarlo despues seria reescribir la historia. */
+  const congelado = (m) => !!((D.ESTADOS[m && m.estado] || {}).congelado);
 
   const esc = (s) => String(s === null || s === undefined ? '' : s)
     .replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;').replace(/"/g, '&quot;');
@@ -115,6 +177,7 @@
 
   /* ── Ruteo ───────────────────────────────────────────────────────────── */
   function render() {
+    pintarPulso();
     const p = (location.hash || '#/').replace(/^#\//, '').split('/');
     if (p[0] === '')      return vHome();
     if (p[0] === 'm')     return vMachote(p[1]);
@@ -207,7 +270,10 @@
    *  memoria y comparar, sin tocar el DOM vivo. */
   function hojaHTML(m, c) {
     const s = m.secciones.find(x => x.id === ST.hoja);
-    return s ? hojaSeccion(m, s, c) : hojaDesglose(m, c);
+    // La banda de estado encabeza TODA hoja. Si sólo saliera en el DESGLOSE,
+    // una hoja de sección congelada mostraría catorce campos apagados sin
+    // decir por qué — que es justo el silencio que perseguimos.
+    return bloqueEstado(m) + (s ? hojaSeccion(m, s, c) : hojaDesglose(m, c));
   }
 
   function pintarHoja(m) {
@@ -319,8 +385,12 @@
         if (i < 0) { s.mo.push({ rol: rol.id, qty: '', personas: 1, pu: rol.pu, moneda: m.moneda }); i = s.mo.length - 1; }
         const l = s.mo[i], cl = C.costoMo(l, m), p = 's:' + s.id + ':mo:' + i + ':';
         const vacia = !(Number(l.qty) > 0);
+        // Verde = este renglon ya tiene cantidad. Con diez renglones fijos por
+        // seccion, saber de un vistazo cuales estan capturados es la diferencia
+        // entre revisar una hoja y leerla entera.
+        const cls = vacia ? 'enCero' : 'capturada';
         filasMo +=
-          '<tr' + (vacia ? ' class="enCero"' : '') + '>' +
+          '<tr class="' + cls + '">' +
           '<td class="rotulo" data-l="Renglón">' + esc(rol.label) + '</td>' +
           '<td data-l="QTY (horas)">' + celNum(p + 'qty', l.qty, 'w60') + '</td>' +
           '<td class="ro solo-ancho" data-l="Unidad">Horas</td>' +
@@ -351,7 +421,7 @@
     // COSTO MATERIALES Y SERVICIOS
     const filasMat = (s.partidas || []).map((l, j) => {
       const cl = C.costoPartida(l, m), p = 's:' + s.id + ':partidas:' + j + ':';
-      return '<tr>' +
+      return '<tr' + (Number(l.qty) >= 1 ? ' class="capturada"' : '') + '>' +
         '<td data-l="Descripción">' + cel(p + 'descripcion', l.descripcion, 'desc') + '</td>' +
         '<td data-l="QTY">' + celNum(p + 'qty', l.qty, 'w60') + '</td>' +
         '<td data-l="Unidad">' + celLibre(p + 'unidad', l.unidad, 'unidades', 'w90') + '</td>' +
@@ -394,6 +464,34 @@
       D.UNIDADES.map(u => '<option value="' + esc(u) + '">').join('') + '</datalist>';
 
     return listaUnidades + cab + leyenda() + tablaMo + tablaMat;
+  }
+
+  /* ── El estado del machote ─────────────────────────────────────────────
+   *
+   * El machote NACE sin orden -casi siempre nace antes que la orden- y por eso
+   * la SO es opcional mientras se arma. Pero al enviarlo a Odoo ya no: enviar
+   * ES confirmar la venta, y una venta sin orden no existe.
+   *
+   * ⚠️ ENVIAR NO ESCRIBE EN ODOO todavia. La regla vigente de este modulo es
+   * que Odoo solo se consulta. El estado, el candado y la exigencia de orden si
+   * son reales; el envio queda esperando que Esteban levante esa regla. */
+  function bloqueEstado(m) {
+    const est = D.ESTADOS[m.estado] || D.ESTADOS.borrador;
+    const cong = congelado(m);
+    const ops = D.FLUJO.map(k =>
+      '<option value="' + k + '"' + (m.estado === k ? ' selected' : '') + '>' +
+      esc(D.ESTADOS[k].label) + '</option>').join('');
+
+    return '<div class="edo' + (cong ? ' cerrado' : '') + '">' +
+      '<span class="chip" style="background:' + est.color + '">' + esc(est.label) + '</span>' +
+      (cong
+        ? '<span class="tiny">🔒 Enviado a Odoo. Este es el documento con el que se vendió: se consulta, no se edita.</span>'
+        : '<label class="tiny">Estado <select class="cel" data-estado>' + ops + '</select></label>') +
+      '<span class="grow"></span>' +
+      '<span class="tiny">' + (m.so
+        ? 'Orden <strong>' + esc(m.so) + '</strong>'
+        : '<span class="n-warn">Sin orden ligada</span> · se puede armar así, pero no enviar') +
+      '</span></div>';
   }
 
   /* ── Hoja DESGLOSE COTIZACIÓN ────────────────────────────────────────── */
@@ -559,6 +657,22 @@
 
   /* ── Enlace de celdas ────────────────────────────────────────────────── */
   function enlazar(m) {
+    /* Un machote congelado se lee, no se edita. Se apagan los campos y se
+     * quitan los botones de estructura en vez de esconder la hoja: el
+     * documento con el que se vendio hay que poder consultarlo. */
+    if (congelado(m)) {
+      $$('[data-cel]').forEach(el => { el.disabled = true; el.classList.add('bloq'); });
+      // `data-nueva` es la pestaña `+`: vive fuera de la hoja, en la banda de
+      // pestañas, y por eso se cuela si sólo se listan los botones de la hoja.
+      $$('[data-add],[data-del],[data-dup],[data-mov],[data-delsec],[data-dupsec],' +
+         '[data-movsec],[data-nueva]').forEach(b => b.remove());
+      $$('[data-esc]').forEach(b => b.onclick = () => {
+        m.escenario = b.dataset.esc; pintarHoja(m); barra(m, C.calcular(m));
+      });
+      const vvc = $('#verVacios');
+      if (vvc) vvc.onchange = () => { ST.verVacios = vvc.checked; pintarHoja(m); };
+      return;
+    }
     $$('[data-cel]').forEach(el => {
       const esSel = el.tagName === 'SELECT';
       const aplicar = () => {
@@ -585,26 +699,43 @@
         }
         // La moneda sigue a la empresa mientras no se haya tocado a mano.
         if (antes !== null && m.moneda === antes) m.moneda = C.monedaPorDefecto(m);
+        tocado();
         pintarHoja(m); barra(m, C.calcular(m));
       };
-      if (!esSel) el.oninput = () => { aplicar(); barra(m, refrescarCalculados(m) || C.calcular(m)); };
+      if (!esSel) el.oninput = () => {
+        aplicar(); tocado();
+        barra(m, refrescarCalculados(m) || C.calcular(m));
+      };
     });
+    const sel = $('[data-estado]');
+    if (sel) sel.onchange = () => {
+      const nuevo = sel.value;
+      // Enviar a Odoo exige orden. Se revierte el selector en vez de dejarlo
+      // mintiendo: un desplegable que muestra un estado que no se aplico es
+      // peor que no dejar cambiarlo.
+      if ((D.ESTADOS[nuevo] || {}).exige_so && !m.so) {
+        sel.value = m.estado;
+        toast('No se puede enviar a Odoo sin una orden ligada.');
+        return;
+      }
+      m.estado = nuevo; tocado(); vMachote(m.id);
+    };
     const vv = $('#verVacios');
     if (vv) vv.onchange = () => { ST.verVacios = vv.checked; pintarHoja(m); };
     $$('[data-esc]').forEach(b => b.onclick = () => {
-      m.escenario = b.dataset.esc; pintarHoja(m); barra(m, C.calcular(m));
+      m.escenario = b.dataset.esc; tocado(); pintarHoja(m); barra(m, C.calcular(m));
     });
     $$('[data-add]').forEach(b => b.onclick = () => {
       const s = m.secciones.find(x => x.id === b.dataset.add); if (!s) return;
       s.partidas.push({ qty: 1, unidad: 'Pieza', tipo: 'Materiales', descripcion: '', modelo: '', marca: '',
                         pu: null, moneda: m.moneda, margen: null, link: '', comentario: '' });
-      pintarHoja(m); barra(m, C.calcular(m));
+      tocado(); pintarHoja(m); barra(m, C.calcular(m));
     });
     const seccionDe = (ref) => {
       const [sid, j] = ref.split('#');
       return { s: m.secciones.find(x => x.id === sid), j: parseInt(j, 10) };
     };
-    const refrescar = () => { pintarHoja(m); barra(m, C.calcular(m)); };
+    const refrescar = () => { tocado(); pintarHoja(m); barra(m, C.calcular(m)); };
 
     $$('[data-del]').forEach(b => b.onclick = () => {
       const { s, j } = seccionDe(b.dataset.del); if (!s) return;
@@ -628,7 +759,7 @@
     $$('[data-delsec]').forEach(b => b.onclick = () => {
       const i = m.secciones.findIndex(x => x.id === b.dataset.delsec);
       if (i < 0 || m.secciones.length < 2) return;
-      m.secciones.splice(i, 1); ST.hoja = 'desglose'; vMachote(m.id);
+      m.secciones.splice(i, 1); ST.hoja = 'desglose'; tocado(); vMachote(m.id);
     });
     $$('[data-dupsec]').forEach(b => b.onclick = () => {
       const i = m.secciones.findIndex(x => x.id === b.dataset.dupsec); if (i < 0) return;
@@ -636,7 +767,7 @@
       copia.id = 's-' + Date.now();
       copia.nombre = (copia.nombre || 'SECCIÓN') + ' (copia)';
       m.secciones.splice(i + 1, 0, copia);
-      ST.hoja = copia.id; vMachote(m.id);
+      ST.hoja = copia.id; tocado(); vMachote(m.id);
     });
     $$('[data-movsec]').forEach(b => b.onclick = () => {
       const [sid, d] = b.dataset.movsec.split('|');
@@ -646,7 +777,7 @@
       // La ranura la da la POSICIÓN, no el nombre: mover una sección cambia a
       // qué renglón del RESUMEN va a caer.
       const t = m.secciones[i]; m.secciones[i] = m.secciones[k]; m.secciones[k] = t;
-      vMachote(m.id);
+      tocado(); vMachote(m.id);
     });
   }
 

--- a/comercial/machote/js/demo.js
+++ b/comercial/machote/js/demo.js
@@ -49,12 +49,19 @@
     ]}
   ];
 
+  /* El flujo del machote, en orden. `congelado` es la propiedad que manda:
+   * un machote enviado a Odoo ya no se toca — es el documento con el que se
+   * vendio, y editarlo despues seria reescribir la historia.
+   *
+   * `exige_so`: no se puede enviar a Odoo sin orden. El machote SI puede nacer
+   * sin ella (casi siempre nace antes que la orden), pero al enviar ya no. */
   const ESTADOS = {
-    borrador:   { label: 'Borrador',   color: '#8b8b8b' },
-    revision:   { label: 'En revisión', color: '#c07a00' },
-    confirmado: { label: 'Confirmado', color: '#1a7f37' },
-    orden:      { label: 'Orden',      color: '#0969da' }
+    borrador:   { label: 'En creación', color: '#8b8b8b', congelado: false, orden: 1 },
+    revision:   { label: 'En revisión', color: '#c07a00', congelado: false, orden: 2 },
+    enviado:    { label: 'Enviado a Odoo', color: '#1a7f37', congelado: true,
+                  exige_so: true, orden: 3 }
   };
+  const FLUJO = ['borrador', 'revision', 'enviado'];
 
   let _n = 0;
   const uid = (p) => p + '-' + (++_n);
@@ -229,7 +236,7 @@
   ];
 
   G.DEMO = {
-    UNIDADES, TIPOS_PROYECTO, ESTADOS, MACHOTES, ORDENES,
+    UNIDADES, TIPOS_PROYECTO, ESTADOS, FLUJO, MACHOTES, ORDENES,
     ROLES: C.ROLES, GRUPOS: C.GRUPOS, TIPOS: C.TIPOS, ESCENARIOS: C.ESCENARIOS
   };
 })(window);

--- a/comercial/machote/tests/pruebas-navegador.js
+++ b/comercial/machote/tests/pruebas-navegador.js
@@ -38,6 +38,12 @@ let ok = 0, mal = 0;
   const b = await chromium.launch(OPCIONES);
   const errs = [];
   const p = await b.newPage({ viewport: { width: 380, height: 780 } });
+  /* El autoguardado es REAL: sin esto, cada prueba heredaria lo que guardo la
+   * anterior y volveria la cascada de fallos que resolvio el recargar. Corre
+   * ANTES de los scripts de la pagina en cada navegacion, asi que la app
+   * siempre arranca con la demo. Cuesta cero recargas extra.
+   * La persistencia se prueba aparte, en una pagina SIN este guion. */
+  await p.addInitScript(() => { try { localStorage.clear(); } catch (e) {} });
   // El contenedor no tiene salida a fonts.googleapis.com, que fts-styles.css
   // importa. Ese fallo es del entorno de prueba, no del prototipo: se filtra
   // por nombre y se reporta aparte, nunca callando el resto.
@@ -748,6 +754,116 @@ let ok = 0, mal = 0;
     const d = await p.evaluate(() => document.documentElement.scrollWidth - document.documentElement.clientWidth);
     if (d > 2) throw new Error('la hoja desborda ' + d + ' px en escritorio');
     await p.setViewportSize({ width: 380, height: 780 });
+  });
+
+  // ── V1.07 · el renglon capturado, el autoguardado y el candado ───────
+  await paso('el renglón con cantidad se pinta distinto del que sigue vacío', async () => {
+    // A ancho de escritorio: en teléfono el renglón es una tarjeta y la marca
+    // es el borde, no el fondo -un fondo verde tras catorce campos no se lee.
+    await p.setViewportSize({ width: 1280, height: 900 });
+    await ir('#/m/M-1041'); await hoja('Suministro');
+    const r = await p.evaluate(() => {
+      const tr = [...document.querySelectorAll('.rejilla.tarjetas tbody tr')];
+      const con = tr.find(x => x.classList.contains('capturada'));
+      // El rotulo de grupo tambien lleva `enCero`; se excluye para comparar
+      // renglon contra renglon y que el dato del log sea el que dice ser.
+      const sin = tr.find(x => x.classList.contains('enCero') && !x.classList.contains('grupo'));
+      const bg = (e) => e ? getComputedStyle(e.querySelector('td')).backgroundColor : null;
+      return { hayCon: !!con, haySin: !!sin, con: bg(con), sin: bg(sin) };
+    });
+    if (!r.hayCon) throw new Error('ningún renglón capturado');
+    if (r.con === r.sin) throw new Error('se ven iguales: ' + r.con);
+    console.log('   capturado', r.con, '· vacío', r.sin);
+    await p.setViewportSize({ width: 380, height: 780 });
+  });
+
+  await paso('poner cantidad en un renglón lo pinta al instante', async () => {
+    await p.setViewportSize({ width: 1280, height: 900 });
+    await ir('#/m/M-1041'); await hoja('Suministro');
+    // Un renglon de mano de obra en cero: se le pone cantidad y debe cambiar.
+    const antes = await p.locator('.rejilla tbody tr.capturada').count();
+    const vacio = p.locator('.rejilla tbody tr.enCero [data-cel$=":qty"]:visible').first();
+    await vacio.fill('8');
+    await vacio.dispatchEvent('change'); await p.waitForTimeout(320);
+    const desp = await p.locator('.rejilla tbody tr.capturada').count();
+    if (desp <= antes) throw new Error('no se pintó: ' + antes + ' → ' + desp);
+    console.log('   renglones capturados', antes, '→', desp);
+    await p.setViewportSize({ width: 380, height: 780 });
+  });
+
+  await paso('editar deja el pulso en guardado, no en sin guardar', async () => {
+    await ir('#/m/M-1041'); await hoja('Suministro');
+    const cel = p.locator('[data-cel$=":pu"]:visible').first();
+    await cel.fill('999'); await cel.dispatchEvent('change');
+    await p.waitForTimeout(900);   // el retardo del autoguardado es de 500 ms
+    const cls = await p.locator('#pulso').getAttribute('class');
+    if (!/p-guardado|p-limpio/.test(cls)) throw new Error('el pulso quedó en: ' + cls);
+    const hay = await p.evaluate(() => !!localStorage.getItem('fts_machote_v1'));
+    if (!hay) throw new Error('no escribió nada en el almacén');
+  });
+
+  await paso('lo capturado sobrevive a salir y volver a entrar', async () => {
+    // Pagina APARTE, sin el guion que limpia: aqui se mide justamente que lo
+    // guardado persista entre cargas.
+    const q = await b.newPage({ viewport: { width: 380, height: 780 } });
+    try {
+      await q.goto(BASE); await q.waitForTimeout(300);
+      await q.evaluate(() => { try { localStorage.clear(); } catch (e) {} });
+      await q.goto(BASE); await q.waitForTimeout(350);
+      await q.evaluate(() => { location.hash = '#/m/M-1041'; }); await q.waitForTimeout(350);
+      await q.locator('.pestana', { hasText: 'Suministro' }).first().click();
+      await q.waitForTimeout(300);
+      const cel = q.locator('[data-cel^="nom:"]');
+      await cel.fill('Prueba de persistencia');
+      await cel.dispatchEvent('change'); await q.waitForTimeout(900);
+      // Se sale y se vuelve a entrar, como haria cualquiera.
+      await q.goto(BASE); await q.waitForTimeout(400);
+      await q.evaluate(() => { location.hash = '#/m/M-1041'; }); await q.waitForTimeout(350);
+      const t = await q.textContent('#vista');
+      if (t.indexOf('Prueba de persistencia') < 0) throw new Error('se perdió al recargar');
+    } finally { await q.close(); }
+  });
+
+  await paso('no se puede enviar a Odoo un machote sin orden', async () => {
+    await ir('#/m/M-1041'); await hoja('DESGLOSE');   // M-1041 nace sin SO
+    const sel = p.locator('[data-estado]');
+    if (await sel.count() === 0) throw new Error('no hay selector de estado');
+    await sel.selectOption('enviado'); await p.waitForTimeout(350);
+    if (await sel.inputValue() === 'enviado') throw new Error('lo dejó enviar sin orden');
+    const t = await p.textContent('body');
+    if (!/sin una orden ligada/.test(t)) throw new Error('no dijo por qué');
+  });
+
+  await paso('un machote enviado a Odoo se consulta pero no se edita', async () => {
+    await ir('#/m/M-1042'); await hoja('DESGLOSE');   // M-1042 sí trae SO
+    await p.locator('[data-estado]').selectOption('enviado'); await p.waitForTimeout(400);
+    await hoja('Adecuación');
+    const r = await p.evaluate(() => {
+      const cs = [...document.querySelectorAll('[data-cel]')];
+      return { total: cs.length, apagados: cs.filter(c => c.disabled).length,
+               botones: document.querySelectorAll('[data-add],[data-del],[data-dupsec],[data-nueva]').length,
+               texto: document.body.textContent.indexOf('se consulta, no se edita') >= 0 };
+    });
+    if (r.total === 0) throw new Error('no pintó la hoja');
+    if (r.apagados !== r.total) throw new Error('quedaron editables: ' + (r.total - r.apagados) + ' de ' + r.total);
+    if (r.botones !== 0) throw new Error('quedaron ' + r.botones + ' botones de estructura');
+    if (!r.texto) throw new Error('no explica por qué está bloqueado');
+  });
+
+  await paso('los colores del machote salen de un solo lugar', async () => {
+    // Si un color de tabla se escribe fuera de las variables, corregir la
+    // paleta cuando lleguen los colores reales se vuelve una caceria.
+    await ir('#/m/M-1041'); await hoja('Suministro');
+    const r = await p.evaluate(() => {
+      const raiz = getComputedStyle(document.documentElement);
+      const v = (n) => raiz.getPropertyValue(n).trim();
+      return { banda: v('--x-banda'), cab: v('--x-cab'), fila: v('--x-fila-ok'),
+               th: getComputedStyle(document.querySelector('.rejilla th')).backgroundColor };
+    });
+    for (const k of ['banda', 'cab', 'fila'])
+      if (!r[k]) throw new Error('falta la variable --x-' + k);
+    if (r.th === 'rgba(0, 0, 0, 0)') throw new Error('el encabezado no tomó color');
+    console.log('   banda', r.banda, '· encabezado', r.cab, '· capturado', r.fila);
   });
 
   await paso('sin errores de consola propios del prototipo', async () => {

--- a/comercial/machote/version.json
+++ b/comercial/machote/version.json
@@ -1,10 +1,15 @@
 {
-  "version": "V1.06",
+  "version": "V1.07",
   "fecha": "2026-09-03",
   "modulo": "comercial/machote",
   "ambito": "El CONTADOR es solo de este modulo. finanzas tambien usa V1.xx desde el 2026-09-03 (instruccion directa de Esteban, corrige el \"no propagar\" del issue #148) pero lleva su propio contador y va en V1.00. operaciones/planeacion sigue en 2.4.1, kiosk y confirmar-horas solo con cadena de build, y siete modulos con un 1.0.0 puesto una vez: a esos no se propaga.",
   "esquema": "V<mayor>.<menor de dos digitos>. Un incremento de 0.01 por cada merge a main. Al pasar de .99 sube el mayor y el menor vuelve a 00.",
   "historial": [
+    {
+      "version": "V1.07",
+      "pr": null,
+      "nota": "Los colores del machote (aproximados, pendientes de captura), el renglon capturado en verde, autoguardado con pulso visible, y el flujo con candado: enviado a Odoo exige orden y congela"
+    },
     {
       "version": "V1.06",
       "pr": null,


### PR DESCRIPTION
## Colores

La retícula toma la paleta de las plantillas de Office: banda azul oscura por bloque, encabezados de columna en azul claro, rótulos de grupo, totales en ámbar con filete.

⚠️ **Son APROXIMACIÓN, no medición.** El conector de SharePoint devuelve los valores y las fórmulas del libro pero **cero estilo** — lo comprobé contra `SO11836`: no viene un solo dato de relleno. Están puestos a ojo.

Viven en **ocho variables** al principio de `css/machote.css` y en ningún otro lado, con una prueba que lo vigila. Corregirlos cuando lleguen los reales es un minuto.

## Renglón capturado

`QTY ≥ 1` pinta el renglón de verde. Con diez renglones de mano de obra fijos por sección —la mayoría en blanco casi siempre— distinguir de un vistazo lo capturado de lo que falta es la diferencia entre revisar una hoja y leerla entera.

En teléfono la marca es el **borde** de la tarjeta, no el fondo: un fondo verde detrás de catorce campos etiquetados no se lee.

## Autoguardado

No hay botón de guardar. Cada cambio programa el guardado medio segundo después de la última tecla; al cambiar de pantalla, al cambiar de pestaña del navegador y al cerrar, lo pendiente se fuerza. Un punto de color en la barra superior dice en cuál de los tres estados va: guardado · sin guardar · guardando.

⚠️ **Hoy escribe en el NAVEGADOR, no en un servidor**, y el archivo lo dice sin adornos. Todo pasa por `js/almacen.js`, que es **la única pieza que cambia** el día que entre el Postgres de la suite (`fts-suite-db`, issue #140); adentro está la lista exacta de lo que falta para ese salto. Se relee lo escrito antes de dar por bueno el guardado.

## El flujo, y el candado

```
En creación  →  En revisión  →  Enviado a Odoo
                                 ↑ exige orden · congela
```

El machote **nace sin orden** — casi siempre nace antes que la orden — así que la SO es opcional mientras se arma. Al enviar a Odoo ya no: enviar **es** confirmar la venta. Si se intenta sin orden, el selector se revierte y dice por qué.

Enviado queda **congelado**: campos apagados, sin botones de estructura (incluida la pestaña `+` de nueva sección), pero la hoja se sigue viendo — es el documento con el que se vendió.

⚠️ **Enviar todavía NO escribe en Odoo.** La regla vigente del módulo es que Odoo sólo se consulta. El estado, el candado y la exigencia de orden ya son reales.

## Dos cosas que levantaron las pruebas, no la revisión de código

1. Una hoja de **sección** congelada apagaba catorce campos **sin decir por qué** — la banda de estado sólo salía en el `DESGLOSE`. Ahora encabeza todas las hojas.
2. La pestaña `+` de nueva sección **seguía viva** en un machote congelado: vive en la banda de pestañas, fuera de la hoja, y se coló al listar sólo los botones de la hoja.

## Pruebas

**60 pasaron, 0 fallaron.** Siete nuevas. Capturas revisadas a 390 y 1440 px.

Las pruebas se aíslan del autoguardado con un guion de arranque que limpia el almacén antes de los scripts de la página — sin eso, cada prueba heredaría lo que guardó la anterior. La persistencia se mide aparte, en una página **sin** ese guion, saliendo y volviendo a entrar de verdad.

## Versión

`V1.06` → **`V1.07`**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013Qzhio6K8R23HXHnJ2RJ64