### PR TITLE
fix(nomina): V1.01 — arreglo del login (el cliente mandaba `user`, el server espera `username`)

### DIFF
--- a/modulos/rh/nomina-incidencias/index.html
+++ b/modulos/rh/nomina-incidencias/index.html
@@ -11,7 +11,7 @@
 <div class="rh-topbar">
   <a class="volver" href="../index.html">← Volver a RH</a>
   <span class="t">Nómina · Incidencias</span>
-  <span class="badge" id="ver-badge">V1.00</span>
+  <span class="badge" id="ver-badge">V1.01</span>
   <span class="badge" id="modo-badge" title="">DEMO</span>
   <span class="sp"></span>
   <span class="quien" id="quien"></span>
@@ -133,7 +133,7 @@
     var r = await window.NomAuth.login($('u').value, $('p').value);
     b.disabled = false; b.textContent = 'Entrar';
     if (!r.ok) {
-      mostrarError(r.msg + (r.retry_after_s ? ' Espera ' + r.retry_after_s + ' s.' : ''));
+      mostrarError(r.msg);   // el server ya redacta el motivo, incluidos los minutos de bloqueo
       return;
     }
     if (!window.NomAuth.tieneScope(window.NomAuth.SCOPE_MODULO)) {

--- a/modulos/rh/nomina-incidencias/js/nom-auth.js
+++ b/modulos/rh/nomina-incidencias/js/nom-auth.js
@@ -49,7 +49,11 @@
   }
 
   async function login(user, password) {
-    var body = { user: String(user || ''), password: String(password || '') };
+    // El workflow espera `username`, NO `user`. Lo verifiqué disparando el webhook:
+    // con {user:…} contesta PAYLOAD_INCOMPLETO sin llegar a comprobar la contraseña.
+    // Copiar el payload de Finanzas sin leer ESTE workflow fue el error (§8 anti-trabón:
+    // el contrato se lee del server que lo sirve, no del vecino que se le parece).
+    var body = { username: String(user || ''), password: String(password || '') };
     var res, data;
     try {
       res = await fetch(n8nBase() + LOGIN_PATH, {
@@ -63,20 +67,28 @@
     try { data = await res.json(); } catch (e) { data = null; }
 
     if (!data) return { ok: false, code: 'BAD_RESPONSE', msg: 'Respuesta inválida del servidor.', http: res.status };
-    if (data._error || !data.token) {
+
+    // Forma real de la respuesta de `auth/suite-login`, leída del workflow y comprobada
+    // en vivo: { ok:false, error:'CODIGO', mensaje:'texto para la persona' }. Antes esto
+    // leía `_error/code/msg` (la forma de Finanzas) y por eso TODO fallo se veía igual:
+    // un "No se pudo iniciar sesión." genérico que escondía el motivo real.
+    if (data.ok === false || data._error || !data.token) {
       return {
         ok: false,
-        code: data.code || 'AUTH_FAILED',
-        msg: data.msg || 'No se pudo iniciar sesión.',
-        http: data.http || res.status,
-        retry_after_s: data.retry_after_s
+        code: data.error || data.code || 'AUTH_FAILED',
+        msg: data.mensaje || data.msg || 'No se pudo iniciar sesión.',
+        http: data.http || res.status
       };
     }
 
     var claims = decodeJwtPayload(data.token) || {};
     var session = {
       token:       data.token,
-      expires_at:  data.expires_at || (claims.exp ? new Date(claims.exp * 1000).toISOString() : null),
+      // El workflow devuelve `exp` (segundos unix). Se acepta también `expires_at` ISO
+      // y el `exp` del propio JWT, por si el emisor cambia de forma.
+      expires_at:  data.expires_at ||
+                   (data.exp ? new Date(data.exp * 1000).toISOString() : null) ||
+                   (claims.exp ? new Date(claims.exp * 1000).toISOString() : null),
       user:        String(user || ''),
       nombre:      data.nombre || claims.nombre || String(user || ''),
       empleado_id: (data.empleado_id !== undefined ? data.empleado_id : claims.empleado_id) || null,

--- a/modulos/rh/nomina-incidencias/version.json
+++ b/modulos/rh/nomina-incidencias/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "V1.00",
+  "version": "V1.01",
   "fecha": "2026-09-03",
   "modulo": "rh/nomina-incidencias",
   "esquema": "V<mayor>.<menor de dos digitos>. Un incremento de 0.01 por cada merge a main. Al pasar de .99 sube el mayor y el menor vuelve a 00.",
@@ -7,8 +7,13 @@
   "historial": [
     {
       "version": "V1.00",
-      "pr": null,
+      "pr": 168,
       "nota": "Estreno del modulo. Pantalla 1 (roster de la semana con candado aritmetico y bloqueos) y pantalla 2 (captura por persona: 26 tipos en 4 grupos con campos condicionales, derivaciones visibles y estados con vigencia). Modo DEMO por defecto sobre el roster real de Odoo (30 activos de company 1 + inactivos con estado vigente); el modo REAL queda cableado y apagado hasta que existan los endpoints /nom/*. Gate de logica (36 asserts, sin DOM) y revision visual en Chromium en tres anchos."
+    },
+    {
+      "version": "V1.01",
+      "pr": null,
+      "nota": "Arreglo del login: NADIE podia entrar en V1.00. El cliente mandaba el campo `user` (copiado de finanzas/js/auth-fin.js) pero el workflow auth/suite-login espera `username`, asi que contestaba PAYLOAD_INCOMPLETO sin llegar a comprobar la contrasena. Ademas se leia la respuesta con la forma de Finanzas (_error/code/msg) en vez de la real (ok/error/mensaje), por lo que TODO fallo se veia igual: un 'No se pudo iniciar sesion.' generico que escondia el motivo. Verificado disparando el webhook en vivo con un usuario desechable (ejecuciones 85367 y 85370) para no gastarle intentos de bloqueo a nadie. El contrato queda fijado en el gate (seccion 7, 11 asserts nuevos) para que no se vuelva a romper en silencio."
     }
   ]
 }

--- a/tests/gate-nomina.js
+++ b/tests/gate-nomina.js
@@ -194,9 +194,69 @@ seccion('Resumen de la semana');
     Log.resumenSemana(ok, SEMANA, [{ id: 1, empleado_id: 99, abierta: true }]).disputas_abiertas === 1);
 }
 
-// ═══════════════════ 7 · RENDER EN JSDOM ═══════════════════
-seccion('Render (jsdom, sobre el index.html real)');
+// ═══════════════════ 7 · CONTRATO CON auth/suite-login ═══════════════════
+// POR QUE EXISTE ESTA SECCION. En V1.00 el login mandaba `user` (copiado de
+// finanzas/js/auth-fin.js) y el workflow espera `username`. Resultado: TODO intento
+// moria en PAYLOAD_INCOMPLETO sin llegar a comprobar la contrasena, y la pantalla
+// mostraba un generico "No se pudo iniciar sesion" que escondia el motivo.
+// Comprobado disparando el webhook en vivo (ejecuciones 85367 y 85370).
+// Estos asserts congelan la forma REAL del contrato, leida del workflow.
+seccion('Contrato con auth/suite-login');
 (async function () {
+  const { JSDOM: J2 } = require('jsdom');
+  const dom0 = new J2('<!doctype html><html><body></body></html>', { url: 'https://example.org/', runScripts: 'outside-only' });
+  const w0 = dom0.window;
+  w0.eval(fs.readFileSync(path.join(MOD, 'js', 'nom-auth.js'), 'utf8'));
+
+  let enviado = null;
+  function responder(obj) {
+    w0.fetch = function (url, opts) {
+      enviado = { url: url, body: JSON.parse(opts.body) };
+      return Promise.resolve({ status: 200, json: function () { return Promise.resolve(obj); } });
+    };
+  }
+
+  // (a) el campo se llama username
+  responder({ ok: false, error: 'CREDENCIALES_INVALIDAS', mensaje: 'Usuario o contrasena incorrectos.' });
+  const r1 = await w0.NomAuth.login('ana.acevedo', 'secreta');
+  check('el login manda `username`, no `user`',
+    enviado && enviado.body.username === 'ana.acevedo' && enviado.body.user === undefined,
+    JSON.stringify(Object.keys(enviado ? enviado.body : {})));
+  check('pega al webhook /auth/suite-login', /\/webhook\/auth\/suite-login$/.test(enviado.url), enviado.url);
+
+  // (b) el error del server llega a la pantalla con su motivo, no con un generico
+  check('propaga el codigo real del error', r1.ok === false && r1.code === 'CREDENCIALES_INVALIDAS', JSON.stringify(r1));
+  check('propaga el mensaje del server (campo `mensaje`)', /Usuario o contrasena/.test(r1.msg), r1.msg);
+
+  responder({ ok: false, error: 'PAYLOAD_INCOMPLETO', mensaje: 'Faltan username o password.' });
+  const r2 = await w0.NomAuth.login('x', 'y');
+  check('un PAYLOAD_INCOMPLETO ya no se ve como fallo de contrasena', r2.code === 'PAYLOAD_INCOMPLETO', JSON.stringify(r2));
+
+  // (c) el exito: token, scopes y caducidad desde `exp` en segundos
+  const iat = Math.floor(Date.now() / 1000);
+  const claims = { sub: 'ana.acevedo', nombre: 'Ana Laura', empleado_id: 101, scopes: ['nomina:write'], iat: iat, exp: iat + 8 * 3600 };
+  const b64 = o => Buffer.from(JSON.stringify(o)).toString('base64').replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '');
+  const tok = b64({ alg: 'HS256', typ: 'JWT' }) + '.' + b64(claims) + '.firma';
+  responder({ ok: true, token: tok, actor: 'ana.acevedo', nombre: 'Ana Laura', empleado_id: 101, scopes: ['nomina:write'], exp: claims.exp, debe_cambiar_password: false });
+  const r3 = await w0.NomAuth.login('ana.acevedo', 'buena');
+  check('un login bueno abre sesion', r3.ok === true, JSON.stringify(r3).slice(0, 120));
+  check('la sesion queda valida (caducidad desde `exp` en segundos)', w0.NomAuth.isValid() === true);
+  check('el scope nomina:write se reconoce', w0.NomAuth.tieneScope('nomina:write') === true);
+  check('un scope que no tiene NO se reconoce', w0.NomAuth.tieneScope('finanzas:write') === false);
+  check('guarda el nombre para la topbar', (w0.NomAuth.getSession() || {}).nombre === 'Ana Laura');
+
+  // (d) sin scope, la puerta no deja pasar aunque el login sea bueno
+  const claims2 = Object.assign({}, claims, { scopes: ['nomina:read'] });
+  responder({ ok: true, token: b64({ alg: 'HS256', typ: 'JWT' }) + '.' + b64(claims2) + '.firma', exp: claims2.exp, scopes: ['nomina:read'] });
+  await w0.NomAuth.login('ana.acevedo', 'buena');
+  check('con solo nomina:read la puerta sigue cerrada', w0.NomAuth.tieneScope('nomina:write') === false);
+
+  arrancarRender();
+})();
+
+// ═══════════════════ 8 · RENDER EN JSDOM ═══════════════════
+seccion('Render (jsdom, sobre el index.html real)');
+function arrancarRender() { (async function () {
   const html = fs.readFileSync(path.join(MOD, 'index.html'), 'utf8');
   const dom = new JSDOM(html, { url: 'https://example.org/modulos/rh/nomina-incidencias/', runScripts: 'outside-only', pretendToBeVisual: true });
   const w = dom.window;
@@ -279,4 +339,4 @@ seccion('Render (jsdom, sobre el index.html real)');
     process.exit(1);
   }
   console.log('GATE VERDE — ' + pass + '/' + pass + ' asserts');
-})();
+})(); }


### PR DESCRIPTION
## Qué pasaba

V1.00 quedó **viva pero inservible**: nadie podía entrar. Esteban lo reportó intentando con los usuarios de Magaly y de Ana.

`nom-auth.js` se escribió espejando `finanzas/js/auth-fin.js`, que manda `{user, password}`. El workflow que sirve **este** módulo — `auth/suite-login` (`kLhyPxVSMbDRwxfC`) — espera `username`, así que contestaba `PAYLOAD_INCOMPLETO` **sin llegar siquiera a comprobar la contraseña**.

Encima, la respuesta se leía con la forma de Finanzas (`_error` / `code` / `msg`) en vez de la real (`ok` / `error` / `mensaje`), así que **todo** fallo se veía igual: un genérico *"No se pudo iniciar sesión."* que escondía el motivo — incluido el bloqueo por intentos, que el server sí redacta con sus minutos.

## Cómo se comprobó

Disparando el webhook en vivo con un usuario desechable (`zz-prueba-contrato`), a propósito para **no gastarle intentos de bloqueo a Ana ni a Magaly**:

```
exec 85367  body {user: …}      → ok:false · PAYLOAD_INCOMPLETO     · "Faltan username o password."
exec 85370  body {username: …}  → ok:false · CREDENCIALES_INVALIDAS · "Usuario o contrasena incorrectos."
```

El segundo llegó hasta la comprobación de contraseña. Ése era el único bit que faltaba.

## Cambios

| Archivo | Qué |
|---|---|
| `js/nom-auth.js` | `username` en el body · lectura de la forma real de la respuesta (`ok`/`error`/`mensaje`) · acepta `exp` en segundos además de `expires_at` ISO |
| `index.html` | el error de login muestra el motivo del server, no un texto fijo · badge a V1.01 |
| `version.json` | V1.01 + historial |
| `tests/gate-nomina.js` | **sección 7 nueva**: 11 asserts que levantan un `fetch` de mentiras en jsdom y fijan el contrato — nombre del campo, propagación del motivo real, sesión con `exp`, y que un usuario con sólo `nomina:read` no pasa la puerta |

## Por qué pasó, y qué lo evita en adelante

Es exactamente la regla anti-trabón de `CLAUDE.md` §8: **el contrato se lee del server que lo sirve, no del vecino que se le parece.** Copié el payload del módulo de al lado sin abrir el workflow de éste.

Lo que lo evita no es acordarse: es la sección 7 del gate. Si alguien vuelve a renombrar el campo, el gate se pone rojo antes de mergear.

## Pruebas

- Gate de lógica: **76/76** (65 → 76, las 11 nuevas son el contrato)
- Revisión visual en Chromium, tres anchos: **72/72**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MDYMMPYZdLqWQCVfuZUAC6