### PR TITLE
comercial(acceso): el alta de usuario sólo exige el username

### DIFF
--- a/docs/comercial/ACCESO.md
+++ b/docs/comercial/ACCESO.md
@@ -26,11 +26,26 @@ no para esconder nada. Conviene tenerlo claro antes de tratarlo como una pared.
 **1 · Genera salt y hash** (en tu máquina, no aquí):
 
 ```bash
-node scripts/generar-usuario-suite.js aldo "Aldo Méndez" "comercial:read" 118
+node scripts/generar-usuario-suite.js aldo.mendez
 ```
 
 Pide la contraseña por teclado —nunca por argumento, que quedaría en el historial
 del shell— e imprime el renglón en JSON. **La contraseña no aparece en la salida.**
+
+**Sólo el username es obligatorio.** `nombre`, `scopes` y `empleado_id` se pueden
+pasar también, pero conviene llenarlos al insertar: **PowerShell de Windows
+destroza los acentos** al pasarlos a un programa nativo, y «Méndez» llegaría al
+renglón como «MÃ©ndez». Si un dato no tiene que pasar por la línea de comandos,
+que no pase.
+
+En PowerShell, para varios de un jalón:
+
+```powershell
+cd <la carpeta del repo>
+foreach ($u in @('aldo.mendez','francisco.montalvo','pablo.bayly')) {
+  node scripts\generar-usuario-suite.js $u
+}
+```
 
 **2 · Ese JSON se inserta como renglón** en la Data Table `suite_usuarios`
 (`YWCP0KoVmgxX2RzL`). Se puede desde la UI de n8n o por MCP.

--- a/scripts/generar-usuario-suite.js
+++ b/scripts/generar-usuario-suite.js
@@ -2,11 +2,19 @@
 /*
  * ═══ Alta de usuario para `auth/suite-login` ═══
  *
- *   node scripts/generar-usuario-suite.js <username> "<Nombre completo>" "<scopes>" [empleado_id]
- *   node scripts/generar-usuario-suite.js aldo "Aldo Méndez" "comercial:read" 118
+ *   node scripts/generar-usuario-suite.js <username> ["<Nombre>"] ["<scopes>"] [empleado_id]
+ *
+ *   node scripts/generar-usuario-suite.js aldo.mendez
+ *   node scripts/generar-usuario-suite.js aldo.mendez "Aldo Méndez" "comercial:read" 78
  *
  * Pide el password por stdin, NO por argv: argv queda en el historial del shell.
  * Imprime `salt` y `hash` para el renglón de la Data Table `suite_usuarios`.
+ *
+ * **Sólo el username es obligatorio.** Nombre, scopes y empleado_id se pueden
+ * omitir y llenarse al insertar el renglón. No es un capricho: PowerShell de
+ * Windows destroza los acentos al pasarlos a un programa nativo, y "Méndez"
+ * llegaría como "MÃ©ndez" al renglón. Si el dato no tiene que pasar por la
+ * línea de comandos, que no pase.
  *
  * ⚠️ La SALIDA no es secreta (salt y hash no son el password) pero el PASSWORD sí:
  *    no lo escribas en el chat, ni en un issue, ni en el repo. Se lo dices a la
@@ -134,9 +142,9 @@ function autoverificar() {
 
 function main() {
   const [username, nombre, scopes, empleadoId] = process.argv.slice(2);
-  if (!username || !nombre) {
-    console.error('uso: node scripts/generar-usuario-suite.js <username> "<Nombre>" "<scopes>" [empleado_id]');
-    console.error('ej : node scripts/generar-usuario-suite.js aldo "Aldo Méndez" "comercial:read" 118');
+  if (!username) {
+    console.error('uso: node scripts/generar-usuario-suite.js <username> ["<Nombre>"] ["<scopes>"] [empleado_id]');
+    console.error('ej : node scripts/generar-usuario-suite.js aldo.mendez');
     process.exit(1);
   }
   autoverificar();
@@ -149,16 +157,19 @@ function main() {
     const hash = derivar(pw, salt);
     console.error('\n── Renglón para la Data Table `suite_usuarios` (n8n) ──');
     console.error('── El PASSWORD no va aquí y no debe ir al chat ni al repo. ──\n');
-    console.log(JSON.stringify({
+    const fila = {
       username: String(username).trim().toLowerCase(),
-      nombre: nombre,
       salt: salt,
       hash: hash,
-      scopes: scopes || 'comercial:read',
       activo: true,
-      empleado_id: empleadoId ? Number(empleadoId) : null,
       debe_cambiar_password: true
-    }, null, 2));
+    };
+    // Sólo se incluye lo que de verdad se dio. Un `nombre: undefined` en el
+    // renglón se ve igual que un nombre vacío a propósito, y no lo es.
+    if (nombre) fila.nombre = nombre;
+    if (scopes) fila.scopes = scopes;
+    if (empleadoId) fila.empleado_id = Number(empleadoId);
+    console.log(JSON.stringify(fila));
   });
 }
 


### PR DESCRIPTION
PowerShell de Windows **destroza los acentos** al pasarlos a un programa nativo: «Méndez» llegaría al renglón como «MÃ©ndez». Y no habría forma de arreglarlo después — la Data Table de n8n por MCP deja **insertar**, no actualizar ni borrar.

Ahora `nombre`, `scopes` y `empleado_id` son **opcionales** y se llenan al insertar, donde los datos salen de Odoo y no de una línea de comandos. El comando queda ASCII puro:

```powershell
node scripts\generar-usuario-suite.js aldo.mendez
```

La salida sólo trae lo que de verdad se dio: un `nombre: undefined` en el renglón se ve igual que un nombre vacío a propósito, y no lo es.

**Origen:** le pasé a Esteban un bucle de bash y estaba en PowerShell.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013Qzhio6K8R23HXHnJ2RJ64