### PR TITLE
fix(acceso): el prompt del password se ve en PowerShell

### DIFF
--- a/scripts/generar-usuario-suite.js
+++ b/scripts/generar-usuario-suite.js
@@ -156,7 +156,12 @@ function main() {
    * Con `_writeToOutput` silenciado no se ve NADA mientras se escribe: ni
    * asteriscos, que es el comportamiento estándar de un prompt de contraseña
    * y el único que no depende de que la terminal entienda secuencias ANSI. */
-  process.stderr.write('Password para "' + username + '" (no se va a ver mientras lo escribes): ');
+  // El aviso TERMINA en salto de linea a proposito. PowerShell no suelta a
+  // pantalla una escritura a stderr que no cierra la linea: el prompt se queda
+  // en el buffer y el usuario ve la terminal colgada, sin saber que le estan
+  // pidiendo algo. Con el salto, se ve siempre y se teclea en la linea de abajo.
+  process.stderr.write('\n  Password para "' + username + '"\n' +
+    '  (no se ve mientras lo escribes; teclealo y dale Enter)\n');
   const rl = readline.createInterface({ input: process.stdin, output: process.stderr, terminal: true });
   rl.mudo = true;
   rl._writeToOutput = function (s) { if (!rl.mudo) rl.output.write(s); };


### PR DESCRIPTION
Escribir a stderr **sin cerrar la línea** deja el aviso en el buffer: PowerShell no lo suelta a pantalla y la terminal se ve colgada, sin que el usuario sepa que le están pidiendo algo.

Con el eco ya silenciado (PR #174), además, no había **ninguna** pista de que el proceso esperaba: ni prompt, ni cursor moviéndose al teclear. Las dos cosas juntas dan una terminal que parece muerta.

Ahora el aviso termina en salto de línea y se teclea en la línea de abajo. Sigue sin verse lo tecleado — verificado ejecutando: el password aparece **0 veces** en la salida completa (`2>&1`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013Qzhio6K8R23HXHnJ2RJ64