### PR TITLE
finanzas(bancos) V1.06: la barra de confianza estaba rota desde que se escribió

### DIFF
--- a/finanzas/js/modules/instrumentos-pago.js
+++ b/finanzas/js/modules/instrumentos-pago.js
@@ -27,7 +27,7 @@
   // comercial/machote y DEBE coincidir con finanzas/version.json — el gate lo verifica, porque
   // una pantalla que dice una versión y un archivo que dice otra deja de ser evidencia de nada.
   // Sustituye a la numeración 0.x.y (última: 0.5.36), conservada en version.json.
-  var IP_BUILD = 'V1.05';
+  var IP_BUILD = 'V1.06';
   var RESIDUAL_UMBRAL_MXN = 10000;        // coherente con fin/captura-status
   var SHEETJS_CDN = 'https://cdn.sheetjs.com/xlsx-0.20.3/package/dist/xlsx.full.min.js';
   // Endpoints reales (contrato construido en la sesión de backend; verificar nombres de
@@ -1380,8 +1380,16 @@
       return '<span class="ip-nivel ' + m[0] + '">' + m[1] + '</span>';
     }
     function scoreBar(sc) {
-      var v = Math.max(0, Math.min(100, +sc || 0));
-      var cls = v >= 85 ? 'g' : v >= 60 ? 'y' : 'r';
+      // El score del motor viaja en escala 0-1 y esto lo trataba como 0-100. Consecuencia:
+      // un 0.56 pintaba una barra del 0.56% de ancho — vacía a la vista — y caía SIEMPRE en
+      // rojo, porque ningún score llega jamás a 60 en esa escala. Un 0.91 se veía igual de mal.
+      // Tolerante en los dos sentidos: si algún día el server manda 0-100, se respeta.
+      var n = +sc || 0;
+      var v = Math.max(0, Math.min(100, n <= 1 ? Math.round(n * 100) : Math.round(n)));
+      // Umbrales alineados con las BANDAS DEL MOTOR (pleno > 70, sugerida >= 30), no con unos
+      // propios: con 85/60 la barra salía roja junto a una etiqueta que decía «Sugerida», o sea
+      // que el color contradecía al texto que tenía al lado.
+      var cls = v > 70 ? 'g' : v >= 30 ? 'y' : 'r';
       return '<span class="ip-score"><span class="ip-scorebar ' + cls + '"><i style="width:' + v + '%"></i></span><span class="ip-scorenum">' + v + '</span></span>';
     }
     function candHtml(t, c, i) {

--- a/finanzas/version.json
+++ b/finanzas/version.json
@@ -1,9 +1,14 @@
 {
-  "version": "V1.05",
+  "version": "V1.06",
   "fecha": "2026-09-03",
   "modulo": "finanzas",
   "esquema": "V<mayor>.<menor de dos dígitos>. Un incremento de 0.01 por cada merge a main. Al pasar de .99 sube el mayor y el menor vuelve a 00.",
   "historial": [
+    {
+      "version": "V1.06",
+      "pr": null,
+      "nota": "La barra de confianza del candidato estaba rota desde que se escribio: el score viaja en escala 0-1 y scoreBar lo trataba como 0-100, asi que un 0.56 pintaba una barra del 0.56% de ancho y caia siempre en rojo — ningun score alcanza 60 en esa escala, ni un 0.91. Ahora convierte y ademas usa los umbrales del motor (pleno > 70, sugerida >= 30) en vez de unos propios de 85/60, que hacian que el color contradijera a la etiqueta de al lado."
+    },
     {
       "version": "V1.05",
       "pr": null,


### PR DESCRIPTION
## El reporte

Un candidato obviamente bueno —`ALAMEDA ELECTRICAL` contra `ALAMEDA ELECTRICAL DISTRIBUTORS INC`, monto exacto— se leía como **probabilidad baja**.

Eran **dos defectos distintos**: uno de pintado y otro de medición.

## 1 · La barra (este PR)

```js
var v = Math.max(0, Math.min(100, +sc || 0));      // sc llega 0.56
var cls = v >= 85 ? 'g' : v >= 60 ? 'y' : 'r';
```

El score viaja en escala **0‑1** y esto lo trataba como **0‑100**. Un `0.56` pintaba una barra del **0.56% de ancho** —vacía a la vista— y caía **siempre en rojo**, porque ningún score llega jamás a 60 en esa escala: un `0.91` se veía igual de mal.

La tabla, en cambio, sí multiplicaba (`BILL3345 · 91`), así que la misma línea mostraba **91 arriba y una barra roja vacía abajo**.

Se convierte —tolerante en los dos sentidos, por si el server algún día manda 0‑100— y los umbrales pasan a ser **los del motor** (pleno > 70, sugerida ≥ 30) en vez de unos propios de 85/60 que hacían que el color contradijera a la etiqueta de al lado.

## 2 · El puntaje (en n8n, no en este repo)

`sim()` usaba **Jaccard**, que castiga las palabras presentes de un solo lado. El banco escribe `ALAMEDA ELECTRICAL DI` —trunca *DIstributors*— contra `ALAMEDA ELECTRICAL DISTRIBUTORS INC`. Cada palabra del banco aparece en el proveedor, pero `distributors` e `inc` bajaban el nombre a 0.50 y el score a 0.56. Mismo castigo para `SA DE CV`, `LLC` o `USA`.

La pregunta correcta no es cuánto se parecen los dos textos, es **cuánto del texto del banco queda explicado por el nombre del proveedor**. Medido sobre los 8 candidatos de FTS‑USA:

| | Jaccard | cobertura |
|---|---|---|
| ALAMEDA | 0.56 | **0.86** |
| Harbor Freight | 0.69 | **0.84** |
| CED ↔ Consolidated | 0.26 | 0.26 |
| CAL‑STEAM ↔ Ferguson | 0.10 | 0.10 |
| FRONTIER AI ↔ Medecins Sans Frontieres | 0.32 | 0.32 |

**La cobertura no inventa coincidencias** — los que no casan siguen exactamente igual. Solo deja de castigar las reales.

## Nota de divergencia

El pase nocturno (`captura-concilia-auto`) tiene **su propia copia** del matcher y no cambió: sigue calculando con Jaccard. Hay que alinearlos cuando se abra el automático a Chase, que es el paso 3 del plan.

## Verificación

| gate | |
|---|---|
| `tests/gate-instrumentos-pago.js` | 55/55 |
| `tests/visual-bancos.js` | 65/65 |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017aCfYqG8Bi1yMHM5g2xsVb

---
_Generated by [Claude Code](https://claude.ai/code/session_017aCfYqG8Bi1yMHM5g2xsVb)_