### PR TITLE
comercial(machote) V1.09: buscar, filtrar y crear machotes

### DIFF
--- a/comercial/machote/README.md
+++ b/comercial/machote/README.md
@@ -65,7 +65,7 @@ versión es peor que no tener indicador.
 | `js/demo.js` | Datos de ejemplo. Lo que viene del machote real va marcado `REAL`; lo inventado, `SUPUESTO`. |
 | `js/app.js` | Vistas y ruteo. |
 | `js/almacen.js` | El autoguardado. UNA pieza entre la pantalla y donde viven los datos. |
-| `tests/pruebas-navegador.js` | 64 pruebas de navegador. |
+| `tests/pruebas-navegador.js` | 71 pruebas de navegador. |
 
 ## Cómo se calcula el precio
 
@@ -223,6 +223,33 @@ exactamente el silencio que este módulo persigue.
 ⚠️ **Enviar todavía NO escribe en Odoo.** La regla vigente del módulo es que
 Odoo sólo se consulta. El estado, el candado y la exigencia de orden ya son
 reales; la escritura espera a que Esteban levante esa regla.
+
+## Buscar, y empezar uno nuevo
+
+La pantalla de entrada es un **buscador**, no una lista: busca por nombre,
+cliente, número de orden e id, palabra por palabra —«topo chico» y «chico topo»
+encuentran lo mismo— y filtra por estado con chips que traen su cuenta. **Los
+contadores son del total, no de lo ya filtrado**: un contador que cambia al
+filtrar no sirve para saber cuántos hay. Y cuando no hay resultados, dice qué se
+buscó, porque una lista vacía sin explicación parece que perdió los machotes.
+
+**Un machote nuevo** nace con:
+
+- la hoja `DESGLOSE COTIZACIÓN`, que siempre existe y no es una sección;
+- una `SECCIÓN 1`;
+- los **diez** renglones de mano de obra con su tarifa de plantilla y **las horas
+  en cero** — la tarifa se pisa, las horas se capturan;
+- **treinta** renglones de materiales vacíos, con el `Tipo` sin elegir: Materiales
+  o Servicios se decide renglón por renglón, y es la columna que escoge el
+  multiplicador.
+
+El machote real trae **~180 renglones en blanco** por sección. Ciento ochenta
+vacíos no son fidelidad, son un muro —y en teléfono, ciento ochenta tarjetas—.
+Treinta cubren lo que se ve en el acervo y `+ partida` agrega sin límite.
+
+Un renglón en blanco **no se marca como hueco**. «Sin precio» sale sólo en uno
+que alguien empezó a llenar; en los treinta vacíos sería una alerta que aparece
+siempre, y una alerta que aparece siempre deja de leerse.
 
 ## Quién entra
 

--- a/comercial/machote/css/machote.css
+++ b/comercial/machote/css/machote.css
@@ -506,3 +506,40 @@ table.rejilla tr.capturada > td:first-child { box-shadow: inset 3px 0 0 var(--x-
            min-height: var(--toque); }
 .tb-user:hover { color: var(--tinta); border-color: var(--suave); }
 @media (max-width: 420px) { .tb-user { max-width: 74px; } }
+
+/* ── Buscar machotes ────────────────────────────────────────────────────
+ * La lista sin buscador servía con cuatro cotizaciones de ejemplo. Con las
+ * de verdad —711 órdenes traen machote— hay que poder encontrar una. */
+.buscador { display: flex; gap: 8px; margin: 10px 0; }
+.buscador input { flex: 1 1 auto; min-width: 0; min-height: var(--toque);
+                  border: 1px solid var(--linea); border-radius: 10px;
+                  padding: 0 12px; font-size: 16px;   /* 16px: menos hace que
+                  iOS haga zoom al enfocar y descuadre la pantalla */
+                  background: var(--fondo); color: var(--tinta); }
+.buscador input:focus { outline: 2px solid var(--acento); outline-offset: 1px; }
+.btn.nuevo { flex: 0 0 auto; width: auto; display: inline-flex; align-items: center;
+             min-height: var(--toque); padding: 0 14px; text-decoration: none;
+             white-space: nowrap; }
+
+.fchips { display: flex; gap: 6px; overflow-x: auto; padding-bottom: 4px; margin-bottom: 10px;
+          -webkit-overflow-scrolling: touch; }
+.fchip { flex: 0 0 auto;
+         /* 44 px, como todo lo que se toca. Puse 34 "porque es un chip" y la
+            prueba lo cachó — es la segunda vez que cometo el mismo error. */
+         min-height: var(--toque); border: 1px solid var(--linea);
+         background: var(--fondo); color: var(--suave); border-radius: 20px;
+         padding: 0 12px; font-size: 12px; font-weight: 600; cursor: pointer;
+         white-space: nowrap; }
+.fchip .n { display: inline-block; margin-left: 5px; padding: 1px 6px; border-radius: 10px;
+            background: var(--papel); color: var(--suave); font-size: 11px; }
+.fchip.on { background: var(--tinta); color: #fff; border-color: var(--tinta); }
+.fchip.on .n { background: rgba(255,255,255,.22); color: #fff; }
+
+/* ── Alta de machote ────────────────────────────────────────────────────*/
+.campo { display: block; margin-bottom: 12px; }
+.campo > span { display: block; font-size: 12px; font-weight: 600; color: var(--suave);
+                margin-bottom: 5px; }
+.campo .cel { width: 100%; min-height: var(--toque); font-size: 16px; padding: 0 12px;
+              border-radius: 8px; }
+.btn.primario { background: var(--acento); color: #fff; border-color: var(--acento);
+                min-height: var(--toque); margin-top: 6px; }

--- a/comercial/machote/js/app.js
+++ b/comercial/machote/js/app.js
@@ -40,7 +40,7 @@
    * 2026-09-03 (por instrucción de Esteban), pero lleva el suyo aparte y va en
    * V1.00. Planeación sigue en `2.4.1` y el kiosko sólo con cadena de build;
    * a esos no se propaga. */
-  const VERSION = 'V1.08';
+  const VERSION = 'V1.09';
   const $  = (s, r) => (r || document).querySelector(s);
   const $$ = (s, r) => Array.prototype.slice.call((r || document).querySelectorAll(s));
   const clon = (x) => JSON.parse(JSON.stringify(x));
@@ -58,6 +58,7 @@
     handoff: _guardado ? (_guardado.handoff || {}) : {},
     confirmadas: {},
     hoja: 'desglose', simMargen: null,
+    busca: '', filtro: 'todos',
     // 'limpio' | 'sucio' | 'guardando' | 'guardado' | 'sin-almacen'
     pulso: (A && A.disponible()) ? 'limpio' : 'sin-almacen'
   };
@@ -216,6 +217,7 @@
     pintarUsuario();
     const p = (location.hash || '#/').replace(/^#\//, '').split('/');
     if (p[0] === '')      return vHome();
+    if (p[0] === 'nuevo') return vNuevo();
     if (p[0] === 'm')     return vMachote(p[1]);
     if (p[0] === 'rev')   return vRevision(p[1]);
     if (p[0] === 'orden') return vOrden(p[1]);
@@ -236,12 +238,44 @@
     : mg < R.UMBRALES.margen_minimo_blando ? 'warn' : 'ok';
 
   /* ── Lista ───────────────────────────────────────────────────────────── */
+  /* ¿Este machote cae en lo que se está buscando?
+   * Se busca sobre lo que la gente recuerda de una cotización: el nombre, el
+   * cliente y el número de orden. El id entra también porque es lo que se
+   * copia y pega cuando alguien pregunta "¿y el M-1042?". */
+  function coincide(m, q) {
+    if (!q) return true;
+    const t = [m.nombre, m.cliente, m.so, m.id].map(x => String(x || '').toLowerCase()).join(' | ');
+    // Cada palabra por separado: "topo chico" y "chico topo" encuentran lo mismo.
+    return q.toLowerCase().split(/\s+/).filter(Boolean).every(w => t.indexOf(w) >= 0);
+  }
+
   function vHome() {
     top('Machote y órdenes', 'Comercial · prototipo', 'DEMO', null, true);
     $('#fija').innerHTML = '';
     const est = D.ESTADOS;
 
-    const filas = ST.machotes.map(m => {
+    // Los contadores salen del universo COMPLETO, no de lo ya filtrado: un
+    // contador que cambia al filtrar no sirve para saber cuántos hay.
+    const cuenta = { todos: ST.machotes.length };
+    D.FLUJO.forEach(k => { cuenta[k] = ST.machotes.filter(m => m.estado === k).length; });
+
+    const visibles = ST.machotes.filter(m =>
+      (ST.filtro === 'todos' || m.estado === ST.filtro) && coincide(m, ST.busca));
+
+    const chip = (k, etiqueta) =>
+      '<button class="fchip' + (ST.filtro === k ? ' on' : '') + '" data-filtro="' + k + '">' +
+      esc(etiqueta) + ' <span class="n">' + (cuenta[k] || 0) + '</span></button>';
+
+    const buscador =
+      '<div class="buscador">' +
+      '<input id="q" type="search" placeholder="Buscar por nombre, cliente u orden…" ' +
+      'value="' + esc(ST.busca) + '" autocomplete="off" enterkeyhint="search">' +
+      '<a class="btn nuevo" href="#/nuevo">+ Nuevo</a>' +
+      '</div>' +
+      '<div class="fchips">' + chip('todos', 'Todos') +
+      D.FLUJO.map(k => chip(k, D.ESTADOS[k].label)).join('') + '</div>';
+
+    const filas = visibles.map(m => {
       const rev = R.revisar(m), c = rev.calc;
       return '<a class="item" href="#/m/' + m.id + '">' +
         '<div class="grow"><strong>' + esc(m.nombre) + '</strong>' +
@@ -259,12 +293,72 @@
       '<div class="right"><div class="mono">' + mx(o.monto) + ' ' + esc(o.moneda) + '</div>' +
       '<div class="tiny">' + (ST.confirmadas[o.id] ? '✓ confirmada' : 'pendiente') + '</div></div></a>').join('');
 
+    // Un "no hay nada" tiene que decir POR QUÉ no hay nada: si la lista sale
+    // vacía por un filtro puesto hace un minuto y no lo dice, parece que se
+    // perdieron los machotes.
+    const vacio = ST.busca
+      ? '<div class="vacio">Ningún machote coincide con «' + esc(ST.busca) + '»' +
+        (ST.filtro !== 'todos' ? ' en ' + esc(est[ST.filtro].label).toLowerCase() : '') + '.</div>'
+      : '<div class="vacio">No hay machotes en ' + esc(est[ST.filtro] ? est[ST.filtro].label.toLowerCase() : 'este estado') + '.</div>';
+
     $('#vista').innerHTML =
       '<div class="pad"><div class="aviso">La retícula reproduce el machote real de FTS, verificada en cinco cotizaciones de 2026. ' +
       'Los datos de las cotizaciones de abajo son demo.</div>' +
-      '<h3>Estación 2.0 · armar la cotización</h3>' + filas +
+      '<h3>Estación 2.0 · armar la cotización</h3>' +
+      buscador +
+      (visibles.length ? filas : vacio) +
       '<h3 style="margin-top:22px">Estación 3.0 · confirmar la orden</h3>' + ords +
       '<div class="ver">versión <strong>' + VERSION + '</strong></div></div>';
+
+    // Se repinta sólo la lista al teclear, no la vista: repintar entera mata
+    // el foco del buscador a media palabra.
+    const q = $('#q');
+    if (q) q.oninput = () => { ST.busca = q.value; vHome(); $('#q').focus();
+                               $('#q').setSelectionRange(ST.busca.length, ST.busca.length); };
+    $$('[data-filtro]').forEach(b => b.onclick = () => { ST.filtro = b.dataset.filtro; vHome(); });
+  }
+
+  /* ── Machote nuevo ─────────────────────────────────────────────────────
+   * La orden es OPCIONAL a propósito: el machote casi siempre nace antes que
+   * la orden. Lo que no se puede es ENVIARLO a Odoo sin ella (V1.07). */
+  function vNuevo() {
+    top('Nuevo machote', 'Comercial · prototipo', 'DEMO', '#/');
+    $('#fija').innerHTML = '';
+    $('#vista').innerHTML =
+      '<div class="pad"><div class="wg">' +
+      '<h4>Datos para arrancar</h4>' +
+      '<label class="campo"><span>Nombre de la cotización</span>' +
+      '<input id="n-nombre" class="cel" placeholder="Ej. Modificación de tren de drenado"></label>' +
+      '<label class="campo"><span>Cliente</span>' +
+      '<input id="n-cliente" class="cel" placeholder="Ej. Nalco de México · Topo Chico"></label>' +
+      '<label class="campo"><span>Orden (opcional)</span>' +
+      '<input id="n-so" class="cel" placeholder="SO11836 — se puede dejar vacío"></label>' +
+      '<label class="campo"><span>Empresa</span>' +
+      '<select id="n-empresa" class="cel">' +
+      C.EMPRESAS.map(e => '<option value="' + e.id + '">' + esc(e.corto) + ' · ' + e.moneda + '</option>').join('') +
+      '</select></label>' +
+      '<div class="tiny nota">Va a nacer con la hoja <strong>DESGLOSE COTIZACIÓN</strong>, una ' +
+      '<strong>SECCIÓN 1</strong>, los diez renglones de mano de obra con su tarifa de plantilla ' +
+      'y las horas en cero, y <strong>' + C.PARTIDAS_EN_BLANCO + ' renglones de materiales</strong> ' +
+      'vacíos. El Tipo (Materiales o Servicios) se elige renglón por renglón, como en el Excel.</div>' +
+      '<button class="btn primario" id="n-crear">Crear machote</button>' +
+      '<div id="n-err" class="tiny n-bad"></div>' +
+      '</div></div>';
+
+    $('#n-crear').onclick = () => {
+      const nombre = $('#n-nombre').value.trim();
+      if (!nombre) { $('#n-err').textContent = 'Ponle un nombre: es como lo vas a encontrar después.'; return; }
+      const m = C.machoteNuevo({
+        nombre: nombre,
+        cliente: $('#n-cliente').value.trim(),
+        so: $('#n-so').value.trim() || null,
+        empresa_id: Number($('#n-empresa').value)
+      });
+      ST.machotes.unshift(m);
+      guardarYa();
+      ST.hoja = 'desglose';
+      location.hash = '#/m/' + m.id;
+    };
   }
 
   /* ── El libro ────────────────────────────────────────────────────────── */
@@ -466,7 +560,11 @@
         '<td data-l="Marca">' + cel(p + 'marca', l.marca, 'w90') + '</td>' +
         '<td data-l="Precio unitario">' + celNum(p + 'pu', l.pu, 'w90') + '</td>' +
         '<td data-l="Moneda">' + celSel(p + 'moneda', l.moneda, ['MXN', 'USD']) + '</td>' +
-        '<td class="vl mono calc' + (cl.sinPrecio ? ' n-bad' : '') + '" data-l="Precio total">' + (cl.sinPrecio ? 'sin precio' : mx(cl.costo)) + '</td>' +
+        // "sin precio" SOLO en un renglón que alguien empezó a llenar. En uno
+        // en blanco no es un hallazgo, es el estado normal del bloque — y con
+        // treinta en blanco por sección, decirlo treinta veces es ruido.
+        '<td class="vl mono calc' + (cl.sinPrecio && cl.usada ? ' n-bad' : '') + '" data-l="Precio total">' +
+        (cl.sinPrecio ? (cl.usada ? 'sin precio' : '—') : mx(cl.costo)) + '</td>' +
         '<td data-l="Margen">' + celNum(p + 'margen', l.margen, 'w60' + (cl.pisado ? ' pisado' : ''), String(cl.porTipo || '')) +
           (cl.pisado ? '<span class="pisado-marca" title="Escrito a mano encima de la fórmula. Por Tipo le tocaría ' +
             cl.porTipo + '.">≠ ' + cl.porTipo + '</span>' : '') + '</td>' +

--- a/comercial/machote/js/calc.js
+++ b/comercial/machote/js/calc.js
@@ -51,6 +51,35 @@
 
   const TIPOS = ['Materiales', 'Servicios'];
 
+  /** ¿Alguien escribió algo en este renglón de materiales?
+   *  Definición ÚNICA: la usan el motor, las reglas y la pantalla. Estaba
+   *  escrita tres veces —dos aquí y una en `reglas.js`— y con matices distintos;
+   *  tres definiciones de lo mismo terminan divergiendo. */
+  const usadaPartida = (l) => !!l && (num(l.qty) > 0 || !vacio(l.pu) || !!l.descripcion);
+
+  /* Cuántos renglones de materiales trae una sección recién creada.
+   *
+   * El machote real trae **~180 en blanco** por sección (§2.4 del levantamiento):
+   * el capturista llena hacia abajo y el resto queda vacío. Ciento ochenta
+   * renglones vacíos en una pantalla no son fidelidad, son un muro — y en
+   * teléfono, donde cada renglón es una tarjeta, son ciento ochenta tarjetas.
+   * Treinta cubren de sobra lo que se ve en el acervo, y «+ partida» agrega
+   * más sin límite. */
+  const PARTIDAS_EN_BLANCO = 30;
+
+  /* Los equipos de la plantilla, a 0,25 cada uno = 100%. Un machote nuevo nace
+   * CUADRADO a propósito: si naciera con el reparto vacío, la regla dura de
+   * "las comisiones no suman 100%" saltaría desde el primer segundo, y una
+   * alerta que sale siempre deja de leerse. */
+  const EQUIPO_VENTA_PLANTILLA = () => ([
+    { nombre: 'ALDO',  pct: 0.25 }, { nombre: 'ANGEL', pct: 0.25 },
+    { nombre: 'DIEGO', pct: 0.25 }, { nombre: 'MONTY', pct: 0.25 }
+  ]);
+  const EQUIPO_OPS_PLANTILLA = () => ([
+    { nombre: 'SUPERVISOR FTS', pct: 0.25 }, { nombre: 'SEGURIDAD', pct: 0.25 },
+    { nombre: 'TECNICO 1', pct: 0.25 }, { nombre: 'TECNICO 2', pct: 0.25 }
+  ]);
+
   /* Las dos empresas y su moneda. Verificado contra Odoo: de las 711 órdenes
    * con machote, 594 son de SERVICIOS FTS (company 1, MXN) y 117 de FTS FULL
    * TECHNOLOGY SYSTEMS LLC (company 6, USD). La moneda del documento nace de
@@ -59,6 +88,73 @@
     { id: 1, nombre: 'Servicios FTS', corto: 'FTS México', moneda: 'MXN' },
     { id: 6, nombre: 'FTS Full Technology Systems LLC', corto: 'FTS USA', moneda: 'USD' }
   ];
+  /* ── Fábrica de machotes y secciones en blanco ─────────────────────────
+   *
+   * Vive en el MOTOR y no en los datos de ejemplo: un machote nuevo tiene que
+   * nacer con exactamente la misma forma que los que ya existen, y esa forma
+   * la define quien la consume. Si la fábrica viviera en `demo.js`, crear uno
+   * de verdad dependería del archivo de datos falsos.
+   */
+
+  /** Una sección en blanco: los diez renglones de mano de obra con su tarifa
+   *  de plantilla y las horas en cero, y `PARTIDAS_EN_BLANCO` renglones de
+   *  materiales vacíos, listos para llenar hacia abajo como en el Excel. */
+  function seccionNueva(nombre, moneda) {
+    moneda = moneda || 'MXN';
+    const mo = ROLES.map(r => ({
+      rol: r.id,
+      qty: '',          // horas: en cero, es lo que se captura
+      personas: 1,
+      pu: r.pu,         // la tarifa de plantilla, que el capturista puede pisar
+      moneda: moneda
+    }));
+    const partidas = [];
+    for (let i = 0; i < PARTIDAS_EN_BLANCO; i++) {
+      partidas.push({
+        qty: '', unidad: '', tipo: '',   // el Tipo lo elige el capturista: es
+        descripcion: '', modelo: '', marca: '',   // la columna que decide el
+        pu: null, moneda: moneda,                 // multiplicador
+        margen: null, link: '', comentario: ''
+      });
+    }
+    return { id: 's-' + Date.now() + '-' + Math.round(Math.random() * 1e6),
+             nombre: nombre || 'SECCIÓN 1', mo: mo, partidas: partidas };
+  }
+
+  /** Un machote en blanco, con su hoja DESGLOSE (que siempre existe, no es una
+   *  sección) y UNA sección lista para capturar. */
+  function machoteNuevo(d) {
+    d = d || {};
+    const empresa = EMPRESAS.find(e => e.id === Number(d.empresa_id)) || EMPRESAS[0];
+    const hoy = new Date();
+    const iso = hoy.getFullYear() + '-' +
+                String(hoy.getMonth() + 1).padStart(2, '0') + '-' +
+                String(hoy.getDate()).padStart(2, '0');
+    return {
+      id: d.id || ('M-' + Date.now()),
+      nombre: d.nombre || 'Cotización sin nombre',
+      cliente: d.cliente || '',
+      so: d.so || null,
+      estado: 'borrador',
+      analista: d.analista || '',
+      fecha: iso,
+      empresa_id: empresa.id,
+      moneda: empresa.moneda,
+      tc: 0, factor_proteccion: 0, tc_fuente: '',
+      margenes: Object.assign({}, MARGENES_PLANTILLA),
+      comision_fts: COMISION_FTS_PLANTILLA,
+      comision_cliente: 0,
+      margen_deseado: MARGEN_DESEADO_PLANTILLA,
+      escenario: 'margen_deseado',
+      reparto: Object.assign({}, REPARTO_PLANTILLA),
+      equipo_venta: EQUIPO_VENTA_PLANTILLA(),
+      equipo_operaciones: EQUIPO_OPS_PLANTILLA(),
+      equipo_cliente: [{ nombre: 'Contacto cliente 1', pct: 1 }],
+      diagnostico: { tipo: '', respuestas: {} },
+      secciones: [seccionNueva('SECCIÓN 1', empresa.moneda)]
+    };
+  }
+
   const empresaDe = (m) => EMPRESAS.find(e => e.id === Number(m && m.empresa_id)) || EMPRESAS[0];
   const monedaPorDefecto = (m) => empresaDe(m).moneda;
   const ESCENARIOS = [
@@ -127,7 +223,12 @@
     const pisado = !vacio(linea.margen) && Math.abs(num(linea.margen) - porTipo) > 0.0001;
     const mult = pisado ? num(linea.margen) : porTipo;
     return { costo, mult, porTipo, pisado,
-             conUtilidad: costo * mult, sinPrecio, sinTipo, sinLink: !linea.link };
+             conUtilidad: costo * mult, sinPrecio, sinTipo, sinLink: !linea.link,
+             // Un renglon del bloque en el que nadie ha escrito nada NO es un
+             // hueco: es un renglon sin usar, como los del Excel. La diferencia
+             // importa porque una seccion nueva trae 30 en blanco, y marcarlos
+             // como defecto convierte la alerta en ruido.
+             usada: usadaPartida(linea) };
   }
 
   function totalSeccion(s, m) {
@@ -144,8 +245,7 @@
     (s.partidas || []).forEach(l => {
       const c = costoPartida(l, m);
       costoMat += c.costo; ventaMat += c.conUtilidad;
-      const usada = num(l.qty) > 0 || !vacio(l.pu) || l.descripcion;
-      if (!usada) return;
+      if (!c.usada) return;
       if (c.sinPrecio) sinPrecio++;
       if (c.sinTipo) sinTipo++;
       if (c.pisado) pisados++;
@@ -344,6 +444,8 @@
     ROLES, ROL, GRUPOS, TIPOS, ESCENARIOS, MAX_SECCIONES,
     EMPRESAS, empresaDe, monedaPorDefecto,
     MARGENES_PLANTILLA, COMISION_FTS_PLANTILLA, MARGEN_DESEADO_PLANTILLA, REPARTO_PLANTILLA,
+    PARTIDAS_EN_BLANCO, EQUIPO_VENTA_PLANTILLA, EQUIPO_OPS_PLANTILLA, usadaPartida,
+    seccionNueva, machoteNuevo,
     tcEfectivo, margenes, costoMo, costoPartida, totalSeccion,
     calcular, precioParaMargen, repartir
   };

--- a/comercial/machote/js/reglas.js
+++ b/comercial/machote/js/reglas.js
@@ -33,7 +33,9 @@
   const secs = (m) => (m.secciones || []);
   const partidas = (m) => secs(m).flatMap(s => (s.partidas || []).map(l => ({ s, l })));
   const renglonesMo = (m) => secs(m).flatMap(s => (s.mo || []).map(l => ({ s, l })));
-  const usada = (l) => (Number(l.qty) > 0) || (l.pu !== null && l.pu !== undefined && l.pu !== '') || !!l.descripcion;
+  // Definicion unica en el motor: estaba repetida aqui y dos veces en calc.js,
+  // con matices distintos. Tres definiciones de lo mismo terminan divergiendo.
+  const usada = (l) => C.usadaPartida(l);
   const tipoDe = (m) => (G.DEMO.TIPOS_PROYECTO.find(t => t.id === (m.diagnostico || {}).tipo) || null);
 
   const REGLAS = [

--- a/comercial/machote/tests/pruebas-navegador.js
+++ b/comercial/machote/tests/pruebas-navegador.js
@@ -896,6 +896,120 @@ let ok = 0, mal = 0;
     console.log('   banda', r.banda, '· encabezado', r.cab, '· capturado', r.fila);
   });
 
+  // ── V1.09 · buscar y crear ───────────────────────────────────────────
+  await paso('la vista principal busca por nombre, cliente y orden', async () => {
+    await ir('#/');
+    const n0 = await p.locator('.item[href^="#/m/"]').count();
+    if (n0 < 3) throw new Error('esperaba varios machotes, hay ' + n0);
+    await p.fill('#q', 'topo chico');
+    await p.waitForTimeout(320);
+    const n1 = await p.locator('.item[href^="#/m/"]').count();
+    if (!(n1 > 0 && n1 < n0)) throw new Error('el buscador no filtró: ' + n0 + ' → ' + n1);
+    // Por número de orden tambien.
+    await p.fill('#q', 'SO11772'); await p.waitForTimeout(320);
+    const t = await p.textContent('#vista');
+    if (t.indexOf('SO11772') < 0) throw new Error('no encontró por número de orden');
+    console.log('   ', n0, 'machotes →', n1, 'con "topo chico"');
+  });
+
+  await paso('buscar no roba el foco a media palabra', async () => {
+    await ir('#/');
+    await p.click('#q');
+    await p.type('#q', 'paso', { delay: 60 });
+    await p.waitForTimeout(300);
+    const r = await p.evaluate(() => ({
+      foco: document.activeElement && document.activeElement.id,
+      valor: document.getElementById('q') ? document.getElementById('q').value : null
+    }));
+    if (r.foco !== 'q') throw new Error('el foco se fue a: ' + r.foco);
+    if (r.valor !== 'paso') throw new Error('se perdieron letras: ' + r.valor);
+  });
+
+  await paso('los filtros por estado cuentan sobre el total, no sobre lo filtrado', async () => {
+    await ir('#/');
+    const total = await p.locator('.item[href^="#/m/"]').count();
+    const antes = await p.locator('.fchip').allTextContents();
+    await p.locator('.fchip', { hasText: 'En revisión' }).first().click();
+    await p.waitForTimeout(300);
+    const desp = await p.locator('.fchip').allTextContents();
+    if (antes.join('|') !== desp.join('|'))
+      throw new Error('los contadores cambiaron al filtrar: ' + antes.join(' ') + ' → ' + desp.join(' '));
+    const enRev = await p.locator('.item[href^="#/m/"]').count();
+    if (!(enRev > 0 && enRev < total)) throw new Error('el filtro no filtró: ' + total + ' → ' + enRev);
+  });
+
+  await paso('cuando no hay resultados, dice por qué', async () => {
+    await ir('#/');
+    await p.fill('#q', 'zzzz-no-existe'); await p.waitForTimeout(320);
+    const t = await p.textContent('#vista');
+    if (t.indexOf('zzzz-no-existe') < 0)
+      throw new Error('no dice qué se buscó: ' + t.slice(0, 160));
+  });
+
+  await paso('un machote nuevo nace con DESGLOSE, una sección y todo en ceros', async () => {
+    await ir('#/');
+    await p.click('.btn.nuevo'); await p.waitForTimeout(320);
+    await p.fill('#n-nombre', 'Cotización de prueba CC');
+    await p.fill('#n-cliente', 'Cliente de prueba');
+    await p.click('#n-crear'); await p.waitForTimeout(450);
+
+    const pest = await p.locator('.pestana:not(.mas)').allTextContents();
+    if (pest.length !== 2) throw new Error('esperaba DESGLOSE + 1 sección, hay: ' + pest.join(' · '));
+    if (!/DESGLOSE/.test(pest[0])) throw new Error('la primera hoja no es el DESGLOSE: ' + pest[0]);
+
+    // El precio arranca en cero: nada capturado todavía.
+    const barra = await p.textContent('.fija');
+    if (!/\$0|\$-/.test(barra)) throw new Error('no arrancó en ceros: ' + barra.trim().slice(0, 60));
+
+    await hoja('SECCIÓN 1');
+    const r = await p.evaluate(() => {
+      const mo = document.querySelectorAll('.rejilla tbody tr:not(.grupo):not(.total)');
+      const qty = [...document.querySelectorAll('[data-cel$=":qty"]')];
+      return { filas: mo.length, qty: qty.length, conValor: qty.filter(x => x.value !== '').length,
+               capturadas: document.querySelectorAll('tr.capturada').length };
+    });
+    if (r.conValor !== 0) throw new Error(r.conValor + ' renglones nacieron con cantidad');
+    if (r.capturadas !== 0) throw new Error('nació con renglones pintados de verde');
+    console.log('   ', pest.join(' · '), '·', r.qty, 'renglones, todos en cero');
+  });
+
+  await paso('la sección nueva trae 10 de mano de obra con tarifa y 30 de materiales', async () => {
+    const r = await p.evaluate(() => {
+      const C = window.MachoteCalc;
+      const m = C.machoteNuevo({ nombre: 'x' });
+      const s = m.secciones[0];
+      return {
+        secciones: m.secciones.length,
+        mo: s.mo.length,
+        conTarifa: s.mo.filter(l => Number(l.pu) > 0).length,
+        conHoras: s.mo.filter(l => l.qty !== '' && l.qty !== null).length,
+        partidas: s.partidas.length,
+        sinTipo: s.partidas.filter(x => x.tipo === '').length,
+        costo: C.calcular(m).costo
+      };
+    });
+    if (r.secciones !== 1) throw new Error('secciones: ' + r.secciones);
+    if (r.mo !== 10) throw new Error('renglones de mano de obra: ' + r.mo);
+    if (r.conTarifa !== 10) throw new Error('sin tarifa de plantilla: ' + (10 - r.conTarifa));
+    if (r.conHoras !== 0) throw new Error('nacieron con horas: ' + r.conHoras);
+    if (r.partidas !== 30) throw new Error('renglones de materiales: ' + r.partidas);
+    if (r.sinTipo !== 30) throw new Error('el Tipo viene preelegido en ' + (30 - r.sinTipo));
+    if (r.costo !== 0) throw new Error('el costo no arranca en cero: ' + r.costo);
+    console.log('    10 mano de obra con tarifa · 30 materiales sin Tipo · costo 0');
+  });
+
+  await paso('el machote nuevo se guarda solo y aparece en la búsqueda', async () => {
+    const guardado = await p.evaluate(() => {
+      const c = localStorage.getItem('fts_machote_v1');
+      return c ? JSON.parse(c).machotes.some(m => m.nombre === 'Cotización de prueba CC') : false;
+    });
+    if (!guardado) throw new Error('no quedó en el almacén');
+    await irSuave('#/');
+    await p.fill('#q', 'prueba CC'); await p.waitForTimeout(320);
+    const t = await p.textContent('#vista');
+    if (t.indexOf('Cotización de prueba CC') < 0) throw new Error('no aparece al buscarlo');
+  });
+
   // ── El gate ──────────────────────────────────────────────────────────
   await paso('sin sesión, el libro no se alcanza a ver', async () => {
     // Pagina LIMPIA, sin la sesion sembrada: debe mandar al login.

--- a/comercial/machote/version.json
+++ b/comercial/machote/version.json
@@ -1,10 +1,15 @@
 {
-  "version": "V1.08",
+  "version": "V1.09",
   "fecha": "2026-09-03",
   "modulo": "comercial/machote",
   "ambito": "El CONTADOR es solo de este modulo. finanzas tambien usa V1.xx desde el 2026-09-03 (instruccion directa de Esteban, corrige el \"no propagar\" del issue #148) pero lleva su propio contador y va en V1.00. operaciones/planeacion sigue en 2.4.1, kiosk y confirmar-horas solo con cadena de build, y siete modulos con un 1.0.0 puesto una vez: a esos no se propaga.",
   "esquema": "V<mayor>.<menor de dos digitos>. Un incremento de 0.01 por cada merge a main. Al pasar de .99 sube el mayor y el menor vuelve a 00.",
   "historial": [
+    {
+      "version": "V1.09",
+      "pr": null,
+      "nota": "Buscar y filtrar machotes por estado, y crear uno nuevo: nace con DESGLOSE, una seccion, 10 renglones de mano de obra con tarifa y 30 de materiales, todo en cero"
+    },
     {
       "version": "V1.08",
       "pr": null,

--- a/docs/comercial/MACHOTE-ESTRUCTURA-REAL.md
+++ b/docs/comercial/MACHOTE-ESTRUCTURA-REAL.md
@@ -107,7 +107,8 @@ Lo que **sí** varía por cotización — y por eso son campos, no constantes:
 
 Columnas: `QTY | UNIDAD | Personas | DESCRIPCIÓN | PRECIO UNITARIO | PRECIO TOTAL | MONEDA | Margen utilidad | PRECIO CON UTILIDAD`
 
-Doce renglones fijos en tres grupos:
+**Diez** renglones fijos en tres grupos — 2 + 3 + 5. (Este documento decía «doce» y
+enumeraba diez; corregido el 2026-09-03 contra `calc.js`, que tiene diez.)
 
 - **Diseño y Programación** — `diseño` $200 (×2,5) · `PROGRAMADOR` $300 (×4,4)
 - **En Planta** — `Supervisor Sr` $200 · `Supervisor Jr - seguridad` $140 · `Técnicos` $140 (×2,5)


### PR DESCRIPTION
## Buscar y filtrar

La pantalla de entrada era una lista de cuatro ejemplos. Ahora es un **buscador**: por nombre, cliente, número de orden e id, **palabra por palabra** — «topo chico» y «chico topo» encuentran lo mismo — con chips de estado que traen su cuenta.

- **Los contadores son del total, no de lo ya filtrado.** Un contador que cambia al filtrar no sirve para saber cuántos hay.
- Cuando no hay resultados, **dice qué se buscó**: una lista vacía sin explicación parece que perdió los machotes.
- Al teclear se repinta sólo la lista, no la vista, o el foco se pierde a media palabra.

## Machote nuevo

Nace con la hoja `DESGLOSE COTIZACIÓN` (que siempre existe y no es una sección), una `SECCIÓN 1`, los **diez** renglones de mano de obra con su tarifa de plantilla y **las horas en cero**, y **treinta** renglones de materiales vacíos con el `Tipo` sin elegir — Materiales o Servicios se decide renglón por renglón, que es la columna que escoge el multiplicador.

La **orden es opcional**: el machote casi siempre nace antes que la orden. Lo que no se puede es enviarlo a Odoo sin ella (V1.07).

La fábrica vive en el **motor**, no en los datos de ejemplo: un machote nuevo tiene que nacer con la misma forma que los que ya existen, y si la fábrica viviera en `demo.js`, crear uno de verdad dependería del archivo de datos falsos. Nace además con el reparto de comisiones **cuadrado al 100%**: si naciera vacío, la regla dura saltaría desde el primer segundo, y una alerta que sale siempre deja de leerse.

### 30 y no 180

El machote real trae **~180 renglones en blanco** por sección (§2.4 del levantamiento). Ciento ochenta vacíos no son fidelidad, son un muro — y en teléfono, ciento ochenta tarjetas. Treinta cubren lo que se ve en el acervo y `+ partida` agrega sin límite.

## Dos cosas que enseñó la captura, no las pruebas

1. **Un renglón en blanco se marcaba «sin precio».** Con treinta por sección, la alerta salía **treinta veces** en un machote recién creado. Un renglón en el que nadie escribió nada no es un hueco: es un renglón sin usar, como en el Excel. Ahora sale sólo en uno que alguien empezó a llenar.
2. **`usada` estaba definida tres veces** —dos en `calc.js` y una en `reglas.js`— con matices distintos. Queda una sola, en el motor.

## Corrección al levantamiento

`docs/comercial/MACHOTE-ESTRUCTURA-REAL.md` decía «**Doce** renglones fijos» de mano de obra… y enumeraba diez. El motor tiene diez. Corregido.

Y el chip de filtro medía 34 px, violando la regla de 44 del propio módulo. Es la segunda vez que cometo ese error; lo cachó la prueba, no yo.

## Pruebas

**71 pasaron, 0 fallaron.** Siete nuevas. Capturas revisadas a 390 y 1440 px.

## Versión

`V1.08` → **`V1.09`**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013Qzhio6K8R23HXHnJ2RJ64