### PR TITLE
finanzas(bancos) V1.07: el foco sigue al pendiente, no al porcentaje

### DIFF
--- a/finanzas/js/modules/instrumentos-pago.js
+++ b/finanzas/js/modules/instrumentos-pago.js
@@ -27,7 +27,7 @@
   // comercial/machote y DEBE coincidir con finanzas/version.json — el gate lo verifica, porque
   // una pantalla que dice una versión y un archivo que dice otra deja de ser evidencia de nada.
   // Sustituye a la numeración 0.x.y (última: 0.5.36), conservada en version.json.
-  var IP_BUILD = 'V1.06';
+  var IP_BUILD = 'V1.07';
   var RESIDUAL_UMBRAL_MXN = 10000;        // coherente con fin/captura-status
   var SHEETJS_CDN = 'https://cdn.sheetjs.com/xlsx-0.20.3/package/dist/xlsx.full.min.js';
   // Endpoints reales (contrato construido en la sesión de backend; verificar nombres de
@@ -603,7 +603,9 @@
 
       // v0.5.16: el semáforo sube aquí, pegado a las fuentes que evalúa (antes vivía después de "Hoy").
       html += '<h2>Semáforo de conciliación — Admin</h2><div class="sem"><div id="ip-semrows"></div>' +
-              '<div class="semnote"><b>Desde el corte</b> — la meta es 100%: verde solo al llegar, amarillo desde 85%, rojo debajo. ' +
+              '<div class="semnote"><b>Desde el corte</b> — el color mide <b>lo que falta por conciliar</b>, no el porcentaje: ' +
+              'verde cuando no queda nada que hacer (aunque el % no llegue a 100 porque hay fondeos o devoluciones), ' +
+              'amarillo a tiro, rojo lejos. ' +
               '<b>Backlog</b> — no tiene color: es deuda que se vacía, no una meta que se cumple. ' +
               'Las fuentes marcadas <b>sin abrir</b> se miden igual que las demás, y su 0% dice ' +
               '<i>no empezado</i>, no <i>fracasado</i>: nadie ha abierto ese journal en el motor todavía.</div></div>';
@@ -1744,11 +1746,21 @@
           var conc = Number(x.post_conc) || 0;
           var faltan = x.post_total - conc;
           var p = x.post_total ? Math.round(conc / x.post_total * 1000) / 10 : null;
-          // Umbrales de META: el objetivo declarado es 100% post-corte, así que solo el 100% es
-          // verde. Amarillo desde 85% (a tiro), rojo debajo. Un 60% no puede pintar amarillo
-          // cuando faltan 47 líneas.
-          var c2 = p === null ? 'off' : (p >= 100 ? 'g' : p >= 85 ? 'y' : 'r');
           var comp = composicionFaltan(x.label, corte, faltan);
+          // EL COLOR SIGUE AL PENDIENTE ACCIONABLE, no al porcentaje de Odoo (V1.07).
+          // Antes salía del porcentaje: con 168 de 172 daba 97.7% y pintaba AMARILLO aunque no
+          // quedara una sola línea por conciliar — las 4 que faltaban eran 2 fondeos y 2
+          // devoluciones, que el motor no cierra y que no son trabajo de nadie. El titular ya
+          // media lo accionable desde V1.02, así que el foco lo contradecía: decía "0 por
+          // conciliar" en grande y encendía la luz de "vas a medias".
+          // El porcentaje NO se toca: sigue siendo el de Odoo y se lee en el renglón de abajo,
+          // junto al total sin conciliar. Lo que cambia es qué pregunta responde el color:
+          // "¿queda algo por hacer?" en vez de "¿cuánto le falta al 100%?".
+          var pendienteReal = (comp.ok && comp.fon + comp.dev > 0) ? comp.conc : faltan;
+          var c2;
+          if (p === null) c2 = 'off';
+          else if (pendienteReal === 0) c2 = 'g';       // nada que conciliar = verde, aunque el % no llegue a 100
+          else c2 = (p >= 85 ? 'y' : 'r');              // amarillo a tiro, rojo lejos
 
           // EL TITULAR ES EL NÚMERO ACCIONABLE, no el total sin conciliar. Con 6 gastos + 2
           // fondeos + 2 devoluciones, un "Faltan 10" se lee como diez pendientes de conciliar y

--- a/finanzas/version.json
+++ b/finanzas/version.json
@@ -1,9 +1,14 @@
 {
-  "version": "V1.06",
+  "version": "V1.07",
   "fecha": "2026-09-03",
   "modulo": "finanzas",
   "esquema": "V<mayor>.<menor de dos dígitos>. Un incremento de 0.01 por cada merge a main. Al pasar de .99 sube el mayor y el menor vuelve a 00.",
   "historial": [
+    {
+      "version": "V1.07",
+      "pr": null,
+      "nota": "El foco de cada fuente sale del pendiente ACCIONABLE, no del porcentaje de Odoo. Jeeves llego a 0 por conciliar y seguia en amarillo: 168 de 172 es 97.7%, pero las 4 que faltaban eran 2 fondeos y 2 devoluciones, que el motor no cierra y no son trabajo de nadie. El titular ya media lo accionable desde V1.02, asi que el color lo contradecia. El porcentaje no se toca: sigue siendo el de Odoo, en el renglon de abajo. Leyenda corregida."
+    },
     {
       "version": "V1.06",
       "pr": null,

--- a/tests/visual-bancos.js
+++ b/tests/visual-bancos.js
@@ -74,7 +74,9 @@ const esDelEntorno = t => /ERR_CONNECTION_RESET|ERR_NAME_NOT_RESOLVED|ERR_BLOCKE
 
     await p.goto(HARNESS, { waitUntil: 'domcontentloaded' });
     await p.waitForSelector('#ip-tblwrap table tbody tr', { timeout: 15000 });
-    await p.waitForFunction(() => document.body.innerHTML.indexOf('BILL3345') >= 0, null, { timeout: 15000 });
+    // Se espera al candidato de la linea de CHASE: en Jeeves ya no queda ninguna pendiente que
+    // pueda traer sugerencia (las 4 restantes son fondeos y devoluciones, excluidas a proposito).
+    await p.waitForFunction(() => document.body.innerHTML.indexOf('BILL/2026/08/0031') >= 0, null, { timeout: 15000 });
     await p.waitForTimeout(300);
 
     check('sin errores de consola propios (' + delEntorno.length + ' del entorno, filtrados)', errs.length === 0, errs.slice(0, 3).join(' | '));
@@ -199,6 +201,25 @@ const esDelEntorno = t => /ERR_CONNECTION_RESET|ERR_NAME_NOT_RESOLVED|ERR_BLOCKE
     })));
     check('las 3 fuentes traen foco, barra y porcentaje (' + cards.length + ' tarjetas)',
       cards.length === 3 && cards.every(c => c.foco && c.barra && c.pct), JSON.stringify(cards));
+
+    // El color sigue al pendiente ACCIONABLE, no al porcentaje. Jeeves está en 168 de 172
+    // (97.7%) y las 4 que faltan son 2 fondeos y 2 devoluciones: no queda nada que conciliar,
+    // así que va VERDE aunque el porcentaje no llegue a 100. Antes pintaba amarillo y
+    // contradecía a su propio titular, que ya decía "0 por conciliar".
+    const focos = await p.evaluate(() => [...document.querySelectorAll('#ip-semrows .s2card')].map(c => {
+      const luz = c.querySelector('.light');
+      return {
+        titulo: ((c.querySelector('.s2ct') || {}).textContent || '').trim().slice(0, 28),
+        meta: ((c.querySelector('.s2goal') || {}).textContent || '').trim(),
+        clase: luz ? luz.className.replace('light', '').trim() : null
+      };
+    }));
+    const jeeves = focos.find(f => /Jeeves/.test(f.titulo));
+    check('con 0 por conciliar el foco es VERDE aunque el % no llegue a 100',
+      !!jeeves && /^0 por conciliar/.test(jeeves.meta) && jeeves.clase === 'g', JSON.stringify(jeeves));
+    check('las fuentes con pendiente NO salen verdes',
+      focos.filter(f => !/^0 por conciliar|Al 100%/.test(f.meta)).every(f => f.clase !== 'g'),
+      JSON.stringify(focos));
     check('la leyenda ya no dice que las fuentes sin motor no llevan porcentaje',
       ((await p.locator('.semnote').textContent().catch(() => '')) || '').indexOf('no llevan porcentaje') < 0);
     check('los paneles del semáforo van apilados a todo el ancho',

--- a/tests/visual-harness-bancos.html
+++ b/tests/visual-harness-bancos.html
@@ -60,11 +60,11 @@ var FILAS = [
     amt: 168574.45, mon: 'MXN', ok: false, res: 168574.45, tarj: '', comp: '', rs: 'Servicios FTS', art: '', ana: '',
     po: '', bill: '', sb: '', ff: '', tk: '' },
   { id: 9006, company_id: 1, _jid: 61, d: '2026-08-27', j: 'Jeeves Tarjeta Credito', tipo: 'Egreso', ref: '[Primary ****6831] PRO Ferrenl',
-    amt: -340.96, mon: 'MXN', ok: false, res: 340.96, tarj: 'Primary', comp: 'Felipe', rs: 'Servicios FTS', art: '',
-    ana: '', po: '', bill: '', sb: '', ff: '', tk: '' },
+    amt: -340.96, mon: 'MXN', ok: true, res: 0, res_apunte: 0, wd: HOY, tarj: 'Primary', comp: 'Felipe', rs: 'Servicios FTS', art: '',
+    ana: '', po: 'PO7345', bill: 'BILL3345', sb: 'PAGADA', ff: '', tk: '' },
   { id: 9007, company_id: 1, _jid: 61, d: '2026-08-28', j: 'Jeeves Tarjeta Credito', tipo: 'Egreso', ref: '[Tarjeta gastos ****4548] Waalaxy',
-    amt: -177.00, mon: 'MXN', ok: false, res: 177.00, tarj: 'Tarjeta gastos', comp: 'Esteban', rs: 'Servicios FTS',
-    art: '', ana: '', po: '', bill: '', sb: '', ff: '', tk: '' },
+    amt: -177.00, mon: 'MXN', ok: true, res: 0, res_apunte: 0, wd: HOY, tarj: 'Tarjeta gastos', comp: 'Esteban', rs: 'Servicios FTS',
+    art: '', ana: '', po: '', bill: 'BILL3346', sb: 'PAGADA', ff: '', tk: '' },
   { id: 9009, company_id: 1, _jid: 61, d: '2026-08-07', j: 'Jeeves Tarjeta Credito', tipo: 'Egreso', ref: '[Primary ****6831] BPK',
     amt: -2605.60, mon: 'MXN', ok: true, res: 0, wd: HOY, po: 'PO7009', bill: 'BILL3009', sb: 'PAGADA', ana: '', ff: '',
     tarj: 'Primary', comp: 'Felipe', rs: 'Servicios FTS', art: '', tk: '' },
@@ -81,14 +81,14 @@ var FILAS = [
     ref: '[FONDEO] Credit Line', amt: 175292.28, mon: 'MXN', ok: false, res: 175292.28, tarj: '', comp: '',
     rs: 'Servicios FTS', art: '', ana: '', po: '', bill: '', sb: '', ff: '', tk: '' },
   { id: 9013, company_id: 1, _jid: 61, d: '2026-08-31', j: 'Jeeves Tarjeta Credito', tipo: 'Egreso',
-    ref: '[Tarjeta gastos ****4548] Oxxo', amt: -48.00, mon: 'MXN', ok: false, res: 48.00,
-    tarj: 'Tarjeta gastos', comp: 'Esteban', rs: 'Servicios FTS', art: '', ana: '', po: '', bill: '', sb: '', ff: '', tk: '' },
+    ref: '[Tarjeta gastos ****4548] Oxxo', amt: -48.00, mon: 'MXN', ok: true, res: 0, res_apunte: 0, wd: HOY,
+    tarj: 'Tarjeta gastos', comp: 'Esteban', rs: 'Servicios FTS', art: '', ana: '', po: '', bill: 'BILL3347', sb: 'PAGADA', ff: '', tk: '' },
   { id: 9014, company_id: 1, _jid: 61, d: '2026-08-28', j: 'Jeeves Tarjeta Credito', tipo: 'Egreso',
-    ref: '[Tarjeta gastos ****4548] JT Carnesnl', amt: -2000.00, mon: 'MXN', ok: false, res: 2000.00,
-    tarj: 'Tarjeta gastos', comp: 'Esteban', rs: 'Servicios FTS', art: '', ana: '', po: '', bill: '', sb: '', ff: '', tk: '' },
+    ref: '[Tarjeta gastos ****4548] JT Carnesnl', amt: -2000.00, mon: 'MXN', ok: true, res: 0, res_apunte: 0, wd: HOY,
+    tarj: 'Tarjeta gastos', comp: 'Esteban', rs: 'Servicios FTS', art: '', ana: '', po: '', bill: 'BILL3348', sb: 'PAGADA', ff: '', tk: '' },
   { id: 9015, company_id: 1, _jid: 61, d: '2026-08-28', j: 'Jeeves Tarjeta Credito', tipo: 'Egreso',
-    ref: '[Felipe Pérez ****4666] Adobe', amt: -99.00, mon: 'MXN', ok: false, res: 99.00,
-    tarj: 'Felipe Pérez', comp: 'Felipe', rs: 'Servicios FTS', art: '', ana: '', po: '', bill: '', sb: '', ff: '', tk: '' },
+    ref: '[Felipe Pérez ****4666] Adobe', amt: -99.00, mon: 'MXN', ok: true, res: 0, res_apunte: 0, wd: HOY,
+    tarj: 'Felipe Pérez', comp: 'Felipe', rs: 'Servicios FTS', art: '', ana: '', po: '', bill: 'BILL3349', sb: 'PAGADA', ff: '', tk: '' },
   { id: 9010, company_id: 6, _jid: 122, d: '2026-08-24', j: 'BUS COMPLETE CHK', tipo: 'Ingreso',
     ref: 'REMOTE ONLINE DEPOSIT # 1', amt: 10700.00, mon: 'USD', ok: false, res: 10700.00, tarj: '', comp: '',
     rs: 'FTS LLC', art: '', ana: '', po: '', bill: '', sb: '', ff: '', tk: '' }
@@ -108,7 +108,7 @@ var STATUS = {
   ],
   cron: { timezone: 'America/Monterrey', rules: ['0,30 7-16 * * 1-5', '0,10,20,30,40,50 17 * * 1-5', '0 18 * * 1-5'] },
   por_journal: [
-    { journal: 61, label: 'Jeeves Tarjeta Credito', en_motor: true, post_total: 168, pre_pend: 1846 },
+    { journal: 61, label: 'Jeeves Tarjeta Credito', en_motor: true, post_total: 172, pre_pend: 1846 },
     { journal: 122, label: 'BUS COMPLETE CHK', en_motor: false, post_total: 224, pre_pend: 199 },
     { journal: 123, label: 'Chase Ink Unlimited 9207', en_motor: false, post_total: 169, pre_pend: 70 }
   ],
@@ -122,9 +122,9 @@ var STATUS = {
   // → faltan 9, que es exactamente lo que reproducen las filas 9004/9005/9006/9007/9011-9015.
   metricas: {
     fecha_corte: '2026-07-24',
-    cumplimiento: { post_corte_total: 561, post_corte_conciliadas: 159 },
+    cumplimiento: { post_corte_total: 565, post_corte_conciliadas: 168 },
     por_journal: [
-      { journal: 61,  label: 'Jeeves Tarjeta Credito',   en_motor: true,  post_total: 168, post_conc: 159, pre_pend: 1846, pre_monto: 5790823 },
+      { journal: 61,  label: 'Jeeves Tarjeta Credito',   en_motor: true,  post_total: 172, post_conc: 168, pre_pend: 1846, pre_monto: 5790823 },
       { journal: 122, label: 'BUS COMPLETE CHK',         en_motor: false, post_total: 224, post_conc: 0,   pre_pend: 199,  pre_monto: 0 },
       { journal: 123, label: 'Chase Ink Unlimited 9207', en_motor: false, post_total: 169, post_conc: 0,   pre_pend: 70,   pre_monto: 0 }
     ],
@@ -146,10 +146,10 @@ window.FinClient = {
       pagination: { total_count: FILAS.length, truncado: false, cap: 6000 } });
     if (ep === '/fin/captura-sugerencias') return Promise.resolve({
       lineas: [
-        { line_id: 9006, nivel: 'sugerida', candidatos: [
-          { bill_aml_id: 111, bill_name: 'BILL3345', partner: 'Proferre', score: 0.91, monto_bill: 340.96,
-            banda: 'alta', pre_marcado: true, fecha: '2026-08-27', days_diff: 0 }] },
-        { line_id: 9007, nivel: 'sin-documento', candidatos: [] },
+        // 9006 y 9007 ya no piden sugerencia: quedaron CONCILIADAS al reproducir el estado real
+        // del 2026-09-03, donde lo unico pendiente en Jeeves son 2 fondeos y 2 devoluciones.
+        // Eso es justo el caso que el foco debe pintar VERDE pese a que el % no llegue a 100.
+        // La cobertura de "linea con candidato" la lleva 9008 (Chase).
         // 9008 es la linea de Chase (company 6). Existe para reproducir el caso REAL del
         // 2026-09-03: candidato bueno, y el conciliar responde NO_SUSPENSE_UNICA porque el
         // motor busca la pata de suspense en la cuenta de la otra empresa.


### PR DESCRIPTION
## El reporte

Jeeves llegó a **0 por conciliar** y seguía en amarillo.

```js
var c2 = p === null ? 'off' : (p >= 100 ? 'g' : p >= 85 ? 'y' : 'r');
```

El color salía del **porcentaje de Odoo**: 168 de 172 es 97.7% → amarillo. Pero las 4 que faltaban son **2 fondeos y 2 devoluciones** — el motor no las cierra y no son trabajo de nadie.

Desde V1.02 el titular ya mide lo **accionable**, así que el foco lo contradecía: decía *«0 por conciliar»* en grande y encendía la luz de *«vas a medias»*. Es la misma incoherencia que este módulo lleva toda la tanda corrigiendo, en la pieza que más rápido se lee.

## El cambio

El color pasa a responder **«¿queda algo por hacer?»** en vez de «¿cuánto le falta al 100%?». Verde cuando el pendiente accionable es cero, aunque el porcentaje no llegue a 100.

Cuando **no se puede descomponer** —ventana corta, o desglose que no cuadra con el server— se cae al comportamiento anterior: nunca se pinta verde sobre un número que no se pudo verificar.

**El porcentaje no se toca.** Sigue siendo el de Odoo y se lee en el renglón de abajo junto al total sin conciliar, que es donde vive la fidelidad al ERP. Y la leyenda se corrigió, porque decía *«la meta es 100%: verde solo al llegar»*.

## El harness

Pasa a reproducir el estado real del 2026‑09‑03 —Jeeves 168/172 con las 4 restantes en fondeos y devoluciones—, que es justo el caso que antes no estaba cubierto por ninguna prueba. Las cinco filas de gasto quedan conciliadas, y la cobertura de «línea con candidato» se mueve a la de Chase, que es la funcionalidad nueva.

## Verificación

| gate | |
|---|---|
| `tests/gate-instrumentos-pago.js` | 55/55 |
| `tests/visual-bancos.js` | **71/71** |

Asserts nuevos, en los tres anchos: con 0 por conciliar el foco es verde aunque el % no llegue a 100, y **ninguna fuente con pendiente sale verde**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017aCfYqG8Bi1yMHM5g2xsVb

---
_Generated by [Claude Code](https://claude.ai/code/session_017aCfYqG8Bi1yMHM5g2xsVb)_