### PR TITLE
finanzas(bancos) V1.08: dejar de usar el mismo verbo para dos cosas distintas

### DIFF
--- a/finanzas/js/modules/instrumentos-pago.js
+++ b/finanzas/js/modules/instrumentos-pago.js
@@ -27,7 +27,7 @@
   // comercial/machote y DEBE coincidir con finanzas/version.json — el gate lo verifica, porque
   // una pantalla que dice una versión y un archivo que dice otra deja de ser evidencia de nada.
   // Sustituye a la numeración 0.x.y (última: 0.5.36), conservada en version.json.
-  var IP_BUILD = 'V1.07';
+  var IP_BUILD = 'V1.08';
   var RESIDUAL_UMBRAL_MXN = 10000;        // coherente con fin/captura-status
   var SHEETJS_CDN = 'https://cdn.sheetjs.com/xlsx-0.20.3/package/dist/xlsx.full.min.js';
   // Endpoints reales (contrato construido en la sesión de backend; verificar nombres de
@@ -1774,7 +1774,12 @@
 
           var detalle = conc + ' de ' + x.post_total + ' · ' +
             '<span style="color:' + barcTxt(c2) + ';font-weight:700">' + (p === null ? '—' : p + '%') + '</span>';
-          if (comp.ok && comp.fon + comp.dev > 0) detalle += ' · ' + faltan + ' sin conciliar en total';
+          // "abiertas en Odoo", no "sin conciliar": el titular de arriba ya usa el verbo
+          // conciliar para el TRABAJO pendiente, y repetirlo aquí para el flag is_reconciled
+          // ponía dos cifras del mismo verbo una debajo de otra —"0 por conciliar" y "4 sin
+          // conciliar"— que se leen como una contradicción. Son dos cosas distintas y ahora
+          // se llaman distinto.
+          if (comp.ok && comp.fon + comp.dev > 0) detalle += ' · ' + faltan + ' abiertas en Odoo';
 
           return '<div class="s2card meta' + (x.en_motor ? '' : ' sinmotor') + '">' +
             '<div class="s2ct"><span class="light ' + c2 + '"></span>' + esc(x.label) +
@@ -1895,14 +1900,31 @@
         return no('<div class="s2cw">El desglose no cuadra con el server (' + local + ' vs ' + faltan +
           '): la tabla ve más pendientes de las que reporta el semáforo. ' + link + '</div>');
       }
-      var partes = [];
-      if (conc) partes.push('<b>' + conc + '</b> por conciliar');
-      if (fon) partes.push('<b>' + fon + '</b> ' + (fon === 1 ? 'fondeo' : 'fondeos'));
-      if (dev) partes.push('<b>' + dev + '</b> ' + (dev === 1 ? 'devolución' : 'devoluciones'));
+      // El desglose ya no repite el titular. Antes decía "5 por conciliar · 2 fondeos · 2
+      // devoluciones" con "5 por conciliar" también arriba en grande; y en el caso de cero
+      // dejaba al lector sumando para entender por qué el total no cuadraba con el titular.
+      // Ahora responde la pregunta que el número de arriba deja abierta: si no hay nada por
+      // conciliar, ¿qué son las que Odoo tiene abiertas?
+      var extra = fon + dev;
+      var txt = '';
+      if (extra) {
+        var comoSon = [];
+        if (fon) comoSon.push('<b>' + fon + '</b> ' + (fon === 1 ? 'fondeo' : 'fondeos'));
+        if (dev) comoSon.push('<b>' + dev + '</b> ' + (dev === 1 ? 'devolución' : 'devoluciones'));
+        var cuantas = extra === 1
+          ? (conc ? 'La otra abierta' : 'La única abierta')
+          : ((conc ? 'Las otras ' : 'Las ') + extra + ' abiertas');
+        // El motivo se dice por categoría, no por instancia: así no hay que concordar el
+        // número y además cada una explica SU razón, que no es la misma.
+        var porque = (fon && dev)
+          ? 'Ninguna casa contra una factura de proveedor: la devolución va contra una nota de crédito y el fondeo contra el lado BBVA.'
+          : (fon ? 'Un fondeo no casa contra una factura: su contrapartida es el lado BBVA, que todavía no se captura en Odoo.'
+                 : 'Una devolución no casa contra una factura: casa contra una nota de crédito, o reduce el bill original.');
+        txt = cuantas + ' no son trabajo pendiente — ' + comoSon.join(' y ') + '. ' + porque + ' ';
+      }
       return { ok: true, conc: conc, fon: fon, dev: dev,
-        html: '<div class="s2cw">' + partes.join(' · ') +
-          (fon + dev ? ' — fondeos y devoluciones no casan contra una factura, el motor no las cierra' : '') +
-          ' · <a class="s2ver" data-vercorte="' + esc(label) + '">ver en la tabla</a></div>' };
+        html: '<div class="s2cw">' + txt +
+          '<a class="s2ver" data-vercorte="' + esc(label) + '">ver en la tabla</a></div>' };
     }
     // Lleva la tabla al MISMO universo que mide el semáforo, para que los dos números se puedan
     // comparar de verdad en vez de creerle a uno de los dos.

--- a/finanzas/version.json
+++ b/finanzas/version.json
@@ -1,9 +1,14 @@
 {
-  "version": "V1.07",
+  "version": "V1.08",
   "fecha": "2026-09-03",
   "modulo": "finanzas",
   "esquema": "V<mayor>.<menor de dos dígitos>. Un incremento de 0.01 por cada merge a main. Al pasar de .99 sube el mayor y el menor vuelve a 00.",
   "historial": [
+    {
+      "version": "V1.08",
+      "pr": null,
+      "nota": "La tarjeta usaba el mismo verbo para dos cosas distintas: \"0 por conciliar\" (trabajo pendiente) y \"4 sin conciliar en total\" (el flag is_reconciled de Odoo), uno debajo del otro. Verificado en Odoo: las 4 son 2 FONDEO y 2 DEVOLUCION, cero gastos. El renglon del porcentaje pasa a decir \"abiertas en Odoo\", y el desglose deja de repetir el titular para responder la pregunta que ese numero deja abierta: si no hay nada por conciliar, que son las que quedan."
+    },
     {
       "version": "V1.07",
       "pr": null,


### PR DESCRIPTION
## El ruido

La tarjeta de Jeeves decía **«0 por conciliar»** en grande y, un renglón abajo, **«4 sin conciliar en total»**. Se leen como una contradicción y no lo son: el primero es **trabajo pendiente**, el segundo es el flag `is_reconciled` de Odoo. El verbo repetido era todo el problema.

## El dato, verificado antes de tocar el texto

Journal 61 desde el corte, sin conciliar:

```
33347  2026-08-31  [FONDEO] Credit Line               168,574.45
32866  2026-08-09  [DEVOLUCIÓN ****Inns] Luis angel       860.98
32848  2026-08-08  [DEVOLUCIÓN ****Inns] Luis angel       861.59
32493  2026-07-31  [FONDEO] Credit Line               175,292.28
```

Cuatro líneas, **cero gastos**. Los dos números eran correctos; era la palabra la que estaba haciendo doble trabajo.

## El cambio

El renglón del porcentaje pasa a decir **«4 abiertas en Odoo»**, que es literalmente lo que significa el flag y no compite con el titular.

Y el desglose deja de repetir lo que ya dice el titular —antes: *«5 por conciliar · 2 fondeos · 2 devoluciones»* con el 5 también arriba en grande— para responder la pregunta que el número deja abierta: **si no hay nada por conciliar, qué son las que quedan.**

> Las **4** abiertas no son trabajo pendiente — **2** fondeos y **2** devoluciones. Ninguna casa contra una factura de proveedor: la devolución va contra una nota de crédito y el fondeo contra el lado BBVA.

El motivo se explica **por categoría y no por instancia**, así que el texto no depende de concordar el número y además cada tipo da su razón, que no es la misma.

## Verificación

| gate | |
|---|---|
| `tests/gate-instrumentos-pago.js` | 55/55 |
| `tests/visual-bancos.js` | 71/71 |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017aCfYqG8Bi1yMHM5g2xsVb

---
_Generated by [Claude Code](https://claude.ai/code/session_017aCfYqG8Bi1yMHM5g2xsVb)_