### PR TITLE
comercial(machote) V1.10: lo que salió de las pruebas con la gente

### DIFF
--- a/comercial/machote/README.md
+++ b/comercial/machote/README.md
@@ -64,8 +64,9 @@ versión es peor que no tener indicador.
 | `js/reglas.js` | 30 reglas en un arreglo de configuración, separadas del motor que las corre. |
 | `js/demo.js` | Datos de ejemplo. Lo que viene del machote real va marcado `REAL`; lo inventado, `SUPUESTO`. |
 | `js/app.js` | Vistas y ruteo. |
+| `js/pegar.js` | El pegado de tablas: separador, columnas y revisión previa. |
 | `js/almacen.js` | El autoguardado. UNA pieza entre la pantalla y donde viven los datos. |
-| `tests/pruebas-navegador.js` | 71 pruebas de navegador. |
+| `tests/pruebas-navegador.js` | 82 pruebas de navegador. |
 
 ## Cómo se calcula el precio
 
@@ -250,6 +251,53 @@ Treinta cubren lo que se ve en el acervo y `+ partida` agrega sin límite.
 Un renglón en blanco **no se marca como hueco**. «Sin precio» sale sólo en uno
 que alguien empezó a llenar; en los treinta vacíos sería una alerta que aparece
 siempre, y una alerta que aparece siempre deja de leerse.
+
+## Pegar una tabla
+
+El proveedor ya mandó la lista escrita. Volverla a teclear no es sólo lento: es
+donde se cuela el error de dedo **en el precio**, que es el dato que nadie vuelve
+a verificar.
+
+`js/pegar.js` interpreta un bloque pegado —de Claude, de un correo, de Excel, de
+un PDF— y saca cantidad, unidad, tipo, descripción, modelo, marca, precio y
+moneda. Elige el separador **por consistencia, no por frecuencia**: gana el que
+produce el mismo número de columnas en la mayoría de los renglones, porque uno
+que da 3 columnas en una fila y 7 en la siguiente no es el separador, es un
+carácter que salía en el texto.
+
+Sin encabezado, adivina por la **forma** de los datos: la columna con más texto
+largo es la descripción, y de las numéricas, **la que trae enteros es la cantidad
+y la que trae decimales es el precio**. Ordenar por magnitud fallaba en cuanto la
+lista traía muchas piezas baratas — «250 cables a 18.50» ponía la cantidad del
+lado del precio.
+
+**Nada se aplica solo.** Interpreta, enseña lo que entendió renglón por renglón
+con sus avisos, y escribe cuando alguien lo aprueba mirándolo. Un parser que
+acierta el 90% y aplica solo mete un 10% de basura que nadie ve.
+
+El `Tipo` que no venga en la tabla **queda vacío**: Materiales o Servicios elige
+el multiplicador, y adivinarlo movería el precio.
+
+## Lo que decide el verde
+
+Un renglón se pinta cuando tiene **cantidad y precio**. Con sólo la cantidad está
+a medias y no aporta un peso al total; pintarlo diría «listo» de algo que todavía
+no suma.
+
+## Nada negativo
+
+Ni horas, ni personas, ni precios, ni multiplicadores. Se corta en el **único
+escritor** (`setPath`) y no en cada campo: el `min=0` del input frena las
+flechitas y el teclado, pero no frena escribir «-5» ni pegarlo. Un precio
+negativo no se ve como un error — se ve como un total más chico, que es peor.
+
+## Borrar un machote
+
+Se borra **En creación** y **En revisión**. **Enviado a Odoo no se borra nunca**:
+es el documento con el que se vendió, y si desaparece, desaparece la única
+explicación de por qué el precio fue ese. Lo que se hace con él es cambiarle el
+estado. El candado está en dos lados —no se pinta el botón, y el manejador lo
+vuelve a comprobar— porque el primero es cosmético.
 
 ## Quién entra
 

--- a/comercial/machote/css/machote.css
+++ b/comercial/machote/css/machote.css
@@ -543,3 +543,36 @@ table.rejilla tr.capturada > td:first-child { box-shadow: inset 3px 0 0 var(--x-
               border-radius: 8px; }
 .btn.primario { background: var(--acento); color: #fff; border-color: var(--acento);
                 min-height: var(--toque); margin-top: 6px; }
+
+/* ── La columna Tipo ────────────────────────────────────────────────────
+ * Iba tan angosta que no se alcanzaba a leer si decía Materiales o Servicios
+ * — y es la columna que elige el multiplicador, o sea la que decide el precio.
+ * Un desplegable que no deja ver lo seleccionado es peor que no tenerlo. */
+.cel.wtipo { min-width: 118px; }
+
+/* ── Borrar un machote de la lista ──────────────────────────────────────*/
+.fila { display: flex; align-items: stretch; gap: 6px; margin-bottom: 8px; }
+.fila .item { flex: 1 1 auto; min-width: 0; margin-bottom: 0; }
+.fila .borrar, .fila .candado { flex: 0 0 auto; align-self: center; }
+.ico.candado { display: inline-flex; align-items: center; justify-content: center;
+               min-width: var(--toque); min-height: var(--toque); font-size: 14px;
+               opacity: .55; cursor: help; }
+
+/* ── Pegar una tabla ────────────────────────────────────────────────────*/
+.modal { position: fixed; inset: 0; background: rgba(0,0,0,.45); z-index: 100;
+         display: flex; align-items: flex-start; justify-content: center;
+         padding: 16px; overflow: auto; }
+.modal .caja { background: var(--fondo); border-radius: 14px; padding: 18px;
+               width: 100%; max-width: 880px; margin: auto; }
+.modal h3 { margin: 0 0 6px; }
+.modal textarea { width: 100%; box-sizing: border-box; font: 13px/1.5 ui-monospace,
+                  SFMono-Regular, Menlo, monospace; padding: 10px;
+                  border: 1px solid var(--linea); border-radius: 10px;
+                  background: var(--fondo); color: var(--tinta); resize: vertical; }
+.modal textarea:focus { outline: 2px solid var(--acento); outline-offset: 1px; }
+.modal .acciones { display: flex; gap: 8px; justify-content: flex-end; margin-top: 14px; }
+.modal .acciones .btn { width: auto; min-height: var(--toque); padding: 0 16px; }
+.modal .rejilla { margin-top: 4px; }
+/* El renglón que necesita una mirada no se esconde ni se descarta: se marca. */
+.modal tr.ojo > td { background: #fff8e5; }
+.aviso.warn { border-left-color: var(--ambar); }

--- a/comercial/machote/index.html
+++ b/comercial/machote/index.html
@@ -36,6 +36,7 @@
 <script src="js/calc.js"></script>
 <script src="js/demo.js"></script>
 <script src="js/reglas.js"></script>
+<script src="js/pegar.js"></script>
 <script src="js/app.js"></script>
 </body>
 </html>

--- a/comercial/machote/js/app.js
+++ b/comercial/machote/js/app.js
@@ -40,7 +40,7 @@
    * 2026-09-03 (por instrucción de Esteban), pero lleva el suyo aparte y va en
    * V1.00. Planeación sigue en `2.4.1` y el kiosko sólo con cadena de build;
    * a esos no se propaga. */
-  const VERSION = 'V1.09';
+  const VERSION = 'V1.10';
   const $  = (s, r) => (r || document).querySelector(s);
   const $$ = (s, r) => Array.prototype.slice.call((r || document).querySelectorAll(s));
   const clon = (x) => JSON.parse(JSON.stringify(x));
@@ -116,6 +116,12 @@
    *  vendio. Editarlo despues seria reescribir la historia. */
   const congelado = (m) => !!((D.ESTADOS[m && m.estado] || {}).congelado);
 
+  /** Un machote enviado a Odoo NO se borra nunca. Es el documento con el que se
+   *  vendió: si desaparece, desaparece la única explicación de por qué el
+   *  precio fue ese. Lo que se hace con él es cambiarle el estado, no borrarlo.
+   *  En creación y En revisión sí se borran: ahí todavía no hay historia. */
+  const borrable = (m) => !((D.ESTADOS[m && m.estado] || {}).sin_borrar);
+
   const esc = (s) => String(s === null || s === undefined ? '' : s)
     .replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;').replace(/"/g, '&quot;');
 
@@ -146,11 +152,16 @@
   const cel = (path, val, cls, ph) =>
     '<input class="cel ' + (cls || '') + '" data-cel="' + path + '" value="' + esc(nn(val)) + '"' +
     (ph ? ' placeholder="' + esc(ph) + '"' : '') + '>';
+  /* Los números que se capturan aquí son cantidades, personas, precios y
+   * multiplicadores. Ninguno tiene sentido en negativo, y un precio negativo
+   * no da un error: da un total más chico y nadie lo nota. `min=0` frena las
+   * flechitas y el teclado numérico del teléfono; el saneo del `setPath` frena
+   * lo que se escriba o se pegue a mano. */
   const celNum = (path, val, cls, ph) =>
-    '<input class="cel num ' + (cls || '') + '" type="number" step="any" data-cel="' + path + '" data-num' +
+    '<input class="cel num ' + (cls || '') + '" type="number" step="any" min="0" data-cel="' + path + '" data-num' +
     ' value="' + esc(nn(val)) + '"' + (ph ? ' placeholder="' + esc(ph) + '"' : '') + '>';
-  const celSel = (path, val, ops) =>
-    '<select class="cel" data-cel="' + path + '">' +
+  const celSel = (path, val, ops, cls) =>
+    '<select class="cel ' + (cls || '') + '" data-cel="' + path + '">' +
     ops.map(o => '<option value="' + esc(o) + '"' + (o === val ? ' selected' : '') + '>' + esc(o || '—') + '</option>').join('') +
     '</select>';
 
@@ -159,6 +170,13 @@
   const celLibre = (path, val, lista, cls) =>
     '<input class="cel ' + (cls || '') + '" list="' + lista + '" data-cel="' + path + '"' +
     ' value="' + esc(nn(val)) + '" autocomplete="off">';
+
+  /** Ningún número de este machote tiene sentido en negativo: ni horas, ni
+   *  personas, ni precios, ni multiplicadores. Y un negativo no se ve como un
+   *  error — se ve como un total más chico, que es peor. Se corta AQUÍ, en el
+   *  único escritor, y no en cada campo: el `min=0` del input frena las
+   *  flechitas y el teclado, pero no frena escribir "-5" ni pegarlo. */
+  const sanea = (v) => (typeof v === 'number' && v < 0) ? 0 : v;
 
   /** Escribe por ruta. `s:<sid>:mo:<i>:campo` · `s:<sid>:partidas:<i>:campo`
    *  `eq:<venta|ops|cli>:<i>:campo` · `nom:<sid>` · o campo anidado. */
@@ -169,17 +187,17 @@
       const s = m.secciones.find(x => x.id === p[1]); if (!s) return;
       const arr = p[2] === 'mo' ? s.mo : s.partidas;
       const l = arr[parseInt(p[3], 10)]; if (!l) return;
-      l[p[4]] = val; return;
+      l[p[4]] = sanea(val); return;
     }
     if (p[0] === 'eq') {
       const key = p[1] === 'venta' ? 'equipo_venta' : p[1] === 'ops' ? 'equipo_operaciones' : 'equipo_cliente';
       const it = (m[key] || [])[parseInt(p[2], 10)]; if (!it) return;
-      it[p[3]] = val; return;
+      it[p[3]] = sanea(val); return;
     }
     const parts = path.split('.');
     let o = m;
     for (let i = 0; i < parts.length - 1; i++) { if (!o[parts[i]]) o[parts[i]] = {}; o = o[parts[i]]; }
-    o[parts[parts.length - 1]] = val;
+    o[parts[parts.length - 1]] = sanea(val);
   }
 
   /* ── Ruteo ───────────────────────────────────────────────────────────── */
@@ -277,13 +295,18 @@
 
     const filas = visibles.map(m => {
       const rev = R.revisar(m), c = rev.calc;
-      return '<a class="item" href="#/m/' + m.id + '">' +
+      return '<div class="fila">' +
+        '<a class="item" href="#/m/' + m.id + '">' +
         '<div class="grow"><strong>' + esc(m.nombre) + '</strong>' +
         '<div class="tiny">' + esc(m.cliente) + (m.so ? ' · ' + esc(m.so) : '') + ' · ' + m.id + '</div></div>' +
         '<div class="right"><span class="chip" style="background:' + est[m.estado].color + '">' + est[m.estado].label + '</span>' +
         '<div class="tiny mono n-' + (c.costoIncompleto ? 'warn' : nivelMargen(c.margen)) + '">' +
         mx(c.precio) + ' · ' + pc(c.margen) + (c.costoIncompleto ? '*' : '') + '</div>' +
-        '<div class="tiny">' + (rev.duras.length ? '⛔ ' + rev.duras.length + ' duras' : '✓ sin duras') + '</div></div></a>';
+        '<div class="tiny">' + (rev.duras.length ? '⛔ ' + rev.duras.length + ' duras' : '✓ sin duras') + '</div></div></a>' +
+        (borrable(m)
+          ? '<button class="ico peligro borrar" data-borrar="' + m.id + '" title="Eliminar machote">×</button>'
+          : '<span class="ico candado" title="Enviado a Odoo: no se borra, sólo cambia de estado">🔒</span>') +
+        '</div>';
     }).join('');
 
     const ords = ST.ordenes.map(o =>
@@ -316,6 +339,21 @@
     if (q) q.oninput = () => { ST.busca = q.value; vHome(); $('#q').focus();
                                $('#q').setSelectionRange(ST.busca.length, ST.busca.length); };
     $$('[data-filtro]').forEach(b => b.onclick = () => { ST.filtro = b.dataset.filtro; vHome(); });
+
+    $$('[data-borrar]').forEach(b => b.onclick = (ev) => {
+      ev.preventDefault(); ev.stopPropagation();
+      const m = mach(b.dataset.borrar);
+      if (!m) return;
+      // Segundo candado, además de no pintar el botón: si mañana alguien pinta
+      // el botón por error, esto sigue impidiendo borrar lo que ya se vendió.
+      if (!borrable(m)) { toast('Un machote enviado a Odoo no se borra.'); return; }
+      if (!confirm('¿Eliminar «' + m.nombre + '»?\n\nNo hay deshacer.')) return;
+      const i = ST.machotes.findIndex(x => x.id === m.id);
+      if (i >= 0) ST.machotes.splice(i, 1);
+      guardarYa();
+      vHome();
+      toast('Machote eliminado.');
+    });
   }
 
   /* ── Machote nuevo ─────────────────────────────────────────────────────
@@ -459,8 +497,10 @@
       ['Materiales y servicio', mx(cs.costoMat)],
       ['Costos Sumados (Mat, Servicio, Mano de obra)', mx2(cs.costo)],
       ['', ''],
-      ['Comisiones CLIENTE', mx(cs.venta ? c.escenario.comisionFts * (cs.venta / (c.venta || 1)) : 0)],
-      ['Comisiones FTS', mx(cs.venta ? c.escenario.comisionCliente * (cs.venta / (c.venta || 1)) : 0)],
+      // El porcentaje al lado del importe: sin él, "Comisiones FTS $79,108"
+      // no dice si eso es un 5% o un 15%, que es lo que se está decidiendo.
+      ['Comisiones CLIENTE ' + pc(c.pctCli), mx(cs.venta ? c.escenario.comisionCliente * (cs.venta / (c.venta || 1)) : 0)],
+      ['Comisiones FTS ' + pc(c.pctFts), mx(cs.venta ? c.escenario.comisionFts * (cs.venta / (c.venta || 1)) : 0)],
       ['Costos totales (Cuanto le cuesta a FTS?)', mx(cs.costo + (c.escenario.comisionFts + c.escenario.comisionCliente) * (cs.venta / (c.venta || 1)))],
       ['Precio de Venta FTS (Antes de comisiones)', mx(cs.venta)],
       ['Precio de Venta a cliente (Despues de comisiones)', mx2(cs.esc ? cs.esc.con_utilidad.precio : null)],
@@ -477,16 +517,7 @@
       '<tr><td class="et">Comision FTS</td><td>' + celNum('comision_fts', m.comision_fts, 'w70') + '</td></tr>' +
       '<tr><td class="et">Comision CLIENTE</td><td>' + celNum('comision_cliente', m.comision_cliente, 'w70') + '</td></tr>';
 
-    const cab =
-      '<div class="cab">' +
-      '<div class="blk"><table class="hoja2"><thead><tr><th>Costos desglosados</th><th></th></tr></thead>' +
-      '<tbody>' + izq +
-      '<tr><td class="et">Horas sección</td><td class="vl mono calc">' + Math.round(cs.horas || 0) + '</td></tr>' +
-      '</tbody></table></div>' +
-      '<div class="blk"><table class="hoja2"><thead><tr><th>Concepto</th><th>Margen de utilidad</th></tr></thead>' +
-      '<tbody>' + der + '</tbody></table>' +
-      '<div class="tiny nota">Horas extras = mano de obra × 2 = <strong>' + mg.extra + '</strong>. No se captura, igual que en el Excel.</div>' +
-      '</div></div>' +
+    const nombreSec =
       '<div class="nomsec"><span class="et">NOMBRE DE SECCIÓN</span>' + cel('nom:' + s.id, s.nombre, 'nombre') +
       '<span class="accsec">' +
         (idx > 0 ? '<button class="ico" data-movsec="' + s.id + '|-1" title="Mover a la izquierda">←</button>' : '') +
@@ -497,6 +528,20 @@
       '<div class="tiny nota">Sección ' + (idx + 1) + ' de ' + m.secciones.length +
       (idx >= C.MAX_SECCIONES ? ' · <strong class="n-bad">fuera de las diez ranuras del machote</strong>' : '') +
       '. Las secciones ocupan la ranura por posición, no por nombre.</div>';
+
+    const cab =
+      // El nombre va PRIMERO: es lo que dice en qué sección estás parado, y
+      // debajo de dos tablas de números no se lee hasta que ya te perdiste.
+      nombreSec +
+      '<div class="cab">' +
+      '<div class="blk"><table class="hoja2"><thead><tr><th>Costos desglosados</th><th></th></tr></thead>' +
+      '<tbody>' + izq +
+      '<tr><td class="et">Horas sección</td><td class="vl mono calc">' + Math.round(cs.horas || 0) + '</td></tr>' +
+      '</tbody></table></div>' +
+      '<div class="blk"><table class="hoja2"><thead><tr><th>Concepto</th><th>Margen de utilidad</th></tr></thead>' +
+      '<tbody>' + der + '</tbody></table>' +
+      '<div class="tiny nota">Horas extras = mano de obra × 2 = <strong>' + mg.extra + '</strong>. No se captura, igual que en el Excel.</div>' +
+      '</div></div>';
 
     // COSTO MANO DE OBRA — los diez renglones siempre presentes, en sus tres grupos.
     let filasMo = '';
@@ -515,10 +560,10 @@
         if (i < 0) { s.mo.push({ rol: rol.id, qty: '', personas: 1, pu: rol.pu, moneda: m.moneda }); i = s.mo.length - 1; }
         const l = s.mo[i], cl = C.costoMo(l, m), p = 's:' + s.id + ':mo:' + i + ':';
         const vacia = !(Number(l.qty) > 0);
-        // Verde = este renglon ya tiene cantidad. Con diez renglones fijos por
-        // seccion, saber de un vistazo cuales estan capturados es la diferencia
-        // entre revisar una hoja y leerla entera.
-        const cls = vacia ? 'enCero' : 'capturada';
+        // Verde = cantidad Y precio. Con sólo horas, el renglón está a medias y
+        // no aporta un peso al total; pintarlo diría "listo" de algo que todavía
+        // no suma.
+        const cls = C.capturada(l) ? 'capturada' : (vacia ? 'enCero' : '');
         filasMo +=
           '<tr class="' + cls + '">' +
           '<td class="rotulo" data-l="Renglón">' + esc(rol.label) + '</td>' +
@@ -551,11 +596,11 @@
     // COSTO MATERIALES Y SERVICIOS
     const filasMat = (s.partidas || []).map((l, j) => {
       const cl = C.costoPartida(l, m), p = 's:' + s.id + ':partidas:' + j + ':';
-      return '<tr' + (Number(l.qty) >= 1 ? ' class="capturada"' : '') + '>' +
+      return '<tr' + (C.capturada(l) ? ' class="capturada"' : '') + '>' +
         '<td data-l="Descripción">' + cel(p + 'descripcion', l.descripcion, 'desc') + '</td>' +
         '<td data-l="QTY">' + celNum(p + 'qty', l.qty, 'w60') + '</td>' +
         '<td data-l="Unidad">' + celLibre(p + 'unidad', l.unidad, 'unidades', 'w90') + '</td>' +
-        '<td data-l="Tipo">' + celSel(p + 'tipo', l.tipo, [''].concat(C.TIPOS)) + '</td>' +
+        '<td data-l="Tipo">' + celSel(p + 'tipo', l.tipo, [''].concat(C.TIPOS), 'wtipo') + '</td>' +
         '<td data-l="Modelo">' + cel(p + 'modelo', l.modelo, 'w110') + '</td>' +
         '<td data-l="Marca">' + cel(p + 'marca', l.marca, 'w90') + '</td>' +
         '<td data-l="Precio unitario">' + celNum(p + 'pu', l.pu, 'w90') + '</td>' +
@@ -591,6 +636,7 @@
       '</td><td></td><td class="vl mono calc fuerte" data-l="Con utilidad">' + mx(cs.ventaMat) + '</td><td colspan="3"></td></tr>' +
       '</tbody></table></div>' +
       '<div class="btnrow"><button class="btn" data-add="' + s.id + '">+ partida</button>' +
+      '<button class="btn" data-pegar="' + s.id + '">Pegar tabla</button>' +
       (cs.pisados ? '<span class="tiny n-warn">' + cs.pisados + ' margen(es) pisado(s) a mano en esta sección</span>' : '') +
       '</div>';
 
@@ -777,6 +823,98 @@
       '</div>';
   }
 
+  /* ── Pegar una tabla ───────────────────────────────────────────────────
+   *
+   * El proveedor ya mandó la lista escrita; volverla a teclear no es sólo lento,
+   * es donde se cuela el error de dedo en el precio, que es el dato que nadie
+   * vuelve a verificar.
+   *
+   * NADA se aplica solo. Se interpreta, se ENSEÑA lo que se entendió renglón
+   * por renglón, y se escribe cuando alguien lo aprueba mirándolo. Un parser
+   * que acierta el 90% y aplica solo mete un 10% de basura que nadie ve. */
+  function modalPegar(m, sid) {
+    const P = G.MachotePegar;
+    const cerrar = () => { const d = $('#modal'); if (d) d.remove(); };
+
+    const html =
+      '<div class="modal" id="modal"><div class="caja">' +
+      '<h3>Pegar una tabla</h3>' +
+      '<p class="tiny nota">Pega aquí una tabla de Claude, de un correo, de Excel o de una ' +
+      'cotización. Se entiende sola y <strong>te enseña qué entendió antes de escribir nada</strong>.</p>' +
+      '<textarea id="pg-txt" rows="7" placeholder="Cantidad | Descripción | Precio unitario&#10;4 | Rodamiento LM25UU | $4,200.00"></textarea>' +
+      '<div id="pg-prev"></div>' +
+      '<div class="acciones">' +
+      '<button class="btn" id="pg-cancel">Cancelar</button>' +
+      '<button class="btn primario" id="pg-ok" disabled>Agregar renglones</button>' +
+      '</div></div></div>';
+    document.body.insertAdjacentHTML('beforeend', html);
+
+    const txt = $('#pg-txt'), prev = $('#pg-prev'), ok = $('#pg-ok');
+    let ultimo = null;
+
+    const revisar = () => {
+      const r = P.interpretar(txt.value, { moneda: m.moneda });
+      ultimo = r;
+      ok.disabled = !r.ok;
+      if (!txt.value.trim()) { prev.innerHTML = ''; return; }
+      if (!r.ok) {
+        prev.innerHTML = '<div class="aviso bad">' + esc(r.motivo) +
+          '<div class="tiny">Prueba con una columna de descripción y una de precio, ' +
+          'separadas por tabulador, coma o barra.</div></div>';
+        return;
+      }
+      const conAviso = r.renglones.filter(x => x._avisos.length).length;
+      prev.innerHTML =
+        '<div class="aviso' + (conAviso ? ' warn' : ' ok') + '">Entendí <strong>' +
+        r.renglones.length + ' renglón(es)</strong> · separador: <strong>' + esc(r.sep) + '</strong> · ' +
+        (r.encabezado ? 'con encabezado' : 'sin encabezado, adiviné las columnas por su forma') +
+        (conAviso ? ' · <strong class="n-warn">' + conAviso + ' con algo que revisar</strong>' : '') +
+        '</div>' +
+        '<div class="scroll"><table class="rejilla"><thead><tr>' +
+        '<th>QTY</th><th>Unidad</th><th>Tipo</th><th>Descripción</th><th>Precio unitario</th><th>Moneda</th><th></th>' +
+        '</tr></thead><tbody>' +
+        r.renglones.map(x =>
+          '<tr' + (x._avisos.length ? ' class="ojo"' : '') + '>' +
+          '<td class="vl mono">' + esc(nn(x.qty)) + '</td>' +
+          '<td>' + esc(x.unidad || '—') + '</td>' +
+          '<td>' + esc(x.tipo || '—') + '</td>' +
+          '<td>' + esc(x.descripcion || '—') + '</td>' +
+          '<td class="vl mono">' + (x.pu === null ? '—' : mx(x.pu)) + '</td>' +
+          '<td>' + esc(x.moneda) + '</td>' +
+          '<td class="tiny n-warn">' + esc(x._avisos.join(', ')) + '</td></tr>').join('') +
+        '</tbody></table></div>' +
+        '<p class="tiny nota">El <strong>Tipo</strong> que no venga en la tabla queda vacío: ' +
+        'Materiales o Servicios decide el multiplicador, y adivinarlo movería el precio.</p>';
+    };
+
+    txt.oninput = revisar;
+    $('#pg-cancel').onclick = cerrar;
+    $('#modal').onclick = (ev) => { if (ev.target.id === 'modal') cerrar(); };
+
+    ok.onclick = () => {
+      if (!ultimo || !ultimo.ok) return;
+      const sec = m.secciones.find(x => x.id === sid);
+      if (!sec) { cerrar(); return; }
+      // Se meten donde caben: primero se rellenan los renglones en blanco que
+      // ya existen, y sólo se agregan nuevos cuando se acaban. Si no, pegar
+      // diez renglones dejaría treinta vacíos colgando debajo.
+      const nuevos = ultimo.renglones.map(x => ({
+        qty: x.qty, unidad: x.unidad, tipo: x.tipo, descripcion: x.descripcion,
+        modelo: x.modelo, marca: x.marca, pu: x.pu, moneda: x.moneda,
+        margen: null, link: x.link, comentario: x.comentario
+      }));
+      nuevos.forEach(n => {
+        const hueco = sec.partidas.findIndex(l => !C.usadaPartida(l));
+        if (hueco >= 0) sec.partidas[hueco] = n; else sec.partidas.push(n);
+      });
+      cerrar();
+      tocado();
+      pintarHoja(m); barra(m, C.calcular(m));
+      toast(nuevos.length + ' renglón(es) agregado(s).');
+    };
+    txt.focus();
+  }
+
   /* ── Barra fija ──────────────────────────────────────────────────────── */
   function barra(m, c) {
     const rev = R.revisar(m);
@@ -841,6 +979,7 @@
         barra(m, refrescarCalculados(m) || C.calcular(m));
       };
     });
+    $$('[data-pegar]').forEach(b => b.onclick = () => modalPegar(m, b.dataset.pegar));
     const sel = $('[data-estado]');
     if (sel) sel.onchange = () => {
       const nuevo = sel.value;

--- a/comercial/machote/js/calc.js
+++ b/comercial/machote/js/calc.js
@@ -57,6 +57,12 @@
    *  tres definiciones de lo mismo terminan divergiendo. */
   const usadaPartida = (l) => !!l && (num(l.qty) > 0 || !vacio(l.pu) || !!l.descripcion);
 
+  /** ¿Este renglón está CAPTURADO? Es lo que lo pinta de verde.
+   *  Cantidad **y** precio: con sólo la cantidad, el renglón está a medias y
+   *  no aporta un peso al total. Pintarlo verde diría "listo" de algo que
+   *  todavía no suma. Vale igual para mano de obra (horas × tarifa). */
+  const capturada = (l) => !!l && num(l.qty) > 0 && num(l.pu) > 0;
+
   /* Cuántos renglones de materiales trae una sección recién creada.
    *
    * El machote real trae **~180 en blanco** por sección (§2.4 del levantamiento):
@@ -108,12 +114,21 @@
       pu: r.pu,         // la tarifa de plantilla, que el capturista puede pisar
       moneda: moneda
     }));
+    /* Los diez primeros vienen preparados: cinco Materiales y cinco Servicios,
+     * en Pieza y con cantidad 0. No es un dato, es un ANDAMIO — arranca la
+     * captura sin obligar a elegir Tipo y Unidad diez veces antes de escribir
+     * la primera descripción. Con cantidad 0 no cuentan como usados, así que
+     * no disparan hallazgos ni se pintan de verde. Del once al treinta van
+     * completamente en blanco, como en el Excel. */
     const partidas = [];
     for (let i = 0; i < PARTIDAS_EN_BLANCO; i++) {
+      const preparada = i < 10;
       partidas.push({
-        qty: '', unidad: '', tipo: '',   // el Tipo lo elige el capturista: es
-        descripcion: '', modelo: '', marca: '',   // la columna que decide el
-        pu: null, moneda: moneda,                 // multiplicador
+        qty: preparada ? 0 : '',
+        unidad: preparada ? 'Pieza' : '',
+        tipo: preparada ? (i < 5 ? 'Materiales' : 'Servicios') : '',
+        descripcion: '', modelo: '', marca: '',
+        pu: null, moneda: moneda,
         margen: null, link: '', comentario: ''
       });
     }
@@ -444,7 +459,8 @@
     ROLES, ROL, GRUPOS, TIPOS, ESCENARIOS, MAX_SECCIONES,
     EMPRESAS, empresaDe, monedaPorDefecto,
     MARGENES_PLANTILLA, COMISION_FTS_PLANTILLA, MARGEN_DESEADO_PLANTILLA, REPARTO_PLANTILLA,
-    PARTIDAS_EN_BLANCO, EQUIPO_VENTA_PLANTILLA, EQUIPO_OPS_PLANTILLA, usadaPartida,
+    PARTIDAS_EN_BLANCO, EQUIPO_VENTA_PLANTILLA, EQUIPO_OPS_PLANTILLA,
+    usadaPartida, capturada,
     seccionNueva, machoteNuevo,
     tcEfectivo, margenes, costoMo, costoPartida, totalSeccion,
     calcular, precioParaMargen, repartir

--- a/comercial/machote/js/demo.js
+++ b/comercial/machote/js/demo.js
@@ -59,7 +59,7 @@
     borrador:   { label: 'En creación', color: '#8b8b8b', congelado: false, orden: 1 },
     revision:   { label: 'En revisión', color: '#c07a00', congelado: false, orden: 2 },
     enviado:    { label: 'Enviado a Odoo', color: '#1a7f37', congelado: true,
-                  exige_so: true, orden: 3 }
+                  exige_so: true, orden: 3, sin_borrar: true }
   };
   const FLUJO = ['borrador', 'revision', 'enviado'];
 

--- a/comercial/machote/js/pegar.js
+++ b/comercial/machote/js/pegar.js
@@ -1,0 +1,292 @@
+/* ═══ Machote · pegado de tablas ═══
+ *
+ * Convierte un bloque de texto pegado —de Claude, de un correo, de Excel, de
+ * una cotización de proveedor— en renglones de materiales.
+ *
+ * POR QUÉ EXISTE: hoy la lista de materiales se teclea renglón por renglón
+ * aunque el proveedor ya la mandó escrita. Teclear otra vez lo que ya está
+ * escrito no es sólo lento: es donde se cuelan los errores de dedo en el
+ * precio, que es el dato que nadie vuelve a verificar.
+ *
+ * LO QUE **NO** HACE, y es deliberado: no aplica nada solo. Interpreta, enseña
+ * lo que entendió renglón por renglón, y sólo escribe cuando alguien lo aprueba
+ * mirándolo. Un parser que acierta el 90% y aplica solo mete un 10% de basura
+ * que nadie ve — y aquí el 10% es un precio mal leído.
+ */
+(function (G) {
+  'use strict';
+
+  /* Separadores, en orden de confianza. El tabulador es el que produce Excel y
+   * el que casi nunca aparece dentro de una descripción; el `|` es el de las
+   * tablas de Markdown que escribe Claude; el `;` y la coma son los del CSV
+   * europeo y el americano, y la coma es la más peligrosa porque también vive
+   * dentro de los números ("1,250.00") y de las descripciones. */
+  const SEPARADORES = ['\t', '|', ';', ','];
+
+  /** Un número escrito por un humano o por una hoja de cálculo.
+   *  Acepta `$1,250.50`, `1.250,50`, `1 250,50`, `(300)` como negativo, y
+   *  devuelve `null` si no es un número. */
+  function aNumero(txt) {
+    if (txt === null || txt === undefined) return null;
+    let t = String(txt).trim();
+    if (!t) return null;
+    const negParen = /^\(.*\)$/.test(t);
+    t = t.replace(/^\(|\)$/g, '');
+    // Fuera moneda, espacios finos y cualquier letra pegada ("12 pzas", "MXN").
+    t = t.replace(/[$€£]|MXN|USD|mxn|usd/g, '').replace(/\s/g, '').trim();
+    if (!t) return null;
+    const tieneComa = t.indexOf(',') >= 0, tienePunto = t.indexOf('.') >= 0;
+    if (tieneComa && tienePunto) {
+      // El ÚLTIMO de los dos es el decimal: "1,250.50" y "1.250,50".
+      t = (t.lastIndexOf(',') > t.lastIndexOf('.'))
+        ? t.replace(/\./g, '').replace(',', '.')
+        : t.replace(/,/g, '');
+    } else if (tieneComa) {
+      // Sola, la coma es decimal si deja 1-2 cifras ("12,5"); si deja tres es
+      // separador de miles ("1,250"). Con más de una coma, siempre miles.
+      const partes = t.split(',');
+      t = (partes.length === 2 && partes[1].length <= 2)
+        ? partes.join('.') : partes.join('');
+    }
+    if (!/^-?\d*\.?\d+$/.test(t)) return null;
+    const n = parseFloat(t);
+    if (!isFinite(n)) return null;
+    return negParen ? -n : n;
+  }
+
+  const esNumero = (t) => aNumero(t) !== null;
+
+  /** Parte el texto en renglones y columnas.
+   *  El separador se elige por CONSISTENCIA, no por frecuencia: gana el que
+   *  produce el mismo número de columnas en la mayoría de los renglones. Un
+   *  separador que da 3 columnas en una fila y 7 en la siguiente no es el
+   *  separador, es un carácter que salía en el texto. */
+  function partir(texto) {
+    const crudas = String(texto || '').split(/\r?\n/)
+      .map(l => l.trim()).filter(l => l.length > 0);
+    if (!crudas.length) return { sep: null, filas: [] };
+
+    // Fuera los adornos de las tablas de Markdown: |---|---|
+    const lineas = crudas.filter(l => !/^[\s|:+-]+$/.test(l));
+    if (!lineas.length) return { sep: null, filas: [] };
+
+    let mejor = null;
+    SEPARADORES.forEach(sep => {
+      const cols = lineas.map(l => trocear(l, sep).length);
+      const max = Math.max.apply(null, cols);
+      if (max < 2) return;
+      // Cuántos renglones coinciden con el ancho más común.
+      const conteo = {};
+      cols.forEach(n => { conteo[n] = (conteo[n] || 0) + 1; });
+      const ancho = Object.keys(conteo).map(Number)
+        .filter(n => n >= 2)
+        .sort((a, b) => (conteo[b] - conteo[a]) || (b - a))[0];
+      if (!ancho) return;
+      const puntaje = conteo[ancho] + ancho * 0.1;   // desempata a más columnas
+      if (!mejor || puntaje > mejor.puntaje) mejor = { sep, ancho, puntaje };
+    });
+
+    // Sin separador claro: dos o más espacios, que es como queda una tabla
+    // copiada de un PDF o de una terminal.
+    if (!mejor) {
+      const filas = lineas.map(l => l.split(/\s{2,}/).map(x => x.trim()));
+      const anchos = filas.map(f => f.length);
+      if (Math.max.apply(null, anchos) < 2) return { sep: null, filas: [] };
+      return { sep: 'espacios', filas: filas };
+    }
+    return { sep: mejor.sep, filas: lineas.map(l => trocear(l, mejor.sep)) };
+  }
+
+  function trocear(linea, sep) {
+    let l = linea;
+    if (sep === '|') l = l.replace(/^\s*\|/, '').replace(/\|\s*$/, '');
+    return l.split(sep).map(x => x.trim());
+  }
+
+  /* Cómo se llama cada columna cuando la tabla trae encabezado. Se compara sin
+   * acentos ni mayúsculas: el acervo escribe "DESCRIPCIÓN", "Descripcion" y
+   * "descripción" en el mismo archivo. */
+  const ALIAS = {
+    qty:         ['qty', 'cant', 'cantidad', 'cants', 'pzas', 'piezas', 'q'],
+    unidad:      ['unidad', 'um', 'u m', 'medida', 'unid'],
+    tipo:        ['tipo', 'clase'],
+    descripcion: ['descripcion', 'description', 'concepto', 'partida', 'articulo',
+                  'producto', 'material', 'detalle', 'item'],
+    modelo:      ['modelo', 'model', 'no parte', 'num parte', 'numero de parte', 'sku', 'codigo', 'clave'],
+    marca:       ['marca', 'brand', 'fabricante'],
+    pu:          ['precio unitario', 'p unitario', 'precio', 'unitario', 'costo unitario',
+                  'costo', 'pu', 'importe unitario', 'unit price', 'price'],
+    total:       ['precio total', 'importe', 'total', 'subtotal', 'monto', 'amount'],
+    moneda:      ['moneda', 'divisa', 'currency'],
+    link:        ['link', 'liga', 'url', 'enlace', 'fuente'],
+    comentario:  ['comentario', 'nota', 'notas', 'observaciones', 'obs']
+  };
+
+  const norm = (t) => String(t || '').toLowerCase()
+    .normalize('NFD').replace(/[̀-ͯ]/g, '')
+    .replace(/[^a-z0-9 ]/g, ' ').replace(/\s+/g, ' ').trim();
+
+  /** ¿La primera fila es un encabezado? Lo es si NINGUNA de sus celdas es un
+   *  número y al menos una casa con un alias conocido. Una fila de puros textos
+   *  que no casa con nada puede ser perfectamente el primer material. */
+  function mapearEncabezado(fila) {
+    if (!fila || fila.length < 2) return null;
+    if (fila.some(esNumero)) return null;
+    const mapa = {}; let casaron = 0;
+    fila.forEach((celda, i) => {
+      const n = norm(celda);
+      if (!n) return;
+      for (const campo in ALIAS) {
+        if (ALIAS[campo].indexOf(n) >= 0 ||
+            ALIAS[campo].some(a => n === a || n.indexOf(a) === 0)) {
+          if (mapa[campo] === undefined) { mapa[campo] = i; casaron++; }
+          return;
+        }
+      }
+    });
+    return casaron >= 2 ? mapa : null;
+  }
+
+  /** Sin encabezado, se adivina por la FORMA de los datos, no por su posición:
+   *  la columna con más texto largo es la descripción; de las numéricas, la de
+   *  valores más chicos y enteros es la cantidad y la de valores más grandes es
+   *  el precio. Es una heurística y por eso el resultado se revisa antes de
+   *  aplicarse. */
+  function adivinar(filas) {
+    const ncol = Math.max.apply(null, filas.map(f => f.length));
+    const perfil = [];
+    for (let i = 0; i < ncol; i++) {
+      const vals = filas.map(f => f[i]).filter(x => x !== undefined && x !== '');
+      if (!vals.length) { perfil.push(null); continue; }
+      const nums = vals.map(aNumero).filter(x => x !== null);
+      perfil.push({
+        i: i,
+        pctNum: nums.length / vals.length,
+        largo: vals.reduce((a, v) => a + String(v).length, 0) / vals.length,
+        media: nums.length ? nums.reduce((a, b) => a + b, 0) / nums.length : 0,
+        enteros: nums.length ? nums.every(n => n === Math.round(n)) : false
+      });
+    }
+    const vivos = perfil.filter(Boolean);
+    const mapa = {};
+
+    const texto = vivos.filter(c => c.pctNum < 0.4).sort((a, b) => b.largo - a.largo);
+    if (texto.length) mapa.descripcion = texto[0].i;
+    if (texto.length > 1) {
+      // La segunda columna de texto más larga suele ser marca o modelo. No se
+      // adivina cuál: se deja fuera antes que ponerla mal.
+    }
+
+    const numericas = vivos.filter(c => c.pctNum >= 0.6).sort((a, b) => a.media - b.media);
+    if (numericas.length === 1) {
+      // Una sola columna de números: es el precio. Una lista con cantidades
+      // pero sin precios no es lo que la gente pega.
+      mapa.pu = numericas[0].i;
+    } else if (numericas.length >= 2) {
+      /* Primero por FORMA, no por magnitud: las cantidades se escriben enteras
+       * y los precios con centavos. Ordenar por promedio falla en cuanto la
+       * lista trae muchas piezas baratas — "250 cables a 18.50" pone la
+       * cantidad del lado del precio. Cuando las dos columnas son enteras (o
+       * las dos decimales) no discrimina, y ahí sí manda la magnitud. */
+      const ent = numericas.filter(c => c.enteros), dec = numericas.filter(c => !c.enteros);
+      if (ent.length && dec.length) {
+        mapa.qty = ent.sort((a, b) => a.media - b.media)[0].i;
+        mapa.pu  = dec.sort((a, b) => b.media - a.media)[0].i;
+      } else {
+        mapa.qty = numericas[0].i;                     // la de valores más chicos
+        mapa.pu  = numericas[numericas.length - 1].i;  // la de valores más grandes
+      }
+      if (numericas.length >= 3) {
+        // Con tres, la de en medio suele ser el precio unitario y la última el
+        // total (total = qty × pu). Se comprueba en vez de suponerlo.
+        const a = numericas[0], b = numericas[1], cc = numericas[2];
+        const casa = filas.some(f => {
+          const q = aNumero(f[a.i]), u = aNumero(f[b.i]), t = aNumero(f[cc.i]);
+          return q !== null && u !== null && t !== null && q * u > 0 &&
+                 Math.abs(q * u - t) / Math.max(Math.abs(t), 1) < 0.02;
+        });
+        if (casa) { mapa.qty = a.i; mapa.pu = b.i; mapa.total = cc.i; }
+      }
+    }
+    return mapa;
+  }
+
+  /** Interpreta un bloque pegado. Devuelve SIEMPRE la explicación de cómo lo
+   *  entendió, para que se pueda revisar antes de aplicar. */
+  function interpretar(texto, opciones) {
+    opciones = opciones || {};
+    const { sep, filas } = partir(texto);
+    if (!filas.length) {
+      return { ok: false, motivo: 'No encontré renglones con columnas en lo que pegaste.',
+               sep: null, encabezado: false, mapa: {}, renglones: [] };
+    }
+    let mapa = mapearEncabezado(filas[0]);
+    const conEncabezado = !!mapa;
+    const cuerpo = conEncabezado ? filas.slice(1) : filas;
+    if (!cuerpo.length) {
+      return { ok: false, motivo: 'Sólo encontré el encabezado; no venían renglones abajo.',
+               sep, encabezado: true, mapa: mapa || {}, renglones: [] };
+    }
+    if (!mapa) mapa = adivinar(cuerpo);
+    if (mapa.descripcion === undefined && mapa.pu === undefined) {
+      return { ok: false, motivo: 'No pude distinguir cuál columna es la descripción ni cuál el precio.',
+               sep, encabezado: conEncabezado, mapa: mapa, renglones: [] };
+    }
+
+    const dame = (f, k) => (mapa[k] === undefined ? '' : (f[mapa[k]] === undefined ? '' : f[mapa[k]]));
+    const monedaDoc = opciones.moneda || 'MXN';
+
+    const renglones = cuerpo.map(f => {
+      const desc = String(dame(f, 'descripcion') || '').trim();
+      let qty = aNumero(dame(f, 'qty'));
+      let pu  = aNumero(dame(f, 'pu'));
+      const total = aNumero(dame(f, 'total'));
+      // Si vino el total y no el unitario, se deriva. Es el caso de las tablas
+      // que sólo traen importe.
+      if (pu === null && total !== null && qty) pu = total / qty;
+      if (qty === null && pu !== null && total !== null && pu) qty = total / pu;
+
+      const tipoCrudo = norm(dame(f, 'tipo'));
+      const tipo = /servicio|mano de obra|mo|labor/.test(tipoCrudo) ? 'Servicios'
+                 : /material|equipo|suministro|insumo/.test(tipoCrudo) ? 'Materiales'
+                 : '';
+      const monCruda = String(dame(f, 'moneda') || '').toUpperCase();
+      const moneda = /USD|DLL|DOLAR/.test(monCruda) ? 'USD'
+                   : /MXN|PESO/.test(monCruda) ? 'MXN'
+                   : (/\$?\s*USD/.test(String(dame(f, 'pu'))) ? 'USD' : monedaDoc);
+
+      const avisos = [];
+      if (!desc) avisos.push('sin descripción');
+      if (pu === null) avisos.push('sin precio');
+      if (qty !== null && qty < 0) avisos.push('cantidad negativa');
+      if (pu !== null && pu < 0) avisos.push('precio negativo');
+
+      return {
+        qty: qty === null ? '' : Math.abs(qty),
+        unidad: String(dame(f, 'unidad') || '').trim(),
+        tipo: tipo,
+        descripcion: desc,
+        modelo: String(dame(f, 'modelo') || '').trim(),
+        marca: String(dame(f, 'marca') || '').trim(),
+        pu: pu === null ? null : Math.abs(pu),
+        moneda: moneda,
+        margen: null,
+        link: String(dame(f, 'link') || '').trim(),
+        comentario: String(dame(f, 'comentario') || '').trim(),
+        _avisos: avisos,
+        _crudo: f
+      };
+    }).filter(r => r.descripcion || r.pu !== null || r.qty !== '');
+
+    return {
+      ok: renglones.length > 0,
+      motivo: renglones.length ? '' : 'Los renglones venían vacíos.',
+      sep: sep === '\t' ? 'tabulador' : sep === 'espacios' ? 'espacios' : sep,
+      encabezado: conEncabezado,
+      mapa: mapa,
+      renglones: renglones
+    };
+  }
+
+  G.MachotePegar = { interpretar, aNumero, partir, ALIAS };
+})(window);

--- a/comercial/machote/tests/pruebas-navegador.js
+++ b/comercial/machote/tests/pruebas-navegador.js
@@ -965,10 +965,13 @@ let ok = 0, mal = 0;
     const r = await p.evaluate(() => {
       const mo = document.querySelectorAll('.rejilla tbody tr:not(.grupo):not(.total)');
       const qty = [...document.querySelectorAll('[data-cel$=":qty"]')];
-      return { filas: mo.length, qty: qty.length, conValor: qty.filter(x => x.value !== '').length,
+      return { filas: mo.length, qty: qty.length,
+               // Desde V1.10 los diez preparados nacen con cantidad CERO a
+               // proposito. Lo que no puede haber es una cantidad POSITIVA.
+               positivas: qty.filter(x => Number(x.value) > 0).length,
                capturadas: document.querySelectorAll('tr.capturada').length };
     });
-    if (r.conValor !== 0) throw new Error(r.conValor + ' renglones nacieron con cantidad');
+    if (r.positivas !== 0) throw new Error(r.positivas + ' renglones nacieron con cantidad positiva');
     if (r.capturadas !== 0) throw new Error('nació con renglones pintados de verde');
     console.log('   ', pest.join(' · '), '·', r.qty, 'renglones, todos en cero');
   });
@@ -993,7 +996,7 @@ let ok = 0, mal = 0;
     if (r.conTarifa !== 10) throw new Error('sin tarifa de plantilla: ' + (10 - r.conTarifa));
     if (r.conHoras !== 0) throw new Error('nacieron con horas: ' + r.conHoras);
     if (r.partidas !== 30) throw new Error('renglones de materiales: ' + r.partidas);
-    if (r.sinTipo !== 30) throw new Error('el Tipo viene preelegido en ' + (30 - r.sinTipo));
+    if (r.sinTipo !== 20) throw new Error('esperaba 20 sin Tipo y 10 preparados, hay ' + r.sinTipo + ' sin Tipo');
     if (r.costo !== 0) throw new Error('el costo no arranca en cero: ' + r.costo);
     console.log('    10 mano de obra con tarifa · 30 materiales sin Tipo · costo 0');
   });
@@ -1008,6 +1011,185 @@ let ok = 0, mal = 0;
     await p.fill('#q', 'prueba CC'); await p.waitForTimeout(320);
     const t = await p.textContent('#vista');
     if (t.indexOf('Cotización de prueba CC') < 0) throw new Error('no aparece al buscarlo');
+  });
+
+  // ── V1.10 · lo que salio de las pruebas con la gente ─────────────────
+  await paso('las comisiones de la sección traen su porcentaje', async () => {
+    await ir('#/m/M-1041'); await hoja('Suministro');
+    const t = await p.textContent('#hoja');
+    if (!/Comisiones FTS\s*[\d.]+%/.test(t)) throw new Error('sin % en Comisiones FTS');
+    if (!/Comisiones CLIENTE\s*[\d.]+%/.test(t)) throw new Error('sin % en Comisiones CLIENTE');
+  });
+
+  await paso('el nombre de la sección va arriba de las tablas', async () => {
+    await ir('#/m/M-1041'); await hoja('Suministro');
+    const r = await p.evaluate(() => {
+      const nom = document.querySelector('.nomsec');
+      const tab = document.querySelector('.cab');
+      if (!nom || !tab) return null;
+      return { nom: nom.getBoundingClientRect().top, tab: tab.getBoundingClientRect().top };
+    });
+    if (!r) throw new Error('no encontré el nombre o las tablas');
+    if (!(r.nom < r.tab)) throw new Error('el nombre quedó abajo: ' + Math.round(r.nom) + ' vs ' + Math.round(r.tab));
+  });
+
+  await paso('la columna Tipo deja ver lo que está seleccionado', async () => {
+    await p.setViewportSize({ width: 1280, height: 900 });
+    await ir('#/m/M-1041'); await hoja('Suministro');
+    const w = await p.evaluate(() => {
+      const s = document.querySelector('[data-cel$=":tipo"]');
+      return s ? Math.round(s.getBoundingClientRect().width) : -1;
+    });
+    if (w < 110) throw new Error('la columna Tipo mide ' + w + 'px, no cabe "Materiales"');
+    console.log('    Tipo mide', w, 'px');
+    await p.setViewportSize({ width: 380, height: 780 });
+  });
+
+  await paso('no deja capturar cantidades ni precios negativos', async () => {
+    await p.setViewportSize({ width: 1280, height: 900 });
+    await ir('#/m/M-1041'); await hoja('Suministro');
+    const cel = p.locator('[data-cel*=":partidas:"][data-cel$=":pu"]:visible').first();
+    await cel.fill('-500'); await cel.dispatchEvent('change');
+    await p.waitForTimeout(950);   // el autoguardado tiene 500 ms de retardo
+    const guardado = await p.evaluate(() => {
+      const c = localStorage.getItem('fts_machote_v1');
+      if (!c) return -1;
+      const m = JSON.parse(c).machotes.find(x => x.id === 'M-1041');
+      const todas = m.secciones.reduce((a, s) => a.concat(s.partidas, s.mo), []);
+      return todas.filter(l => Number(l.pu) < 0 || Number(l.qty) < 0).length;
+    });
+    if (guardado === -1) throw new Error('no alcanzó a guardar nada');
+    if (guardado !== 0) throw new Error('quedaron ' + guardado + ' valores negativos guardados');
+    const min = await cel.getAttribute('min');
+    if (min !== '0') throw new Error('el campo no declara min=0');
+    await p.setViewportSize({ width: 380, height: 780 });
+  });
+
+  await paso('el verde exige cantidad Y precio, no sólo cantidad', async () => {
+    const r = await p.evaluate(() => {
+      const C = window.MachoteCalc;
+      return {
+        soloQty:  C.capturada({ qty: 5, pu: null }),
+        soloPu:   C.capturada({ qty: '', pu: 100 }),
+        ambos:    C.capturada({ qty: 5, pu: 100 }),
+        ceroPu:   C.capturada({ qty: 5, pu: 0 })
+      };
+    });
+    if (r.soloQty) throw new Error('se pintó con sólo cantidad');
+    if (r.soloPu) throw new Error('se pintó con sólo precio');
+    if (r.ceroPu) throw new Error('se pintó con precio 0');
+    if (!r.ambos) throw new Error('no se pintó teniendo los dos');
+  });
+
+  await paso('la sección nueva trae 5 Materiales y 5 Servicios en Pieza', async () => {
+    const r = await p.evaluate(() => {
+      const s = window.MachoteCalc.machoteNuevo({ nombre: 'x' }).secciones[0];
+      const t = {}; s.partidas.forEach(x => { t[x.tipo || 'vacio'] = (t[x.tipo || 'vacio'] || 0) + 1; });
+      return { t: t, pieza: s.partidas.filter(x => x.unidad === 'Pieza').length,
+               qty0: s.partidas.filter(x => x.qty === 0).length,
+               usadas: s.partidas.filter(window.MachoteCalc.usadaPartida).length };
+    });
+    if (r.t.Materiales !== 5) throw new Error('Materiales: ' + r.t.Materiales);
+    if (r.t.Servicios !== 5) throw new Error('Servicios: ' + r.t.Servicios);
+    if (r.t.vacio !== 20) throw new Error('en blanco: ' + r.t.vacio);
+    if (r.pieza !== 10) throw new Error('en Pieza: ' + r.pieza);
+    if (r.qty0 !== 10) throw new Error('con cantidad 0: ' + r.qty0);
+    // Con cantidad 0 no cuentan como usados: no disparan hallazgos.
+    if (r.usadas !== 0) throw new Error('los preparados cuentan como usados: ' + r.usadas);
+  });
+
+  await paso('se puede borrar un machote en creación', async () => {
+    await ir('#/');
+    const antes = await p.locator('.item[href^="#/m/"]').count();
+    p.once('dialog', d => d.accept());
+    await p.locator('[data-borrar]').first().click();
+    await p.waitForTimeout(400);
+    const desp = await p.locator('.item[href^="#/m/"]').count();
+    if (desp !== antes - 1) throw new Error('no borró: ' + antes + ' → ' + desp);
+  });
+
+  await paso('un machote enviado a Odoo no se puede borrar', async () => {
+    await ir('#/m/M-1042'); await hoja('DESGLOSE');
+    await p.locator('[data-estado]').selectOption('enviado'); await p.waitForTimeout(400);
+    await irSuave('#/');
+    const r = await p.evaluate(() => {
+      const filas = [...document.querySelectorAll('.fila')];
+      const f = filas.find(x => x.textContent.indexOf('M-1042') >= 0);
+      return f ? { borrar: !!f.querySelector('[data-borrar]'), candado: !!f.querySelector('.candado') } : null;
+    });
+    if (!r) throw new Error('no encontré M-1042 en la lista');
+    if (r.borrar) throw new Error('le dejó el botón de borrar');
+    if (!r.candado) throw new Error('no muestra por qué no se puede');
+  });
+
+  // ── Pegar una tabla ──────────────────────────────────────────────────
+  await paso('el pegado entiende una tabla de Claude, de Excel y de un PDF', async () => {
+    const r = await p.evaluate(() => {
+      const P = window.MachotePegar;
+      const casos = {
+        claude: '| Cantidad | Descripción | Precio unitario |\n|---|---|---|\n| 4 | Rodamiento LM25UU | $4,200.00 |\n| 1 | Placa A36 | $38,000.00 |',
+        excel:  'QTY\tDESCRIPCION\tPRECIO UNITARIO\tMONEDA\n12\tTubo cedula 40\t1,250.50\tMXN\n3\tValvula 2in\t890\tUSD',
+        sinCab: 'Cable THW cal 12\t250\t18.50\nConduit 1/2\t80\t45.00',
+        total:  'Cant;Concepto;Importe\n5;Soporte PTR;2500',
+        pdf:    'Descripcion            Cant   Precio\nBomba 2HP     2    18500\nManometro    10      450',
+        basura: 'hola que tal\ncomo estas'
+      };
+      const out = {};
+      for (const k in casos) {
+        const x = P.interpretar(casos[k], { moneda: 'MXN' });
+        out[k] = { ok: x.ok, n: x.renglones.length, r0: x.renglones[0] || null };
+      }
+      return out;
+    });
+    if (!r.claude.ok || r.claude.n !== 2) throw new Error('markdown: ' + JSON.stringify(r.claude));
+    if (r.claude.r0.qty !== 4 || r.claude.r0.pu !== 4200) throw new Error('markdown mal: ' + JSON.stringify(r.claude.r0));
+    if (r.excel.r0.pu !== 1250.5) throw new Error('excel no leyó 1,250.50: ' + r.excel.r0.pu);
+    if (r.excel.n !== 2) throw new Error('excel: ' + r.excel.n);
+    // El caso que invertía cantidad y precio antes del arreglo por enteros.
+    if (r.sinCab.r0.qty !== 250 || r.sinCab.r0.pu !== 18.5)
+      throw new Error('sin encabezado invirtió cantidad y precio: ' + JSON.stringify(r.sinCab.r0));
+    if (r.total.r0.pu !== 500) throw new Error('no derivó el unitario del importe: ' + r.total.r0.pu);
+    if (r.pdf.r0.qty !== 2 || r.pdf.r0.pu !== 18500) throw new Error('pdf: ' + JSON.stringify(r.pdf.r0));
+    if (r.basura.ok) throw new Error('dijo que sí a texto sin tabla');
+    console.log('    6 formas de tabla entendidas, basura rechazada');
+  });
+
+  await paso('pegar enseña lo que entendió antes de escribir nada', async () => {
+    await p.setViewportSize({ width: 1280, height: 900 });
+    await ir('#/m/M-1041'); await hoja('Suministro');
+    const antes = await p.textContent('.fija .mono');
+    await p.click('[data-pegar]'); await p.waitForTimeout(300);
+    await p.fill('#pg-txt', 'Cantidad\tDescripcion\tPrecio\n7\tBrida de acero 4in\t1350.25\n2\tEmpaque espirometalico\t480');
+    await p.waitForTimeout(400);
+    const prev = await p.textContent('#pg-prev');
+    if (!/Entendí\s*2 renglón/.test(prev)) throw new Error('no dijo qué entendió: ' + prev.slice(0, 120));
+    if (prev.indexOf('Brida de acero 4in') < 0) throw new Error('no muestra los renglones');
+    // Hasta aqui NO debe haber escrito nada.
+    const durante = await p.textContent('.fija .mono');
+    if (durante !== antes) throw new Error('escribió antes de que se aprobara: ' + antes + ' → ' + durante);
+    await p.click('#pg-ok'); await p.waitForTimeout(500);
+    const desp = await p.textContent('.fija .mono');
+    if (desp === antes) throw new Error('no aplicó al aprobar');
+    // Ojo: la descripción vive en el `value` de un input; `textContent` de la
+    // hoja NUNCA la va a contener. Se busca donde de verdad está.
+    const llego = await p.evaluate(() => [...document.querySelectorAll('[data-cel$=":descripcion"]')]
+      .some(i => i.value === 'Brida de acero 4in'));
+    if (!llego) throw new Error('el renglón no llegó a la hoja');
+    console.log('   ', antes.trim(), '→', desp.trim());
+    await p.setViewportSize({ width: 380, height: 780 });
+  });
+
+  await paso('pegar texto que no es tabla lo dice, y no deja aplicar', async () => {
+    await p.setViewportSize({ width: 1280, height: 900 });
+    await ir('#/m/M-1041'); await hoja('Suministro');
+    await p.click('[data-pegar]'); await p.waitForTimeout(300);
+    await p.fill('#pg-txt', 'buenos dias\nadjunto la cotizacion');
+    await p.waitForTimeout(400);
+    if (!(await p.locator('#pg-ok').isDisabled())) throw new Error('dejó aplicar basura');
+    const t = await p.textContent('#pg-prev');
+    if (!/No encontré|No pude/.test(t)) throw new Error('no explicó: ' + t.slice(0, 100));
+    await p.click('#pg-cancel'); await p.waitForTimeout(250);
+    await p.setViewportSize({ width: 380, height: 780 });
   });
 
   // ── El gate ──────────────────────────────────────────────────────────

--- a/comercial/machote/version.json
+++ b/comercial/machote/version.json
@@ -1,10 +1,15 @@
 {
-  "version": "V1.09",
-  "fecha": "2026-09-03",
+  "version": "V1.10",
+  "fecha": "2026-09-04",
   "modulo": "comercial/machote",
   "ambito": "El CONTADOR es solo de este modulo. finanzas tambien usa V1.xx desde el 2026-09-03 (instruccion directa de Esteban, corrige el \"no propagar\" del issue #148) pero lleva su propio contador y va en V1.00. operaciones/planeacion sigue en 2.4.1, kiosk y confirmar-horas solo con cadena de build, y siete modulos con un 1.0.0 puesto una vez: a esos no se propaga.",
   "esquema": "V<mayor>.<menor de dos digitos>. Un incremento de 0.01 por cada merge a main. Al pasar de .99 sube el mayor y el menor vuelve a 00.",
   "historial": [
+    {
+      "version": "V1.10",
+      "pr": null,
+      "nota": "Lo que salio de las pruebas con la gente: comisiones con su %, nombre de seccion arriba, columna Tipo legible, 5+5 preseleccionados en Pieza, nada negativo, verde exige cantidad Y precio, borrar machotes salvo los enviados, y pegado de tablas con revision previa"
+    },
     {
       "version": "V1.09",
       "pr": null,


### PR DESCRIPTION
Los ocho cambios que salieron de probar el módulo.

| # | Cambio |
|---|---|
| 1 | Las comisiones de la tarjeta de sección traen su **porcentaje** |
| 2 | El **nombre de la sección va arriba** |
| 3 | La columna **Tipo**, ancha y legible |
| 4 | Los diez primeros renglones nacen **5 Materiales + 5 Servicios**, en Pieza, cantidad 0 |
| 5 | **Nada negativo** |
| 6 | El **verde exige cantidad y precio** |
| 7 | **Borrar machotes**, salvo los enviados a Odoo |
| 8 | **Pegar una tabla** (`js/pegar.js`, nuevo) |

Y el porqué de los que no son obvios:

- **(1)** «Comisiones FTS $79,108» no dice si eso es un 5% o un 15%, que es lo que se está decidiendo.
- **(2)** Debajo de dos tablas de números, el nombre no se lee hasta que ya te perdiste.
- **(4)** Es un **andamio**, no un dato: con cantidad 0 no cuentan como usados, no disparan hallazgos ni se pintan de verde. Del once al treinta siguen en blanco.
- **(5)** Se corta en el **único escritor**, no en cada campo: el `min=0` del input frena las flechitas y el teclado, pero no frena escribir «-5» ni pegarlo. Un precio negativo no se ve como un error — se ve como un total más chico, que es peor.
- **(6)** Con sólo la cantidad el renglón está a medias y no aporta un peso al total; pintarlo diría «listo» de algo que todavía no suma.
- **(7)** Enviado a Odoo **no se borra nunca**: es el documento con el que se vendió. El candado está en dos lados —no se pinta el botón, y el manejador lo vuelve a comprobar— porque no pintar el botón es cosmético.

## El pegado

Interpreta un bloque de Claude, de un correo, de Excel o de un PDF. Elige el separador **por consistencia, no por frecuencia**: uno que da 3 columnas en una fila y 7 en la siguiente no es el separador, es un carácter que salía en el texto.

Sin encabezado adivina por la **forma**: la columna con más texto largo es la descripción; de las numéricas, **la de enteros es la cantidad y la de decimales es el precio**. Ordenar por magnitud fallaba en cuanto la lista traía piezas baratas — «250 cables a 18.50» ponía la cantidad del lado del precio — y lo cachó una prueba con seis formas de tabla reales.

**Nada se aplica solo**: interpreta, **enseña lo que entendió** renglón por renglón con sus avisos, y escribe cuando alguien lo aprueba mirándolo. Un parser que acierta el 90% y aplica solo mete un 10% de basura que nadie ve. El `Tipo` que no venga en la tabla queda vacío: adivinarlo movería el precio.

## Pruebas

**82 pasaron, 0 fallaron.** Once nuevas. Capturas revisadas.

Cuatro pruebas viejas quedaron desalineadas con los cambios 4 y 6 y se corrigieron. Una de ellas buscaba la descripción en el `textContent` de la hoja, **donde nunca iba a estar**: vive en el `value` de un input.

## Versión

`V1.09` → **`V1.10`**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013Qzhio6K8R23HXHnJ2RJ64