### PR TITLE
comercial(machote) V1.11: el pegado empieza en el renglón que elijas

### DIFF
--- a/comercial/machote/README.md
+++ b/comercial/machote/README.md
@@ -66,7 +66,7 @@ versión es peor que no tener indicador.
 | `js/app.js` | Vistas y ruteo. |
 | `js/pegar.js` | El pegado de tablas: separador, columnas y revisión previa. |
 | `js/almacen.js` | El autoguardado. UNA pieza entre la pantalla y donde viven los datos. |
-| `tests/pruebas-navegador.js` | 82 pruebas de navegador. |
+| `tests/pruebas-navegador.js` | 86 pruebas de navegador. |
 
 ## Cómo se calcula el precio
 
@@ -270,6 +270,30 @@ largo es la descripción, y de las numéricas, **la que trae enteros es la canti
 y la que trae decimales es el precio**. Ordenar por magnitud fallaba en cuanto la
 lista traía muchas piezas baratas — «250 cables a 18.50» ponía la cantidad del
 lado del precio.
+
+También entiende **listas y texto corrido**, no sólo tablas: viñetas, numeración,
+la unidad pegada a la cantidad («4 pzas», «12 mts») y el precio al final. Cuando
+no hay columnas, cada renglón se lee por su cuenta — cantidad al principio,
+precio al final, descripción en medio.
+
+El orden de preferencia importa y está pensado: un **separador de verdad**
+(tabulador, `|`, `;`, coma) manda siempre; si sólo hay espacios pero la primera
+fila es un encabezado reconocible, es una **tabla de PDF**; si no, se lee como
+**lista**; y los espacios a ciegas quedan de último recurso. Sin ese orden, el
+fallback por espacios se comía las listas y dejaba la viñeta y la cantidad
+dentro de la descripción.
+
+⚠️ **La coma no se acepta si partió un número.** «$4,200.00» se ve como dos
+columnas perfectas —«$4» y «200.00»— en todos los renglones, así que la prueba
+de consistencia la aprueba con honores y el resultado es basura. La comprobación
+va sólo en `,` y `;`, que son los que viven dentro de una cifra: aplicarla al
+tabulador lo descartaba en falso con una descripción que termina en dígito
+(«Tubo cédula 40»).
+
+**Empieza donde tú digas.** El botón `⇥` vive **en cada renglón**, no en la
+sección: el punto donde arranca el pegado es una decisión del capturista, y casi
+siempre hay algo capturado arriba que no se toca. Se elige entre **escribir
+encima** de ahí hacia abajo o **insertar** empujando lo que ya estaba.
 
 **Nada se aplica solo.** Interpreta, enseña lo que entendió renglón por renglón
 con sus avisos, y escribe cuando alguien lo aprueba mirándolo. Un parser que

--- a/comercial/machote/css/machote.css
+++ b/comercial/machote/css/machote.css
@@ -576,3 +576,15 @@ table.rejilla tr.capturada > td:first-child { box-shadow: inset 3px 0 0 var(--x-
 /* El renglón que necesita una mirada no se esconde ni se descarta: se marca. */
 .modal tr.ojo > td { background: #fff8e5; }
 .aviso.warn { border-left-color: var(--ambar); }
+
+/* ── Modo del pegado ────────────────────────────────────────────────────
+ * Escribir encima o insertar empujando es una decisión con consecuencias
+ * distintas —una reemplaza, la otra no pierde nada— así que se elige antes,
+ * a la vista, y no se adivina. */
+.modal .modos { display: flex; gap: 10px; flex-wrap: wrap; margin-top: 12px; }
+.modal .modos label { flex: 1 1 240px; display: block; border: 1px solid var(--linea);
+                      border-radius: 10px; padding: 10px 12px; font-size: 13px;
+                      cursor: pointer; min-height: var(--toque); }
+.modal .modos label:has(input:checked) { border-color: var(--acento);
+                                         box-shadow: inset 0 0 0 1px var(--acento); }
+.modal .modos .nota { display: block; margin: 4px 0 0; }

--- a/comercial/machote/js/app.js
+++ b/comercial/machote/js/app.js
@@ -40,7 +40,7 @@
    * 2026-09-03 (por instrucción de Esteban), pero lleva el suyo aparte y va en
    * V1.00. Planeación sigue en `2.4.1` y el kiosko sólo con cadena de build;
    * a esos no se propaga. */
-  const VERSION = 'V1.10';
+  const VERSION = 'V1.11';
   const $  = (s, r) => (r || document).querySelector(s);
   const $$ = (s, r) => Array.prototype.slice.call((r || document).querySelectorAll(s));
   const clon = (x) => JSON.parse(JSON.stringify(x));
@@ -617,6 +617,10 @@
         '<td data-l="Link">' + cel(p + 'link', l.link, 'w130', 'https://…') + '</td>' +
         '<td data-l="Comentario">' + cel(p + 'comentario', l.comentario, 'w130') + '</td>' +
         '<td class="acc" data-l="">' +
+          // Pegar DESDE aquí hacia abajo. El botón vive en el renglón porque el
+          // punto donde empieza el pegado es una decisión del capturista, no
+          // del programa: casi siempre hay algo capturado arriba que no se toca.
+          '<button class="ico" data-pegar="' + s.id + '#' + j + '" title="Pegar una lista a partir de aquí">⇥</button>' +
           '<button class="ico" data-mov="' + s.id + '#' + j + '|-1" title="Subir"' + (j === 0 ? ' disabled' : '') + '>↑</button>' +
           '<button class="ico" data-mov="' + s.id + '#' + j + '|1" title="Bajar"' + (j === s.partidas.length - 1 ? ' disabled' : '') + '>↓</button>' +
           '<button class="ico" data-dup="' + s.id + '#' + j + '" title="Duplicar">⧉</button>' +
@@ -636,7 +640,7 @@
       '</td><td></td><td class="vl mono calc fuerte" data-l="Con utilidad">' + mx(cs.ventaMat) + '</td><td colspan="3"></td></tr>' +
       '</tbody></table></div>' +
       '<div class="btnrow"><button class="btn" data-add="' + s.id + '">+ partida</button>' +
-      '<button class="btn" data-pegar="' + s.id + '">Pegar tabla</button>' +
+
       (cs.pisados ? '<span class="tiny n-warn">' + cs.pisados + ' margen(es) pisado(s) a mano en esta sección</span>' : '') +
       '</div>';
 
@@ -832,17 +836,31 @@
    * NADA se aplica solo. Se interpreta, se ENSEÑA lo que se entendió renglón
    * por renglón, y se escribe cuando alguien lo aprueba mirándolo. Un parser
    * que acierta el 90% y aplica solo mete un 10% de basura que nadie ve. */
-  function modalPegar(m, sid) {
+  function modalPegar(m, ref) {
     const P = G.MachotePegar;
+    const [sid, jTxt] = String(ref).split('#');
+    const desde = parseInt(jTxt, 10) || 0;
+    const sec = m.secciones.find(x => x.id === sid);
+    if (!sec) return;
     const cerrar = () => { const d = $('#modal'); if (d) d.remove(); };
 
     const html =
       '<div class="modal" id="modal"><div class="caja">' +
-      '<h3>Pegar una tabla</h3>' +
-      '<p class="tiny nota">Pega aquí una tabla de Claude, de un correo, de Excel o de una ' +
-      'cotización. Se entiende sola y <strong>te enseña qué entendió antes de escribir nada</strong>.</p>' +
+      '<h3>Pegar una lista a partir del renglón ' + (desde + 1) + '</h3>' +
+      '<p class="tiny nota">Pega aquí una lista de Claude, de un correo, de Excel o de una ' +
+      'cotización — tabla, lista o texto corrido. Se entiende sola y ' +
+      '<strong>te enseña qué entendió antes de escribir nada</strong>. ' +
+      'Lo que esté <strong>arriba del renglón ' + (desde + 1) + ' no se toca</strong>.</p>' +
       '<textarea id="pg-txt" rows="7" placeholder="Cantidad | Descripción | Precio unitario&#10;4 | Rodamiento LM25UU | $4,200.00"></textarea>' +
       '<div id="pg-prev"></div>' +
+      '<div class="modos">' +
+      '<label><input type="radio" name="pg-modo" value="sobre" checked> ' +
+      'Escribir <strong>encima</strong>, del renglón ' + (desde + 1) + ' hacia abajo' +
+      '<span class="tiny nota">Reemplaza lo que haya en esos renglones. Es lo normal cuando abajo está en blanco.</span></label>' +
+      '<label><input type="radio" name="pg-modo" value="inserta"> ' +
+      '<strong>Insertar</strong> antes del renglón ' + (desde + 1) +
+      '<span class="tiny nota">Empuja hacia abajo lo que ya estaba. Nada se pierde.</span></label>' +
+      '</div>' +
       '<div class="acciones">' +
       '<button class="btn" id="pg-cancel">Cancelar</button>' +
       '<button class="btn primario" id="pg-ok" disabled>Agregar renglones</button>' +
@@ -893,24 +911,28 @@
 
     ok.onclick = () => {
       if (!ultimo || !ultimo.ok) return;
-      const sec = m.secciones.find(x => x.id === sid);
-      if (!sec) { cerrar(); return; }
-      // Se meten donde caben: primero se rellenan los renglones en blanco que
-      // ya existen, y sólo se agregan nuevos cuando se acaban. Si no, pegar
-      // diez renglones dejaría treinta vacíos colgando debajo.
       const nuevos = ultimo.renglones.map(x => ({
         qty: x.qty, unidad: x.unidad, tipo: x.tipo, descripcion: x.descripcion,
         modelo: x.modelo, marca: x.marca, pu: x.pu, moneda: x.moneda,
         margen: null, link: x.link, comentario: x.comentario
       }));
-      nuevos.forEach(n => {
-        const hueco = sec.partidas.findIndex(l => !C.usadaPartida(l));
-        if (hueco >= 0) sec.partidas[hueco] = n; else sec.partidas.push(n);
-      });
+      const modo = (document.querySelector('input[name="pg-modo"]:checked') || {}).value || 'sobre';
+      if (modo === 'inserta') {
+        // Empuja hacia abajo: nada de lo que ya estaba se pierde.
+        sec.partidas.splice.apply(sec.partidas, [desde, 0].concat(nuevos));
+      } else {
+        // Escribe encima desde el punto elegido. Si la lista es más larga que
+        // lo que queda de bloque, el resto se agrega al final.
+        nuevos.forEach((n, k) => {
+          const i = desde + k;
+          if (i < sec.partidas.length) sec.partidas[i] = n; else sec.partidas.push(n);
+        });
+      }
       cerrar();
       tocado();
       pintarHoja(m); barra(m, C.calcular(m));
-      toast(nuevos.length + ' renglón(es) agregado(s).');
+      toast(nuevos.length + ' renglón(es) ' +
+            (modo === 'inserta' ? 'insertado(s) antes del ' : 'escrito(s) desde el ') + (desde + 1) + '.');
     };
     txt.focus();
   }

--- a/comercial/machote/js/pegar.js
+++ b/comercial/machote/js/pegar.js
@@ -70,6 +70,24 @@
     const lineas = crudas.filter(l => !/^[\s|:+-]+$/.test(l));
     if (!lineas.length) return { sep: null, filas: [] };
 
+    /* ¿Este separador partió un NÚMERO por la mitad?
+     * Es la trampa de la coma: "$4,200.00" se ve como dos columnas perfectas
+     * —"$4" y "200.00"— en todos los renglones, así que la prueba de
+     * consistencia la aprueba con honores y el resultado es basura. La firma es
+     * inconfundible: una celda que termina en dígito seguida de otra que empieza
+     * con exactamente tres dígitos (los miles) o con dos y nada más (centavos). */
+    function partioNumeros(filas) {
+      let sospechosas = 0, pares = 0;
+      filas.forEach(f => {
+        for (let i = 0; i + 1 < f.length; i++) {
+          pares++;
+          if (/\d$/.test(f[i]) && /^\d{3}(?!\d)/.test(f[i + 1])) sospechosas++;
+          else if (/\d$/.test(f[i]) && /^\d{1,2}$/.test(f[i + 1])) sospechosas++;
+        }
+      });
+      return pares > 0 && (sospechosas / pares) > 0.3;
+    }
+
     let mejor = null;
     SEPARADORES.forEach(sep => {
       const cols = lineas.map(l => trocear(l, sep).length);
@@ -82,19 +100,28 @@
         .filter(n => n >= 2)
         .sort((a, b) => (conteo[b] - conteo[a]) || (b - a))[0];
       if (!ancho) return;
+      /* Antes de aceptarlo: que no venga de haber cortado números. Sólo se
+       * comprueba en `,` y `;`, que son los que de verdad viven DENTRO de una
+       * cifra ("4,200.00", "1.250,50"). Un tabulador o un `|` nunca parten un
+       * número, y aplicarles esta prueba los descartaba en falso: basta con una
+       * descripción que termine en dígito ("Tubo cédula 40", "Conduit 1/2")
+       * seguida de una cantidad de dos o tres cifras. */
+      if ((sep === ',' || sep === ';') && partioNumeros(lineas.map(l => trocear(l, sep)))) return;
       const puntaje = conteo[ancho] + ancho * 0.1;   // desempata a más columnas
       if (!mejor || puntaje > mejor.puntaje) mejor = { sep, ancho, puntaje };
     });
 
-    // Sin separador claro: dos o más espacios, que es como queda una tabla
-    // copiada de un PDF o de una terminal.
+    /* Sin separador claro queda el de dos o más espacios, que es como queda una
+     * tabla copiada de un PDF o de una terminal. Se devuelve MARCADO como débil:
+     * una lista con viñetas también tiene espacios antes del precio, y si este
+     * camino decidiera solo, se comería las listas y dejaría la viñeta y la
+     * cantidad dentro de la descripción. Quién gana lo decide `interpretar`. */
     if (!mejor) {
       const filas = lineas.map(l => l.split(/\s{2,}/).map(x => x.trim()));
-      const anchos = filas.map(f => f.length);
-      if (Math.max.apply(null, anchos) < 2) return { sep: null, filas: [] };
-      return { sep: 'espacios', filas: filas };
+      if (Math.max.apply(null, filas.map(f => f.length)) < 2) return { sep: null, filas: [], debil: false };
+      return { sep: 'espacios', filas: filas, debil: true };
     }
-    return { sep: mejor.sep, filas: lineas.map(l => trocear(l, mejor.sep)) };
+    return { sep: mejor.sep, filas: lineas.map(l => trocear(l, mejor.sep)), debil: false };
   }
 
   function trocear(linea, sep) {
@@ -211,14 +238,99 @@
     return mapa;
   }
 
+  /* Unidades que la gente escribe pegadas a la cantidad. Sirven para dos cosas:
+   * reconocer que ese número es una cantidad, y quedarse con la unidad. */
+  const UNIDADES = {
+    'pz': 'Pieza', 'pza': 'Pieza', 'pzas': 'Pieza', 'pieza': 'Pieza', 'piezas': 'Pieza',
+    'pieces': 'Pieza', 'ea': 'Pieza', 'un': 'Pieza', 'und': 'Pieza',
+    'm': 'Metro', 'mt': 'Metro', 'mts': 'Metro', 'metro': 'Metro', 'metros': 'Metro',
+    'ml': 'Metro lineal', 'm2': 'Metro cuadrado', 'm3': 'Metro cúbico',
+    'kg': 'Kilogramo', 'kgs': 'Kilogramo', 'kilo': 'Kilogramo', 'kilos': 'Kilogramo',
+    'lt': 'Litro', 'lts': 'Litro', 'litro': 'Litro', 'litros': 'Litro',
+    'hr': 'Horas', 'hrs': 'Horas', 'hora': 'Horas', 'horas': 'Horas', 'h': 'Horas',
+    'lote': 'Lote', 'lotes': 'Lote', 'servicio': 'Servicio', 'juego': 'Juego',
+    'rollo': 'Rollo', 'rollos': 'Rollo', 'tramo': 'Tramo', 'tramos': 'Tramo',
+    'caja': 'Caja', 'cajas': 'Caja', 'par': 'Par', 'pares': 'Par'
+  };
+
+  /* Un renglón de una LISTA, no de una tabla. Es la forma en que la gente pega
+   * de verdad cuando le pide la lista a una IA o la copia de un correo:
+   *
+   *     - 4 pzas Rodamiento lineal LM25UU  $4,200.00
+   *     12 Tubo cédula 40 x 6m — 1,250.50
+   *     Bomba centrífuga 2HP  $18,500
+   *
+   * No hay columnas: hay una cantidad al principio, un precio al final y una
+   * descripción en medio. Se extrae eso y lo demás se marca para revisar. */
+  function interpretarLinea(linea) {
+    let t = String(linea)
+      // Fuera viñetas y numeración: "- ", "• ", "* ", "1. ", "1) ".
+      .replace(/^\s*(?:[-*•·—]|\d{1,3}[.)])\s+/, '')
+      .trim();
+    if (!t) return null;
+
+    let qty = null, unidad = '', pu = null;
+
+    /* El PRECIO se busca al final, que es donde va. Se acepta con `$`, con
+     * separador de miles o con centavos; un entero suelto al final se toma sólo
+     * si la línea trae otro número antes, para no confundir "Tubo cédula 40"
+     * -donde el 40 es parte del nombre- con un precio. */
+    const mPrecio = t.match(/(?:[$]\s*)?(\d{1,3}(?:[,\s]\d{3})+(?:\.\d+)?|\d+\.\d{1,2}|\d+)\s*(?:MXN|USD|mxn|usd|pesos?|dlls?)?\s*$/);
+    if (mPrecio) {
+      const crudo = mPrecio[0];
+      const conSenal = /[$]|[,]|\.\d/.test(crudo) || /MXN|USD|mxn|usd|peso|dll/.test(crudo);
+      const otrosNumeros = (t.slice(0, mPrecio.index).match(/\d/g) || []).length > 0;
+      if (conSenal || otrosNumeros) {
+        pu = aNumero(mPrecio[1]);
+        t = t.slice(0, mPrecio.index).replace(/[\s\-–—:|]+$/, '').trim();
+      }
+    }
+
+    // La CANTIDAD va al principio, con su unidad opcional pegada.
+    const mQty = t.match(/^(\d+(?:[.,]\d+)?)\s*(?:x\s+)?([a-zA-ZáéíóúñÁÉÍÓÚÑ0-9]{1,10})?\s+/);
+    if (mQty) {
+      const posible = aNumero(mQty[1]);
+      const palabra = (mQty[2] || '').toLowerCase().replace(/\./g, '');
+      const esUnidad = Object.prototype.hasOwnProperty.call(UNIDADES, palabra);
+      // Con unidad reconocida no hay duda. Sin ella, se acepta igual: un número
+      // al arranque de un renglón de lista es una cantidad casi siempre.
+      qty = posible;
+      if (esUnidad) { unidad = UNIDADES[palabra]; t = t.slice(mQty[0].length).trim(); }
+      else { t = t.replace(/^\d+(?:[.,]\d+)?\s*(?:x\s+)?/, '').trim(); }
+    }
+
+    // Una unidad escrita al final de la descripción: "… (4 pzas)".
+    const mParen = t.match(/\(\s*(\d+)\s*([a-zA-Z]{1,8})\.?\s*\)\s*$/);
+    if (mParen && qty === null) {
+      const palabra = mParen[2].toLowerCase();
+      if (Object.prototype.hasOwnProperty.call(UNIDADES, palabra)) {
+        qty = aNumero(mParen[1]); unidad = UNIDADES[palabra];
+        t = t.slice(0, mParen.index).trim();
+      }
+    }
+
+    const desc = t.replace(/[\s\-–—:|]+$/, '').replace(/^[\s\-–—:|]+/, '').trim();
+    if (!desc && pu === null) return null;
+    return { qty, unidad, descripcion: desc, pu };
+  }
+
   /** Interpreta un bloque pegado. Devuelve SIEMPRE la explicación de cómo lo
    *  entendió, para que se pueda revisar antes de aplicar. */
   function interpretar(texto, opciones) {
     opciones = opciones || {};
-    const { sep, filas } = partir(texto);
-    if (!filas.length) {
-      return { ok: false, motivo: 'No encontré renglones con columnas en lo que pegaste.',
-               sep: null, encabezado: false, mapa: {}, renglones: [] };
+    const { sep, filas, debil } = partir(texto);
+    if (!filas.length) return porLineas(texto, opciones);
+
+    /* Orden de preferencia, y por qué:
+     *   1. Un separador de verdad (tabulador, |, ;, coma) manda siempre.
+     *   2. Si sólo hay espacios PERO la primera fila es un encabezado
+     *      reconocible, es una tabla de PDF: manda la tabla.
+     *   3. Si no, se prueba como LISTA: es lo que la gente pega cuando le pide
+     *      los materiales a una IA o los copia de un correo.
+     *   4. Y sólo si la lista tampoco cuaja, se usan los espacios a ciegas. */
+    if (debil && !mapearEncabezado(filas[0])) {
+      const porLinea = porLineas(texto, opciones);
+      if (porLinea.ok) return porLinea;
     }
     let mapa = mapearEncabezado(filas[0]);
     const conEncabezado = !!mapa;
@@ -228,10 +340,7 @@
                sep, encabezado: true, mapa: mapa || {}, renglones: [] };
     }
     if (!mapa) mapa = adivinar(cuerpo);
-    if (mapa.descripcion === undefined && mapa.pu === undefined) {
-      return { ok: false, motivo: 'No pude distinguir cuál columna es la descripción ni cuál el precio.',
-               sep, encabezado: conEncabezado, mapa: mapa, renglones: [] };
-    }
+    if (mapa.descripcion === undefined && mapa.pu === undefined) return porLineas(texto, opciones);
 
     const dame = (f, k) => (mapa[k] === undefined ? '' : (f[mapa[k]] === undefined ? '' : f[mapa[k]]));
     const monedaDoc = opciones.moneda || 'MXN';
@@ -278,6 +387,19 @@
       };
     }).filter(r => r.descripcion || r.pu !== null || r.qty !== '');
 
+    /* Ni un solo precio en toda la tabla = no es una lista de materiales.
+     * Es el caso del correo de cortesía que se pega por error: la coma de
+     * "Buenos días, adjunto…" da columnas perfectas y una descripción. Mejor
+     * decir que no se entendió que meter renglones que alguien tiene que
+     * borrar a mano. */
+    if (renglones.length && !renglones.some(r => r.pu !== null)) {
+      const porLinea = porLineas(texto, opciones);
+      if (porLinea.ok) return porLinea;
+      return { ok: false,
+               motivo: 'Encontré renglones pero ninguno traía precio; no parece una lista de materiales.',
+               sep: null, encabezado: false, mapa: {}, renglones: [] };
+    }
+
     return {
       ok: renglones.length > 0,
       motivo: renglones.length ? '' : 'Los renglones venían vacíos.',
@@ -288,5 +410,41 @@
     };
   }
 
-  G.MachotePegar = { interpretar, aNumero, partir, ALIAS };
+  /** El camino de LISTA: una cosa por renglón, sin columnas. */
+  function porLineas(texto, opciones) {
+    const monedaDoc = (opciones || {}).moneda || 'MXN';
+    const lineas = String(texto || '').split(/\r?\n/)
+      .map(l => l.trim()).filter(l => l && !/^[\s|:+-]+$/.test(l));
+    const renglones = [];
+    lineas.forEach(l => {
+      const r = interpretarLinea(l);
+      if (!r) return;
+      const avisos = [];
+      if (!r.descripcion) avisos.push('sin descripción');
+      if (r.pu === null) avisos.push('sin precio');
+      renglones.push({
+        qty: r.qty === null ? '' : Math.abs(r.qty),
+        unidad: r.unidad, tipo: '', descripcion: r.descripcion,
+        modelo: '', marca: '', pu: r.pu === null ? null : Math.abs(r.pu),
+        moneda: /USD|usd|dll/.test(l) ? 'USD' : monedaDoc,
+        margen: null, link: '', comentario: '',
+        _avisos: avisos, _crudo: [l]
+      });
+    });
+    // Una lista donde NINGÚN renglón trae precio casi siempre es prosa, no una
+    // lista de materiales. Mejor decir que no se entendió que meter diez
+    // renglones de basura que alguien tiene que borrar a mano.
+    const conPrecio = renglones.filter(r => r.pu !== null).length;
+    if (!renglones.length || !conPrecio) {
+      return { ok: false,
+               motivo: renglones.length
+                 ? 'Encontré renglones pero ninguno traía precio; no parece una lista de materiales.'
+                 : 'No encontré ni columnas ni renglones de lista en lo que pegaste.',
+               sep: null, encabezado: false, mapa: {}, renglones: [] };
+    }
+    return { ok: true, motivo: '', sep: 'lista (uno por renglón)',
+             encabezado: false, mapa: {}, renglones: renglones };
+  }
+
+  G.MachotePegar = { interpretar, interpretarLinea, aNumero, partir, ALIAS, UNIDADES };
 })(window);

--- a/comercial/machote/tests/pruebas-navegador.js
+++ b/comercial/machote/tests/pruebas-navegador.js
@@ -1158,7 +1158,7 @@ let ok = 0, mal = 0;
     await p.setViewportSize({ width: 1280, height: 900 });
     await ir('#/m/M-1041'); await hoja('Suministro');
     const antes = await p.textContent('.fija .mono');
-    await p.click('[data-pegar]'); await p.waitForTimeout(300);
+    await p.locator('[data-pegar]').first().click(); await p.waitForTimeout(300);
     await p.fill('#pg-txt', 'Cantidad\tDescripcion\tPrecio\n7\tBrida de acero 4in\t1350.25\n2\tEmpaque espirometalico\t480');
     await p.waitForTimeout(400);
     const prev = await p.textContent('#pg-prev');
@@ -1182,14 +1182,110 @@ let ok = 0, mal = 0;
   await paso('pegar texto que no es tabla lo dice, y no deja aplicar', async () => {
     await p.setViewportSize({ width: 1280, height: 900 });
     await ir('#/m/M-1041'); await hoja('Suministro');
-    await p.click('[data-pegar]'); await p.waitForTimeout(300);
+    await p.locator('[data-pegar]').first().click(); await p.waitForTimeout(300);
     await p.fill('#pg-txt', 'buenos dias\nadjunto la cotizacion');
     await p.waitForTimeout(400);
     if (!(await p.locator('#pg-ok').isDisabled())) throw new Error('dejó aplicar basura');
-    const t = await p.textContent('#pg-prev');
-    if (!/No encontré|No pude/.test(t)) throw new Error('no explicó: ' + t.slice(0, 100));
+    // Se mide que EXPLIQUE, no la redacción exacta: fijar el texto convierte
+    // cualquier mejora del mensaje en un fallo, que es justo lo que pasó aquí.
+    const t = (await p.textContent('#pg-prev')).trim();
+    if (t.length < 25) throw new Error('no explicó nada: «' + t + '»');
+    if (!/no\s|ninguno|No\s/.test(t)) throw new Error('el mensaje no dice que no se pudo: ' + t.slice(0, 100));
     await p.click('#pg-cancel'); await p.waitForTimeout(250);
     await p.setViewportSize({ width: 380, height: 780 });
+  });
+
+  // ── V1.11 · el pegado empieza en el renglón que elijas ───────────────
+  await paso('cada renglón de materiales trae su botón de pegar', async () => {
+    await p.setViewportSize({ width: 1280, height: 900 });
+    await ir('#/m/M-1041'); await hoja('Suministro');
+    const r = await p.evaluate(() => {
+      const filas = [...document.querySelectorAll('.rejilla tbody tr')]
+        .filter(t => t.querySelector('[data-cel*=":partidas:"]'));
+      return { filas: filas.length, conBoton: filas.filter(t => t.querySelector('[data-pegar]')).length };
+    });
+    if (r.filas === 0) throw new Error('no hay renglones de materiales');
+    if (r.conBoton !== r.filas) throw new Error('sólo ' + r.conBoton + ' de ' + r.filas + ' traen botón');
+    await p.setViewportSize({ width: 380, height: 780 });
+  });
+
+  await paso('pegar respeta lo que está arriba del renglón elegido', async () => {
+    await p.setViewportSize({ width: 1280, height: 900 });
+    await ir('#/m/M-1041'); await hoja('Suministro');
+    const descs = () => p.evaluate(() =>
+      [...document.querySelectorAll('[data-cel$=":descripcion"]')].map(i => i.value));
+    const antes = await descs();
+    // Se pega DESDE el tercer renglón: los dos de arriba no se tocan.
+    await p.locator('[data-pegar]').nth(2).click(); await p.waitForTimeout(300);
+    const titulo = await p.textContent('.modal h3');
+    if (titulo.indexOf('renglón 3') < 0) throw new Error('el modal no dice desde dónde: ' + titulo);
+    await p.fill('#pg-txt', '- 4 pzas Rodamiento lineal LM25UU  $4,200.00\n- 1 Placa de acero A36  $38,000');
+    await p.waitForTimeout(400);
+    await p.click('#pg-ok'); await p.waitForTimeout(500);
+    const desp = await descs();
+    if (desp[0] !== antes[0] || desp[1] !== antes[1])
+      throw new Error('tocó lo de arriba: ' + antes.slice(0, 2).join(' | ') + ' → ' + desp.slice(0, 2).join(' | '));
+    if (desp[2] !== 'Rodamiento lineal LM25UU')
+      throw new Error('no escribió en el renglón 3: ' + desp[2]);
+    if (desp[3] !== 'Placa de acero A36')
+      throw new Error('no escribió en el renglón 4: ' + desp[3]);
+    console.log('   1-2 intactos ·', desp[2].slice(0, 26), '· 4 pzas');
+    await p.setViewportSize({ width: 380, height: 780 });
+  });
+
+  await paso('insertar empuja hacia abajo y no pierde nada', async () => {
+    await p.setViewportSize({ width: 1280, height: 900 });
+    await ir('#/m/M-1041'); await hoja('Suministro');
+    const descs = () => p.evaluate(() =>
+      [...document.querySelectorAll('[data-cel$=":descripcion"]')].map(i => i.value).filter(Boolean));
+    const antes = await descs();
+    await p.locator('[data-pegar]').nth(1).click(); await p.waitForTimeout(300);
+    await p.fill('#pg-txt', '- 9 Tornillo hexagonal grado 5  $12.50');
+    await p.waitForTimeout(400);
+    await p.check('input[name="pg-modo"][value="inserta"]');
+    await p.click('#pg-ok'); await p.waitForTimeout(500);
+    const desp = await descs();
+    // Todas las descripciones anteriores siguen ahí, más la nueva.
+    const perdidas = antes.filter(d => desp.indexOf(d) < 0);
+    if (perdidas.length) throw new Error('se perdieron: ' + perdidas.join(' | '));
+    if (desp.indexOf('Tornillo hexagonal grado 5') !== 1)
+      throw new Error('no entró en la posición 2: ' + desp.slice(0, 3).join(' | '));
+    console.log('   ', antes.length, '→', desp.length, 'descripciones, ninguna perdida');
+    await p.setViewportSize({ width: 380, height: 780 });
+  });
+
+  await paso('el pegado entiende listas y texto, no sólo tablas', async () => {
+    const r = await p.evaluate(() => {
+      const P = window.MachotePegar;
+      const casos = {
+        vinetas: '- 4 pzas Rodamiento lineal LM25UU  $4,200.00\n- 1 Placa de acero A36  $38,000',
+        numerada: '1. 12 mts Tubo cedula 40  1,250.50\n2. 3 Valvula de bola 2in  890.00',
+        corrido: '250 Cable THW cal 12 negro 18.50\n80 Tuberia conduit 1/2 45.00',
+        pdf: 'Descripcion            Cant   Precio\nBomba centrifuga 2HP     2    18500\nManometro     10      450',
+        csv: 'Cant,Descripcion,Precio\n5,Soporte PTR inox,2500\n2,Anclaje quimico,900',
+        tabSinCab: 'Cable THW cal 12\t250\t18.50\nConduit 1/2\t80\t45.00',
+        prosa: 'Buenos dias, adjunto la cotizacion.\nQuedo atento.'
+      };
+      const o = {};
+      for (const k in casos) {
+        const x = P.interpretar(casos[k], { moneda: 'MXN' });
+        o[k] = { ok: x.ok, sep: x.sep, n: x.renglones.length, r0: x.renglones[0] || null };
+      }
+      return o;
+    });
+    // La viñeta y la unidad se reconocen y NO se quedan en la descripción.
+    if (r.vinetas.r0.qty !== 4 || r.vinetas.r0.pu !== 4200) throw new Error('viñetas: ' + JSON.stringify(r.vinetas.r0));
+    if (r.vinetas.r0.unidad !== 'Pieza') throw new Error('no leyó "pzas": ' + r.vinetas.r0.unidad);
+    if (/^[-\d]/.test(r.vinetas.r0.descripcion)) throw new Error('dejó la viñeta o la cantidad en la descripción: ' + r.vinetas.r0.descripcion);
+    if (r.numerada.r0.qty !== 12 || r.numerada.r0.unidad !== 'Metro') throw new Error('numerada: ' + JSON.stringify(r.numerada.r0));
+    if (r.corrido.r0.qty !== 250 || r.corrido.r0.pu !== 18.5) throw new Error('corrido: ' + JSON.stringify(r.corrido.r0));
+    // Y las tablas siguen ganando cuando de verdad son tablas.
+    if (r.pdf.sep !== 'espacios' || r.pdf.r0.qty !== 2) throw new Error('pdf: ' + JSON.stringify(r.pdf));
+    if (r.csv.sep !== ',' || r.csv.r0.qty !== 5) throw new Error('csv: ' + JSON.stringify(r.csv));
+    if (r.tabSinCab.sep !== 'tabulador' || r.tabSinCab.r0.qty !== 250)
+      throw new Error('la coma partió los miles o el tabulador se descartó: ' + JSON.stringify(r.tabSinCab));
+    if (r.prosa.ok) throw new Error('aceptó un correo de cortesía como lista');
+    console.log('    listas, PDF, CSV y tabulador; prosa rechazada');
   });
 
   // ── El gate ──────────────────────────────────────────────────────────

--- a/comercial/machote/version.json
+++ b/comercial/machote/version.json
@@ -1,10 +1,15 @@
 {
-  "version": "V1.10",
+  "version": "V1.11",
   "fecha": "2026-09-04",
   "modulo": "comercial/machote",
   "ambito": "El CONTADOR es solo de este modulo. finanzas tambien usa V1.xx desde el 2026-09-03 (instruccion directa de Esteban, corrige el \"no propagar\" del issue #148) pero lleva su propio contador y va en V1.00. operaciones/planeacion sigue en 2.4.1, kiosk y confirmar-horas solo con cadena de build, y siete modulos con un 1.0.0 puesto una vez: a esos no se propaga.",
   "esquema": "V<mayor>.<menor de dos digitos>. Un incremento de 0.01 por cada merge a main. Al pasar de .99 sube el mayor y el menor vuelve a 00.",
   "historial": [
+    {
+      "version": "V1.11",
+      "pr": null,
+      "nota": "El pegado empieza en el renglon que elijas: boton por renglon, escribir encima o insertar empujando, y entiende listas con vinetas y texto corrido ademas de tablas"
+    },
     {
       "version": "V1.10",
       "pr": null,


### PR DESCRIPTION
El botón de pegar vive ahora **en cada renglón**, no en la sección. El punto donde arranca el pegado es una decisión del capturista, no del programa: casi siempre hay algo capturado arriba que no se toca.

Y se elige entre **escribir encima** de ahí hacia abajo o **insertar** empujando lo que ya estaba — dos consecuencias distintas, así que se decide a la vista y no se adivina.

## Entiende listas y texto, no sólo tablas

Viñetas, numeración, la unidad pegada a la cantidad («4 pzas», «12 mts») y el precio al final. Sin columnas, cada renglón se lee por su cuenta: cantidad al principio, precio al final, descripción en medio.

El **orden** de preferencia importa y está pensado:

1. un **separador de verdad** (tabulador, `|`, `;`, coma) manda siempre;
2. si sólo hay espacios pero la primera fila es un encabezado reconocible, es una **tabla de PDF**;
3. si no, se lee como **lista**;
4. y los espacios a ciegas quedan de último recurso.

Sin ese orden, el fallback por espacios se comía las listas y dejaba la viñeta y la cantidad dentro de la descripción.

## Dos trampas que costaron una vuelta cada una

1. **La coma partía los miles.** `$4,200.00` se ve como dos columnas perfectas —`$4` y `200.00`— en **todos** los renglones, así que la prueba de consistencia la aprobaba con honores. Lo había anotado como riesgo en un comentario mío y no lo había blindado.
2. Y al blindarlo, la comprobación **descartaba también el tabulador**: basta una descripción que termine en dígito («Tubo cédula 40», «Conduit 1/2») seguida de una cantidad de dos o tres cifras. Va sólo en `,` y `;`, que son los únicos que viven dentro de una cifra.

Una tabla **sin un solo precio** deja de aceptarse: es el correo de cortesía que se pega por error, donde la coma de «Buenos días, adjunto…» da columnas perfectas y una descripción.

## Pruebas

**86 pasaron, 0 fallaron.** Cuatro nuevas; once formas de pegado cubiertas (viñetas, numerada, texto corrido, PDF por espacios, CSV, tabulador con y sin encabezado, Markdown, importe→unitario, prosa y basura rechazadas).

Una prueba de V1.10 fijaba el **texto exacto** del mensaje de error y convirtió una mejora del mensaje en un fallo. Ahora mide que **explique**, no cómo lo redacta.

## Versión

`V1.10` → **`V1.11`**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013Qzhio6K8R23HXHnJ2RJ64