### PR TITLE
comercial(machote) V1.12: el botón de pegar, donde se pueda ver

### DIFF
--- a/comercial/machote/README.md
+++ b/comercial/machote/README.md
@@ -66,7 +66,7 @@ versión es peor que no tener indicador.
 | `js/app.js` | Vistas y ruteo. |
 | `js/pegar.js` | El pegado de tablas: separador, columnas y revisión previa. |
 | `js/almacen.js` | El autoguardado. UNA pieza entre la pantalla y donde viven los datos. |
-| `tests/pruebas-navegador.js` | 86 pruebas de navegador. |
+| `tests/pruebas-navegador.js` | 88 pruebas de navegador. |
 
 ## Cómo se calcula el precio
 
@@ -294,6 +294,14 @@ tabulador lo descartaba en falso con una descripción que termina en dígito
 sección: el punto donde arranca el pegado es una decisión del capturista, y casi
 siempre hay algo capturado arriba que no se toca. Se elige entre **escribir
 encima** de ahí hacia abajo o **insertar** empujando lo que ya estaba.
+
+Es la **primera columna** de la tabla, y **se queda fija** al desplazar en
+horizontal. Nació al final, después de trece columnas, y ahí quedaba **fuera de
+la pantalla**: medido, `x=1473` con la ventana en 1440 px, con 218 px de arrastre
+para dar con él. Existía y las pruebas lo alcanzaban —Playwright desplaza solo
+antes de hacer clic— así que pasaban en verde mientras nadie lo encontraba.
+**Existir y poder encontrarse no son lo mismo**, y ahora hay una prueba que mide
+que el botón caiga dentro de la ventana a 1440, 1280 y 390 px.
 
 **Nada se aplica solo.** Interpreta, enseña lo que entendió renglón por renglón
 con sus avisos, y escribe cuando alguien lo aprueba mirándolo. Un parser que

--- a/comercial/machote/css/machote.css
+++ b/comercial/machote/css/machote.css
@@ -588,3 +588,33 @@ table.rejilla tr.capturada > td:first-child { box-shadow: inset 3px 0 0 var(--x-
 .modal .modos label:has(input:checked) { border-color: var(--acento);
                                          box-shadow: inset 0 0 0 1px var(--acento); }
 .modal .modos .nota { display: block; margin: 4px 0 0; }
+
+/* ── El botón de pegar, donde se ve ─────────────────────────────────────
+ * Estaba al final de trece columnas. Medido: quedaba en x=1473 con la ventana
+ * en 1440 px — FUERA de la pantalla, y había que arrastrar la tabla 218 px
+ * para dar con él. Existía y Playwright lo alcanzaba (por eso las pruebas
+ * pasaban), pero una persona no lo encontraba.
+ *
+ * Ahora es la PRIMERA columna y se queda fija al desplazar en horizontal, que
+ * es donde además se lee bien: se señala el renglón donde empieza el pegado. */
+table.rejilla th.acc-ini, table.rejilla td.acc-ini {
+  position: sticky; left: 0; z-index: 2; width: 1%; white-space: nowrap;
+  padding: 2px 4px; text-align: center; background: var(--fondo);
+  box-shadow: 1px 0 0 var(--linea2);
+}
+table.rejilla th.acc-ini { background: var(--x-cab); color: var(--x-cab-tx); }
+table.rejilla tr.capturada > td.acc-ini { background: var(--x-fila-ok); }
+table.rejilla tr.total > td.acc-ini { background: var(--x-total); }
+.ico.pegar { color: var(--acento); font-weight: 700; }
+.ico.pegar:hover { background: var(--papel); }
+
+@media (max-width: 719px) {
+  /* En tarjetas no hay columnas que se salgan, así que el botón deja de ser
+     una celda fija y pasa a ser el encabezado de la tarjeta: la acción de
+     "pegar a partir de aquí" sigue apuntando a este renglón. */
+  table.rejilla.tarjetas td.acc-ini { position: static; width: auto;
+        display: flex; justify-content: flex-end; background: transparent;
+        box-shadow: none; padding: 4px 10px 0; }
+  table.rejilla.tarjetas td.acc-ini::before { content: none; }
+  table.rejilla.tarjetas tr.total > td.acc-ini { display: none; }
+}

--- a/comercial/machote/js/app.js
+++ b/comercial/machote/js/app.js
@@ -40,7 +40,7 @@
    * 2026-09-03 (por instrucción de Esteban), pero lleva el suyo aparte y va en
    * V1.00. Planeación sigue en `2.4.1` y el kiosko sólo con cadena de build;
    * a esos no se propaga. */
-  const VERSION = 'V1.11';
+  const VERSION = 'V1.12';
   const $  = (s, r) => (r || document).querySelector(s);
   const $$ = (s, r) => Array.prototype.slice.call((r || document).querySelectorAll(s));
   const clon = (x) => JSON.parse(JSON.stringify(x));
@@ -597,6 +597,13 @@
     const filasMat = (s.partidas || []).map((l, j) => {
       const cl = C.costoPartida(l, m), p = 's:' + s.id + ':partidas:' + j + ':';
       return '<tr' + (C.capturada(l) ? ' class="capturada"' : '') + '>' +
+        // Pegar DESDE aquí hacia abajo. Va en la PRIMERA columna, y fija: al
+        // final de trece columnas el botón caía fuera de la pantalla —medido:
+        // x=1473 en una ventana de 1440— y había que arrastrar la tabla para
+        // encontrarlo. Además leído de izquierda a derecha dice lo que hace:
+        // se señala el renglón donde empieza el pegado.
+        '<td class="acc-ini" data-l=""><button class="ico pegar" data-pegar="' + s.id + '#' + j + '"' +
+        ' title="Pegar una lista a partir de este renglón" aria-label="Pegar a partir del renglón ' + (j + 1) + '">⇥</button></td>' +
         '<td data-l="Descripción">' + cel(p + 'descripcion', l.descripcion, 'desc') + '</td>' +
         '<td data-l="QTY">' + celNum(p + 'qty', l.qty, 'w60') + '</td>' +
         '<td data-l="Unidad">' + celLibre(p + 'unidad', l.unidad, 'unidades', 'w90') + '</td>' +
@@ -617,10 +624,6 @@
         '<td data-l="Link">' + cel(p + 'link', l.link, 'w130', 'https://…') + '</td>' +
         '<td data-l="Comentario">' + cel(p + 'comentario', l.comentario, 'w130') + '</td>' +
         '<td class="acc" data-l="">' +
-          // Pegar DESDE aquí hacia abajo. El botón vive en el renglón porque el
-          // punto donde empieza el pegado es una decisión del capturista, no
-          // del programa: casi siempre hay algo capturado arriba que no se toca.
-          '<button class="ico" data-pegar="' + s.id + '#' + j + '" title="Pegar una lista a partir de aquí">⇥</button>' +
           '<button class="ico" data-mov="' + s.id + '#' + j + '|-1" title="Subir"' + (j === 0 ? ' disabled' : '') + '>↑</button>' +
           '<button class="ico" data-mov="' + s.id + '#' + j + '|1" title="Bajar"' + (j === s.partidas.length - 1 ? ' disabled' : '') + '>↓</button>' +
           '<button class="ico" data-dup="' + s.id + '#' + j + '" title="Duplicar">⧉</button>' +
@@ -631,11 +634,12 @@
     const tablaMat =
       '<div class="secc-tit">COSTO MATERIALES Y SERVICIOS</div>' +
       '<div class="scroll"><table class="rejilla tarjetas">' +
-      '<thead><tr><th>DESCRIPCIÓN</th><th>QTY</th><th>UNIDAD</th><th>Tipo</th><th>MODELO</th><th>MARCA</th>' +
+      '<thead><tr><th class="acc-ini" title="Pegar una lista a partir de un renglón">⇥</th>' +
+      '<th>DESCRIPCIÓN</th><th>QTY</th><th>UNIDAD</th><th>Tipo</th><th>MODELO</th><th>MARCA</th>' +
       '<th>PRECIO UNITARIO</th><th>MONEDA</th><th>PRECIO TOTAL</th><th>Margen utilidad</th>' +
       '<th>PRECIO CON UTILIDAD</th><th>Link</th><th>Comentario</th><th></th></tr></thead><tbody>' +
-      (filasMat || '<tr><td colspan="14" class="vacio2">Sin partidas.</td></tr>') +
-      '<tr class="total"><td class="rotulo" data-l="">TOTAL</td><td colspan="7"></td>' +
+      (filasMat || '<tr><td colspan="15" class="vacio2">Sin partidas.</td></tr>') +
+      '<tr class="total"><td class="acc-ini"></td><td class="rotulo" data-l="">TOTAL</td><td colspan="7"></td>' +
       '<td class="vl mono calc" data-l="Costo materiales">' + mx(cs.costoMat) +
       '</td><td></td><td class="vl mono calc fuerte" data-l="Con utilidad">' + mx(cs.ventaMat) + '</td><td colspan="3"></td></tr>' +
       '</tbody></table></div>' +

--- a/comercial/machote/tests/pruebas-navegador.js
+++ b/comercial/machote/tests/pruebas-navegador.js
@@ -693,7 +693,10 @@ let ok = 0, mal = 0;
       const out = [];
       document.querySelectorAll('.rejilla.tarjetas tbody tr:not(.grupo):not(.total) td').forEach(td => {
         if (getComputedStyle(td).display === 'none') return;
-        if (td.classList.contains('rotulo') || td.classList.contains('acc')) return;
+        // Las celdas de acciones no llevan etiqueta de columna a proposito: no
+        // son un dato, son botones. `acc-ini` es la del boton de pegar.
+        if (td.classList.contains('rotulo') || td.classList.contains('acc') ||
+            td.classList.contains('acc-ini')) return;
         if (!td.getAttribute('data-l')) out.push(td.className || '(sin clase)');
       });
       return out;
@@ -1196,6 +1199,44 @@ let ok = 0, mal = 0;
   });
 
   // ── V1.11 · el pegado empieza en el renglón que elijas ───────────────
+  await paso('el botón de pegar SE VE sin arrastrar la tabla', async () => {
+    /* La prueba que faltaba. La anterior comprobaba que el botón EXISTIERA y
+     * Playwright lo alcanzaba desplazando solo, así que pasaba en verde
+     * mientras el botón caía fuera de la pantalla: medido, x=1473 con la
+     * ventana en 1440 px. Existir y poder encontrarse no son lo mismo. */
+    for (const [w, h] of [[1440, 900], [1280, 900], [390, 844]]) {
+      await p.setViewportSize({ width: w, height: h });
+      await ir('#/m/M-1041'); await hoja('Suministro');
+      const r = await p.evaluate(() => {
+        const b = document.querySelector('[data-pegar]');
+        if (!b) return { hay: false };
+        const rb = b.getBoundingClientRect();
+        return { hay: true, x: Math.round(rb.left), der: Math.round(rb.right),
+                 ancho: window.innerWidth,
+                 dentro: rb.left >= 0 && rb.right <= window.innerWidth + 1 };
+      });
+      if (!r.hay) throw new Error('no hay botón de pegar a ' + w + 'px');
+      if (!r.dentro) throw new Error('a ' + w + 'px el botón cae fuera: x=' + r.x + '–' + r.der);
+    }
+    console.log('    visible a 1440, 1280 y 390 px');
+    await p.setViewportSize({ width: 380, height: 780 });
+  });
+
+  await paso('el botón de pegar se queda fijo al desplazar en horizontal', async () => {
+    await p.setViewportSize({ width: 1280, height: 900 });
+    await ir('#/m/M-1041'); await hoja('Suministro');
+    const r = await p.evaluate(() => {
+      const b = document.querySelector('[data-pegar]');
+      const cont = b.closest('.scroll');
+      const antes = Math.round(b.getBoundingClientRect().left);
+      cont.scrollLeft = cont.scrollWidth;   // hasta el extremo derecho
+      const desp = Math.round(b.getBoundingClientRect().left);
+      return { antes, desp, movio: Math.abs(desp - antes) };
+    });
+    if (r.movio > 2) throw new Error('se fue con el desplazamiento: ' + r.antes + ' → ' + r.desp);
+    await p.setViewportSize({ width: 380, height: 780 });
+  });
+
   await paso('cada renglón de materiales trae su botón de pegar', async () => {
     await p.setViewportSize({ width: 1280, height: 900 });
     await ir('#/m/M-1041'); await hoja('Suministro');

--- a/comercial/machote/version.json
+++ b/comercial/machote/version.json
@@ -1,10 +1,15 @@
 {
-  "version": "V1.11",
+  "version": "V1.12",
   "fecha": "2026-09-04",
   "modulo": "comercial/machote",
   "ambito": "El CONTADOR es solo de este modulo. finanzas tambien usa V1.xx desde el 2026-09-03 (instruccion directa de Esteban, corrige el \"no propagar\" del issue #148) pero lleva su propio contador y va en V1.00. operaciones/planeacion sigue en 2.4.1, kiosk y confirmar-horas solo con cadena de build, y siete modulos con un 1.0.0 puesto una vez: a esos no se propaga.",
   "esquema": "V<mayor>.<menor de dos digitos>. Un incremento de 0.01 por cada merge a main. Al pasar de .99 sube el mayor y el menor vuelve a 00.",
   "historial": [
+    {
+      "version": "V1.12",
+      "pr": null,
+      "nota": "El boton de pegar se ve: era la ultima de trece columnas y caia fuera de la pantalla (x=1473 con la ventana en 1440). Ahora es la primera y se queda fija al desplazar"
+    },
     {
       "version": "V1.11",
       "pr": null,


### PR DESCRIPTION
Esteban preguntó dónde estaba el botón de pegar. **Estaba al final de trece columnas**: medido, `x=1473` con la ventana en 1440 px, con **218 px de arrastre horizontal** para dar con él. En teléfono sí se veía, porque ahí cada renglón es una tarjeta.

Ahora es la **primera columna** y **se queda fija** al desplazar. Ahí además se lee mejor: de izquierda a derecha, se señala el renglón donde empieza el pegado.

## La prueba que faltaba

La que había comprobaba que el botón **existiera**, y Playwright lo alcanzaba —desplaza solo antes de hacer clic—. Así que **pasaba en verde mientras el botón caía fuera de la pantalla**.

Existir y poder encontrarse no son lo mismo. Las dos nuevas miden lo que importa:

- que el botón caiga **dentro de la ventana** a 1440, 1280 y 390 px;
- que **no se vaya** cuando la tabla se desplaza hasta el extremo derecho.

## Pruebas

**88 pasaron, 0 fallaron.**

## Versión

`V1.11` → **`V1.12`**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013Qzhio6K8R23HXHnJ2RJ64