### PR TITLE
comercial(machote) V1.13: el pegado lee cualquier forma de lista

### DIFF
--- a/comercial/machote/README.md
+++ b/comercial/machote/README.md
@@ -66,7 +66,7 @@ versión es peor que no tener indicador.
 | `js/app.js` | Vistas y ruteo. |
 | `js/pegar.js` | El pegado de tablas: separador, columnas y revisión previa. |
 | `js/almacen.js` | El autoguardado. UNA pieza entre la pantalla y donde viven los datos. |
-| `tests/pruebas-navegador.js` | 88 pruebas de navegador. |
+| `tests/pruebas-navegador.js` | 95 pruebas de navegador. |
 
 ## Cómo se calcula el precio
 
@@ -293,7 +293,9 @@ tabulador lo descartaba en falso con una descripción que termina en dígito
 **Empieza donde tú digas.** El botón `⇥` vive **en cada renglón**, no en la
 sección: el punto donde arranca el pegado es una decisión del capturista, y casi
 siempre hay algo capturado arriba que no se toca. Se elige entre **escribir
-encima** de ahí hacia abajo o **insertar** empujando lo que ya estaba.
+**escribir debajo** o **escribir arriba** del renglón señalado. En los dos
+casos lo que ya estaba **se recorre, no se sobrescribe**: la única decisión es
+dónde va, que es la que de verdad importa.
 
 Es la **primera columna** de la tabla, y **se queda fija** al desplazar en
 horizontal. Nació al final, después de trece columnas, y ahí quedaba **fuera de
@@ -302,6 +304,30 @@ para dar con él. Existía y las pruebas lo alcanzaban —Playwright desplaza so
 antes de hacer clic— así que pasaban en verde mientras nadie lo encontraba.
 **Existir y poder encontrarse no son lo mismo**, y ahora hay una prueba que mide
 que el botón caiga dentro de la ventana a 1440, 1280 y 390 px.
+
+**No depende del orden de las columnas.** Hay listas donde el precio va primero
+y la cantidad en medio (`$ 890.00 c/u - 8 PZAS - Lámpara LED…`). Leer por
+posición rechazaba esa lista entera; ahora cada pedazo del renglón se clasifica
+por **lo que es** —un precio trae `$` o dice `c/u`; una cantidad es un número con
+su unidad— y la descripción es lo que sobra.
+
+**La columna de unidad se reconoce por su contenido**, no por su encabezado: una
+tabla de `5 | PZA | … | 2,450.00` no dice en ningún lado que la segunda columna
+sean unidades, y antes se perdía entera. `PZA`, `MTS`, `JGO`, `HORA` se llevan a
+`Pieza`, `Metro`, `Juego`, `Horas`; lo que no está en el catálogo **se queda tal
+cual**, porque el acervo tiene unidades propias y borrarlas sería peor.
+
+**El Tipo se deduce de la descripción** cuando la lista no lo trae, y sale
+marcado como *deducido* en la vista previa. La señal del **principio pesa el
+triple**: «Instalación de tubería de cobre» es un servicio aunque traiga dos
+sustantivos de material detrás — lo que se cotiza es la acción, y el material es
+su objeto. Contando parejo salía Materiales, que es exactamente al revés. Si no
+hay señal clara, se queda vacío.
+
+⚠️ **Lo que el pegado no resuelve, no lo borra.** Se hereda del renglón donde
+estás pegando. Antes, pegar una lista sin columna de Unidad dejaba en blanco los
+`Pieza` y `Horas` ya capturados — reproducido y medido. Un pegado que borra datos
+que no venía a tocar es peor que no pegar.
 
 **Nada se aplica solo.** Interpreta, enseña lo que entendió renglón por renglón
 con sus avisos, y escribe cuando alguien lo aprueba mirándolo. Un parser que

--- a/comercial/machote/js/app.js
+++ b/comercial/machote/js/app.js
@@ -40,7 +40,7 @@
    * 2026-09-03 (por instrucción de Esteban), pero lleva el suyo aparte y va en
    * V1.00. Planeación sigue en `2.4.1` y el kiosko sólo con cadena de build;
    * a esos no se propaga. */
-  const VERSION = 'V1.12';
+  const VERSION = 'V1.13';
   const $  = (s, r) => (r || document).querySelector(s);
   const $$ = (s, r) => Array.prototype.slice.call((r || document).querySelectorAll(s));
   const clon = (x) => JSON.parse(JSON.stringify(x));
@@ -858,13 +858,15 @@
       '<textarea id="pg-txt" rows="7" placeholder="Cantidad | Descripción | Precio unitario&#10;4 | Rodamiento LM25UU | $4,200.00"></textarea>' +
       '<div id="pg-prev"></div>' +
       '<div class="modos">' +
-      '<label><input type="radio" name="pg-modo" value="sobre" checked> ' +
-      'Escribir <strong>encima</strong>, del renglón ' + (desde + 1) + ' hacia abajo' +
-      '<span class="tiny nota">Reemplaza lo que haya en esos renglones. Es lo normal cuando abajo está en blanco.</span></label>' +
-      '<label><input type="radio" name="pg-modo" value="inserta"> ' +
-      '<strong>Insertar</strong> antes del renglón ' + (desde + 1) +
-      '<span class="tiny nota">Empuja hacia abajo lo que ya estaba. Nada se pierde.</span></label>' +
+      '<label><input type="radio" name="pg-modo" value="debajo" checked> ' +
+      'Escribir <strong>debajo</strong> del renglón ' + (desde + 1) +
+      '<span class="tiny nota">Los renglones nuevos entran después de éste.</span></label>' +
+      '<label><input type="radio" name="pg-modo" value="arriba"> ' +
+      'Escribir <strong>arriba</strong> del renglón ' + (desde + 1) +
+      '<span class="tiny nota">Los renglones nuevos entran antes de éste.</span></label>' +
       '</div>' +
+      '<p class="tiny nota">En los dos casos <strong>nada se pierde</strong>: lo que ya estaba ' +
+      'se recorre, no se sobrescribe.</p>' +
       '<div class="acciones">' +
       '<button class="btn" id="pg-cancel">Cancelar</button>' +
       '<button class="btn primario" id="pg-ok" disabled>Agregar renglones</button>' +
@@ -899,14 +901,17 @@
           '<tr' + (x._avisos.length ? ' class="ojo"' : '') + '>' +
           '<td class="vl mono">' + esc(nn(x.qty)) + '</td>' +
           '<td>' + esc(x.unidad || '—') + '</td>' +
-          '<td>' + esc(x.tipo || '—') + '</td>' +
+          '<td>' + (x.tipo ? esc(x.tipo) + (x._tipoDeducido ? ' <span class="tiny n-warn">deducido</span>' : '') : '—') + '</td>' +
           '<td>' + esc(x.descripcion || '—') + '</td>' +
           '<td class="vl mono">' + (x.pu === null ? '—' : mx(x.pu)) + '</td>' +
           '<td>' + esc(x.moneda) + '</td>' +
           '<td class="tiny n-warn">' + esc(x._avisos.join(', ')) + '</td></tr>').join('') +
         '</tbody></table></div>' +
-        '<p class="tiny nota">El <strong>Tipo</strong> que no venga en la tabla queda vacío: ' +
-        'Materiales o Servicios decide el multiplicador, y adivinarlo movería el precio.</p>';
+        '<p class="tiny nota">El <strong>Tipo</strong> que no venga en la lista se ' +
+        '<strong>deduce de la descripción</strong> y sale marcado como <em>deducido</em>: ' +
+        'Materiales o Servicios elige el multiplicador, así que revísalo aquí. ' +
+        'Si no hay señal clara se queda vacío, y la <strong>Unidad</strong> que no venga ' +
+        'se hereda del renglón donde estás pegando en vez de borrarse.</p>';
     };
 
     txt.oninput = revisar;
@@ -915,28 +920,41 @@
 
     ok.onclick = () => {
       if (!ultimo || !ultimo.ok) return;
+      /* Lo que el pegado NO resolvió se hereda del renglón que estaba en ese
+       * lugar, no se deja en blanco. Si no, pegar una lista sin columna de
+       * Unidad borraba los "Pieza" y "Horas" que ya estaban capturados —
+       * reproducido: `Pieza`, `Horas` → vacío, y el Tipo igual. Un pegado que
+       * borra datos que no venía a tocar es peor que no pegar. */
+      const base = sec.partidas[desde] || {};
       const nuevos = ultimo.renglones.map(x => ({
-        qty: x.qty, unidad: x.unidad, tipo: x.tipo, descripcion: x.descripcion,
+        qty: x.qty,
+        unidad: x.unidad || base.unidad || '',
+        tipo: x.tipo || base.tipo || '',
+        descripcion: x.descripcion,
         modelo: x.modelo, marca: x.marca, pu: x.pu, moneda: x.moneda,
         margen: null, link: x.link, comentario: x.comentario
       }));
-      const modo = (document.querySelector('input[name="pg-modo"]:checked') || {}).value || 'sobre';
-      if (modo === 'inserta') {
-        // Empuja hacia abajo: nada de lo que ya estaba se pierde.
-        sec.partidas.splice.apply(sec.partidas, [desde, 0].concat(nuevos));
-      } else {
-        // Escribe encima desde el punto elegido. Si la lista es más larga que
-        // lo que queda de bloque, el resto se agrega al final.
-        nuevos.forEach((n, k) => {
-          const i = desde + k;
-          if (i < sec.partidas.length) sec.partidas[i] = n; else sec.partidas.push(n);
-        });
-      }
+      /* Arriba o debajo del renglón señalado, y en los DOS casos se recorre lo
+       * que ya estaba en vez de sobrescribirlo. Antes un modo reemplazaba y el
+       * otro no, y eso obligaba a entender la diferencia antes de pegar; ahora
+       * la única decisión es dónde va, que es la que de verdad importa. */
+      const modo = (document.querySelector('input[name="pg-modo"]:checked') || {}).value || 'debajo';
+      const en = (modo === 'arriba') ? desde : desde + 1;
+      sec.partidas.splice.apply(sec.partidas, [en, 0].concat(nuevos));
+
+      /* Y se recorta la cola de renglones vacíos que el recorrido empujó: si no,
+       * pegar diez deja treinta en blanco colgando y la hoja crece sin parar.
+       * Sólo se quitan los que nadie ha tocado, y se dejan diez para seguir
+       * capturando a mano. */
+      let cola = 0;
+      for (let i = sec.partidas.length - 1; i >= 0 && !C.usadaPartida(sec.partidas[i]); i--) cola++;
+      if (cola > 10) sec.partidas.splice(sec.partidas.length - (cola - 10), cola - 10);
+
       cerrar();
       tocado();
       pintarHoja(m); barra(m, C.calcular(m));
       toast(nuevos.length + ' renglón(es) ' +
-            (modo === 'inserta' ? 'insertado(s) antes del ' : 'escrito(s) desde el ') + (desde + 1) + '.');
+            (modo === 'arriba' ? 'arriba' : 'debajo') + ' del renglón ' + (desde + 1) + '.');
     };
     txt.focus();
   }

--- a/comercial/machote/js/pegar.js
+++ b/comercial/machote/js/pegar.js
@@ -149,6 +149,61 @@
     comentario:  ['comentario', 'nota', 'notas', 'observaciones', 'obs']
   };
 
+  /* ── Materiales o Servicios, deducido de la descripción ────────────────
+   *
+   * Es la columna que elige el multiplicador, o sea la que decide el precio.
+   * Antes se dejaba en blanco cuando la tabla no lo traía, para no moverlo por
+   * una corazonada. Pero dejar treinta renglones sin Tipo tampoco es neutral:
+   * un renglón sin Tipo no aporta al precio y sale como hallazgo, así que el
+   * costo de callar es el mismo que el de equivocarse, sólo que más callado.
+   *
+   * Se deduce con dos listas y un marcador: gana la que tenga más señales, y
+   * si empatan o no hay ninguna, se queda VACÍO. Lo deducido se marca en la
+   * vista previa para que se corrija ahí, antes de escribir nada. */
+  const SENALES_SERVICIO = [
+    'mano de obra', 'instalacion', 'montaje', 'desmontaje', 'servicio', 'maquinado',
+    'ingenieria', 'diseno', 'supervision', 'prueba', 'puesta en marcha', 'arranque',
+    'capacitacion', 'flete', 'renta', 'alquiler', 'calibracion', 'mantenimiento',
+    'limpieza', 'acarreo', 'maniobra', 'subcontrat', 'honorarios', 'asesoria',
+    'levantamiento', 'memoria de calculo', 'plano', 'dibujo', 'comisionamiento',
+    'obra civil', 'transporte', 'viatico', 'inspeccion', 'reparacion', 'ajuste',
+    'aplicacion', 'suministro e instalacion', 'jornada', 'hora hombre', 'consultoria'
+  ];
+  const SENALES_MATERIAL = [
+    'tubo', 'tuberia', 'cable', 'placa', 'perfil', 'ptr', 'angulo', 'tornillo',
+    'tuerca', 'rondana', 'anclaje', 'valvula', 'brida', 'empaque', 'rodamiento',
+    'bomba', 'motor', 'tablero', 'gabinete', 'sensor', 'transmisor', 'manometro',
+    'conduit', 'canaleta', 'electrodo', 'lamina', 'solera', 'varilla', 'codo',
+    'tee', 'reduccion', 'niple', 'abrazadera', 'junta', 'filtro', 'ventilador',
+    'extractor', 'luminaria', 'lampara', 'breaker', 'contactor', 'variador',
+    'plc', 'hmi', 'mini split', 'minisplit', 'refrigerante', 'cemento', 'grava',
+    'arena', 'block', 'acero', 'inox', 'galvanizado', 'aluminio', 'cobre',
+    'manguera', 'conector', 'terminal', 'kit', 'equipo', 'bushing', 'buje',
+    'chumacera', 'banda', 'polea', 'engrane', 'balero', 'sello', 'oring',
+    'pintura', 'primario', 'thinner', 'silicon', 'cinta', 'herraje', 'soporte'
+  ];
+
+  /* Unidades que por sí solas ya dicen de qué lado va el renglón. */
+  const UNIDAD_SERVICIO = ['Horas', 'Servicio', 'Jornada'];
+
+  /** Devuelve 'Materiales', 'Servicios' o '' si no hay señal clara. */
+  function deducirTipo(descripcion, unidad) {
+    const t = norm(descripcion);
+    if (!t) return '';
+    /* La señal del PRINCIPIO pesa el triple. "Instalación de tubería de cobre"
+     * es un servicio aunque traiga dos sustantivos de material detrás: lo que
+     * se cotiza es la acción, y el material es su objeto. Contando parejo salía
+     * Materiales, que es exactamente al revés. */
+    const cuenta = (lista) => lista.reduce((a, k) => {
+      const i = t.indexOf(k);
+      return a + (i < 0 ? 0 : (i <= 2 ? 3 : 1));
+    }, 0);
+    let serv = cuenta(SENALES_SERVICIO), mat = cuenta(SENALES_MATERIAL);
+    if (unidad && UNIDAD_SERVICIO.indexOf(unidad) >= 0) serv += 1;
+    if (serv === mat) return '';        // empate o nada: mejor vacío que mal
+    return serv > mat ? 'Servicios' : 'Materiales';
+  }
+
   const norm = (t) => String(t || '').toLowerCase()
     .normalize('NFD').replace(/[̀-ͯ]/g, '')
     .replace(/[^a-z0-9 ]/g, ' ').replace(/\s+/g, ' ').trim();
@@ -197,7 +252,14 @@
     const vivos = perfil.filter(Boolean);
     const mapa = {};
 
-    const texto = vivos.filter(c => c.pctNum < 0.4).sort((a, b) => b.largo - a.largo);
+    /* La columna de UNIDAD se busca ANTES que la descripción: si no, una
+     * columna de "PZA / MTS / KIT" compite como texto y, peor, la unidad se
+     * pierde. Se reconoce por su contenido, no por su posición. */
+    const textos = vivos.filter(c => c.pctNum < 0.4);
+    const uni = textos.find(c => pareceUnidades(filas.map(f => f[c.i])));
+    if (uni) mapa.unidad = uni.i;
+
+    const texto = textos.filter(c => c.i !== mapa.unidad).sort((a, b) => b.largo - a.largo);
     if (texto.length) mapa.descripcion = texto[0].i;
     if (texto.length > 1) {
       // La segunda columna de texto más larga suele ser marca o modelo. No se
@@ -250,8 +312,36 @@
     'hr': 'Horas', 'hrs': 'Horas', 'hora': 'Horas', 'horas': 'Horas', 'h': 'Horas',
     'lote': 'Lote', 'lotes': 'Lote', 'servicio': 'Servicio', 'juego': 'Juego',
     'rollo': 'Rollo', 'rollos': 'Rollo', 'tramo': 'Tramo', 'tramos': 'Tramo',
-    'caja': 'Caja', 'cajas': 'Caja', 'par': 'Par', 'pares': 'Par'
+    'caja': 'Caja', 'cajas': 'Caja', 'par': 'Par', 'pares': 'Par',
+    'kit': 'Kit', 'kits': 'Kit', 'jgo': 'Juego', 'jgos': 'Juego', 'juegos': 'Juego',
+    'set': 'Juego', 'serv': 'Servicio', 'srv': 'Servicio', 'servicios': 'Servicio',
+    'gbl': 'Global', 'global': 'Global', 'glb': 'Global',
+    'pto': 'Punto', 'ptos': 'Punto', 'punto': 'Punto', 'puntos': 'Punto',
+    'salida': 'Salida', 'salidas': 'Salida', 'ton': 'Tonelada', 'tons': 'Tonelada'
   };
+
+  /** Lleva una unidad escrita como sea a su forma del catálogo. Lo que no
+   *  reconoce lo devuelve TAL CUAL: el acervo está lleno de unidades propias
+   *  ("tramo de 6 m") y borrarlas por no estar en una lista sería peor. */
+  function normalizaUnidad(u) {
+    const t = String(u || '').trim();
+    if (!t) return '';
+    const k = t.toLowerCase().replace(/\./g, '');
+    return Object.prototype.hasOwnProperty.call(UNIDADES, k) ? UNIDADES[k] : t;
+  }
+
+  /** ¿Esta columna es de unidades? Lo es si la mayoría de sus valores son
+   *  unidades reconocibles. Sin esto, una tabla con su columna de UNIDAD la
+   *  perdía entera: `adivinar` sólo buscaba descripción, cantidad y precio. */
+  function pareceUnidades(vals) {
+    const v = vals.filter(x => x !== undefined && x !== '');
+    if (v.length < 2) return false;
+    const casan = v.filter(x => {
+      const k = String(x).trim().toLowerCase().replace(/\./g, '');
+      return Object.prototype.hasOwnProperty.call(UNIDADES, k);
+    }).length;
+    return (casan / v.length) >= 0.6;
+  }
 
   /* Un renglón de una LISTA, no de una tabla. Es la forma en que la gente pega
    * de verdad cuando le pide la lista a una IA o la copia de un correo:
@@ -262,6 +352,23 @@
    *
    * No hay columnas: hay una cantidad al principio, un precio al final y una
    * descripción en medio. Se extrae eso y lo demás se marca para revisar. */
+  /** ¿Este pedazo es un precio? Lo es si trae `$`, o dice `c/u`, o es un número
+   *  a solas con centavos. */
+  function esPrecio(seg) {
+    if (/[$]/.test(seg)) return true;
+    if (/\bc\/?u\b|\bc\.u\.?|\bcada uno\b|\bunitario\b/i.test(seg)) return true;
+    return /^\s*\d{1,3}(?:[,\s]\d{3})*\.\d{1,2}\s*(?:MXN|USD)?\s*$/i.test(seg);
+  }
+
+  /** ¿Y este es una cantidad con su unidad? "8 PZAS", "45 MTS", "3 ROLLOS". */
+  function esCantidad(seg) {
+    const m = String(seg).trim().match(/^(\d+(?:[.,]\d+)?)\s*([a-zA-ZáéíóúñÁÉÍÓÚÑ]{1,10})?\.?$/);
+    if (!m) return null;
+    const palabra = (m[2] || '').toLowerCase().replace(/\./g, '');
+    if (m[2] && !Object.prototype.hasOwnProperty.call(UNIDADES, palabra)) return null;
+    return { qty: aNumero(m[1]), unidad: palabra ? UNIDADES[palabra] : '' };
+  }
+
   function interpretarLinea(linea) {
     let t = String(linea)
       // Fuera viñetas y numeración: "- ", "• ", "* ", "1. ", "1) ".
@@ -270,6 +377,35 @@
     if (!t) return null;
 
     let qty = null, unidad = '', pu = null;
+
+    /* ── Renglón por CAMPOS, cuando los trae ──────────────────────────────
+     * Hay listas donde el precio va PRIMERO y la cantidad en medio:
+     *
+     *     $ 890.00 c/u - 8 PZAS - Lámpara LED industrial 150W high bay
+     *
+     * Leer por posición —cantidad al principio, precio al final— no sirve ahí:
+     * esa lista se rechazaba entera. Cuando el renglón viene partido por " - ",
+     * cada pedazo se clasifica por lo que ES, no por dónde está, y la
+     * descripción es lo que sobra. Así da igual el orden. */
+    const segs = t.split(/\s+[-–—|]\s+/).map(x => x.trim()).filter(Boolean);
+    if (segs.length >= 2) {
+      const resto = [];
+      segs.forEach(seg => {
+        const c = esCantidad(seg);
+        if (c && qty === null) { qty = c.qty; if (c.unidad) unidad = c.unidad; return; }
+        if (esPrecio(seg) && pu === null) {
+          const n = aNumero(seg.replace(/\bc\/?u\b|\bc\.u\.?|\bcada uno\b|\bunitario\b/ig, ''));
+          if (n !== null) { pu = n; return; }
+        }
+        resto.push(seg);
+      });
+      // La descripción es lo que sobró, con sus guiones de vuelta: un nombre
+      // como «Manguera liquidtight 1/2" - reforzada» no debe quedar partido.
+      const desc = resto.join(' - ').replace(/^[\s\-–—:|]+|[\s\-–—:|]+$/g, '').trim();
+      if (desc && (pu !== null || qty !== null)) return { qty, unidad, descripcion: desc, pu };
+      // Si no cuajó, se sigue por el camino de siempre.
+      qty = null; unidad = ''; pu = null;
+    }
 
     /* El PRECIO se busca al final, que es donde va. Se acepta con `$`, con
      * separador de miles o con centavos; un entero suelto al final se toma sólo
@@ -356,9 +492,12 @@
       if (qty === null && pu !== null && total !== null && pu) qty = total / pu;
 
       const tipoCrudo = norm(dame(f, 'tipo'));
-      const tipo = /servicio|mano de obra|mo|labor/.test(tipoCrudo) ? 'Servicios'
-                 : /material|equipo|suministro|insumo/.test(tipoCrudo) ? 'Materiales'
-                 : '';
+      let tipo = /servicio|mano de obra|mo|labor/.test(tipoCrudo) ? 'Servicios'
+               : /material|equipo|suministro|insumo/.test(tipoCrudo) ? 'Materiales'
+               : '';
+      // Si la tabla no lo trae, se deduce de la descripción y se MARCA.
+      let tipoDeducido = false;
+      if (!tipo) { tipo = deducirTipo(desc, normalizaUnidad(dame(f, 'unidad'))); tipoDeducido = !!tipo; }
       const monCruda = String(dame(f, 'moneda') || '').toUpperCase();
       const moneda = /USD|DLL|DOLAR/.test(monCruda) ? 'USD'
                    : /MXN|PESO/.test(monCruda) ? 'MXN'
@@ -372,8 +511,8 @@
 
       return {
         qty: qty === null ? '' : Math.abs(qty),
-        unidad: String(dame(f, 'unidad') || '').trim(),
-        tipo: tipo,
+        unidad: normalizaUnidad(dame(f, 'unidad')),
+        tipo: tipo, _tipoDeducido: tipoDeducido,
         descripcion: desc,
         modelo: String(dame(f, 'modelo') || '').trim(),
         marca: String(dame(f, 'marca') || '').trim(),
@@ -422,9 +561,10 @@
       const avisos = [];
       if (!r.descripcion) avisos.push('sin descripción');
       if (r.pu === null) avisos.push('sin precio');
+      const tipo = deducirTipo(r.descripcion, r.unidad);
       renglones.push({
         qty: r.qty === null ? '' : Math.abs(r.qty),
-        unidad: r.unidad, tipo: '', descripcion: r.descripcion,
+        unidad: r.unidad, tipo: tipo, _tipoDeducido: !!tipo, descripcion: r.descripcion,
         modelo: '', marca: '', pu: r.pu === null ? null : Math.abs(r.pu),
         moneda: /USD|usd|dll/.test(l) ? 'USD' : monedaDoc,
         margen: null, link: '', comentario: '',
@@ -446,5 +586,6 @@
              encabezado: false, mapa: {}, renglones: renglones };
   }
 
-  G.MachotePegar = { interpretar, interpretarLinea, aNumero, partir, ALIAS, UNIDADES };
+  G.MachotePegar = { interpretar, interpretarLinea, aNumero, partir, deducirTipo,
+                     normalizaUnidad, ALIAS, UNIDADES };
 })(window);

--- a/comercial/machote/tests/pruebas-navegador.js
+++ b/comercial/machote/tests/pruebas-navegador.js
@@ -1256,12 +1256,13 @@ let ok = 0, mal = 0;
     const descs = () => p.evaluate(() =>
       [...document.querySelectorAll('[data-cel$=":descripcion"]')].map(i => i.value));
     const antes = await descs();
-    // Se pega DESDE el tercer renglón: los dos de arriba no se tocan.
+    // Se pega ARRIBA del tercer renglón: los dos de arriba no se tocan.
     await p.locator('[data-pegar]').nth(2).click(); await p.waitForTimeout(300);
     const titulo = await p.textContent('.modal h3');
     if (titulo.indexOf('renglón 3') < 0) throw new Error('el modal no dice desde dónde: ' + titulo);
     await p.fill('#pg-txt', '- 4 pzas Rodamiento lineal LM25UU  $4,200.00\n- 1 Placa de acero A36  $38,000');
     await p.waitForTimeout(400);
+    await p.check('input[name="pg-modo"][value="arriba"]');
     await p.click('#pg-ok'); await p.waitForTimeout(500);
     const desp = await descs();
     if (desp[0] !== antes[0] || desp[1] !== antes[1])
@@ -1283,7 +1284,7 @@ let ok = 0, mal = 0;
     await p.locator('[data-pegar]').nth(1).click(); await p.waitForTimeout(300);
     await p.fill('#pg-txt', '- 9 Tornillo hexagonal grado 5  $12.50');
     await p.waitForTimeout(400);
-    await p.check('input[name="pg-modo"][value="inserta"]');
+    await p.check('input[name="pg-modo"][value="arriba"]');
     await p.click('#pg-ok'); await p.waitForTimeout(500);
     const desp = await descs();
     // Todas las descripciones anteriores siguen ahí, más la nueva.
@@ -1327,6 +1328,197 @@ let ok = 0, mal = 0;
       throw new Error('la coma partió los miles o el tabulador se descartó: ' + JSON.stringify(r.tabSinCab));
     if (r.prosa.ok) throw new Error('aceptó un correo de cortesía como lista');
     console.log('    listas, PDF, CSV y tabulador; prosa rechazada');
+  });
+
+  // ── V1.13 · lo que se rompía al pegar ────────────────────────────────
+  await paso('pegar NO borra la unidad ni el tipo que ya estaban', async () => {
+    await p.setViewportSize({ width: 1280, height: 900 });
+    await ir('#/m/M-1041'); await hoja('Suministro');
+    const leer = () => p.evaluate(() => ({
+      u: [...document.querySelectorAll('[data-cel*=":partidas:"][data-cel$=":unidad"]')].map(x => x.value),
+      t: [...document.querySelectorAll('[data-cel*=":partidas:"][data-cel$=":tipo"]')].map(x => x.value)
+    }));
+    const antes = await leer();
+    // Una lista SIN columna de unidad, pegada donde ya había "Pieza"/"Horas".
+    await p.locator('[data-pegar]').first().click(); await p.waitForTimeout(300);
+    await p.fill('#pg-txt', 'Rodamiento LM25UU 4200\nPlaca de acero A36 38000');
+    await p.waitForTimeout(400);
+    await p.click('#pg-ok'); await p.waitForTimeout(500);
+    const desp = await leer();
+    const vacias = desp.u.slice(0, antes.u.length).filter(v => v === '').length;
+    if (vacias > antes.u.filter(v => v === '').length)
+      throw new Error('borró unidades: ' + antes.u.slice(0, 4).join('|') + ' → ' + desp.u.slice(0, 4).join('|'));
+    if (desp.t.slice(0, 2).some(v => v === ''))
+      throw new Error('dejó el Tipo vacío: ' + desp.t.slice(0, 4).join('|'));
+    console.log('    unidades', desp.u.slice(0, 3).join('/'), '· tipos', desp.t.slice(0, 3).join('/'));
+    await p.setViewportSize({ width: 380, height: 780 });
+  });
+
+  await paso('deduce Materiales o Servicios de la descripción', async () => {
+    const r = await p.evaluate(() => {
+      const d = window.MachotePegar.deducirTipo;
+      return {
+        rodamiento: d('Rodamiento lineal LM25UU', ''),
+        instalacion: d('Instalacion de tuberia de cobre', ''),
+        ingenieria: d('Ingenieria de detalle', 'Horas'),
+        maquinado: d('Maquinado externo de bujes', ''),
+        placa: d('Placa de acero A36 y consumibles', ''),
+        desmontaje: d('Desmontaje de equipos existentes', ''),
+        raro: d('Cosa rarisima sin senales', '')
+      };
+    });
+    const esperado = { rodamiento: 'Materiales', instalacion: 'Servicios',
+                       ingenieria: 'Servicios', maquinado: 'Servicios',
+                       placa: 'Materiales', desmontaje: 'Servicios', raro: '' };
+    for (const k in esperado)
+      if (r[k] !== esperado[k])
+        throw new Error(k + ': ' + (r[k] || 'vacío') + ', esperaba ' + (esperado[k] || 'vacío'));
+    // "Instalación de tubería de cobre" es el caso que importa: dos sustantivos
+    // de material detrás de un verbo de servicio. Contando parejo salía al revés.
+    console.log('    el verbo del principio manda sobre los sustantivos');
+  });
+
+  await paso('el pegado marca lo que dedujo, para poder corregirlo', async () => {
+    await p.setViewportSize({ width: 1280, height: 900 });
+    await ir('#/m/M-1041'); await hoja('Suministro');
+    await p.locator('[data-pegar]').first().click(); await p.waitForTimeout(300);
+    await p.fill('#pg-txt', '- 4 Rodamiento lineal LM25UU  $4,200\n- 8 Instalacion de tuberia de cobre  $1,500');
+    await p.waitForTimeout(450);
+    const t = await p.textContent('#pg-prev');
+    if (t.indexOf('deducido') < 0) throw new Error('no marca lo deducido: ' + t.slice(0, 160));
+    if (t.indexOf('Materiales') < 0 || t.indexOf('Servicios') < 0)
+      throw new Error('no dedujo los dos lados: ' + t.slice(0, 200));
+    await p.click('#pg-cancel'); await p.waitForTimeout(250);
+    await p.setViewportSize({ width: 380, height: 780 });
+  });
+
+  await paso('lee una lista con el precio PRIMERO y la cantidad en medio', async () => {
+    /* La forma que reventaba: "$ 890.00 c/u - 8 PZAS - Lámpara LED…". El lector
+     * asumía cantidad al principio y precio al final, así que rechazaba la lista
+     * entera. Ahora cada pedazo se clasifica por lo que ES, no por dónde está. */
+    const r = await p.evaluate(() => {
+      const T = '$ 890.00 c/u - 8 PZAS - Lampara LED industrial 150W high bay\n' +
+                '$ 1,275.50 c/u - 3 ROLLOS - Charola portacables 4 x 3m galvanizada\n' +
+                '$ 62.00 c/u - 45 MTS - Manguera liquidtight 1/2\"\n' +
+                '$ 4,300.00 c/u - 1 PZA - Variador de frecuencia 5HP 220V\n' +
+                '$ 155.75 c/u - 20 PZAS - Terminal ponchable ojillo 6 AWG';
+      const x = window.MachotePegar.interpretar(T, { moneda: 'MXN' });
+      return { ok: x.ok, n: x.renglones.length, r: x.renglones };
+    });
+    if (!r.ok) throw new Error('la rechazó entera');
+    if (r.n !== 5) throw new Error('leyó ' + r.n + ' de 5');
+    const esperado = [
+      { qty: 8,  pu: 890,     u: 'Pieza', d: 'Lampara LED industrial 150W high bay' },
+      { qty: 3,  pu: 1275.5,  u: 'Rollo' },
+      { qty: 45, pu: 62,      u: 'Metro' },
+      { qty: 1,  pu: 4300,    u: 'Pieza' },
+      { qty: 20, pu: 155.75,  u: 'Pieza' }
+    ];
+    esperado.forEach((e, i) => {
+      const g = r.r[i];
+      if (g.qty !== e.qty) throw new Error('renglón ' + (i + 1) + ' cantidad: ' + g.qty + ' ≠ ' + e.qty);
+      if (g.pu !== e.pu) throw new Error('renglón ' + (i + 1) + ' precio: ' + g.pu + ' ≠ ' + e.pu);
+      if (g.unidad !== e.u) throw new Error('renglón ' + (i + 1) + ' unidad: ' + g.unidad + ' ≠ ' + e.u);
+      if (e.d && g.descripcion !== e.d) throw new Error('renglón 1 descripción: ' + g.descripcion);
+      if (g.tipo !== 'Materiales') throw new Error('renglón ' + (i + 1) + ' no dedujo Materiales: ' + g.tipo);
+    });
+    // Y la comilla de 1/2" no debe partir la descripción.
+    if (r.r[2].descripcion !== 'Manguera liquidtight 1/2"')
+      throw new Error('se comió parte de la descripción: ' + r.r[2].descripcion);
+    console.log('    5 de 5, con unidad y tipo deducidos');
+  });
+
+  await paso('lee las cinco formas de tabla que trajo Esteban', async () => {
+    /* Las cinco que probó en vivo, tal como las pegó. Las tres que ya
+     * funcionaban entran aquí para que NO se rompan al arreglar la que no. */
+    const r = await p.evaluate(() => {
+      const P = window.MachotePegar;
+      const casos = {
+        pipes: '5   | PZA  | Interruptor termomagnetico 3P 100A     | 2,450.00\n' +
+               '12  | MTS  | Cable THHN calibre 8 AWG negro         | 38.50\n' +
+               '2   | KIT  | Kit de montaje para gabinete NEMA 4X   | 1,180.00\n' +
+               '30  | PZA  | Conector recto tuberia 3/4             | 24.90\n' +
+               '1   | SERV | Puesta en marcha y pruebas en sitio    | 15,800.00',
+        csvRaro: 'descripcion,precio_unitario,unidad,cantidad\n' +
+               'Bomba centrifuga sanitaria 2HP acero inox,18750.00,PZA,2\n' +
+               'Sello mecanico repuesto serie 21,940.25,PZA,6\n' +
+               'Tuberia sanitaria cedula 10 tramo 6m,2310.00,TRAMO,9\n' +
+               'Abrazadera clamp con empaque EPDM,187.40,JGO,24\n' +
+               'Mano de obra soldadura orbital,650.00,HORA,40'
+      };
+      const o = {};
+      for (const k in casos) {
+        const x = P.interpretar(casos[k], { moneda: 'MXN' });
+        o[k] = { ok: x.ok, n: x.renglones.length, r: x.renglones };
+      }
+      return o;
+    });
+
+    // La de pipes NO trae encabezado: la columna de unidad hay que reconocerla
+    // por su contenido. Antes se perdia entera.
+    if (!r.pipes.ok || r.pipes.n !== 5) throw new Error('pipes: ' + JSON.stringify(r.pipes).slice(0, 120));
+    const p0 = r.pipes.r[0];
+    if (p0.qty !== 5 || p0.pu !== 2450) throw new Error('pipes fila 1: ' + JSON.stringify(p0));
+    const unidadesPipes = r.pipes.r.map(x => x.unidad);
+    if (unidadesPipes.some(u => !u)) throw new Error('perdio unidades: ' + unidadesPipes.join('|'));
+    if (unidadesPipes.join('|') !== 'Pieza|Metro|Kit|Pieza|Servicio')
+      throw new Error('no normalizo las unidades: ' + unidadesPipes.join('|'));
+    if (r.pipes.r[4].tipo !== 'Servicios')
+      throw new Error('"Puesta en marcha" no salio Servicios: ' + r.pipes.r[4].tipo);
+
+    // La CSV trae encabezado pero en OTRO orden, y con precio_unitario.
+    if (!r.csvRaro.ok || r.csvRaro.n !== 5) throw new Error('csv: ' + JSON.stringify(r.csvRaro).slice(0, 120));
+    const c0 = r.csvRaro.r[0];
+    if (c0.qty !== 2 || c0.pu !== 18750) throw new Error('csv fila 1: ' + JSON.stringify(c0));
+    if (r.csvRaro.r.map(x => x.unidad).join('|') !== 'Pieza|Pieza|Tramo|Juego|Horas')
+      throw new Error('csv unidades: ' + r.csvRaro.r.map(x => x.unidad).join('|'));
+    if (r.csvRaro.r[4].tipo !== 'Servicios')
+      throw new Error('"Mano de obra" no salio Servicios: ' + r.csvRaro.r[4].tipo);
+    console.log('    pipes sin encabezado y CSV en otro orden, con unidad normalizada');
+  });
+
+  await paso('los dos modos son arriba y debajo, y ninguno pierde nada', async () => {
+    await p.setViewportSize({ width: 1280, height: 900 });
+    await ir('#/m/M-1041'); await hoja('Suministro');
+    const usadas = () => p.evaluate(() =>
+      [...document.querySelectorAll('[data-cel$=":descripcion"]')].map(i => i.value).filter(Boolean));
+    const antes = await usadas();
+    await p.locator('[data-pegar]').nth(1).click(); await p.waitForTimeout(300);
+    const modos = await p.locator('.modos label').allTextContents();
+    if (!/debajo/.test(modos.join(' ')) || !/arriba/.test(modos.join(' ')))
+      throw new Error('los modos no dicen arriba/debajo: ' + modos.join(' | '));
+    await p.fill('#pg-txt', '- 9 Tornillo hexagonal grado 5  $12.50');
+    await p.waitForTimeout(400);
+    await p.click('#pg-ok'); await p.waitForTimeout(500);   // "debajo" es el de por defecto
+    const desp = await usadas();
+    const perdidas = antes.filter(d => desp.indexOf(d) < 0);
+    if (perdidas.length) throw new Error('se perdieron: ' + perdidas.join(' | '));
+    if (desp.indexOf('Tornillo hexagonal grado 5') !== 2)
+      throw new Error('"debajo" no lo puso después del renglón 2: ' + desp.slice(0, 4).join(' | '));
+    await p.setViewportSize({ width: 380, height: 780 });
+  });
+
+  await paso('pegar no deja la hoja creciendo con renglones vacíos', async () => {
+    const r = await p.evaluate(() => {
+      const C = window.MachoteCalc;
+      const m = C.machoteNuevo({ nombre: 'x' });
+      return { antes: m.secciones[0].partidas.length };
+    });
+    if (r.antes !== 30) throw new Error('la sección nueva no trae 30: ' + r.antes);
+    await p.setViewportSize({ width: 1280, height: 900 });
+    await ir('#/m/M-1042'); await hoja('Adecuación');
+    const cuenta = () => p.evaluate(() =>
+      document.querySelectorAll('[data-cel*=":partidas:"][data-cel$=":descripcion"]').length);
+    const antes = await cuenta();
+    await p.locator('[data-pegar]').first().click(); await p.waitForTimeout(300);
+    await p.fill('#pg-txt', '- 1 Uno  $10\n- 2 Dos  $20\n- 3 Tres  $30\n- 4 Cuatro  $40\n- 5 Cinco  $50');
+    await p.waitForTimeout(400);
+    await p.click('#pg-ok'); await p.waitForTimeout(500);
+    const desp = await cuenta();
+    // Crece porque entran cinco, pero no se dispara: la cola vacía se recorta.
+    if (desp > antes + 5) throw new Error('la hoja creció de más: ' + antes + ' → ' + desp);
+    console.log('   ', antes, '→', desp, 'renglones tras pegar 5');
+    await p.setViewportSize({ width: 380, height: 780 });
   });
 
   // ── El gate ──────────────────────────────────────────────────────────

--- a/comercial/machote/version.json
+++ b/comercial/machote/version.json
@@ -1,10 +1,15 @@
 {
-  "version": "V1.12",
+  "version": "V1.13",
   "fecha": "2026-09-04",
   "modulo": "comercial/machote",
   "ambito": "El CONTADOR es solo de este modulo. finanzas tambien usa V1.xx desde el 2026-09-03 (instruccion directa de Esteban, corrige el \"no propagar\" del issue #148) pero lleva su propio contador y va en V1.00. operaciones/planeacion sigue en 2.4.1, kiosk y confirmar-horas solo con cadena de build, y siete modulos con un 1.0.0 puesto una vez: a esos no se propaga.",
   "esquema": "V<mayor>.<menor de dos digitos>. Un incremento de 0.01 por cada merge a main. Al pasar de .99 sube el mayor y el menor vuelve a 00.",
   "historial": [
+    {
+      "version": "V1.13",
+      "pr": null,
+      "nota": "El pegado lee cualquier forma de lista: precio primero, columna de unidad sin encabezado, CSV en cualquier orden. Deduce Materiales/Servicios, normaliza unidades y ya no borra lo que no supo llenar. Los modos son arriba y debajo, y ninguno pierde nada"
+    },
     {
       "version": "V1.12",
       "pr": null,


### PR DESCRIPTION
Esteban probó cinco tablas. Tres se leían bien, **una se leía a medias sin que se notara**, y una se rechazaba entera.

## La que se rechazaba: el precio iba primero

```
$ 890.00 c/u - 8 PZAS - Lámpara LED industrial 150W high bay
```

El lector asumía cantidad al principio y precio al final, así que la tiraba completa. Ahora, cuando el renglón viene partido, cada pedazo se clasifica por **lo que es** —un precio trae `$` o dice `c/u`; una cantidad es un número con su unidad— y la descripción es lo que sobra. Da igual el orden.

## La que se leía a medias: perdía la columna de unidad

```
5   | PZA  | Interruptor termomagnético 3P 100A | 2,450.00
```

Sin encabezado, `adivinar` sólo buscaba descripción, cantidad y precio: `PZA`, `MTS`, `KIT` y `SERV` se iban a la basura **y nadie lo notaba**. Ahora la columna de unidad se reconoce por su **contenido**.

Y las unidades se normalizan: `PZA`/`MTS`/`JGO`/`HORA` → `Pieza`/`Metro`/`Juego`/`Horas`. Lo que no está en el catálogo **se queda tal cual**, porque el acervo tiene unidades propias y borrarlas sería peor.

## Materiales o Servicios, deducido

Se deduce de la descripción y sale **marcado como deducido** en la vista previa. La señal del **principio pesa el triple**: «Instalación de tubería de cobre» es un servicio aunque traiga dos sustantivos de material detrás — lo que se cotiza es la acción, y el material es su objeto. Contando parejo salía Materiales, o sea al revés. Sin señal clara se queda vacío.

## El pegado ya no borra lo que no supo llenar

**Reproducido y medido:** pegar una lista sin columna de Unidad dejaba en blanco los `Pieza` y `Horas` ya capturados, y el `Tipo` igual. Ahora lo no resuelto **se hereda** del renglón donde se pega. Un pegado que borra datos que no venía a tocar es peor que no pegar.

## Modos más simples

**Escribir debajo** y **escribir arriba** del renglón señalado. En los dos casos lo que ya estaba **se recorre, no se sobrescribe**: la única decisión es dónde va. Y se recorta la cola de renglones vacíos para que la hoja no crezca sin parar.

## Pruebas

**95 pasaron, 0 fallaron.** Las cinco tablas quedaron como caso de prueba — **las tres que ya servían incluidas**, para que no se rompan al arreglar la que no. El parser cubre 14 formas: Markdown, tabulador con y sin encabezado, CSV simple y en otro orden, pipes sin encabezado, PDF por espacios, importe→unitario, viñetas, numerada, texto corrido, precio-primero, y prosa/basura rechazadas.

## Versión

`V1.12` → **`V1.13`**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013Qzhio6K8R23HXHnJ2RJ64