### PR TITLE
Carga MO V1.00 · la nómina de RH llega sola al elegir la semana

### DIFF
--- a/modulos/rh/nomina-incidencias/version.json
+++ b/modulos/rh/nomina-incidencias/version.json
@@ -3,7 +3,7 @@
   "fecha": "2026-09-04",
   "modulo": "rh/nomina-incidencias",
   "esquema": "V<mayor>.<menor de dos digitos>. Un incremento de 0.01 por cada merge a main. Al pasar de .99 sube el mayor y el menor vuelve a 00.",
-  "ambito": "El CONTADOR es solo de este modulo. finanzas y comercial/machote usan el mismo esquema con contadores propios (ver sus version.json). operaciones/planeacion sigue en 2.4.1; kiosk y confirmar-horas solo con cadena de build.",
+  "ambito": "El CONTADOR es solo de este modulo. finanzas, comercial/machote y operaciones/carga-mo usan el mismo esquema con contadores PROPIOS (ver sus version.json): que aqui vaya en V1.16 y carga-mo en V1.00 es lo correcto, no un desfase — son modulos distintos que avanzan por separado. operaciones/planeacion sigue en 2.4.1; kiosk y confirmar-horas solo con cadena de build.",
   "historial": [
     {
       "version": "V1.00",

--- a/operaciones/carga-mo/index.html
+++ b/operaciones/carga-mo/index.html
@@ -4,18 +4,25 @@
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 <title>Validación de Nómina y Carga de Mano de Obra — FTS Suite</title>
-<script>(function(){ window.CMO_BUILD = '20260904-cmo-cruce-rh'; })();</script>
+<!-- La version de ESTE modulo. Su contador es propio: no lo comparte con
+     rh/nomina-incidencias ni con finanzas, aunque los tres usen el mismo esquema
+     Vx.yy. Se bumpea junto con version.json y con el ?v= de cada script, y el gate
+     exige que los tres digan lo mismo: un badge que anuncia una version mientras
+     el navegador corre el codigo viejo miente en la peor direccion. -->
+<script>(function(){ window.CMO_VER = 'V1.00'; })();</script>
 <script src="../../finanzas/js/auth-fin.js"></script>
 <script src="https://cdnjs.cloudflare.com/ajax/libs/xlsx/0.18.5/xlsx.full.min.js"></script>
-<script src="js/cruce-rh.js?v=20260904-cmo-cruce-rh"></script>
-<script src="js/resolver.js"></script>
+<script src="js/cruce-rh.js?v=V1.00"></script>
+<script src="js/resolver.js?v=V1.00"></script>
 <style>
   :root{ --azul:#1a4480; --ok:#1a7a3a; --warn:#BA7517; --err:#b3261e; --info:#3b5bdb; --bg:#f4f6f9; }
   *{ box-sizing:border-box; }
   body{ margin:0; font-family:'Segoe UI',Arial,sans-serif; background:var(--bg); color:#1c1c1c; }
   .top{ display:flex; align-items:center; gap:14px; background:var(--azul); color:#fff; padding:10px 16px; }
   .top a{ color:#fff; text-decoration:none; font-size:14px; opacity:.9; }
-  .top .t{ font-weight:600; flex:1; } .top .b{ font-size:10px; opacity:.6; }
+  .top .t{ font-weight:600; flex:1; }
+  .top .b{ font-size:12px; font-weight:700; letter-spacing:.3px; background:rgba(255,255,255,.18);
+           border-radius:20px; padding:2px 10px; margin-left:8px; }
   .wrap{ max-width:1080px; margin:0 auto; padding:16px; }
   .card{ background:#fff; border-radius:10px; padding:16px; box-shadow:0 1px 6px rgba(0,0,0,.06); margin-bottom:14px; }
   .card h3{ margin:0 0 10px; font-size:15px; }
@@ -157,15 +164,14 @@
       </div>
     </div>
     <div class="sep"></div>
-    <!-- El archivo de RH. Va en la misma barra que el de CONTPAQi a proposito: son
-         los dos insumos de la misma decision, y separarlos haria parecer que uno es
-         opcional. Es opcional para VALIDAR, pero no para mandar con confianza. -->
+    <!-- Lo que mando RH ya NO se sube: se trae del sistema al elegir la semana.
+         Aqui solo se ve su estado. Pedirle a Ulises el Excel de Magaly era pedirle
+         que consiguiera por correo un dato que el sistema ya tiene guardado —y de
+         paso abria la puerta a que cruzara contra un archivo viejo o editado. -->
     <div class="fld">
-      <label>Archivo de RH (Magaly)</label>
+      <label>Lo que mandó RH</label>
       <div class="fld-in">
-        <button class="btn btn-g" id="drop-rh">📋 Elegir archivo…</button>
-        <span class="mut" id="fname-rh">ninguno</span>
-        <input type="file" id="file-rh" accept=".csv,.xlsx,.xls" style="display:none">
+        <span id="rh-est" class="mut">elige la semana…</span>
       </div>
     </div>
     <div class="acts">
@@ -174,6 +180,13 @@
     </div>
   </div>
   <div class="mut catline" id="cat-st">catálogo: cargando…</div>
+
+  <!-- La nómina que RH envió, tal cual la mandó. Va AQUÍ, fuera de #result y pegada
+       al selector, porque se puede leer sin haber subido nada: es la instrucción que
+       Ulises va a capturar, y verla antes de capturar es la mitad del trabajo. El
+       cruce contra el CONTPAQi vive mas abajo, dentro de #result, y contesta otra
+       pregunta: si lo que capturó coincide con esto. -->
+  <div id="despacho-panel"></div>
 
   <div id="result" style="display:none">
 
@@ -243,7 +256,16 @@ var WRITE_WEBHOOK = 'https://primary-production-5c3c.up.railway.app/webhook/plan
 var CAT = null, CAT_ERR = null, PARSED = null, LAST_REPORT = null;
 var BANNER = null;    /* estado del banner grande: lo pinta render() y lo completa renderReport() */
 var DIM = false;      /* archivo con fallas de INTEGRIDAD -> los derivados no son confiables */
-document.getElementById('b').textContent = window.CMO_BUILD;
+document.getElementById('b').textContent = window.CMO_VER;
+/* version.json manda; el literal de arriba es solo el respaldo para cuando el fetch
+   no contesta (Pages cacheando, red caida, abrir por file://). Si difieren, gana el
+   archivo y se DICE en consola: un badge atrasado es como no tener badge. */
+fetch('version.json?t=' + Date.now()).then(function(r){ return r.json(); }).then(function(v){
+  if(v && v.version){
+    document.getElementById('b').textContent = v.version;
+    if(v.version !== window.CMO_VER) console.warn('carga-mo: version.json dice ' + v.version + ' y el html ' + window.CMO_VER);
+  }
+}).catch(function(){});
 
 /* ── utilidades ──────────────────────────────────────────────────────────── */
 function $(id){ return document.getElementById(id); }
@@ -307,6 +329,26 @@ function boot(){
   var s = window.FinAuth && FinAuth.getSession && FinAuth.getSession();
   $('u').textContent = (s && s.user) || 'nómina';
   cargarCatalogo();
+  arrancarSemana();
+}
+
+/* La semana que se propone al abrir es la ÚLTIMA CERRADA, no la de hoy.
+   La semana corre VIE→JUE: un viernes la semana "actual" lleva un día de vida y no
+   hay nada que capturar en ella. Lo que se procesa un viernes es la semana que
+   acaba de terminar. Es la misma regla que usa nom/semana del lado de RH, y tiene
+   que ser la misma o las dos pantallas hablarían de semanas distintas.
+   Es una PROPUESTA: si el Excel de CONTPAQi es de otra semana, el cruce de más
+   abajo lo marca como falla de integridad y no deja mandar. */
+function arrancarSemana(){
+  var hoy = new Date();
+  var d = Date.UTC(hoy.getFullYear(), hoy.getMonth(), hoy.getDate());
+  var jue = d + ((4 - new Date(d).getUTCDay() + 7) % 7) * 864e5;
+  if(jue >= d) jue -= 7*864e5;                 /* la de hoy sigue abierta */
+  var vie = new Date(jue - 6*864e5).toISOString().slice(0,10);
+  $('f-vie').value = vie;
+  $('f-jue').textContent = new Date(jue).toISOString().slice(0,10);
+  $('f-sem').textContent = semanaDeViernes(vie) || '—';
+  cargarDespacho();
 }
 async function doLogin(){
   var u = ($('lg-u').value||'').trim(), p = $('lg-p').value||'';
@@ -335,6 +377,10 @@ $('f-vie').addEventListener('change', function(e){
   var v = e.target.value; if(!v) return;
   var d = new Date(v+'T12:00:00'), j = new Date(d.getTime()+6*864e5);
   $('f-jue').textContent = j.toISOString().slice(0,10);
+  $('f-sem').textContent = semanaDeViernes(v) || '—';
+  /* Elegir la semana es el gesto que trae lo de RH. Antes habia que ir por el Excel
+     de Magaly al correo; ahora ya esta aqui cuando Ulises suelta el CONTPAQi. */
+  cargarDespacho();
   if(PARSED) render();
 });
 
@@ -372,42 +418,173 @@ function leer(f){
   rd.readAsArrayBuffer(f);
 }
 
-/* ── el archivo que mandó RH ──────────────────────────────────────────────
-   Se acepta .csv y .xlsx porque RH manda los dos y es el MISMO archivo: el csv es
-   el acuse (lo que se congela al enviar) y el xlsx la vista. Obligar a uno solo
-   seria pedirle a Ulises que sepa cual le tocó. */
-var RH = null;
-var dropRh = $('drop-rh'), fileRh = $('file-rh');
-dropRh.addEventListener('click', function(){ fileRh.click(); });
-dropRh.addEventListener('dragover', function(e){ e.preventDefault(); dropRh.style.background='#e8f2ff'; });
-dropRh.addEventListener('dragleave', function(){ dropRh.style.background=''; });
-dropRh.addEventListener('drop', function(e){ e.preventDefault(); dropRh.style.background='';
-  if(e.dataTransfer.files[0]) leerRH(e.dataTransfer.files[0]); });
-fileRh.addEventListener('change', function(e){ if(e.target.files[0]) leerRH(e.target.files[0]); });
+/* ── lo que mandó RH, traído del sistema ──────────────────────────────────
+   Ulises ya no sube nada de RH. Al elegir la semana se le pide a nom/despacho el
+   archivo CONGELADO del envío —los mismos bytes que RH mandó, no una regeneración
+   con los datos de hoy— y contra eso se evalúa el CONTPAQi.
 
-function leerRH(f){
-  $('fname-rh').textContent = f.name;
-  var rd = new FileReader();
-  var esCsv = /\.csv$/i.test(f.name);
-  rd.onload = function(ev){
-    try{
-      if(esCsv){
-        RH = CruceRH.parseDespacho(ev.target.result);
-      }else{
-        var wb = XLSX.read(new Uint8Array(ev.target.result), { type:'array' });
-        /* La hoja que importa es la de instrucciones: es la que RH manda. La de
-           Detalle es el respaldo por concepto y no cambia el cruce. */
-        var hoja = wb.Sheets['Instrucciones'] || wb.Sheets[wb.SheetNames[0]];
-        RH = CruceRH.desdeFilas(XLSX.utils.sheet_to_json(hoja, { header:1, raw:false, defval:'' }));
-      }
-    }catch(err){
-      RH = { error: 'No se pudo abrir el archivo: ' + err.message, filas: [] };
+   RH_EST distingue tres cosas que en la version anterior se veian igual:
+     'nada'   — todavia no se ha elegido semana
+     'falta'  — el sistema contesto y RH NO ha enviado esa semana
+     'error'  — no se pudo preguntar (red, sesion, servidor)
+   La diferencia importa: 'falta' es un pendiente de Magaly y 'error' es un problema
+   nuestro. Fundirlos en un solo mensaje gris manda a Ulises a hablar con la persona
+   equivocada. */
+var RH = null;
+var RH_EST = { estado:'nada', msg:'' };
+var RH_SEM = null;          /* la semana que se pidio, para no pintar una respuesta vieja */
+var DESPACHO_WEBHOOK = 'https://primary-production-5c3c.up.railway.app/webhook/nom/despacho';
+
+/* El viernes elegido -> el id de semana 'Snn/aaaa'.
+   El ancla es la misma de toda la nomina: el jueves 2026-07-23 es la SEM 30 porque
+   asi quedaron escritas las lineas en Odoo (docs/operaciones/ESTADO.md §1). Es el
+   mismo numero que trae el Excel de CONTPAQi en su periodo, y por eso el cruce de
+   semanas de mas abajo puede compararlos de tu a tu. */
+function semanaDeViernes(vie){
+  if(!vie) return null;
+  var v = new Date(vie + 'T12:00:00Z');
+  if(isNaN(v.getTime())) return null;
+  var jue = new Date(v.getTime() + 6*864e5);
+  var ancla = Date.UTC(2026, 6, 23);
+  var n = 30 + Math.round((Date.UTC(jue.getUTCFullYear(), jue.getUTCMonth(), jue.getUTCDate()) - ancla) / (7*864e5));
+  return 'S' + n + '/' + jue.getUTCFullYear();
+}
+
+function pintarEstadoRh(){
+  var el = $('rh-est'); if(!el) return;
+  if(RH_EST.estado === 'cargando'){ el.className = 'mut'; el.textContent = 'consultando…'; return; }
+  if(RH_EST.estado === 'ok'){
+    el.className = ''; el.style.color = 'var(--ok)'; el.style.fontWeight = '600';
+    el.textContent = '✓ ' + (RH.semana || RH_SEM) + (RH.version ? ' v' + RH.version : '');
+    return;
+  }
+  el.className = 'mut'; el.style.fontWeight = '600';
+  el.style.color = RH_EST.estado === 'error' ? 'var(--err)' : 'var(--warn)';
+  el.textContent = RH_EST.estado === 'error' ? '⚠️ no se pudo consultar'
+                 : RH_EST.estado === 'falta' ? 'aún no la envían'
+                 : 'elige la semana…';
+}
+
+async function cargarDespacho(){
+  var semId = semanaDeViernes($('f-vie').value);
+  RH = null; RH_SEM = semId;
+  if(!semId){ RH_EST = { estado:'nada', msg:'' }; pintarEstadoRh(); refrescarCruce(); return; }
+
+  RH_EST = { estado:'cargando', msg:'' }; pintarEstadoRh();
+  var pedida = semId;
+  try{
+    var r = await fetch(DESPACHO_WEBHOOK, {
+      method:'POST', headers:{ 'Content-Type':'application/json' },
+      body: JSON.stringify({ semana: semId, token: (window.FinAuth && FinAuth.getToken && FinAuth.getToken()) || '' })
+    });
+    var j = await r.json();
+    /* Si mientras respondia el server Ulises cambio de semana, esta respuesta ya no
+       es la buena. Pintarla seria mostrarle la semana pasada creyendo que ve la que
+       acaba de elegir — el peor error posible en una pantalla que decide dinero. */
+    if(pedida !== RH_SEM) return;
+
+    if(!r.ok || j._error || j.ok === false){
+      RH_EST = { estado:'error', msg: (j && j.msg) || ('el servidor contestó ' + r.status) };
+    }else if(!j.enviada){
+      RH_EST = { estado:'falta', msg: j.msg || 'RH todavía no ha enviado esta semana.' };
+    }else{
+      RH = CruceRH.parseDespacho(j.archivo);
+      RH.version = j.version || RH.version;
+      RH.enviado_por = j.enviado_por || null;
+      RH.enviado_en = j.enviado_en || null;
+      RH.cambios_despues = Number(j.cambios_despues) || 0;
+      RH_EST = { estado:'ok', msg:'' };
     }
-    /* El cruce caduca junto con el reporte: cambiar un insumo invalida lo validado. */
-    invalidarReporte();
-    if(PARSED) render(); else pintarCruceRH(null);
-  };
-  if(esCsv) rd.readAsText(f, 'utf-8'); else rd.readAsArrayBuffer(f);
+  }catch(e){
+    if(pedida !== RH_SEM) return;
+    RH_EST = { estado:'error', msg: 'no se pudo consultar el envío de RH: ' + e.message };
+  }
+  pintarEstadoRh();
+  refrescarCruce();
+}
+
+/* Cambiar un insumo invalida lo validado: el cruce caduca junto con el reporte. */
+function refrescarCruce(){
+  invalidarReporte();
+  pintarDespacho();
+  if(PARSED) render(); else pintarCruceRH(null);
+}
+
+/* ── la previa de lo que mandó RH ─────────────────────────────────────────
+   Es una VISTA de lo que ya está en el sistema, no un insumo que Ulises aporte.
+   Muestra las mismas columnas del archivo que RH manda —código, número, persona,
+   instrucción y qué revisar— porque la instrucción ES el producto: no hay un total
+   que cuadrar aquí, hay renglones que capturar.
+
+   Solo se pinta cuando la semana viene ENVIADA. Un borrador no se enseña: mientras
+   Magaly no oprima enviar, esos números todavía pueden cambiar y ponerlos en la
+   pantalla de Ulises lo pondría a cuadrar contra algo que se mueve. */
+function pintarDespacho(){
+  var box = $('despacho-panel'); if(!box) return;
+
+  if(!RH){
+    /* Con 'nada' se queda callado a proposito: la barra de arriba ya dice 'elige la
+       semana' y repetirlo en una tarjeta grande es ruido. Los otros dos SÍ se
+       pintan, porque son un pendiente concreto de alguien. */
+    if(RH_EST.estado === 'error'){
+      box.innerHTML = '<div class="card"><h3>La nómina que envió RH</h3>'
+        + '<div class="msg m-int"><div><b>No se pudo consultar.</b>'
+        + '<div class="mono" style="font-size:12px;margin:3px 0">' + esc(RH_EST.msg) + '</div>'
+        + '<div class="mut" style="font-size:12px">→ Vuelve a elegir la semana para reintentar.</div></div></div></div>';
+    }else if(RH_EST.estado === 'falta'){
+      box.innerHTML = '<div class="card"><h3>La nómina que envió RH</h3>'
+        + '<div class="msg m-avi"><div><b>La ' + esc(RH_SEM || 'semana') + ' todavía no la envían.</b>'
+        + '<div class="mut" style="font-size:12px;margin-top:3px">En cuanto Magaly la mande, aparece aquí sola.'
+        + '</div></div></div></div>';
+    }else{
+      box.innerHTML = '';
+    }
+    return;
+  }
+
+  if(RH.error){
+    box.innerHTML = '<div class="card"><h3>La nómina que envió RH</h3>'
+      + '<div class="msg m-int"><div><b>El archivo que mandó RH no se pudo leer.</b>'
+      + '<div class="mono" style="font-size:12px;margin:3px 0">' + esc(RH.error) + '</div>'
+      + '<div class="mut" style="font-size:12px">→ Avísale a Magaly: el envío quedó guardado con un'
+      + ' formato que esta pantalla no reconoce.</div></div></div></div>';
+    return;
+  }
+
+  var conIns = 0, conRev = 0;
+  for(var i=0;i<RH.filas.length;i++){
+    if(String(RH.filas[i].instruccion||'').trim()) conIns++;
+    if(String(RH.filas[i].revisar||'').trim()) conRev++;
+  }
+
+  /* Se listan TODAS las personas, no solo las que traen instrucción: que alguien
+     aparezca sin nada que hacer es información —significa 'a esta persona no le
+     toca ajuste'— y esconderla dejaría a Ulises sin saber si se le olvidó o si de
+     verdad no había nada. Las que sí traen instrucción van resaltadas. */
+  var cuerpo = RH.filas.map(function(f){
+    var ins = String(f.instruccion||'').trim();
+    var rev = String(f.revisar||'').trim();
+    return '<tr' + (ins ? ' style="background:#fbfcff"' : '') + '>'
+      + '<td class="mono">' + esc(f.codigo || '—') + '</td>'
+      + '<td class="mono">' + esc(f.no_empleado || '') + '</td>'
+      + '<td>' + esc(f.nombre) + '</td>'
+      + '<td>' + (ins ? esc(ins) : '<span class="mut">sin ajustes</span>') + '</td>'
+      + '<td>' + (rev ? '<span style="color:var(--warn)">' + esc(rev) + '</span>' : '') + '</td>'
+      + '</tr>';
+  }).join('');
+
+  box.innerHTML = '<div class="card">'
+    + '<h3>La nómina que envió RH <span class="mut" style="font-weight:400">· ' + esc(RH.semana)
+    + (RH.version ? ' v' + RH.version : '')
+    + (RH.enviado_en ? ' · enviada ' + esc(String(RH.enviado_en).slice(0,10)) : '')
+    + (RH.enviado_por ? ' por ' + esc(RH.enviado_por) : '') + '</span></h3>'
+    + '<div class="mut" style="font-size:12px;margin-bottom:8px">'
+    + RH.filas.length + ' personas · <b>' + conIns + ' con instrucción</b>'
+    + (conRev ? ' · ' + conRev + ' con algo que revisar' : '')
+    + ' — esto es lo que hay que capturar en CONTPAQi.</div>'
+    + '<div style="overflow-x:auto"><table><thead><tr>'
+    + '<th>Código</th><th>No.</th><th>Empleado</th><th>Instrucción</th><th>Revisar</th>'
+    + '</tr></thead><tbody>' + cuerpo + '</tbody></table></div></div>';
 }
 
 /* ── el cruce, pintado ────────────────────────────────────────────────────
@@ -421,16 +598,49 @@ function pintarCruceRH(P){
      dentro de #result, o sea que Ulises suelta el archivo de Magaly y no pasa nada.
      Lo cazo la prueba visual, no la de logica — la logica veia el texto correcto en
      un elemento de cero pixeles. */
-  if (RH) $('result').style.display = 'block';
+  if (RH || RH_EST.estado === 'falta' || RH_EST.estado === 'error') $('result').style.display = 'block';
   if(!RH){
-    box.innerHTML = '<div class="card"><h3>Revisión contra lo que mandó RH</h3>'
-      + '<div class="msg m-avi"><div><b>No se cargó el archivo de RH.</b>'
-      + '<div class="mut" style="font-size:12px;margin-top:3px">La nómina se está validando'
-      + ' <b>contra sí misma</b>: que cuadre, que los conceptos estén catalogados, que los totales'
-      + ' cierren. Eso no dice si trae lo que RH pidió. Sube arriba el archivo que te mandó Magaly'
-      + ' para compararlos.</div></div></div></div>';
+    /* Los tres 'no hay nada que cruzar' NO son el mismo problema y no se le dicen
+       igual a Ulises: uno lo resuelve el eligiendo semana, otro lo resuelve Magaly
+       enviando, y el tercero lo resolvemos nosotros. En los tres casos se dice
+       ademas que NO se comparo nada, para que un panel sin hallazgos no se lea como
+       un visto bueno. */
+    var cuerpo;
+    if(RH_EST.estado === 'error'){
+      cuerpo = '<div class="msg m-int"><div><b>No se pudo traer lo que mandó RH.</b>'
+        + '<div class="mono" style="font-size:12px;margin:3px 0">' + esc(RH_EST.msg) + '</div>'
+        + '<div class="mut" style="font-size:12px">→ La nómina de abajo está validada'
+        + ' <b>contra sí misma</b>, pero <b>nadie comparó</b> si trae lo que RH pidió.'
+        + ' Vuelve a elegir la semana para reintentar; si sigue fallando, avisa antes de mandar.</div></div></div>';
+    }else if(RH_EST.estado === 'falta'){
+      cuerpo = '<div class="msg m-avi"><div><b>RH todavía no ha enviado la ' + esc(RH_SEM || 'semana') + '.</b>'
+        + '<div class="mut" style="font-size:12px;margin-top:3px">Puedes validar el archivo de CONTPAQi'
+        + ' <b>contra sí mismo</b> —que cuadre, que los conceptos estén catalogados, que los totales'
+        + ' cierren—, pero hasta que Magaly envíe no hay contra qué comparar lo que trae.</div></div></div>';
+    }else{
+      cuerpo = '<div class="msg m-avi"><div><b>Elige arriba la semana.</b>'
+        + '<div class="mut" style="font-size:12px;margin-top:3px">Al elegirla se trae sola la nómina'
+        + ' que RH envió, y con ella se compara el archivo de CONTPAQi.</div></div></div>';
+    }
+    box.innerHTML = '<div class="card"><h3>Revisión contra lo que mandó RH</h3>' + cuerpo + '</div>';
     return 0;
   }
+  /* Sin nomina de CONTPAQi NO se cruza. Cruzar contra una lista vacia da un hallazgo
+     de INTEGRIDAD por cada persona —"RH la incluyo y no aparece"— que es cierto en lo
+     literal y falso en lo que importa: no falta nadie, falta el archivo. Antes esto
+     casi no se veia porque el cruce solo corria cuando Ulises subia a mano el archivo
+     de RH; ahora que llega solo al elegir la semana, la pantalla abriria con tres
+     alarmas rojas y cero nomina cargada. Una alarma que suena sola es una alarma que
+     se aprende a ignorar, y despues no suena la de verdad. */
+  if(!P || !P.empleados){
+    box.innerHTML = '<div class="card"><h3>Revisión contra lo que mandó RH</h3>'
+      + '<div class="msg m-avi"><div><b>Falta la otra mitad: la nómina de CONTPAQi.</b>'
+      + '<div class="mut" style="font-size:12px;margin-top:3px">Arriba ya está lo que pidió RH.'
+      + ' En cuanto subas el archivo de CONTPAQi se comparan renglón por renglón:'
+      + ' qué pidió RH que no capturaste, y qué capturaste que RH no pidió.</div></div></div></div>';
+    return 0;
+  }
+
   var semSel = (P && P.periodo) ? ('S' + P.periodo.periodo + '/' + (new Date(P.periodo.inicio+'T12:00:00')).getFullYear()) : null;
   var r = CruceRH.cruzar(RH, (P && P.empleados) || [], semSel);
   var nInt = CruceRH.contar(r.hallazgos, 'INTEGRIDAD');
@@ -438,8 +648,23 @@ function pintarCruceRH(P){
 
   var cab = '<h3>Revisión contra lo que mandó RH'
     + (RH.semana ? ' <span class="mut" style="font-weight:400">· ' + esc(RH.semana)
-        + (RH.version ? ' v' + RH.version : '') + ' · ' + r.resumen.total_rh + ' personas</span>' : '')
+        + (RH.version ? ' v' + RH.version : '') + ' · ' + r.resumen.total_rh + ' personas'
+        + (RH.enviado_en ? ' · enviada ' + esc(String(RH.enviado_en).slice(0,10)) : '')
+        + (RH.enviado_por ? ' por ' + esc(RH.enviado_por) : '')
+        + '</span>' : '')
     + '</h3>';
+
+  /* Lo que se cruza es el archivo CONGELADO del envio. Si RH movio capturas
+     despues de mandarlo, lo de aqui sigue siendo lo correcto contra que validar
+     —es lo que se mando— pero ya no es lo ultimo que RH sabe, y eso se DICE en vez
+     de servir callado un dato que quiza esta por cambiar. */
+  if(RH.cambios_despues > 0){
+    cab += '<div class="msg m-cla"><div><b>RH movió ' + RH.cambios_despues
+        + (RH.cambios_despues === 1 ? ' captura' : ' capturas') + ' después de enviar.</b>'
+        + '<div class="mut" style="font-size:12px;margin-top:3px">Abajo se compara contra'
+        + ' <b>lo que se envió</b>, que es lo correcto. Pero antes de cargar a Odoo, pregúntale'
+        + ' a Magaly si va a reenviar la semana.</div></div></div>';
+  }
 
   if(!r.hallazgos.length){
     box.innerHTML = '<div class="card">' + cab
@@ -798,7 +1023,7 @@ function armarPayload(modo){
       resueltas: P.layout.conceptos,
       no_catalogadas: P.layout.no_catalogadas,
       headers_crudos: P.layout.headers_crudos,
-      build: window.CMO_BUILD
+      build: window.CMO_VER
     },
     /* empleados: campos legacy (bruto/vac/asim) + campos v2. El motor viejo ignora los nuevos. */
     empleados: P.empleados.map(function(e){

--- a/operaciones/carga-mo/version.json
+++ b/operaciones/carga-mo/version.json
@@ -1,0 +1,14 @@
+{
+  "version": "V1.00",
+  "fecha": "2026-09-04",
+  "modulo": "operaciones/carga-mo",
+  "esquema": "V<mayor>.<menor de dos digitos>. Un incremento de 0.01 por cada merge a main. Al pasar de .99 sube el mayor y el menor vuelve a 00.",
+  "ambito": "El CONTADOR es SOLO de este modulo y arranca en V1.00 aunque el modulo lleve meses en produccion: antes se versionaba con una cadena de build (la ultima fue 20260904-cmo-cruce-rh) y esa numeracion no se puede continuar. rh/nomina-incidencias, finanzas y comercial/machote usan el MISMO esquema con contadores PROPIOS — que aqui diga V1.00 y alla V1.16 es lo correcto, no un desfase.",
+  "historial": [
+    {
+      "version": "V1.00",
+      "pr": null,
+      "nota": "Estreno del contador propio, y con el la previa del despacho traida del sistema. Ulises ya NO sube el archivo de Magaly: al elegir la semana, la pantalla le pide a nom/despacho lo que RH envio y lo pinta debajo del header. Se quita el campo 'Archivo de RH' de la barra. El archivo que llega es el CONGELADO del envio, no uno regenerado: contra eso se evalua el CONTPAQi. Endpoint nuevo nom/despacho (n8n RyfiafaRa4f1UUqb), de solo lectura, que valida la sesion de Finanzas y se niega a entregar borradores."
+    }
+  ]
+}

--- a/tests/gate-cruce-rh.js
+++ b/tests/gate-cruce-rh.js
@@ -11,6 +11,7 @@
 
 'use strict';
 const path = require('path');
+const fs = require('fs');
 const RAIZ = path.join(__dirname, '..');
 const Cruce = require(path.join(RAIZ, 'operaciones', 'carga-mo', 'js', 'cruce-rh.js'));
 const Des = require(path.join(RAIZ, 'modulos', 'rh', 'nomina-incidencias', 'js', 'despacho.js'));
@@ -253,6 +254,92 @@ seccion('Forma de los hallazgos');
   check('los niveles son los tres del resolver',
     r.hallazgos.every(x => ['INTEGRIDAD', 'REVISION', 'AVISO'].indexOf(x.nivel) >= 0));
   check('contar() cuenta por nivel', Cruce.contar(r.hallazgos, 'INTEGRIDAD') >= 1);
+}
+
+seccion('El calendario del frontend contra el del workflow');
+{
+  // Carga MO le pide una semana a nom/despacho por su id 'Snn/aaaa'. Si el frontend
+  // y el workflow numeran distinto, Ulises pide una semana y RH le contesta con
+  // otra — y las dos pantallas se ven perfectamente bien mientras hablan de cosas
+  // distintas. Por eso el calculo del html se lee del html y se compara contra el
+  // del workflow, no contra una copia de este archivo.
+  const html = fs.readFileSync(path.join(RAIZ, 'operaciones/carga-mo/index.html'), 'utf8');
+  const m = /function semanaDeViernes\(vie\)\{[\s\S]*?\n\}/.exec(html);
+  check('el html define semanaDeViernes', !!m);
+  const semanaDeViernes = new Function('return ' + String(m[0]).replace('function semanaDeViernes', 'function'))();
+
+  const ANCLA = Date.UTC(2026, 6, 23), MS = 864e5;
+  const idDelWorkflow = jue => 'S' + (30 + Math.round((jue - ANCLA) / (7 * MS))) + '/' + new Date(jue).getUTCFullYear();
+
+  check('el ancla: el viernes 17-jul-2026 es la S30/2026', semanaDeViernes('2026-07-17') === 'S30/2026');
+
+  let divergen = 0, primera = null;
+  for (let k = -60; k <= 60; k++) {
+    const jue = ANCLA + k * 7 * MS;
+    const vie = new Date(jue - 6 * MS).toISOString().slice(0, 10);
+    if (semanaDeViernes(vie) !== idDelWorkflow(jue)) { divergen++; if (!primera) primera = vie; }
+  }
+  check('120 semanas seguidas dan el mismo id que el workflow', divergen === 0,
+    divergen ? divergen + ' divergen, la primera el ' + primera : '');
+
+  // El anio del id sale del JUEVES que cierra, no del viernes que abre: el workflow
+  // rechaza el id si el anio no cuadra, asi que equivocarse aqui es un 400.
+  check('en el cruce de anio manda el jueves', /\/2027$/.test(semanaDeViernes('2027-01-01')));
+  check('entrada vacia no truena', semanaDeViernes('') === null);
+  check('entrada basura no truena', semanaDeViernes('no-es-fecha') === null);
+
+  // La semana que se propone al abrir es la ULTIMA CERRADA. Un viernes la semana en
+  // curso lleva un dia de vida y no hay nada que capturar en ella; lo que se procesa
+  // es la que acaba de cerrar. Tiene que ser la MISMA regla que usa nom/semana del
+  // lado de RH, o las dos pantallas abren en semanas distintas.
+  const m2 = /function arrancarSemana\(\)\{[\s\S]*?\n\}/.exec(html);
+  check('el html define arrancarSemana', !!m2);
+  check('arrancarSemana retrocede cuando la semana sigue abierta', /jue >= d\) jue -= 7\*864e5/.test(String(m2[0])));
+
+  const propuesta = hoyIso => {
+    const hoy = new Date(hoyIso + 'T12:00:00');
+    const d = Date.UTC(hoy.getFullYear(), hoy.getMonth(), hoy.getDate());
+    let jue = d + ((4 - new Date(d).getUTCDay() + 7) % 7) * 864e5;
+    if (jue >= d) jue -= 7 * 864e5;
+    return new Date(jue - 6 * 864e5).toISOString().slice(0, 10);
+  };
+  const semanaDelViernes4 = ['2026-09-04', '2026-09-05', '2026-09-07', '2026-09-10']
+    .every(dia => propuesta(dia) === '2026-08-28');
+  check('del vie 4-sep al jue 10-sep se propone la semana que cerro el 3-sep', semanaDelViernes4);
+  check('el viernes siguiente ya salta a la que cerro', propuesta('2026-09-11') === '2026-09-04');
+  check('la propuesta del 4-sep es la S36/2026', semanaDeViernes(propuesta('2026-09-04')) === 'S36/2026');
+}
+
+seccion('Contrato con nom/despacho');
+{
+  // El endpoint devuelve el TEXTO del csv congelado, y el motor lo lee con el mismo
+  // parseDespacho que antes leia el archivo subido a mano. Que siga siendo el mismo
+  // camino es lo que hace que quitar el drop manual no cambie el resultado.
+  const html = fs.readFileSync(path.join(RAIZ, 'operaciones/carga-mo/index.html'), 'utf8');
+  check('la pantalla ya NO pide el archivo de RH a mano',
+    !/id="file-rh"/.test(html) && !/id="drop-rh"/.test(html));
+  check('lo que llega del endpoint se lee con parseDespacho',
+    /RH = CruceRH\.parseDespacho\(j\.archivo\)/.test(html));
+  check('se manda el token de Finanzas en el body, no en un header',
+    /body: JSON\.stringify\(\{ semana: semId, token:/.test(html));
+  check('una respuesta de una semana vieja se descarta',
+    /if\(pedida !== RH_SEM\) return;/.test(html));
+  check('un borrador no se pinta como enviado', /if\(!j\.enviada\)/.test(html));
+
+  // Los tres 'no hay nada que cruzar' NO son el mismo problema: uno lo resuelve
+  // Ulises, otro Magaly y el tercero nosotros. Fundirlos manda a Ulises a hablar con
+  // la persona equivocada.
+  check('el estado distingue falta de RH y falla nuestra',
+    /RH_EST = \{ estado:'falta'/.test(html) && /RH_EST = \{ estado:'error'/.test(html));
+  check('cuando no se pudo consultar, se DICE que no se comparo nada',
+    /nadie comparó<\/b> si trae lo que RH pidió/.test(html));
+
+  // El texto que devuelve el endpoint es el mismo que produce el generador de RH,
+  // asi que el parser tiene que sacarle la semana y la version igual que siempre.
+  const comoDelEndpoint = Cruce.parseDespacho(archivoRH([persona({ id: 62, codigo: '013' })]));
+  check('del texto del endpoint sale la semana', comoDelEndpoint.semana === 'S36/2026', comoDelEndpoint.semana);
+  check('y sale sin error', !comoDelEndpoint.error, comoDelEndpoint.error || '');
+  check('y salen las personas', comoDelEndpoint.filas.length === 1);
 }
 
 console.log('\n' + '═'.repeat(64));

--- a/tests/visual-cargamo.js
+++ b/tests/visual-cargamo.js
@@ -109,7 +109,7 @@ function archivoRH() {
 (async () => {
   console.log('Chromium: ' + (EXE || '(default)'));
   const tmpCsv = path.join(OUT, 'rh-S36.csv');
-  fs.writeFileSync(tmpCsv, archivoRH(), 'utf8');
+  fs.writeFileSync(tmpCsv, archivoRH(), 'utf8');   // solo para inspeccionarlo al depurar
   const tmpXls = path.join(OUT, 'contpaqi-S36.xlsx');
   fs.writeFileSync(tmpXls, archivoContpaqi());
 
@@ -122,7 +122,8 @@ function archivoRH() {
     const ctx = await navegador.newContext({ viewport: { width: w, height: h } });
     const page = await ctx.newPage();
     const errores = [];
-    page.on('pageerror', e => errores.push(String(e)));
+    const excepciones = [];                       // excepciones NO atrapadas: nunca son aceptables
+    page.on('pageerror', e => { excepciones.push(String(e)); errores.push(String(e)); });
     page.on('console', m => { if (m.type() === 'error') errores.push(m.text()); });
 
     // Se siembra la sesión REAL que lee la página (fts_fin_session con expires_at
@@ -153,43 +154,104 @@ function archivoRH() {
         body: JSON.stringify({ content: catRaw.toString('base64'), sha: 'prueba' }) }));
     await page.route('**/raw.githubusercontent.com/**contpaqi_conceptos.json**', r =>
       r.fulfill({ status: 200, contentType: 'application/json', body: catRaw }));
+    // version.json se sirve del disco por el mismo servidor estatico, no hace falta ruta.
+
+    // El endpoint nom/despacho: lo que antes era un archivo que Ulises subia ahora
+    // llega del sistema. Se responde con el archivo generado por el MISMO codigo que
+    // lo genera en produccion (Des.texto), en el mismo sobre que manda el workflow,
+    // para que el camino de lectura de la pagina sea el real.
+    // `despachoModo` deja que cada tramo de la prueba cambie la respuesta sin
+    // reinstalar la ruta: asi se ejercitan enviada / borrador / caida.
+    let despachoModo = 'enviada';
+    await page.route('**/webhook/nom/despacho', r => {
+      if (despachoModo === 'caida') return r.fulfill({ status: 500, contentType: 'application/json',
+        body: JSON.stringify({ ok: false, _error: true, code: 'BOOM', msg: 'el servidor tronó' }) });
+      if (despachoModo === 'borrador') return r.fulfill({ status: 200, contentType: 'application/json',
+        body: JSON.stringify({ ok: true, semana: { id: 'S36/2026' }, enviada: false, estado: 'borrador',
+                               msg: 'RH tiene esta semana en borrador; todavia no la manda.' }) });
+      return r.fulfill({ status: 200, contentType: 'application/json',
+        body: JSON.stringify({ ok: true, semana: { id: 'S36/2026' }, enviada: true, estado: 'enviada',
+                               version: 2, enviado_por: 'magaly.perez',
+                               enviado_en: '2026-09-04T15:00:00.000Z',
+                               nombre_archivo: 'rh-S36.csv', archivo: archivoRH(),
+                               cambios_despues: 0 }) });
+    });
     await page.goto(base, { waitUntil: 'domcontentloaded' });
-    await page.waitForTimeout(400);
+    await page.waitForTimeout(600);
 
     check('la puerta deja pasar con sesión válida',
       await page.locator('#main').isVisible());
 
-    // ── la barra: los DOS archivos ────────────────────────────────────────
+    // ── la versión, arriba y legible ──────────────────────────────────────
+    // El badge es lo que Esteban mira para saber que su cambio se desplegó. Que sea
+    // legible es parte del contrato, no cosmética: un badge de 10px al 60% de
+    // opacidad no se lee, y uno que miente es peor que ninguno.
+    const badge = await page.locator('#b').textContent();
+    check('el badge dice la versión, no una cadena de build', /^V\d+\.\d\d$/.test((badge || '').trim()), badge);
+    const tam = await page.locator('#b').evaluate(el => parseFloat(getComputedStyle(el).fontSize));
+    check('el badge se puede leer (≥12px)', tam >= 12, tam + 'px');
+    const vj = JSON.parse(fs.readFileSync(path.join(RAIZ, 'operaciones/carga-mo/version.json'), 'utf8'));
+    check('el badge coincide con version.json', (badge || '').trim() === vj.version, badge + ' vs ' + vj.version);
+    const html = fs.readFileSync(path.join(RAIZ, 'operaciones/carga-mo/index.html'), 'utf8');
+    const vs = [...html.matchAll(/\bsrc="js\/[^"]*\?v=([^"]+)"/g)].map(m => m[1]);
+    check('todos los scripts traen ?v= de esa misma versión',
+      vs.length >= 2 && vs.every(x => x === vj.version), vs.join(', ') || 'ninguno');
+
+    // ── la barra: un solo archivo, el de Ulises ───────────────────────────
     check('la barra ofrece el archivo de CONTPAQi', await page.locator('#drop').isVisible());
-    check('y el archivo de RH, en la misma barra',  await page.locator('#drop-rh').isVisible());
-    const bRh = await page.locator('#drop-rh').boundingBox();
-    check('el selector de RH cabe en el ancho',
-      !!bRh && bRh.x >= 0 && (bRh.x + bRh.width) <= w + 1,
-      bRh ? Math.round(bRh.x + bRh.width) + ' de ' + w : 'sin botón');
+    check('y ya NO pide el archivo de RH', await page.locator('#drop-rh').count() === 0);
 
-    // ── nómina cargada, SIN archivo de RH: la pantalla lo DICE ────────────
-    // Es el assert que impide el peor mensaje posible: una validación en verde que
-    // en realidad no comparó nada contra lo que RH pidió.
+    // ── la semana se propone sola, y con ella llega lo de RH ──────────────
+    check('al abrir ya hay una semana propuesta',
+      /^\d{4}-\d{2}-\d{2}$/.test(await page.locator('#f-vie').inputValue()),
+      await page.locator('#f-vie').inputValue());
+
     await page.fill('#f-vie', '2026-08-28');
+    await page.dispatchEvent('#f-vie', 'change');
+    await page.waitForTimeout(600);
+
+    check('la barra dice que la semana de RH ya llegó',
+      /S36\/2026/.test(await page.locator('#rh-est').textContent()),
+      await page.locator('#rh-est').textContent());
+
+    // ── la previa: se ve ANTES de subir nada ──────────────────────────────
+    // Es el corazón de lo que pidió Esteban: al elegir la semana, el resumen se
+    // carga ahí mismo. Si esto solo apareciera después del Excel de CONTPAQi, el
+    // cambio no serviría de nada.
+    const prev = await page.locator('#despacho-panel');
+    check('la previa de lo que mandó RH se ve SIN haber subido el CONTPAQi',
+      await prev.isVisible() && (await prev.textContent()).length > 50);
+    const tPrev = await prev.textContent();
+    check('la previa dice de qué semana es', /S36\/2026/.test(tPrev), tPrev.slice(0, 80));
+    check('y su versión y quién la envió', /v2/.test(tPrev) && /magaly/.test(tPrev), tPrev.slice(0, 120));
+    check('lista a las personas de la semana', /3 personas/.test(tPrev), tPrev.slice(0, 160));
+    check('y trae los nombres, no solo el conteo', /Leonel/.test(tPrev), tPrev.slice(0, 200));
+    check('la previa se lee ARRIBA, antes del resultado', await page.evaluate(() => {
+      const a = document.getElementById('despacho-panel'), b = document.getElementById('result');
+      return !!(a && b) && !!(a.compareDocumentPosition(b) & Node.DOCUMENT_POSITION_FOLLOWING);
+    }));
+    const bPrev = await prev.boundingBox();
+    check('la previa cabe en el ancho',
+      !!bPrev && bPrev.x >= 0 && (bPrev.x + bPrev.width) <= w + 1,
+      bPrev ? Math.round(bPrev.x + bPrev.width) + ' de ' + w : 'sin previa');
+
+    // Con la nómina de RH cargada pero SIN el CONTPAQi, el cruce no debe inventar
+    // alarmas: comparar contra una lista vacía haría que TODOS salgan como faltantes,
+    // y la pantalla abriría en rojo sin que nadie haya hecho nada mal.
+    const tSinNom = await page.locator('#rh-panel').textContent();
+    check('sin el CONTPAQi, el cruce NO marca a todos como faltantes',
+      !/impiden mandar/.test(tSinNom), tSinNom.slice(0, 120));
+    check('y dice que lo que falta es el archivo, no la gente',
+      /Falta la otra mitad/.test(tSinNom), tSinNom.slice(0, 100));
+    check('el botón de validar sigue cerrado sin nómina',
+      await page.locator('#send').isDisabled());
+
+    await page.screenshot({ path: path.join(OUT, nombre + '-1-previa-rh.png'), fullPage: true });
+
+    // ── ahora sí, el Excel de CONTPAQi ────────────────────────────────────
     await page.setInputFiles('#file', tmpXls);
-    await page.waitForTimeout(500);
+    await page.waitForTimeout(600);
     check('el Excel de CONTPAQi se leyó', await page.locator('#c-kpi').isVisible());
-
-    const txtVacio = await page.locator('#rh-panel').textContent();
-    check('con nómina y sin archivo de RH, la pantalla avisa que no se comparó nada',
-      /No se cargó el archivo de RH/.test(txtVacio), (txtVacio || '').slice(0, 70));
-    check('y explica que la nómina se validó contra sí misma',
-      /contra sí misma/.test(txtVacio));
-
-    await page.screenshot({ path: path.join(OUT, nombre + '-1-sin-rh.png'), fullPage: true });
-
-    // ── se carga el archivo de RH ─────────────────────────────────────────
-    await page.setInputFiles('#file-rh', tmpCsv);
-    await page.waitForTimeout(500);
-
-    check('el nombre del archivo de RH aparece en la barra',
-      /rh-S36\.csv/.test(await page.locator('#fname-rh').textContent()),
-      await page.locator('#fname-rh').textContent());
 
     const txt = await page.locator('#rh-panel').textContent();
     check('el panel dice de qué semana es el archivo de RH', /S36\/2026/.test(txt), txt.slice(0, 80));
@@ -229,12 +291,56 @@ function archivoRH() {
 
     await page.screenshot({ path: path.join(OUT, nombre + '-2-con-rh.png'), fullPage: true });
 
+    // ── borrador: se ve distinto que "enviada" y NO se pinta la previa ─────
+    // Un borrador todavía puede cambiar. Enseñarlo pondría a Ulises a cuadrar contra
+    // números que Magaly aún mueve, y a reclamar diferencias que no existen.
+    despachoModo = 'borrador';
+    await page.fill('#f-vie', '2026-08-21');
+    await page.dispatchEvent('#f-vie', 'change');
+    await page.waitForTimeout(600);
+    const tBorr = await page.locator('#despacho-panel').textContent();
+    check('un borrador NO se pinta como nómina enviada',
+      !/3 personas/.test(tBorr) && /todavía no la envían/.test(tBorr), tBorr.slice(0, 100));
+    check('y la barra lo dice sin sonar a falla nuestra',
+      /aún no la envían/.test(await page.locator('#rh-est').textContent()),
+      await page.locator('#rh-est').textContent());
+    const tCruceBorr = await page.locator('#rh-panel').textContent();
+    check('con la semana sin enviar, el cruce dice que no comparó nada',
+      /contra sí mismo/.test(tCruceBorr), tCruceBorr.slice(0, 120));
+
+    // ── el servidor caído se ve DISTINTO de "RH no ha mandado" ─────────────
+    // Uno lo resuelve Magaly y el otro lo resolvemos nosotros. Fundirlos en un
+    // mensaje gris manda a Ulises a hablar con la persona equivocada.
+    const erroresAntesDeTirarlo = errores.filter(t => !esDelEntorno(t)).length;
+    despachoModo = 'caida';
+    await page.fill('#f-vie', '2026-08-14');
+    await page.dispatchEvent('#f-vie', 'change');
+    await page.waitForTimeout(600);
+    const tCaida = await page.locator('#despacho-panel').textContent();
+    check('una falla del servidor NO se lee como "RH no ha mandado"',
+      /No se pudo consultar/.test(tCaida) && !/todavía no la envían/.test(tCaida), tCaida.slice(0, 100));
+    check('y el cruce avisa que NADIE comparó',
+      /nadie comparó/.test(await page.locator('#rh-panel').textContent()));
+    check('la barra marca la falla en rojo',
+      /no se pudo consultar/.test(await page.locator('#rh-est').textContent()),
+      await page.locator('#rh-est').textContent());
+
+    await page.screenshot({ path: path.join(OUT, nombre + '-3-sin-envio.png'), fullPage: true });
+
     const desb = await page.evaluate(() =>
       Math.max(0, document.documentElement.scrollWidth - document.documentElement.clientWidth));
     check('la página no desborda a lo ancho', desb <= 1, desb + 'px');
 
+    // Dos medidas distintas, a propósito:
+    //  · hasta antes de tirar el servidor a mano, CERO errores propios;
+    //  · y en TODO el recorrido, cero excepciones no atrapadas — porque el 500 que la
+    //    prueba provoca debe salir por el camino de error de la página, no reventarla.
+    // Filtrar los 500 en general escondería uno de verdad.
     const propios = errores.filter(t => !esDelEntorno(t));
-    check('cero errores de JavaScript propios', propios.length === 0, propios.slice(0, 2).join(' | '));
+    check('cero errores de JavaScript propios antes de la caída provocada',
+      erroresAntesDeTirarlo === 0, propios.slice(0, 2).join(' | '));
+    check('el servidor caído se maneja sin reventar la página',
+      excepciones.length === 0, excepciones.slice(0, 2).join(' | '));
 
     await ctx.close();
   }


### PR DESCRIPTION
## Lo que cambia para Ulises

Abre la pantalla y **ya está la semana propuesta** (la última cerrada) **y ya está lo que mandó RH**, debajo del header. No sube nada de Magaly: el sistema ya lo tiene guardado.

El campo «Archivo de RH» desaparece de la barra. Era pedirle a Ulises que consiguiera por correo un dato que el sistema ya tiene — y de paso abría la puerta a que cruzara contra un archivo viejo o editado a mano.

## Lo que se sirve es el archivo congelado, no uno nuevo

Lo que viaja es **el archivo del envío, tal cual quedó guardado**, no una regeneración con los datos de hoy. Regenerarlo haría que Ulises validara contra otra cosa mientras la pantalla se ve igual — el modo de falla peor, porque es invisible.

Y **un borrador no se entrega**. Mientras Magaly no oprima enviar, esos números todavía se mueven; enseñarlos pondría a Ulises a reclamar diferencias que no existen.

## Endpoint nuevo

`nom/despacho` — n8n `RyfiafaRa4f1UUqb`, 10 nodos, **publicado y activo** (`versionId == activeVersionId == 401ff0b8-43d8-4df9-a445-9dbb8261f405`, `triggerCount: 1`, verificado por read-back).

Solo lectura. Valida la sesión de **Finanzas** — el realm de Ulises, no el de RH: son secretos distintos (`FINANZAS_JWT_SECRET` vs `SUITE_JWT_SECRET`), y por eso no se pudo reusar `nom/semana` para el mismo dato.

El bloque de cripto en JS puro se **probó contra el `crypto` de Node antes de instalarlo**: 60/60, incluido el rechazo de un payload alterado sin re-firmar. Transcribir 83 líneas de SHA-256 donde un carácter cambiado rompe todas las firmas no se valida leyéndolo.

## Contador de versión propio

Arranca en **V1.00** aunque el módulo lleve meses en producción: antes se versionaba con una cadena de build (`20260904-cmo-cruce-rh`) y esa numeración no se puede continuar.

Que aquí diga V1.00 y en `rh/nomina-incidencias` V1.16 **es lo correcto, no un desfase** — son módulos distintos que avanzan por separado. Los dos `version.json` ahora se citan mutuamente para que no vuelva a leerse como error.

El badge sube al header y se hace legible (12px, en píldora) en vez de una cadena de build a 10px con 60% de opacidad.

## Un defecto corregido de paso

Sin el archivo de CONTPAQi, el cruce marcaba a **todas** las personas como faltantes. Cierto en lo literal, falso en lo que importa: no faltaba nadie, faltaba el archivo.

Antes casi no se veía, porque el cruce solo corría cuando Ulises subía el archivo de RH a mano. Ahora que llega solo al elegir la semana, la pantalla habría abierto con tres alarmas rojas y cero nómina cargada. Una alarma que suena sola se aprende a ignorar, y después no suena la de verdad.

## Test plan

- [x] `gate-cruce-rh` **52 → 73**. Dos secciones nuevas: el calendario del frontend contra el del workflow (120 semanas seguidas, cruce de año, los 7 días de la propuesta) y el contrato con `nom/despacho`. **Verificado que muerden:** moviendo el ancla de 30 a 31 fallan 3 asserts.
- [x] `visual-cargamo` **66 → 123** en tres anchos. Maneja el endpoint en vez del input de archivo, y cubre tres estados que antes no se podían alcanzar: **enviada**, **borrador** y **servidor caído**. El assert de errores se partió en dos para no esconder un 500 real detrás del que la prueba provoca a propósito.
- [x] `gate-nomina` 246 y `visual-nomina` 119, sin cambios.
- [x] Capturas revisadas a ojo en los tres anchos: la previa cabe en móvil, y la pantalla de servidor caído dice «no se pudo consultar» sin sonar a que RH no mandó.

Los tres «no hay nada que cruzar» se dicen distinto a propósito: uno lo resuelve Ulises (elegir semana), otro Magaly (enviar) y el tercero nosotros (el servidor). Fundirlos en un mensaje gris lo manda a hablar con la persona equivocada.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MDYMMPYZdLqWQCVfuZUAC6

---
_Generated by [Claude Code](https://claude.ai/code/session_01MDYMMPYZdLqWQCVfuZUAC6)_