### PR TITLE
feat(comercial/machote) V1.14: comisiones en %, la fila cabe en pantalla, y el cliente sale de Odoo

### DIFF
--- a/comercial/machote/README.md
+++ b/comercial/machote/README.md
@@ -66,7 +66,8 @@ versión es peor que no tener indicador.
 | `js/app.js` | Vistas y ruteo. |
 | `js/pegar.js` | El pegado de tablas: separador, columnas y revisión previa. |
 | `js/almacen.js` | El autoguardado. UNA pieza entre la pantalla y donde viven los datos. |
-| `tests/pruebas-navegador.js` | 95 pruebas de navegador. |
+| `js/clientes.js` | El catálogo de clientes, leído de Odoo. Guarda el id, pinta el nombre. |
+| `tests/pruebas-navegador.js` | 104 pruebas de navegador. |
 
 ## Cómo se calcula el precio
 
@@ -98,7 +99,7 @@ trece columnas. La hoja `DESGLOSE COTIZACIÓN` trae los tres escenarios, el
 `RESUMEN BUDGET`, las diez ranuras de sección, el `BUDGET ODOO` y la tabla de
 comisiones.
 
-**En teléfono la retícula desaparece.** Catorce columnas con el pulgar no se
+**En teléfono la retícula desaparece.** Trece columnas con el pulgar no se
 capturan: cada renglón se vuelve una tarjeta con sus campos etiquetados, los
 renglones de mano de obra en cero se pliegan detrás de un interruptor que dice
 cuántos hay, y nada de lo que se toca mide menos de 44 px. En pantalla ancha
@@ -185,7 +186,7 @@ un vistazo lo capturado de lo que falta es la diferencia entre revisar una hoja
 y leerla entera.
 
 En teléfono la marca es el **borde** de la tarjeta, no el fondo: un fondo verde
-detrás de catorce campos etiquetados no se lee.
+detrás de once campos etiquetados no se lee.
 
 ## Autoguardado
 
@@ -218,7 +219,8 @@ se revierte y dice por qué.
 Un machote enviado queda **congelado**: los campos se apagan y desaparecen los
 botones de estructura, pero la hoja se sigue viendo — es el documento con el que
 se vendió y hay que poder consultarlo. La banda de estado encabeza **todas** las
-hojas, no sólo el `DESGLOSE`: catorce campos apagados sin decir por qué son
+hojas, no sólo el `DESGLOSE`: una hoja entera de campos apagados sin decir por
+qué es
 exactamente el silencio que este módulo persigue.
 
 ⚠️ **Enviar todavía NO escribe en Odoo.** La regla vigente del módulo es que
@@ -228,7 +230,8 @@ reales; la escritura espera a que Esteban levante esa regla.
 ## Buscar, y empezar uno nuevo
 
 La pantalla de entrada es un **buscador**, no una lista: busca por nombre,
-cliente, número de orden e id, palabra por palabra —«topo chico» y «chico topo»
+cliente —el vivo de Odoo y el guardado—, número de orden, id del machote e **id
+del cliente en Odoo**, palabra por palabra —«topo chico» y «chico topo»
 encuentran lo mismo— y filtra por estado con chips que traen su cuenta. **Los
 contadores son del total, no de lo ya filtrado**: un contador que cambia al
 filtrar no sirve para saber cuántos hay. Y cuando no hay resultados, dice qué se
@@ -259,8 +262,9 @@ donde se cuela el error de dedo **en el precio**, que es el dato que nadie vuelv
 a verificar.
 
 `js/pegar.js` interpreta un bloque pegado —de Claude, de un correo, de Excel, de
-un PDF— y saca cantidad, unidad, tipo, descripción, modelo, marca, precio y
-moneda. Elige el separador **por consistencia, no por frecuencia**: gana el que
+un PDF— y saca cantidad, unidad, tipo, descripción, precio y moneda. Si la
+tabla trae la especificación, el modelo o la marca en columnas aparte, los
+**suma a la descripción** separados por `·`, que es donde viven ahora. Elige el separador **por consistencia, no por frecuencia**: gana el que
 produce el mismo número de columnas en la mayoría de los renglones, porque uno
 que da 3 columnas en una fila y 7 en la siguiente no es el separador, es un
 carácter que salía en el texto.
@@ -293,7 +297,7 @@ tabulador lo descartaba en falso con una descripción que termina en dígito
 **Empieza donde tú digas.** El botón `⇥` vive **en cada renglón**, no en la
 sección: el punto donde arranca el pegado es una decisión del capturista, y casi
 siempre hay algo capturado arriba que no se toca. Se elige entre **escribir
-**escribir debajo** o **escribir arriba** del renglón señalado. En los dos
+debajo** o **escribir arriba** del renglón señalado. En los dos
 casos lo que ya estaba **se recorre, no se sobrescribe**: la única decisión es
 dónde va, que es la que de verdad importa.
 
@@ -303,7 +307,8 @@ la pantalla**: medido, `x=1473` con la ventana en 1440 px, con 218 px de arrastr
 para dar con él. Existía y las pruebas lo alcanzaban —Playwright desplaza solo
 antes de hacer clic— así que pasaban en verde mientras nadie lo encontraba.
 **Existir y poder encontrarse no son lo mismo**, y ahora hay una prueba que mide
-que el botón caiga dentro de la ventana a 1440, 1280 y 390 px.
+que los dos botones fijos —pegar y borrar— caigan dentro de la ventana a 1440,
+1280 y 1024 px, y que a 1440 la tabla no desborde ni un píxel.
 
 **No depende del orden de las columnas.** Hay listas donde el precio va primero
 y la cantidad en medio (`$ 890.00 c/u - 8 PZAS - Lámpara LED…`). Leer por
@@ -329,12 +334,92 @@ estás pegando. Antes, pegar una lista sin columna de Unidad dejaba en blanco lo
 `Pieza` y `Horas` ya capturados — reproducido y medido. Un pegado que borra datos
 que no venía a tocar es peor que no pegar.
 
+### Las tablas que escribe Claude
+
+Vienen en Markdown, y traían **tres trampas a la vez** que las tiraban enteras a
+la lectura por lista —el encabezado terminaba convertido en un renglón, que es
+justo lo que se reportó—:
+
+- **El maquillaje.** Claude pone los precios en negritas, `**$76,379**`. El
+  asterisco convertía el precio en texto ilegible, así que la fila del
+  encabezado dejaba de parecerse a un encabezado. Se quitan `**`, `__` y las
+  comillas invertidas antes de mirar nada.
+- **La unidad dentro de la cantidad.** La celda dice `1 pza`, `240 m`,
+  `10 juegos`. Si la columna de unidad no viene aparte, se parte ahí: número a
+  `QTY`, palabra a `Unidad`.
+- **La columna del precio viejo.** Un encabezado que diga `anterior`, `previo`,
+  `antes` u `original` es el precio de la cotización pasada, y ganaba por estar
+  primero. Ahora se descarta a propósito: el que entra es el **nuevo**.
+
 **Nada se aplica solo.** Interpreta, enseña lo que entendió renglón por renglón
 con sus avisos, y escribe cuando alguien lo aprueba mirándolo. Un parser que
 acierta el 90% y aplica solo mete un 10% de basura que nadie ve.
 
 El `Tipo` que no venga en la tabla **queda vacío**: Materiales o Servicios elige
 el multiplicador, y adivinarlo movería el precio.
+
+## El cliente sale de Odoo
+
+Al crear un machote, el cliente se elige de una **lista leída de Odoo en vivo**
+—escribiendo se filtra— y lo que se **guarda es el id** (`1247`), no el nombre.
+El nombre se lee de Odoo cada vez que se pinta.
+
+No es un detalle de forma. Si a un cliente le cambian la razón social, las
+cotizaciones viejas la muestran corregida solas; con el nombre copiado se
+quedarían con la versión del día que se capturaron. Y **este repo es público**:
+el día que los machotes salgan del navegador, lo que viaje es un número, no la
+cartera de clientes.
+
+**El catálogo no se guarda en el repo ni en `localStorage`** — vive en Odoo y se
+cachea en memoria mientras la pestaña está abierta. Sólo llegan al navegador las
+**empresas** (`is_company`): los otros 483 registros con `customer_rank > 0` son
+los **contactos persona** de cada cliente, con nombre y apellido de gente real.
+Y de cada uno sale únicamente `id` y `nombre`: ni correo, ni teléfono, ni RFC.
+
+**Si Odoo no contesta, el campo sigue siendo texto libre y se guarda igual**, con
+un aviso que dice por qué la lista está vacía. Un prospecto que todavía no está
+dado de alta también se acepta, como texto y sin id. Nunca se bloquea crear un
+machote porque el catálogo no llegó — el machote casi siempre nace antes que la
+orden, y a veces antes que el cliente.
+
+Detalle completo, con el endpoint y lo que quedó sin verificar, en
+[`docs/comercial/CLIENTES-DESDE-ODOO.md`](../../docs/comercial/CLIENTES-DESDE-ODOO.md).
+
+## Porcentajes en la pantalla, razones en el archivo
+
+Las comisiones y el margen deseado se **escriben y se leen en por ciento** —
+`5.5`, `40`— con el `%` a la derecha del campo. Adentro siguen siendo razones
+(`0.055`, `0.4`), que es lo que el motor multiplica y lo que el machote real
+guarda.
+
+La conversión vive en **dos lugares y nada más**: `celPct()` al pintar (×100) y
+`aplicar()` al guardar (÷100, redondeado a ocho decimales para que `5.5 %` no
+vuelva como `0.055000000000000005`). Nadie pedía calcular con `0.055` a mano:
+la gente que cotiza piensa en 5.5 %, y verlo en decimales era leerlo mal a la
+primera.
+
+**Los multiplicadores no llevan `%`.** `2.5` es «dos veces y media el costo»,
+no «dos y medio por ciento»; ponerles el signo habría sido peor que no
+convertirlos.
+
+## Que la fila quepa
+
+La tabla de materiales cabe en la pantalla **sin arrastre horizontal**, medido a
+1440, 1280 y 1024 px.
+
+Tres cosas la metieron adentro:
+
+- **Fuera `Marca` y `Modelo`.** Eran dos columnas de 200 px que se llevaban el
+  ancho que necesita la descripción, que es lo que en realidad se lee. Van
+  **dentro de la descripción** —el encabezado lo dice— y el pegado las une ahí
+  solo cuando la tabla que se pega las trae por separado.
+- **La descripción se queda con el ancho** (`min-width: 260px; width: 40%`) y el
+  resto de los campos se acortó a lo que su contenido necesita.
+- **Las dos columnas de acciones se fijan a los bordes**: pegar `⇥` a la
+  izquierda, y mover/duplicar/borrar a la derecha. Aunque un día la tabla vuelva
+  a desbordarse por una descripción larguísima, **el botón de borrar sigue
+  visible** — que es exactamente lo que se reportó desde las pruebas con la
+  gente.
 
 ## Lo que decide el verde
 
@@ -361,8 +446,10 @@ vuelve a comprobar— porque el primero es cosmético.
 
 El libro está detrás de un gate: `shared/auth-jwt.js`, cliente de
 **`auth/suite-login`** — el mismo emisor de identidad que usa RH (Fase 0 del
-issue #136). Pide el permiso `comercial:read`. Quién entró se ve en la barra
-superior y ahí mismo se cierra la sesión.
+issue #136). Pide el permiso `comercial:read`. El **nombre** de quien entró se
+ve en la barra superior —no su usuario: `esteban.delacruz` truncado a
+`esteban.delac…` no dice quién está capturando; el usuario exacto queda en el
+`title`— y ahí mismo se cierra la sesión.
 
 ⚠️ **El gate decide si la pantalla se PINTA, no si el archivo se descarga.**
 GitHub Pages es público. Sirve para saber quién está probando y que su input sea
@@ -420,3 +507,6 @@ encontrado:
   cotizaciones grandes **las secciones se renombran** al alcance real.
 - Los umbrales de `reglas.js` marcados `SUPUESTO` necesitan números de FTS.
 - El cuestionario de diagnóstico es invención: el machote no lo tiene.
+- **Activar el webhook `comercial/clientes`** (`RyeFlCTdLu301Gjz`) en la UI de
+  n8n: el API no deja activarlo por MCP. Mientras esté apagado, el campo de
+  cliente funciona como texto libre y lo avisa.

--- a/comercial/machote/css/machote.css
+++ b/comercial/machote/css/machote.css
@@ -618,3 +618,40 @@ table.rejilla tr.total > td.acc-ini { background: var(--x-total); }
   table.rejilla.tarjetas td.acc-ini::before { content: none; }
   table.rejilla.tarjetas tr.total > td.acc-ini { display: none; }
 }
+
+/* ── Que la fila quepa en la pantalla ───────────────────────────────────
+ * Montalvo: "la línea está muy larga, no se ve completa para tener la opción
+ * de borrar" y "tenemos que hacer scroll horizontal".
+ *
+ * Dos medidas, y las dos hacen falta:
+ *   1. Menos columnas — Modelo y Marca se fueron dentro de la descripción.
+ *   2. Los botones se quedan FIJOS al borde derecho, como el de pegar al
+ *      izquierdo. Aunque un día vuelva a sobrar ancho, borrar se alcanza. */
+table.rejilla th.acc, table.rejilla td.acc {
+  position: sticky; right: 0; z-index: 2; background: var(--fondo);
+  box-shadow: -1px 0 0 var(--linea2); white-space: nowrap; padding: 2px;
+}
+table.rejilla th.acc { background: var(--x-cab); }
+table.rejilla tr.capturada > td.acc { background: var(--x-fila-ok); }
+table.rejilla tr.total > td.acc { background: var(--x-total); }
+/* Los botones angostan de ancho pero NO de alto: la regla de 44 px es de
+   altura, que es lo que se toca con el pulgar. */
+td.acc .ico { min-width: 32px; padding: 0 2px; }
+
+/* La descripción se lleva el ancho que soltaron Modelo y Marca. */
+table.rejilla th.descol, table.rejilla td.descol { min-width: 260px; width: 40%; }
+table.rejilla td.descol .cel { width: 100%; }
+th .hint { font-weight: 400; text-transform: none; opacity: .75; }
+.cel.wmon { min-width: 64px; }
+.cel.w80 { width: 80px; }
+
+/* ── Porcentajes ────────────────────────────────────────────────────────
+ * El signo va pegado al campo para que no se lea "5.5" y se entienda 5.5
+ * veces. Es el mismo dato de siempre: por dentro sigue siendo 0.055. */
+.pctwrap { display: inline-flex; align-items: center; gap: 3px; }
+.pctwrap i { font-style: normal; color: var(--suave); font-size: 12px; }
+@media (max-width: 719px) {
+  /* En tarjetas nada es fijo: no hay columnas de donde salirse. */
+  table.rejilla.tarjetas td.acc, table.rejilla.tarjetas th.acc { position: static; }
+  table.rejilla.tarjetas td.descol, table.rejilla.tarjetas th.descol { min-width: 0; width: auto; }
+}

--- a/comercial/machote/index.html
+++ b/comercial/machote/index.html
@@ -37,6 +37,7 @@
 <script src="js/demo.js"></script>
 <script src="js/reglas.js"></script>
 <script src="js/pegar.js"></script>
+<script src="js/clientes.js"></script>
 <script src="js/app.js"></script>
 </body>
 </html>

--- a/comercial/machote/js/app.js
+++ b/comercial/machote/js/app.js
@@ -40,7 +40,7 @@
    * 2026-09-03 (por instrucción de Esteban), pero lleva el suyo aparte y va en
    * V1.00. Planeación sigue en `2.4.1` y el kiosko sólo con cadena de build;
    * a esos no se propaga. */
-  const VERSION = 'V1.13';
+  const VERSION = 'V1.14';
   const $  = (s, r) => (r || document).querySelector(s);
   const $$ = (s, r) => Array.prototype.slice.call((r || document).querySelectorAll(s));
   const clon = (x) => JSON.parse(JSON.stringify(x));
@@ -160,6 +160,22 @@
   const celNum = (path, val, cls, ph) =>
     '<input class="cel num ' + (cls || '') + '" type="number" step="any" min="0" data-cel="' + path + '" data-num' +
     ' value="' + esc(nn(val)) + '"' + (ph ? ' placeholder="' + esc(ph) + '"' : '') + '>';
+  /* Un campo que por dentro es una RAZÓN (0.055) pero que la gente lee y
+   * escribe en PORCENTAJE (5.5%). Se guarda igual que siempre —dividido entre
+   * cien— para no tocar el motor ni lo ya guardado; lo único que cambia es en
+   * qué unidad se ve y se teclea. Montalvo: "que las comisiones aparezcan en %
+   * y no en decimales".
+   *
+   * El redondeo a seis decimales es a propósito: 5.5/100 en coma flotante da
+   * 0.055000000000000004, y ese ruido acaba escrito en el almacén. */
+  const celPct = (path, val, cls) => {
+    const v = (val === null || val === undefined || val === '') ? '' :
+              +(Number(val) * 100).toFixed(6);
+    return '<span class="pctwrap"><input class="cel num ' + (cls || 'w70') +
+      '" type="number" step="any" min="0" data-cel="' + path + '" data-num data-pct' +
+      ' value="' + esc(nn(v)) + '"><i>%</i></span>';
+  };
+
   const celSel = (path, val, ops, cls) =>
     '<select class="cel ' + (cls || '') + '" data-cel="' + path + '">' +
     ops.map(o => '<option value="' + esc(o) + '"' + (o === val ? ' selected' : '') + '>' + esc(o || '—') + '</option>').join('') +
@@ -211,9 +227,13 @@
     const S = G.SuiteAuth, ses = S && S.getSession();
     if (!ses) { el.style.display = 'none'; return; }
     el.style.display = '';
-    el.textContent = ses.actor;
+    // El NOMBRE, no el usuario: `esteban.delacruz` truncado a `esteban.delac…`
+    // no le dice a nadie quién está capturando. El usuario queda en el título
+    // para cuando haga falta el dato exacto.
+    el.textContent = ses.nombre || ses.actor;
+    el.title = ses.actor;
     el.onclick = () => {
-      if (!confirm('¿Cerrar la sesión de ' + ses.actor + '?')) return;
+      if (!confirm('¿Cerrar la sesión de ' + (ses.nombre || ses.actor) + '?')) return;
       S.logout();
       location.replace('../login.html');
     };
@@ -251,6 +271,12 @@
   }
   window.addEventListener('hashchange', render);
 
+  /* El nombre del cliente sale de UNA sola función. Con el catálogo cargado
+   * gana Odoo; sin él, el respaldo que quedó guardado. Que esté en un solo
+   * lugar es lo que evita que media pantalla muestre el nombre vivo y la otra
+   * media el congelado. */
+  const cli = (m) => (G.Clientes ? G.Clientes.nombre(m) : (m && m.cliente) || '');
+
   const nivelMargen = (mg) => mg === null ? 'warn'
     : mg < R.UMBRALES.margen_minimo_duro ? 'bad'
     : mg < R.UMBRALES.margen_minimo_blando ? 'warn' : 'ok';
@@ -262,7 +288,10 @@
    * copia y pega cuando alguien pregunta "¿y el M-1042?". */
   function coincide(m, q) {
     if (!q) return true;
-    const t = [m.nombre, m.cliente, m.so, m.id].map(x => String(x || '').toLowerCase()).join(' | ');
+    // El id de Odoo entra a la búsqueda a propósito: es lo que se guarda, y
+    // quien lo tenga a la mano debe poder encontrar la cotización con él.
+    const t = [m.nombre, cli(m), m.cliente, m.so, m.id, m.cliente_id]
+      .map(x => String(x || '').toLowerCase()).join(' | ');
     // Cada palabra por separado: "topo chico" y "chico topo" encuentran lo mismo.
     return q.toLowerCase().split(/\s+/).filter(Boolean).every(w => t.indexOf(w) >= 0);
   }
@@ -298,7 +327,7 @@
       return '<div class="fila">' +
         '<a class="item" href="#/m/' + m.id + '">' +
         '<div class="grow"><strong>' + esc(m.nombre) + '</strong>' +
-        '<div class="tiny">' + esc(m.cliente) + (m.so ? ' · ' + esc(m.so) : '') + ' · ' + m.id + '</div></div>' +
+        '<div class="tiny">' + esc(cli(m)) + (m.so ? ' · ' + esc(m.so) : '') + ' · ' + m.id + '</div></div>' +
         '<div class="right"><span class="chip" style="background:' + est[m.estado].color + '">' + est[m.estado].label + '</span>' +
         '<div class="tiny mono n-' + (c.costoIncompleto ? 'warn' : nivelMargen(c.margen)) + '">' +
         mx(c.precio) + ' · ' + pc(c.margen) + (c.costoIncompleto ? '*' : '') + '</div>' +
@@ -368,7 +397,10 @@
       '<label class="campo"><span>Nombre de la cotización</span>' +
       '<input id="n-nombre" class="cel" placeholder="Ej. Modificación de tren de drenado"></label>' +
       '<label class="campo"><span>Cliente</span>' +
-      '<input id="n-cliente" class="cel" placeholder="Ej. Nalco de México · Topo Chico"></label>' +
+      '<input id="n-cliente" class="cel" list="n-clientes" autocomplete="off" ' +
+      'placeholder="Escribe para buscar en Odoo…">' +
+      '<datalist id="n-clientes"></datalist>' +
+      '<span id="n-cliente-est" class="tiny">Leyendo el catálogo de Odoo…</span></label>' +
       '<label class="campo"><span>Orden (opcional)</span>' +
       '<input id="n-so" class="cel" placeholder="SO11836 — se puede dejar vacío"></label>' +
       '<label class="campo"><span>Empresa</span>' +
@@ -386,9 +418,16 @@
     $('#n-crear').onclick = () => {
       const nombre = $('#n-nombre').value.trim();
       if (!nombre) { $('#n-err').textContent = 'Ponle un nombre: es como lo vas a encontrar después.'; return; }
+      // El id es lo que se guarda; el texto queda como respaldo para pintar
+      // cuando Odoo no conteste. Si lo tecleado no casa con ningún cliente
+      // —un prospecto que todavía no está dado de alta— se guarda tal cual y
+      // `cliente_id` queda en null: NUNCA se bloquea por eso.
+      const txtCliente = $('#n-cliente').value.trim();
+      const hit = G.Clientes ? G.Clientes.resolver(txtCliente) : null;
       const m = C.machoteNuevo({
         nombre: nombre,
-        cliente: $('#n-cliente').value.trim(),
+        cliente: hit ? hit.nombre : txtCliente,
+        cliente_id: hit ? hit.id : null,
         so: $('#n-so').value.trim() || null,
         empresa_id: Number($('#n-empresa').value)
       });
@@ -397,6 +436,31 @@
       ST.hoja = 'desglose';
       location.hash = '#/m/' + m.id;
     };
+
+    poblarClientes();
+  }
+
+  /* Llena la lista del campo Cliente. La pantalla YA está pintada cuando esto
+   * corre: si Odoo tarda o no contesta, el campo se queda como texto libre y
+   * el aviso lo dice — no se traba la creación (regla anti-trabón §8). */
+  function poblarClientes() {
+    const est = $('#n-cliente-est'), dl = $('#n-clientes');
+    if (!est || !dl || !G.Clientes) return;
+    G.Clientes.cargar().then(r => {
+      // La vista pudo cambiar mientras la red iba y venía.
+      if (!document.body.contains(est)) return;
+      if (!r.ok) {
+        est.className = 'tiny n-warn';
+        est.textContent = 'No se pudo leer el catálogo de Odoo (' + r.error +
+          '). Escribe el nombre del cliente: se guarda igual.';
+        return;
+      }
+      dl.innerHTML = r.clientes
+        .map(c => '<option value="' + esc(c.nombre) + '"></option>').join('');
+      est.className = 'tiny';
+      est.textContent = r.clientes.length + ' clientes de Odoo. Si el tuyo no está, ' +
+        'escríbelo: se guarda como texto hasta que lo den de alta.';
+    });
   }
 
   /* ── El libro ────────────────────────────────────────────────────────── */
@@ -406,7 +470,7 @@
     // abierta de la anterior deja al analista en una sección que no pidió.
     if (ST.libroAbierto !== id) { ST.hoja = 'desglose'; ST.libroAbierto = id; }
     const c = C.calcular(m);
-    top(m.cliente, m.id + (m.so ? ' · ' + m.so : ''), 'MACHOTE', '#/');
+    top(cli(m), m.id + (m.so ? ' · ' + m.so : ''), 'MACHOTE', '#/');
 
     const hojas = [{ id: 'desglose', label: 'DESGLOSE COTIZACIÓN' }]
       .concat(m.secciones.map(s => ({ id: s.id, label: s.nombre || 'SECCIÓN' })));
@@ -514,8 +578,8 @@
       ['Materiales', 'margenes.materiales', mg.materiales],
       ['Servicios', 'margenes.servicios', mg.servicios]
     ].map(r => '<tr><td class="et">' + r[0] + '</td><td>' + celNum(r[1], r[2], 'w70') + '</td></tr>').join('') +
-      '<tr><td class="et">Comision FTS</td><td>' + celNum('comision_fts', m.comision_fts, 'w70') + '</td></tr>' +
-      '<tr><td class="et">Comision CLIENTE</td><td>' + celNum('comision_cliente', m.comision_cliente, 'w70') + '</td></tr>';
+      '<tr><td class="et">Comision FTS</td><td>' + celPct('comision_fts', m.comision_fts) + '</td></tr>' +
+      '<tr><td class="et">Comision CLIENTE</td><td>' + celPct('comision_cliente', m.comision_cliente) + '</td></tr>';
 
     const nombreSec =
       '<div class="nomsec"><span class="et">NOMBRE DE SECCIÓN</span>' + cel('nom:' + s.id, s.nombre, 'nombre') +
@@ -604,14 +668,15 @@
         // se señala el renglón donde empieza el pegado.
         '<td class="acc-ini" data-l=""><button class="ico pegar" data-pegar="' + s.id + '#' + j + '"' +
         ' title="Pegar una lista a partir de este renglón" aria-label="Pegar a partir del renglón ' + (j + 1) + '">⇥</button></td>' +
-        '<td data-l="Descripción">' + cel(p + 'descripcion', l.descripcion, 'desc') + '</td>' +
+        // Modelo y Marca se fueron: van DENTRO de la descripción. Eran dos
+        // columnas de 200 px que empujaban la fila fuera de la pantalla y le
+        // robaban ancho justo a la descripción, que es lo que hay que leer.
+        '<td class="descol" data-l="Descripción">' + cel(p + 'descripcion', l.descripcion, 'desc') + '</td>' +
         '<td data-l="QTY">' + celNum(p + 'qty', l.qty, 'w60') + '</td>' +
-        '<td data-l="Unidad">' + celLibre(p + 'unidad', l.unidad, 'unidades', 'w90') + '</td>' +
+        '<td data-l="Unidad">' + celLibre(p + 'unidad', l.unidad, 'unidades', 'w80') + '</td>' +
         '<td data-l="Tipo">' + celSel(p + 'tipo', l.tipo, [''].concat(C.TIPOS), 'wtipo') + '</td>' +
-        '<td data-l="Modelo">' + cel(p + 'modelo', l.modelo, 'w110') + '</td>' +
-        '<td data-l="Marca">' + cel(p + 'marca', l.marca, 'w90') + '</td>' +
-        '<td data-l="Precio unitario">' + celNum(p + 'pu', l.pu, 'w90') + '</td>' +
-        '<td data-l="Moneda">' + celSel(p + 'moneda', l.moneda, ['MXN', 'USD']) + '</td>' +
+        '<td data-l="Precio unitario">' + celNum(p + 'pu', l.pu, 'w80') + '</td>' +
+        '<td data-l="Moneda">' + celSel(p + 'moneda', l.moneda, ['MXN', 'USD'], 'wmon') + '</td>' +
         // "sin precio" SOLO en un renglón que alguien empezó a llenar. En uno
         // en blanco no es un hallazgo, es el estado normal del bloque — y con
         // treinta en blanco por sección, decirlo treinta veces es ruido.
@@ -621,8 +686,8 @@
           (cl.pisado ? '<span class="pisado-marca" title="Escrito a mano encima de la fórmula. Por Tipo le tocaría ' +
             cl.porTipo + '.">≠ ' + cl.porTipo + '</span>' : '') + '</td>' +
         '<td class="vl mono calc fuerte" data-l="Precio con utilidad">' + mx(cl.conUtilidad) + '</td>' +
-        '<td data-l="Link">' + cel(p + 'link', l.link, 'w130', 'https://…') + '</td>' +
-        '<td data-l="Comentario">' + cel(p + 'comentario', l.comentario, 'w130') + '</td>' +
+        '<td data-l="Link">' + cel(p + 'link', l.link, 'w80', 'https://…') + '</td>' +
+        '<td data-l="Comentario">' + cel(p + 'comentario', l.comentario, 'w80') + '</td>' +
         '<td class="acc" data-l="">' +
           '<button class="ico" data-mov="' + s.id + '#' + j + '|-1" title="Subir"' + (j === 0 ? ' disabled' : '') + '>↑</button>' +
           '<button class="ico" data-mov="' + s.id + '#' + j + '|1" title="Bajar"' + (j === s.partidas.length - 1 ? ' disabled' : '') + '>↓</button>' +
@@ -635,11 +700,12 @@
       '<div class="secc-tit">COSTO MATERIALES Y SERVICIOS</div>' +
       '<div class="scroll"><table class="rejilla tarjetas">' +
       '<thead><tr><th class="acc-ini" title="Pegar una lista a partir de un renglón">⇥</th>' +
-      '<th>DESCRIPCIÓN</th><th>QTY</th><th>UNIDAD</th><th>Tipo</th><th>MODELO</th><th>MARCA</th>' +
-      '<th>PRECIO UNITARIO</th><th>MONEDA</th><th>PRECIO TOTAL</th><th>Margen utilidad</th>' +
-      '<th>PRECIO CON UTILIDAD</th><th>Link</th><th>Comentario</th><th></th></tr></thead><tbody>' +
-      (filasMat || '<tr><td colspan="15" class="vacio2">Sin partidas.</td></tr>') +
-      '<tr class="total"><td class="acc-ini"></td><td class="rotulo" data-l="">TOTAL</td><td colspan="7"></td>' +
+      '<th class="descol">DESCRIPCIÓN <span class="hint">(incluye modelo y marca)</span></th>' +
+      '<th>QTY</th><th>UNIDAD</th><th>Tipo</th>' +
+      '<th>P. UNITARIO</th><th>MON.</th><th>P. TOTAL</th><th>Margen</th>' +
+      '<th>CON UTILIDAD</th><th>Link</th><th>Coment.</th><th class="acc"></th></tr></thead><tbody>' +
+      (filasMat || '<tr><td colspan="13" class="vacio2">Sin partidas.</td></tr>') +
+      '<tr class="total"><td class="acc-ini"></td><td class="rotulo descol" data-l="">TOTAL</td><td colspan="5"></td>' +
       '<td class="vl mono calc" data-l="Costo materiales">' + mx(cs.costoMat) +
       '</td><td></td><td class="vl mono calc fuerte" data-l="Con utilidad">' + mx(cs.ventaMat) + '</td><td colspan="3"></td></tr>' +
       '</tbody></table></div>' +
@@ -718,7 +784,7 @@
       '<div class="blk"><div class="et2">ELIGE UN ESCENARIO PARA TU COTIZACIÓN</div>' +
       '<div class="escs">' + escOps + '</div></div>' +
       '<div class="blk"><table class="hoja2"><tbody>' +
-      '<tr><td class="et">MARGEN DESEADO</td><td>' + celNum('margen_deseado', m.margen_deseado, 'w80') + '</td></tr>' +
+      '<tr><td class="et">MARGEN DESEADO</td><td>' + celPct('margen_deseado', m.margen_deseado, 'w80') + '</td></tr>' +
       '<tr><td class="et">HORAS PROYECTO</td><td class="vl mono calc">' + Math.round(c.horas) + '</td></tr>' +
       '<tr><td class="et">Factor_req</td><td class="vl mono calc">' + (c.factorReq ? c.factorReq.toFixed(9) : '—') + '</td></tr>' +
       '<tr><td class="et">Empresa</td><td>' +
@@ -731,7 +797,7 @@
           ? '<div class="tiny n-warn">' + esc(C.empresaDe(m).corto) + ' factura en ' +
             C.monedaPorDefecto(m) + '.</div>' : '') + '</td></tr>' +
       '<tr><td class="et">Tipo de cambio</td><td>' + celNum('tc', m.tc, 'w80') + '</td></tr>' +
-      '<tr><td class="et">Factor de protección</td><td>' + celNum('factor_proteccion', m.factor_proteccion, 'w80') + '</td></tr>' +
+      '<tr><td class="et">Factor de protección</td><td>' + celPct('factor_proteccion', m.factor_proteccion, 'w80') + '</td></tr>' +
       '<tr><td class="et">Origen del tipo de cambio</td><td>' +
         celLibre('tc_fuente', m.tc_fuente, 'fuentes-tc') + '</td></tr>' +
       '<tr><td class="et">TC efectivo</td><td class="vl mono calc">' + C.tcEfectivo(m).toFixed(4) + '</td></tr>' +
@@ -805,7 +871,7 @@
       return '<tr class="grupo"><td colspan="3">' + titulo + ' · bolsa ' + mx(bolsa) + '</td></tr>' +
         (m[key] || []).map((it, i) =>
           '<tr><td>' + cel('eq:' + rep + ':' + i + ':nombre', it.nombre, 'desc') + '</td>' +
-          '<td>' + celNum('eq:' + rep + ':' + i + ':pct', it.pct, 'w70') + '</td>' +
+          '<td>' + celPct('eq:' + rep + ':' + i + ':pct', it.pct) + '</td>' +
           '<td class="vl mono calc">' + mx(bolsa * Number(it.pct)) + '</td></tr>').join('') +
         '<tr class="total"><td class="et">Suma</td><td class="vl mono n-' +
         (Math.abs(suma - 1) < 0.0001 ? 'ok' : 'bad') + '">' + pc(suma) + '</td><td></td></tr>';
@@ -994,6 +1060,9 @@
       const aplicar = () => {
         let v = el.value;
         if (el.hasAttribute('data-num')) v = (v === '' ? null : (parseFloat(v) || 0));
+        // Lo que se teclea en % se guarda como razón: el motor y lo ya guardado
+        // siguen hablando en 0.055, y sólo la pantalla habla en 5.5.
+        if (v !== null && el.hasAttribute('data-pct')) v = +(v / 100).toFixed(8);
         setPath(m, el.dataset.cel, v);
       };
       // Al salir del campo se repinta -puede haber cambiado la estructura-.
@@ -1192,4 +1261,12 @@
 
   render();
   avisoPassword();
+
+  /* El catálogo se pide UNA vez al arrancar, en segundo plano. La pantalla no
+   * lo espera: se pinta con el nombre de respaldo y se repinta sola cuando
+   * Odoo contesta. Sólo se repinta si de verdad hay algo que cambiar —un
+   * machote con `cliente_id`—, para no parpadear de gratis. */
+  if (G.Clientes && ST.machotes.some(m => m.cliente_id)) {
+    G.Clientes.cargar().then(r => { if (r.ok) render(); });
+  }
 })(window);

--- a/comercial/machote/js/calc.js
+++ b/comercial/machote/js/calc.js
@@ -148,7 +148,11 @@
     return {
       id: d.id || ('M-' + Date.now()),
       nombre: d.nombre || 'Cotización sin nombre',
+      // `cliente_id` es LO QUE MANDA: el nombre se lee de Odoo al pintar.
+      // `cliente` queda como respaldo para cuando Odoo no conteste, y como
+      // el único dato de los machotes que nacieron antes del catálogo.
       cliente: d.cliente || '',
+      cliente_id: (typeof d.cliente_id === 'number') ? d.cliente_id : null,
       so: d.so || null,
       estado: 'borrador',
       analista: d.analista || '',

--- a/comercial/machote/js/clientes.js
+++ b/comercial/machote/js/clientes.js
@@ -1,0 +1,152 @@
+/* ── El catálogo de clientes ──────────────────────────────────────────────
+ * Issue #148 · lo que pidió Esteban: «que sea solo visual y alomejor
+ * publicamente grabe el ID, para que al publico solo se vea el ID y lo
+ * dinamico sea la lectura en odoo. esto en backend. en front end no veriamos
+ * eso, en frontend solo veriamos el nombre del cliente».
+ *
+ * Lo que se GUARDA en el machote es `cliente_id`, un número. El NOMBRE se lee
+ * de Odoo cada vez que se pinta. Dos razones, y ninguna es de estilo:
+ *
+ *   1. Si al cliente le cambian la razón social en Odoo, las cotizaciones
+ *      viejas la muestran corregida sola. Un nombre copiado se queda con la
+ *      versión del día que se capturó y nadie vuelve a tocarla.
+ *   2. Este repo es PÚBLICO y sirve Pages (CLAUDE.md §20 regla 7). El día que
+ *      los machotes salgan del navegador, lo que viaje es `1247`, no la
+ *      cartera de clientes de FTS.
+ *
+ * ⚠️ EL CATÁLOGO NO SE GUARDA EN EL REPO. Vive en Odoo, se pide al vuelo y se
+ * cachea en memoria mientras la pestaña está abierta. Ni localStorage ni JSON
+ * commiteado: un archivo con los 250 clientes en un repo público es la misma
+ * filtración, sólo que más difícil de deshacer.
+ *
+ * ── Degradar sin trabar (CLAUDE.md §8, regla anti-trabón) ────────────────
+ * Este lado es el TOLERANTE. Si el webhook no existe todavía, si n8n está
+ * caído o si el token venció, el campo de cliente **sigue siendo un texto
+ * libre que funciona**: se guarda lo que se escriba y `cliente_id` queda en
+ * null. Nunca se bloquea crear un machote porque Odoo no contestó — el
+ * machote casi siempre nace antes que la orden, y a veces antes que el alta
+ * del cliente.
+ */
+(function (G) {
+  'use strict';
+
+  var BASE = 'https://primary-production-5c3c.up.railway.app/webhook';
+  var URL_CLIENTES = BASE + '/comercial/clientes';
+  var TIMEOUT_MS = 12000;
+
+  /* Una sola lectura por pestaña. `promesa` guarda la petición EN VUELO, no
+   * sólo el resultado: si dos pantallas piden el catálogo al mismo tiempo,
+   * comparten la misma llamada en vez de pegarle dos veces a Odoo. */
+  var estado = { promesa: null, clientes: null, error: null, porId: null };
+
+  function indexar(lista) {
+    var m = {};
+    for (var i = 0; i < lista.length; i++) m[lista[i].id] = lista[i].nombre;
+    return m;
+  }
+
+  /** Lee el catálogo. Resuelve SIEMPRE —nunca rechaza— con
+   *  `{ok:true, clientes:[{id,nombre}]}` o `{ok:false, error, mensaje}`. */
+  function cargar() {
+    if (estado.promesa) return estado.promesa;
+
+    var S = G.SuiteAuth;
+    var token = S && S.getToken && S.getToken();
+    if (!token) {
+      estado.error = 'SIN_SESION';
+      return Promise.resolve({ ok: false, error: 'SIN_SESION',
+        mensaje: 'No hay sesión: el cliente se escribe a mano.' });
+    }
+
+    var corta = null;
+    var ctrl = (typeof AbortController === 'function') ? new AbortController() : null;
+    var opciones = {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      // El token va en el CUERPO, no en Authorization: el header dispara un
+      // preflight CORS que el webhook de n8n no contesta (CLAUDE.md §15 #5).
+      body: JSON.stringify({ token: token })
+    };
+    if (ctrl) opciones.signal = ctrl.signal;
+
+    estado.promesa = fetch(URL_CLIENTES, opciones)
+      .then(function (r) {
+        if (!r.ok) throw new Error('HTTP ' + r.status);
+        return r.json();
+      })
+      .then(function (d) {
+        if (!d || d.ok !== true || !Array.isArray(d.clientes)) {
+          throw new Error((d && d.error) || 'RESPUESTA_INVALIDA');
+        }
+        estado.clientes = d.clientes;
+        estado.porId = indexar(d.clientes);
+        estado.error = null;
+        return { ok: true, clientes: d.clientes };
+      })
+      .catch(function (e) {
+        // El catálogo se pierde, la captura no. Se deja constancia del porqué
+        // en la consola y el llamador decide cómo degradar.
+        estado.error = String((e && e.message) || e);
+        // Se limpia la promesa para que el siguiente intento vuelva a probar:
+        // cachear un fallo de red condena la pestaña entera.
+        estado.promesa = null;
+        return { ok: false, error: 'SIN_CATALOGO', mensaje: estado.error };
+      })
+      .then(function (res) { if (corta) clearTimeout(corta); return res; });
+
+    if (ctrl) corta = setTimeout(function () { ctrl.abort(); }, TIMEOUT_MS);
+    return estado.promesa;
+  }
+
+  /** El nombre que se PINTA. Con el catálogo cargado gana Odoo; sin él, lo
+   *  último que se supo. Nunca devuelve vacío si hay algo que decir. */
+  function nombre(m) {
+    if (!m) return '';
+    if (m.cliente_id && estado.porId && estado.porId[m.cliente_id]) {
+      return estado.porId[m.cliente_id];
+    }
+    if (m.cliente) return m.cliente;
+    return m.cliente_id ? ('Cliente ' + m.cliente_id) : '';
+  }
+
+  /** ¿Lo que se está pintando salió de Odoo, o es el respaldo local? */
+  function esDeOdoo(m) {
+    return !!(m && m.cliente_id && estado.porId && estado.porId[m.cliente_id]);
+  }
+
+  /** Del texto tecleado al id. Exacto primero; si no, sin acentos ni
+   *  mayúsculas — nadie teclea «Abamex Ingeniería» con la tilde puesta. */
+  function resolver(texto) {
+    var t = String(texto || '').trim();
+    if (!t || !estado.clientes) return null;
+    var i;
+    for (i = 0; i < estado.clientes.length; i++) {
+      if (estado.clientes[i].nombre === t) return estado.clientes[i];
+    }
+    var plano = aplanar(t);
+    var halladas = [];
+    for (i = 0; i < estado.clientes.length; i++) {
+      if (aplanar(estado.clientes[i].nombre) === plano) halladas.push(estado.clientes[i]);
+    }
+    // Dos clientes que sólo se distinguen por un acento existen de verdad en
+    // Odoo («Alta Extracción» y «ALTA EXTRACCION» son ids distintos). Ante el
+    // empate no se elige: se deja el texto libre y se ve en la pantalla.
+    return halladas.length === 1 ? halladas[0] : null;
+  }
+
+  function aplanar(s) {
+    s = String(s || '').toLowerCase();
+    if (s.normalize) s = s.normalize('NFD').replace(/[\u0300-\u036f]/g, '');
+    return s.replace(/\s+/g, ' ').trim();
+  }
+
+  G.Clientes = {
+    cargar: cargar,
+    nombre: nombre,
+    esDeOdoo: esDeOdoo,
+    resolver: resolver,
+    lista: function () { return estado.clientes; },
+    error: function () { return estado.error; },
+    URL: URL_CLIENTES
+  };
+})(window);

--- a/comercial/machote/js/pegar.js
+++ b/comercial/machote/js/pegar.js
@@ -117,17 +117,26 @@
      * camino decidiera solo, se comería las listas y dejaría la viñeta y la
      * cantidad dentro de la descripción. Quién gana lo decide `interpretar`. */
     if (!mejor) {
-      const filas = lineas.map(l => l.split(/\s{2,}/).map(x => x.trim()));
+      const filas = lineas.map(l => l.split(/\s{2,}/).map(x => sinAdornos(x)));
       if (Math.max.apply(null, filas.map(f => f.length)) < 2) return { sep: null, filas: [], debil: false };
       return { sep: 'espacios', filas: filas, debil: true };
     }
     return { sep: mejor.sep, filas: lineas.map(l => trocear(l, mejor.sep)), debil: false };
   }
 
+  /* Fuera el maquillaje de Markdown. Claude escribe las tablas con negritas
+   * —`**$76,379**`— y ese asterisco convierte el precio en texto ilegible: el
+   * renglón queda sin precio, la tabla entera se cae al camino de lista y el
+   * encabezado acaba entrando como si fuera un material. */
+  const sinAdornos = (t) => String(t)
+    .replace(/\*\*|__|`/g, '')
+    .replace(/^\s*[*_]\s*|\s*[*_]\s*$/g, '')
+    .trim();
+
   function trocear(linea, sep) {
     let l = linea;
     if (sep === '|') l = l.replace(/^\s*\|/, '').replace(/\|\s*$/, '');
-    return l.split(sep).map(x => x.trim());
+    return l.split(sep).map(x => sinAdornos(x));
   }
 
   /* Cómo se llama cada columna cuando la tabla trae encabezado. Se compara sin
@@ -139,9 +148,12 @@
     tipo:        ['tipo', 'clase'],
     descripcion: ['descripcion', 'description', 'concepto', 'partida', 'articulo',
                   'producto', 'material', 'detalle', 'item'],
+    // La especificación no es una columna aparte del machote: se suma a la
+    // descripción, igual que el modelo y la marca desde V1.14.
+    especificacion: ['especificacion', 'especificaciones', 'spec', 'caracteristicas'],
     modelo:      ['modelo', 'model', 'no parte', 'num parte', 'numero de parte', 'sku', 'codigo', 'clave'],
     marca:       ['marca', 'brand', 'fabricante'],
-    pu:          ['precio unitario', 'p unitario', 'precio', 'unitario', 'costo unitario',
+    pu:          ['precio unitario', 'p unitario', 'p u', 'precio', 'unitario', 'costo unitario',
                   'costo', 'pu', 'importe unitario', 'unit price', 'price'],
     total:       ['precio total', 'importe', 'total', 'subtotal', 'monto', 'amount'],
     moneda:      ['moneda', 'divisa', 'currency'],
@@ -180,7 +192,13 @@
     'arena', 'block', 'acero', 'inox', 'galvanizado', 'aluminio', 'cobre',
     'manguera', 'conector', 'terminal', 'kit', 'equipo', 'bushing', 'buje',
     'chumacera', 'banda', 'polea', 'engrane', 'balero', 'sello', 'oring',
-    'pintura', 'primario', 'thinner', 'silicon', 'cinta', 'herraje', 'soporte'
+    'pintura', 'primario', 'thinner', 'silicon', 'cinta', 'herraje', 'soporte',
+    // Eléctrico, que es la mitad de lo que cotiza FTS y no estaba.
+    'interruptor', 'termomagnetico', 'pastilla', 'centro de carga', 'transformador',
+    'arrancador', 'guardamotor', 'relevador', 'fusible', 'portafusible', 'charola',
+    'zapata', 'ojillo', 'ponchable', 'liquidtight', 'thhn', 'thw', 'nema',
+    'tornilleria', 'cincho', 'consumible', 'mufa', 'registro', 'apagador',
+    'contacto', 'clavija', 'balastro', 'reflector', 'led', 'aisl'
   ];
 
   /* Unidades que por sí solas ya dicen de qué lado va el renglón. */
@@ -211,6 +229,11 @@
   /** ¿La primera fila es un encabezado? Lo es si NINGUNA de sus celdas es un
    *  número y al menos una casa con un alias conocido. Una fila de puros textos
    *  que no casa con nada puede ser perfectamente el primer material. */
+  /* Un encabezado que dice "anterior", "previo" o "antes" es el precio VIEJO.
+   * Tomarlo cotizaría con el precio de la lista pasada, que es exactamente el
+   * error que nadie detectaría mirando la pantalla. */
+  const esColumnaVieja = (n) => /\banterior\b|\bprevio\b|\bantes\b|\bold\b|\boriginal\b/.test(n);
+
   function mapearEncabezado(fila) {
     if (!fila || fila.length < 2) return null;
     if (fila.some(esNumero)) return null;
@@ -218,6 +241,7 @@
     fila.forEach((celda, i) => {
       const n = norm(celda);
       if (!n) return;
+      if (esColumnaVieja(n)) return;
       for (const campo in ALIAS) {
         if (ALIAS[campo].indexOf(n) >= 0 ||
             ALIAS[campo].some(a => n === a || n.indexOf(a) === 0)) {
@@ -370,7 +394,7 @@
   }
 
   function interpretarLinea(linea) {
-    let t = String(linea)
+    let t = sinAdornos(String(linea))
       // Fuera viñetas y numeración: "- ", "• ", "* ", "1. ", "1) ".
       .replace(/^\s*(?:[-*•·—]|\d{1,3}[.)])\s+/, '')
       .trim();
@@ -482,8 +506,29 @@
     const monedaDoc = opciones.moneda || 'MXN';
 
     const renglones = cuerpo.map(f => {
-      const desc = String(dame(f, 'descripcion') || '').trim();
-      let qty = aNumero(dame(f, 'qty'));
+      /* La descripción se ARMA: especificación, modelo y marca se suman a ella
+       * en vez de perderse. Desde V1.14 la tabla del machote no tiene columnas
+       * de Modelo ni Marca —van dentro de la descripción, como pidió Montalvo—
+       * así que una tabla pegada que sí las trae tiene que fundirlas aquí o el
+       * dato desaparece sin que nadie lo note. */
+      const desc = [dame(f, 'descripcion'), dame(f, 'especificacion'),
+                    dame(f, 'modelo'), dame(f, 'marca')]
+        .map(x => String(x || '').trim()).filter(Boolean)
+        .filter((x, i, a) => a.indexOf(x) === i)      // sin repetir
+        .join(' · ');
+
+      /* Una celda de cantidad suele traer la unidad pegada: "1 pza", "240 m",
+       * "10 juegos". `aNumero` la rechaza entera y la unidad se pierde. */
+      const celdaQty = String(dame(f, 'qty') || '').trim();
+      let qty = aNumero(celdaQty), unidadDeQty = '';
+      if (qty === null && celdaQty) {
+        const mq = celdaQty.match(/^(\d+(?:[.,]\d+)?)\s*([a-zA-ZáéíóúñÁÉÍÓÚÑ]{1,10})\.?$/);
+        if (mq) {
+          qty = aNumero(mq[1]);
+          const k = mq[2].toLowerCase();
+          if (Object.prototype.hasOwnProperty.call(UNIDADES, k)) unidadDeQty = UNIDADES[k];
+        }
+      }
       let pu  = aNumero(dame(f, 'pu'));
       const total = aNumero(dame(f, 'total'));
       // Si vino el total y no el unitario, se deriva. Es el caso de las tablas
@@ -496,8 +541,9 @@
                : /material|equipo|suministro|insumo/.test(tipoCrudo) ? 'Materiales'
                : '';
       // Si la tabla no lo trae, se deduce de la descripción y se MARCA.
+      const unidad = normalizaUnidad(dame(f, 'unidad')) || unidadDeQty;
       let tipoDeducido = false;
-      if (!tipo) { tipo = deducirTipo(desc, normalizaUnidad(dame(f, 'unidad'))); tipoDeducido = !!tipo; }
+      if (!tipo) { tipo = deducirTipo(desc, unidad); tipoDeducido = !!tipo; }
       const monCruda = String(dame(f, 'moneda') || '').toUpperCase();
       const moneda = /USD|DLL|DOLAR/.test(monCruda) ? 'USD'
                    : /MXN|PESO/.test(monCruda) ? 'MXN'
@@ -511,11 +557,10 @@
 
       return {
         qty: qty === null ? '' : Math.abs(qty),
-        unidad: normalizaUnidad(dame(f, 'unidad')),
+        unidad: unidad,
         tipo: tipo, _tipoDeducido: tipoDeducido,
         descripcion: desc,
-        modelo: String(dame(f, 'modelo') || '').trim(),
-        marca: String(dame(f, 'marca') || '').trim(),
+        modelo: '', marca: '',      // fundidos en la descripción, arriba
         pu: pu === null ? null : Math.abs(pu),
         moneda: moneda,
         margen: null,

--- a/comercial/machote/tests/pruebas-navegador.js
+++ b/comercial/machote/tests/pruebas-navegador.js
@@ -60,6 +60,28 @@ let ok = 0, mal = 0;
         debe_cambiar_password: false
       }));
     } catch (e) {}
+
+    /* El catálogo de clientes se finge. Dos razones:
+     *   - Determinismo: la prueba no puede depender de lo que haya hoy en Odoo.
+     *   - El contenedor no alcanza Railway (403 del proxy), así que un fetch
+     *     real ensucia la consola con un error que NO es del prototipo.
+     * Se intercepta SÓLO la URL del catálogo; cualquier otro fetch pasa. */
+    const original = window.fetch;
+    window.fetch = function (u, o) {
+      if (String(u).indexOf('/comercial/clientes') >= 0) {
+        return Promise.resolve({
+          ok: true,
+          json: function () {
+            return Promise.resolve({ ok: true, total: 3, clientes: [
+              { id: 49,   nombre: 'ABINSA SA DE CV' },
+              { id: 1247, nombre: 'BBVA México' },
+              { id: 385,  nombre: 'Abamex Ingeniería, SA de CV' }
+            ] });
+          }
+        });
+      }
+      return original.apply(this, arguments);
+    };
   });
   // El contenedor no tiene salida a fonts.googleapis.com, que fts-styles.css
   // importa. Ese fallo es del entorno de prueba, no del prototipo: se filtra
@@ -503,12 +525,22 @@ let ok = 0, mal = 0;
     const antes = await p.textContent('.fija .mono');
     const tcAntes = await p.textContent('td.calc:near(:text("TC efectivo"))').catch(() => null);
 
-    await p.fill('[data-cel="factor_proteccion"]', '0.10');
+    // Desde V1.14 se teclea en PORCENTAJE: 10, no 0.10.
+    await p.fill('[data-cel="factor_proteccion"]', '10');
     await p.dispatchEvent('[data-cel="factor_proteccion"]', 'change');
     await p.waitForTimeout(280);
     const desp = await p.textContent('.fija .mono');
     if (antes === desp) throw new Error('cambiarlo no movió el precio: ' + antes);
-    console.log('   con tc=18:', antes.trim(), '→ con factor 0.10:', desp.trim());
+    // Y lo guardado sigue siendo la RAZÓN, no el porcentaje.
+    const guardado = await p.evaluate(() => {
+      const c = localStorage.getItem('fts_machote_v1');
+      if (!c) return null;
+      const m = JSON.parse(c).machotes.find(x => x.id === 'M-1043');
+      return m ? m.factor_proteccion : null;
+    });
+    if (guardado !== null && Math.abs(guardado - 0.10) > 1e-6)
+      throw new Error('guardó ' + guardado + ', esperaba 0.10');
+    console.log('   con tc=18:', antes.trim(), '→ con factor 10%:', desp.trim());
   });
 
   // ══ V1.06 · edición estructural y moneda ═════════════════════════════
@@ -1521,6 +1553,285 @@ let ok = 0, mal = 0;
     await p.setViewportSize({ width: 380, height: 780 });
   });
 
+  // ── V1.14 · lo que pidió Montalvo ────────────────────────────────────
+  await paso('las comisiones se capturan en % y se guardan como razón', async () => {
+    await p.setViewportSize({ width: 1280, height: 900 });
+    await ir('#/m/M-1041'); await hoja('Suministro');
+    const campo = p.locator('[data-cel="comision_fts"]');
+    if (await campo.count() === 0) throw new Error('no está el campo de comisión');
+    // 0.055 por dentro se ve como 5.5 en pantalla.
+    const enPantalla = await campo.inputValue();
+    if (Math.abs(Number(enPantalla) - 5.5) > 1e-6)
+      throw new Error('en pantalla dice ' + enPantalla + ', esperaba 5.5');
+    if (!await campo.evaluate(e => e.hasAttribute('data-pct')))
+      throw new Error('el campo no se declara de porcentaje');
+    // Y al teclear 8 se guarda 0.08, no 8.
+    await campo.fill('8'); await campo.dispatchEvent('change');
+    await p.waitForTimeout(900);
+    const guardado = await p.evaluate(() => {
+      const c = localStorage.getItem('fts_machote_v1');
+      if (!c) return null;
+      const m = JSON.parse(c).machotes.find(x => x.id === 'M-1041');
+      return m ? m.comision_fts : null;
+    });
+    if (guardado === null) throw new Error('no alcanzó a guardar');
+    if (Math.abs(guardado - 0.08) > 1e-8) throw new Error('guardó ' + guardado + ', esperaba 0.08');
+    console.log('    pantalla 5.5% · almacén 0.055 · tecleado 8% → 0.08');
+    await p.setViewportSize({ width: 380, height: 780 });
+  });
+
+  await paso('la tabla de materiales ya no trae Modelo ni Marca', async () => {
+    await p.setViewportSize({ width: 1440, height: 900 });
+    await ir('#/m/M-1041'); await hoja('Suministro');
+    const r = await p.evaluate(() => ({
+      modelo: document.querySelectorAll('[data-cel*=":partidas:"][data-cel$=":modelo"]').length,
+      marca: document.querySelectorAll('[data-cel*=":partidas:"][data-cel$=":marca"]').length,
+      desc: document.querySelectorAll('[data-cel*=":partidas:"][data-cel$=":descripcion"]').length
+    }));
+    if (r.modelo || r.marca) throw new Error('siguen ' + r.modelo + ' modelo y ' + r.marca + ' marca');
+    if (!r.desc) throw new Error('se llevó también la descripción');
+    await p.setViewportSize({ width: 380, height: 780 });
+  });
+
+  await paso('la fila de materiales cabe en pantalla, y borrar siempre se alcanza', async () => {
+    /* Montalvo: "la línea está muy larga, no se ve completa para tener la
+     * opción de borrar" y "tenemos que hacer scroll horizontal". Se mide lo
+     * uno y lo otro: que a 1440 no sobre ancho, y que los botones queden
+     * DENTRO de la ventana a cualquier tamaño. */
+    for (const w of [1440, 1280, 1024]) {
+      await p.setViewportSize({ width: w, height: 900 });
+      await ir('#/m/M-1041'); await hoja('Suministro');
+      const r = await p.evaluate(() => {
+        const t = [...document.querySelectorAll('.rejilla')]
+          .find(x => x.querySelector('[data-cel*=":partidas:"]'));
+        const c = t.closest('.scroll');
+        const acc = t.querySelector('td.acc'), ini = t.querySelector('td.acc-ini');
+        const rb = acc.getBoundingClientRect(), ri = ini.getBoundingClientRect();
+        return { sobra: Math.round(c.scrollWidth - c.clientWidth),
+                 borrarDentro: rb.left >= 0 && rb.right <= window.innerWidth + 1,
+                 pegarDentro: ri.left >= 0 && ri.right <= window.innerWidth + 1 };
+      });
+      if (!r.borrarDentro) throw new Error('a ' + w + 'px los botones caen fuera');
+      if (!r.pegarDentro) throw new Error('a ' + w + 'px el botón de pegar cae fuera');
+      if (w === 1440 && r.sobra > 2) throw new Error('a 1440px la tabla desborda ' + r.sobra + 'px');
+    }
+    console.log('    cabe a 1440; a 1024 los botones siguen fijos a los bordes');
+    await p.setViewportSize({ width: 380, height: 780 });
+  });
+
+  await paso('una tabla de Claude con negritas no mete el encabezado como renglón', async () => {
+    const r = await p.evaluate(() => {
+      const T = [
+        '| #  | Concepto              | Especificacion                         |     Cant. | P.U. anterior | **P.U. +8%** | **Importe +8%** |',
+        '| -- | --------------------- | -------------------------------------- | --------: | ------------: | -----------: | --------------: |',
+        '| A1 | Interruptor principal | Schneider PowerPact M 400 A, 3P, 600 V |     1 pza |       $70,721 |  **$76,379** |     **$76,379** |',
+        '| A2 | Cable de fuerza       | Cu THW-LS 4/0 AWG                      |     240 m |          $607 |     **$656** |    **$157,440** |',
+        '| A9 | Mano de obra          | Instalacion charola y tendido          |    1 lote |       $18,000 |  **$19,440** |     **$19,440** |'
+      ].join('\n');
+      const x = window.MachotePegar.interpretar(T, { moneda: 'MXN' });
+      return { ok: x.ok, sep: x.sep, enc: x.encabezado, n: x.renglones.length, r: x.renglones };
+    });
+    if (!r.ok) throw new Error('la rechazó');
+    if (r.sep !== '|') throw new Error('no la leyó como tabla, se fue por: ' + r.sep);
+    if (!r.enc) throw new Error('no reconoció el encabezado');
+    if (r.n !== 3) throw new Error('leyó ' + r.n + ' renglones; el encabezado se coló');
+    if (r.r.some(x => /Concepto|Especificacion/i.test(x.descripcion)))
+      throw new Error('un renglón trae el texto del encabezado');
+    // El precio bueno es el NUEVO, no el "anterior".
+    if (r.r[0].pu !== 76379) throw new Error('tomó el precio viejo: ' + r.r[0].pu);
+    if (r.r[1].pu !== 656) throw new Error('renglón 2 precio: ' + r.r[1].pu);
+    // La cantidad venía pegada a la unidad.
+    if (r.r[0].qty !== 1 || r.r[0].unidad !== 'Pieza')
+      throw new Error('no leyó "1 pza": ' + JSON.stringify({ q: r.r[0].qty, u: r.r[0].unidad }));
+    if (r.r[1].qty !== 240 || r.r[1].unidad !== 'Metro')
+      throw new Error('no leyó "240 m": ' + JSON.stringify({ q: r.r[1].qty, u: r.r[1].unidad }));
+    // Y la especificación entró a la descripción en vez de perderse.
+    if (r.r[0].descripcion.indexOf('Schneider') < 0)
+      throw new Error('perdió la especificación: ' + r.r[0].descripcion);
+    if (r.r[2].tipo !== 'Servicios') throw new Error('"Mano de obra" no salió Servicios');
+    console.log('    encabezado fuera · precio nuevo · unidad de "1 pza" · especificación dentro');
+  });
+
+  // ── El cliente, desde Odoo ───────────────────────────────────────────
+  await paso('al crear, el cliente sale de una lista leída de Odoo', async () => {
+    await ir('#/nuevo');
+    await p.waitForTimeout(320);
+    const r = await p.evaluate(() => {
+      const dl = document.querySelector('#n-clientes');
+      const est = document.querySelector('#n-cliente-est');
+      const inp = document.querySelector('#n-cliente');
+      return {
+        opciones: dl ? [...dl.querySelectorAll('option')].map(o => o.value) : null,
+        estado: est ? est.textContent : null,
+        lista: inp ? inp.getAttribute('list') : null,
+        aviso: est ? est.className : null
+      };
+    });
+    if (r.lista !== 'n-clientes') throw new Error('el campo no está ligado a la lista');
+    if (!r.opciones || r.opciones.length !== 3)
+      throw new Error('opciones: ' + JSON.stringify(r.opciones));
+    if (r.opciones.indexOf('BBVA México') < 0) throw new Error('falta un cliente del catálogo');
+    if (!/3 clientes de Odoo/.test(r.estado || '')) throw new Error('el aviso dice: ' + r.estado);
+    if (/n-warn/.test(r.aviso || '')) throw new Error('marcó aviso de fallo con el catálogo cargado');
+    console.log('    3 clientes en la lista · aviso: ' + (r.estado || '').slice(0, 40) + '…');
+  });
+
+  await paso('lo que se guarda es el ID de Odoo, no el nombre', async () => {
+    /* El fondo del cambio que pidió Esteban: "publicamente grabe el ID … lo
+     * dinamico sea la lectura en odoo". Si se guardara el nombre, cambiarle
+     * la razón social a un cliente dejaría todas las cotizaciones viejas con
+     * el nombre de ayer — y este repo es público. */
+    await ir('#/nuevo');
+    await p.waitForTimeout(320);
+    await p.fill('#n-nombre', 'ZZ prueba de cliente');
+    await p.fill('#n-cliente', 'BBVA México');
+    await p.click('#n-crear');
+    await p.waitForTimeout(320);
+    const r = await p.evaluate(() => {
+      const m = JSON.parse(localStorage.getItem('fts_machote_v1') || '{}')
+        .machotes.find(x => x.nombre === 'ZZ prueba de cliente');
+      return { id: m && m.cliente_id, txt: m && m.cliente,
+               barra: (document.querySelector('#tbT') || {}).textContent };
+    });
+    if (r.id !== 1247) throw new Error('cliente_id guardado: ' + JSON.stringify(r.id));
+    if (r.barra !== 'BBVA México') throw new Error('la barra muestra: ' + r.barra);
+    console.log('    guardó cliente_id 1247 · la pantalla dice "' + r.barra + '"');
+  });
+
+  await paso('el nombre se lee de Odoo, no del texto guardado', async () => {
+    /* Un machote guardado con el nombre VIEJO debe pintarse con el nombre
+     * vivo. Es la prueba de que el id manda sobre el respaldo — y de que el
+     * repintado tras la lectura de Odoo de verdad ocurre.
+     *
+     * Página aparte, SIN el guion que limpia el almacén: aquí hay que escribir
+     * en localStorage y volver a cargar, y el guion global lo borraría en la
+     * navegación siguiente. (Ya pasó al escribir esta prueba.) */
+    const o = await b.newPage({ viewport: { width: 380, height: 780 } });
+    await o.addInitScript(() => {
+      try {
+        localStorage.setItem('fts_suite_session', JSON.stringify({
+          token: 'prueba.prueba.prueba', actor: 'zz.prueba', nombre: 'ZZ Prueba',
+          empleado_id: null, scopes: ['comercial:read'],
+          exp: Math.floor(Date.now() / 1000) + 3600, debe_cambiar_password: false
+        }));
+      } catch (e) {}
+      const original = window.fetch;
+      window.fetch = function (u) {
+        if (String(u).indexOf('/comercial/clientes') >= 0) {
+          return Promise.resolve({ ok: true, json: function () {
+            return Promise.resolve({ ok: true, total: 1, clientes: [
+              { id: 1247, nombre: 'BBVA México' }
+            ] });
+          } });
+        }
+        return original.apply(this, arguments);
+      };
+    });
+    try {
+      /* El almacén sólo se escribe cuando algo CAMBIA — cargar la demo no
+       * guarda nada—, así que primero se crea un machote de verdad. Eso
+       * dispara el guardado y deja el archivo en localStorage para sembrarlo.
+       * (Suponer que ya estaba escrito fue el primer intento, y falló.) */
+      await o.goto(BASE); await o.waitForTimeout(400);
+      await o.evaluate(() => { location.hash = '#/nuevo'; });
+      await o.waitForTimeout(400);
+      await o.fill('#n-nombre', 'ZZ nombre viejo');
+      await o.fill('#n-cliente', 'BANCOMER (nombre viejo)');   // no está en el catálogo
+      await o.click('#n-crear');
+      await o.waitForTimeout(400);
+
+      const sembro = await o.evaluate(() => {
+        const crudo = localStorage.getItem('fts_machote_v1');
+        if (!crudo) return false;
+        const d = JSON.parse(crudo);
+        const m = d.machotes.find(x => x.nombre === 'ZZ nombre viejo');
+        if (!m) return false;
+        // El id de Odoo entra a mano; el texto guardado se queda VIEJO a
+        // propósito: es lo que no debe ganarle a la lectura de Odoo.
+        m.cliente_id = 1247;
+        localStorage.setItem('fts_machote_v1', JSON.stringify(d));
+        return true;
+      });
+      if (!sembro) throw new Error('el almacén no tenía nada que sembrar');
+      await o.goto(BASE); await o.waitForTimeout(1100);  // el catálogo llega y repinta
+      // El recién creado va al principio de la lista (`unshift`).
+      const t = await o.evaluate(() => document.querySelector('.fila .tiny').textContent);
+      if (t.indexOf('BBVA México') < 0)
+        throw new Error('siguió mostrando el nombre guardado: ' + t);
+      if (t.indexOf('BANCOMER') >= 0) throw new Error('mostró el nombre viejo: ' + t);
+      console.log('    guardado "BANCOMER (nombre viejo)" → pinta "BBVA México"');
+    } finally { await o.close(); }
+  });
+
+  await paso('un cliente que no está en Odoo se guarda igual, como texto', async () => {
+    await ir('#/nuevo');
+    await p.waitForTimeout(320);
+    await p.fill('#n-nombre', 'ZZ prospecto');
+    await p.fill('#n-cliente', 'Prospecto que nadie ha dado de alta');
+    await p.click('#n-crear');
+    await p.waitForTimeout(300);
+    const r = await p.evaluate(() => {
+      const m = JSON.parse(localStorage.getItem('fts_machote_v1') || '{}')
+        .machotes.find(x => x.nombre === 'ZZ prospecto');
+      return { id: m && m.cliente_id, txt: m && m.cliente,
+               barra: (document.querySelector('#tbT') || {}).textContent };
+    });
+    if (r.id !== null) throw new Error('inventó un id: ' + JSON.stringify(r.id));
+    if (r.txt !== 'Prospecto que nadie ha dado de alta')
+      throw new Error('perdió el texto: ' + r.txt);
+    if (r.barra !== 'Prospecto que nadie ha dado de alta')
+      throw new Error('no lo pinta: ' + r.barra);
+  });
+
+  await paso('si Odoo no contesta, el cliente se captura a mano y se dice', async () => {
+    /* La mitad TOLERANTE del contrato (§8 anti-trabón): el webhook puede no
+     * existir todavía, o n8n estar caído. Crear un machote no se bloquea por
+     * eso — y el aviso explica por qué la lista está vacía, en vez de dejar
+     * un campo mudo que parece roto. */
+    const f = await b.newPage({ viewport: { width: 380, height: 780 } });
+    try {
+      await f.addInitScript(() => {
+        try {
+          localStorage.clear();
+          localStorage.setItem('fts_suite_session', JSON.stringify({
+            token: 'x.y.z', actor: 'zz.prueba', nombre: 'ZZ Prueba',
+            scopes: ['comercial:read'], exp: Math.floor(Date.now() / 1000) + 3600
+          }));
+        } catch (e) {}
+        const original = window.fetch;
+        window.fetch = function (u) {
+          if (String(u).indexOf('/comercial/clientes') >= 0) {
+            return Promise.reject(new Error('n8n caído'));
+          }
+          return original.apply(this, arguments);
+        };
+      });
+      await f.goto(BASE); await f.waitForTimeout(400);
+      await f.evaluate(() => { location.hash = '#/nuevo'; });
+      await f.waitForTimeout(500);
+      const est = await f.evaluate(() => {
+        const e = document.querySelector('#n-cliente-est');
+        return { txt: e && e.textContent, cls: e && e.className };
+      });
+      if (!/no se pudo leer el catálogo/i.test(est.txt || ''))
+        throw new Error('no avisó: ' + est.txt);
+      if (!/n-warn/.test(est.cls || '')) throw new Error('el aviso no se marca');
+      if (!/se guarda igual/.test(est.txt || ''))
+        throw new Error('no dice que igual se puede capturar: ' + est.txt);
+
+      await f.fill('#n-nombre', 'ZZ sin odoo');
+      await f.fill('#n-cliente', 'Cliente a mano');
+      await f.click('#n-crear');
+      await f.waitForTimeout(300);
+      const m = await f.evaluate(() => JSON.parse(localStorage.getItem('fts_machote_v1'))
+        .machotes.find(x => x.nombre === 'ZZ sin odoo'));
+      if (!m) throw new Error('no dejó crear el machote sin catálogo');
+      if (m.cliente !== 'Cliente a mano') throw new Error('perdió el cliente: ' + m.cliente);
+      if (m.cliente_id !== null) throw new Error('inventó un id sin catálogo');
+      console.log('    catálogo caído → se avisa, y el machote se crea igual');
+    } finally { await f.close(); }
+  });
+
   // ── El gate ──────────────────────────────────────────────────────────
   await paso('sin sesión, el libro no se alcanza a ver', async () => {
     // Pagina LIMPIA, sin la sesion sembrada: debe mandar al login.
@@ -1535,10 +1846,15 @@ let ok = 0, mal = 0;
     } finally { await g.close(); }
   });
 
-  await paso('la sesión dice quién entró y deja salir', async () => {
+  await paso('la sesión dice quién entró, por su nombre, y deja salir', async () => {
+    /* Montalvo pidió ver al usuario. `zz.prueba` truncado no dice quién es;
+     * el NOMBRE sí. El usuario exacto queda en el title, para cuando haga
+     * falta el dato literal. */
     await ir('#/m/M-1041');
     const t = await p.locator('#tbUser').textContent();
-    if (t.trim() !== 'zz.prueba') throw new Error('la barra dice: ' + t);
+    if (t.trim() !== 'ZZ Prueba') throw new Error('la barra dice: ' + t);
+    const tit = await p.locator('#tbUser').getAttribute('title');
+    if (tit !== 'zz.prueba') throw new Error('el title no trae el usuario: ' + tit);
     const vis = await p.locator('#tbUser').isVisible();
     if (!vis) throw new Error('el botón de sesión no se ve');
   });

--- a/comercial/machote/version.json
+++ b/comercial/machote/version.json
@@ -1,10 +1,15 @@
 {
-  "version": "V1.13",
+  "version": "V1.14",
   "fecha": "2026-09-04",
   "modulo": "comercial/machote",
   "ambito": "El CONTADOR es solo de este modulo. finanzas tambien usa V1.xx desde el 2026-09-03 (instruccion directa de Esteban, corrige el \"no propagar\" del issue #148) pero lleva su propio contador y va en V1.00. operaciones/planeacion sigue en 2.4.1, kiosk y confirmar-horas solo con cadena de build, y siete modulos con un 1.0.0 puesto una vez: a esos no se propaga.",
   "esquema": "V<mayor>.<menor de dos digitos>. Un incremento de 0.01 por cada merge a main. Al pasar de .99 sube el mayor y el menor vuelve a 00.",
   "historial": [
+    {
+      "version": "V1.14",
+      "pr": null,
+      "nota": "Lo que pidio Montalvo: las comisiones y los margenes se escriben en % y no en decimales, la tabla de materiales cabe en la pantalla sin scroll horizontal -fuera Marca y Modelo, que van en la descripcion- con el boton de pegar fijo a la izquierda y borrar/mover fijos a la derecha, el pegado de tablas de Claude ya no convierte el encabezado en un renglon, el cliente se elige de una lista leida de Odoo -se guarda el ID, el nombre se lee vivo- y la barra dice el nombre de quien entro, no su usuario"
+    },
     {
       "version": "V1.13",
       "pr": null,

--- a/docs/comercial/CLIENTES-DESDE-ODOO.md
+++ b/docs/comercial/CLIENTES-DESDE-ODOO.md
@@ -1,0 +1,135 @@
+# El cliente del machote sale de Odoo
+
+> Issue #148 · construido el 2026-09-04 · workflow `RyeFlCTdLu301Gjz`
+
+## Qué pidió Esteban, textual
+
+> «Cuando hago la creacion del machote **sigue sin darme un droplist del cliente
+> visual**. podemos ver que sea solo visual y alomejor **publicamente grabe el
+> ID**, para que al publico solo se vea el ID y **lo dinamico sea la lectura en
+> odoo**. esto en backend. en front end no veriamos eso, en frontend solo
+> veriamos **el nombre del cliente** y si se puede tamjien **del usuario**.»
+
+## Lo que se guarda, y lo que se ve
+
+| | dato |
+|---|---|
+| se **guarda** en el machote | `cliente_id` — un número (`1247`) |
+| se **ve** en la pantalla | el nombre, leído de Odoo al pintar |
+| respaldo | `cliente` — el último nombre conocido, sólo para cuando Odoo no contesta |
+
+Dos razones, ninguna cosmética:
+
+1. **El nombre vivo corrige solo.** Si a un cliente le cambian la razón social
+   en Odoo, las cotizaciones viejas la muestran corregida sin que nadie las
+   toque. Un nombre copiado se queda con la versión del día que se capturó.
+2. **Este repo es público y sirve Pages** (CLAUDE.md §20 regla 7). El día que
+   los machotes salgan del navegador, lo que viaje es `1247`, no la cartera de
+   clientes de FTS.
+
+**El catálogo NO se guarda en el repo ni en `localStorage`.** Vive en Odoo, se
+pide al vuelo y se cachea en memoria mientras la pestaña está abierta. Un JSON
+con los 250 clientes commiteado sería la misma filtración, sólo que más difícil
+de deshacer — borrarlo del archivo no lo borra del historial.
+
+## El endpoint
+
+```
+POST https://primary-production-5c3c.up.railway.app/webhook/comercial/clientes
+body: { "token": "<el de auth/suite-login>" }
+→    { "ok": true, "clientes": [{ "id": 49, "nombre": "ABINSA SA DE CV" }, …],
+       "total": 250, "_meta": { … } }
+```
+
+Workflow n8n **`comercial/clientes`**, id **`RyeFlCTdLu301Gjz`**, 7 nodos.
+
+- **SOLO LECTURA.** No escribe en Odoo. Nunca. Es la restricción que puso
+  Esteban para todo este frente («no editar NADA de la base de datos de odoo,
+  odoo solo consulta»).
+- **Token en el cuerpo, no en `Authorization`**: el header dispara un preflight
+  CORS que el webhook de n8n no contesta (CLAUDE.md §15 #5).
+- Exige **scope `comercial:read`**, el mismo que abre el módulo.
+- La criptografía del nodo `Code - Verificar token` viene **recortada
+  programáticamente** de `docs/n8n-workflows/fase0/jwt-verify.js` (9/9 contra
+  `crypto` de Node, incluido payload manipulado), no transcrita a mano.
+
+### El dominio de Odoo, y por qué `is_company`
+
+```
+is_company    = true
+active        = true
+customer_rank >= 1        (greaterOrEqual — `greaterThan` NO existe en el nodo
+                           Odoo v1 de n8n, CLAUDE.md §17 quirk 1)
+fieldsList    = ['id', 'name']
+```
+
+Medido el 2026-09-04 contra Odoo:
+
+```
+is_company = true  · customer_rank > 0 · active  →  250 empresas
+is_company = false · customer_rank > 0 · active  →  483 PERSONAS
+```
+
+Esos 483 son los **contactos** de cada cliente (`parent_id` apunta a la
+empresa), con nombre y apellido de gente real. **El filtro `is_company` no es
+cosmético: es lo que impide mandar 483 nombres de personas a un navegador.** Y
+del partner sale únicamente `id` y `name` — ni correo, ni teléfono, ni RFC.
+
+## Degradar sin trabar
+
+El frontend es la mitad **tolerante** del contrato (CLAUDE.md §8, regla
+anti-trabón). Si el webhook no está activo, si n8n está caído o si el token
+venció:
+
+- el campo de cliente **sigue siendo texto libre y se guarda**,
+- `cliente_id` queda en `null`,
+- y un aviso ámbar dice por qué la lista está vacía, en vez de dejar un campo
+  mudo que parece roto.
+
+Nunca se bloquea crear un machote porque Odoo no contestó. El machote casi
+siempre nace antes que la orden, y a veces antes del alta del cliente.
+
+También se acepta un cliente **que no está en el catálogo** — un prospecto — y
+se guarda como texto sin id.
+
+## Empate por acento
+
+En Odoo conviven `Alta Extracción S.A. de C.V.` (id 388) y
+`ALTA EXTRACCION, S.A. DE C.V` (id 461): son ids distintos y ninguno es un
+error de captura. La resolución texto→id busca primero **exacta**, y sólo si
+falla compara sin acentos ni mayúsculas. **Ante empate no elige**: deja el
+texto libre, y se ve en la pantalla. Elegir al azar habría metido la
+cotización en el cliente equivocado sin que nadie lo notara.
+
+## Cómo se verificó, y qué NO se verificó
+
+| | cómo |
+|---|---|
+| el dominio de Odoo y los conteos | ejecutado contra Odoo por MCP, read-only |
+| la criptografía del token | `node docs/n8n-workflows/fase0/test-jwt.js` → 9/9 |
+| el workflow existe y su forma | read-back con `get_workflow_details` |
+| el frontend, con catálogo | Playwright, `fetch` fingido |
+| el frontend, sin catálogo | Playwright, `fetch` que rechaza |
+
+⚠️ **Lo que NO está verificado: la llamada real navegador → n8n → Odoo.** Dos
+motivos, los dos del entorno:
+
+1. El contenedor de Claude Code **no alcanza Railway** — 403 del proxy de
+   salida— así que no se puede hacer `curl` al webhook.
+2. Correr el workflow con `test_workflow` **volcaría `SUITE_JWT_SECRET` al
+   transcript**: la herramienta devuelve el output de todos los nodos, y uno de
+   ellos es el `Set` que materializa el secreto (CLAUDE.md §9, la regla que
+   costó rotar la `ODOO_RPC_KEY`). No se corrió a propósito.
+
+La prueba que falta es de un clic: **activar el workflow en la UI de n8n** y
+abrir la pantalla de machote nuevo. Si la lista aparece, el círculo cerró; si
+aparece el aviso ámbar, el aviso mismo dice qué falló.
+
+## Pendiente
+
+- **Activar `RyeFlCTdLu301Gjz` en la UI** (el API no deja activar por MCP —
+  CLAUDE.md §18 lección 2). Mientras esté inactivo, el campo funciona como
+  texto libre y avisa.
+- Sin HMAC de webhook, como el resto del Suite. Este endpoint es de lectura y
+  exige un JWT con scope, así que no empeora el modelo — pero entra en la misma
+  deuda pendiente (CLAUDE.md §9).


### PR DESCRIPTION
Cierra los cinco puntos que trajo Montalvo de las pruebas, y el cliente desde Odoo que quedó pendiente. Issue #148.

## Lo que pidió, y qué se hizo

| lo que pidió | qué se hizo |
|---|---|
| «que las comisiones aparezcan en % y no en decimales» | se teclean y se leen `5.5 %`. Adentro siguen siendo razones (`0.055`) |
| «la linea esta muy larga no se ve complete para tener la opción de borar» | borrar/mover quedan **fijos al borde derecho**; pegar, fijo al izquierdo |
| «eliminar las columnas de marca y modelo, eso lo pones en descripción» | fuera las dos (15 → 13 columnas); la descripción se queda con el ancho |
| «esta tabla no esta bien centrada... tenemos que hacer scroll horizontal» | a 1440 px sobra **0 px**. Medido también a 1280 y 1024 |
| «las tablas de Claude... me esta haciendo una linea para los encabezados» | corregido; eran **tres** causas a la vez, no una |
| «sigue sin darme un droplist del cliente... publicamente grabe el ID» | lista leída de Odoo en vivo; se guarda `cliente_id`, el nombre se lee vivo |
| «en frontend... el nombre del cliente y si se puede tambien del usuario» | la barra dice el **nombre** de quien entró, no su usuario |

## Porcentajes en la pantalla, razones en el archivo

La conversión vive en **dos lugares y nada más**: `celPct()` al pintar (×100) y `aplicar()` al guardar (÷100, redondeado a ocho decimales para que `5.5 %` no vuelva como `0.055000000000000005`).

**Los multiplicadores NO llevan `%`**: `2.5` es «dos veces y media el costo», no «dos y medio por ciento». Ponerles el signo habría sido peor que no convertirlos.

## Que la fila quepa

Tres cosas la metieron adentro: fuera `Marca` y `Modelo` (dos columnas de 200 px que le robaban ancho a lo único que de verdad se lee), la descripción con `min-width: 260px; width: 40%`, y las dos columnas de acciones fijas a los bordes. Aunque un día la tabla vuelva a desbordarse por una descripción larguísima, **el botón de borrar sigue visible** — que es exactamente lo que se reportó.

Medido:

```
1440px → sobra 0 px   · pegar x=1   · borrar dentro de la ventana
1280px → sobra 28 px  · los dos botones siguen fijos a los bordes
1024px → sobra 284 px · los dos botones siguen fijos a los bordes
```

## Las tablas que escribe Claude

El encabezado se volvía un renglón porque la tabla ni siquiera llegaba a leerse como tabla: caía entera a la lectura por lista. **Tres trampas a la vez**, y arreglar una sola no alcanzaba:

1. **El maquillaje de Markdown.** Los precios vienen en negritas (`**$76,379**`); el asterisco convertía el precio en texto ilegible y la fila del encabezado dejaba de parecerse a un encabezado.
2. **La unidad dentro de la cantidad.** La celda dice `1 pza`, `240 m`, `10 juegos`.
3. **La columna del precio viejo.** Un encabezado que dice `anterior` ganaba por estar primero. Ahora se descarta a propósito: entra el **nuevo**.

Sobre la tabla exacta que mandó:

```
ok: true · sep: | · encabezado: true · n: 4
1) qty=1   u=Pieza  pu=76379 Materiales · Interruptor principal · Schneider PowerPact…
2) qty=240 u=Metro  pu=656   Materiales · Cable de fuerza · Cu THW-LS 4/0 AWG…
3) qty=11  u=Pieza  pu=1549  Materiales · Charola escalera · Aluminio 12" × 9"…
4) qty=1   u=Lote   pu=19440 Servicios  · Mano de obra · Instalación charola…
```

## El cliente sale de Odoo

Lo que se **guarda** es `cliente_id` (`1247`). El **nombre se lee de Odoo cada vez que se pinta**. Dos razones, ninguna cosmética:

1. Si a un cliente le cambian la razón social, las cotizaciones viejas la muestran corregida solas. Un nombre copiado se queda con la versión del día que se capturó.
2. **Este repo es público y sirve Pages.** El día que los machotes salgan del navegador, lo que viaje es un número, no la cartera de clientes.

**El catálogo no se guarda en el repo ni en `localStorage`** — vive en Odoo y se cachea en memoria mientras la pestaña está abierta.

### Endpoint nuevo — `comercial/clientes` (n8n `RyeFlCTdLu301Gjz`)

**SOLO LECTURA.** No escribe en Odoo, nunca. Token en el **cuerpo**, no en `Authorization` (el header dispara un preflight CORS que el webhook de n8n no contesta). Exige scope `comercial:read`. La criptografía del nodo que verifica el token viene **recortada programáticamente** de `docs/n8n-workflows/fase0/jwt-verify.js` (9/9 contra `crypto` de Node), no transcrita a mano.

**Sólo van al navegador las empresas.** Medido contra Odoo:

```
is_company = true  · customer_rank > 0 · active  →  250 empresas
is_company = false · customer_rank > 0 · active  →  483 PERSONAS
```

Esos 483 son los **contactos** de cada cliente, con nombre y apellido de gente real. El filtro `is_company` no es cosmético: es lo que impide mandarlos. Y de cada partner sale únicamente `id` y `name` — ni correo, ni teléfono, ni RFC.

### Degradar sin trabar

El frontend es la mitad **tolerante** del contrato. Si el webhook no está activo, si n8n está caído o si el token venció: el campo **sigue siendo texto libre y se guarda**, `cliente_id` queda en `null`, y un aviso ámbar dice por qué la lista está vacía. Nunca se bloquea crear un machote porque Odoo no contestó — el machote casi siempre nace antes que la orden, y a veces antes del alta del cliente. Un prospecto sin dar de alta también se acepta.

### Empate por acento

En Odoo conviven `Alta Extracción S.A. de C.V.` (388) y `ALTA EXTRACCION, S.A. DE C.V` (461): ids distintos, ninguno es error de captura. **Ante empate no se elige** — se deja el texto libre y se ve en la pantalla. Elegir al azar habría metido la cotización en el cliente equivocado sin que nadie lo notara.

## Pruebas

`104 pasaron, 0 fallaron.` Cinco nuevas:

```
    3 clientes en la lista · aviso: 3 clientes de Odoo. Si el tuyo no está, …
✓ al crear, el cliente sale de una lista leída de Odoo
    guardó cliente_id 1247 · la pantalla dice "BBVA México"
✓ lo que se guarda es el ID de Odoo, no el nombre
    guardado "BANCOMER (nombre viejo)" → pinta "BBVA México"
✓ el nombre se lee de Odoo, no del texto guardado
✓ un cliente que no está en Odoo se guarda igual, como texto
    catálogo caído → se avisa, y el machote se crea igual
✓ si Odoo no contesta, el cliente se captura a mano y se dice
```

y las cuatro de V1.14 que ya venían verdes:

```
    pantalla 5.5% · almacén 0.055 · tecleado 8% → 0.08
✓ las comisiones se capturan en % y se guardan como razón
✓ la tabla de materiales ya no trae Modelo ni Marca
    cabe a 1440; a 1024 los botones siguen fijos a los bordes
✓ la fila de materiales cabe en pantalla, y borrar siempre se alcanza
    encabezado fuera · precio nuevo · unidad de "1 pza" · especificación dentro
✓ una tabla de Claude con negritas no mete el encabezado como renglón
```

## ⚠️ Lo que NO está verificado, y por qué

**La llamada real navegador → n8n → Odoo.** Dos motivos, los dos del entorno:

1. El contenedor **no alcanza Railway** (403 del proxy de salida), así que no se puede hacer `curl` al webhook.
2. Correr el workflow con `test_workflow` **volcaría `SUITE_JWT_SECRET` al transcript**: la herramienta devuelve el output de todos los nodos, y uno es el `Set` que materializa el secreto. No se corrió a propósito.

Lo que **sí** está ejecutado y observado: el dominio de Odoo y los conteos (read-only, contra Odoo), la criptografía del token (9/9), la existencia y forma del workflow (read-back), y el frontend en Playwright por los dos caminos — con catálogo y sin él.

## Para Esteban, dos cosas

1. **Activar `comercial/clientes` en la UI de n8n.** Quedó creado pero **inactivo**: activarlo por API no se puede, y el intento por MCP lo bloqueó el clasificador. Mientras esté apagado, el campo funciona como texto libre y lo avisa.
2. **Los colores siguen siendo aproximados** hasta que mandes la captura o los hexadecimales.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013Qzhio6K8R23HXHnJ2RJ64

---
_Generated by [Claude Code](https://claude.ai/code/session_013Qzhio6K8R23HXHnJ2RJ64)_