### PR TITLE
Cinco fuentes de falsos positivos en el cruce, medidas contra la SEM 36 real

### DIFF
--- a/modulos/rh/nomina-incidencias/index.html
+++ b/modulos/rh/nomina-incidencias/index.html
@@ -16,7 +16,7 @@
        que se ve si el fetch de version.json no contesta (abrir el archivo por file://,
        Pages cacheando, red caída). Dejarlo atrasado convierte el badge en un falso
        negativo: el código es nuevo y la pantalla jura que es viejo. -->
-  <span class="badge" id="ver-badge">V1.16</span>
+  <span class="badge" id="ver-badge">V1.17</span>
   <button class="badge modo" id="modo-badge" title="Cambiar entre datos reales y modo práctica">REAL</button>
   <span class="sp"></span>
   <span class="guardado" id="guardado"></span>
@@ -108,15 +108,15 @@
      resultado es un badge que dice la version nueva corriendo el codigo viejo, y
      eso manda a buscar los bugs al lugar equivocado. El valor es el MISMO de
      version.json y del badge, y el gate exige que los tres coincidan. -->
-<script src="js/catalogo.js?v=V1.16"></script>
-<script src="js/logica.js?v=V1.16"></script>
-<script src="js/despacho.js?v=V1.16"></script>
-<script src="js/excel.js?v=V1.16"></script>
-<script src="js/indice.js?v=V1.16"></script>
-<script src="js/nom-auth.js?v=V1.16"></script>
-<script src="js/nom-client.js?v=V1.16"></script>
-<script src="js/nom-resolver.js?v=V1.16"></script>
-<script src="js/app.js?v=V1.16"></script>
+<script src="js/catalogo.js?v=V1.17"></script>
+<script src="js/logica.js?v=V1.17"></script>
+<script src="js/despacho.js?v=V1.17"></script>
+<script src="js/excel.js?v=V1.17"></script>
+<script src="js/indice.js?v=V1.17"></script>
+<script src="js/nom-auth.js?v=V1.17"></script>
+<script src="js/nom-client.js?v=V1.17"></script>
+<script src="js/nom-resolver.js?v=V1.17"></script>
+<script src="js/app.js?v=V1.17"></script>
 <script>
 (function () {
   'use strict';

--- a/modulos/rh/nomina-incidencias/js/catalogo.js
+++ b/modulos/rh/nomina-incidencias/js/catalogo.js
@@ -51,6 +51,15 @@
   //   'vac'   → vacaciones y festivos (día pagado, no trabajado)
   //   'falta' → faltas, permisos, incapacidad
   //   null    → no consume días de la semana (dinero, descuentos, descanso trabajado)
+  // ── ¿El monto del bono es lo que le llega, o lo que se carga a la nómina? ──
+  // Ulises captura en CONTPAQi el BRUTO. Cuando el bono va libre, hace el cálculo
+  // inverso para que al empleado le llegue exactamente lo prometido: $1,000 libres
+  // se capturan como $1,271.62 o $1,353.33 según la tasa marginal de esa persona.
+  // Si RH no dice cuál de los dos es, Ulises adivina y el cruce no puede comparar:
+  // una diferencia legítima del ISR se ve idéntica a un error de dedo.
+  var IMPUESTOS = ['Libre de impuestos (le llega el monto completo)', 'Con ISR a cargo del empleado'];
+  var LIBRE = IMPUESTOS[0];
+
   var CATALOGO = {
     dias: {
       titulo: 'Días y ausencias',
@@ -72,9 +81,9 @@
       titulo: 'Dinero adicional',
       ayuda: 'Percepciones que no son el sueldo de la semana. Todas piden fuente de pago.',
       items: {
-        bono_proyecto:    { label: 'Bono de proyecto', multi: true, fuente: true, rubro: true, campos: [['monto', 'Monto', 'num'], ['so', 'Proyecto', 'so']] },
-        bono_productividad: { label: 'Bono de productividad', fuente: true, campos: [['monto', 'Monto', 'num'], ['motivo', 'Motivo', 'txt']] },
-        bono_condicionado:  { label: 'Bono condicionado',     fuente: true, campos: [['monto', 'Monto', 'num'], ['motivo', 'Condición', 'txt']] },
+        bono_proyecto:    { label: 'Bono de proyecto', multi: true, fuente: true, rubro: true, campos: [['monto', 'Monto', 'num'], ['so', 'Proyecto', 'so'], ['isr', 'Impuestos', IMPUESTOS]] },
+        bono_productividad: { label: 'Bono de productividad', fuente: true, campos: [['monto', 'Monto', 'num'], ['motivo', 'Motivo', 'txt'], ['isr', 'Impuestos', IMPUESTOS]] },
+        bono_condicionado:  { label: 'Bono condicionado',     fuente: true, campos: [['monto', 'Monto', 'num'], ['motivo', 'Condición', 'txt'], ['isr', 'Impuestos', IMPUESTOS]] },
         prima_vacacional: { label: 'Prima vacacional', fuente: true, campos: [['monto', 'Monto', 'num']] },
         aguinaldo:        { label: 'Aguinaldo',        fuente: true, campos: [['monto', 'Monto', 'num']] },
         fondo_ahorro:     { label: 'Fondo de ahorro',  fuente: true, campos: [['monto', 'Monto', 'num']] },
@@ -138,6 +147,11 @@
     JOURNALS: JOURNALS,
     PUESTOS_SUPERVISION: PUESTOS_SUPERVISION,
     CATALOGO: CATALOGO,
+    // Se exportan para que el generador del despacho y el gate hablen del MISMO
+    // texto. Repetir el literal en tres archivos es la forma de que un dia digan
+    // cosas distintas y nadie lo note.
+    IMPUESTOS: IMPUESTOS,
+    LIBRE: LIBRE,
     meta: meta,
     rubroBono: rubroBono,
     tiposDeclarables: tiposDeclarables,

--- a/modulos/rh/nomina-incidencias/js/despacho.js
+++ b/modulos/rh/nomina-incidencias/js/despacho.js
@@ -256,7 +256,10 @@
         // El bono de proyecto trae varios renglones: se dice el total —que es lo que
         // se captura— y luego el desglose por proyecto, que es lo que lo justifica.
         var efB = EFECTO[dec.tipo] || { v: 'AGREGAR' };
-        frases.push((efB.v ? efB.v + ' ' : '') + pesos(suma) + ' · ' + etiqueta +
+        // Misma marca de impuestos que la rama de un solo renglón: el bono de
+        // proyecto se captura igual y el bruto depende igual de esto.
+        var impB = v.isr ? ' · ' + (v.isr === Cat.LIBRE ? 'LIBRE DE IMPUESTOS' : 'con ISR al empleado') : '';
+        frases.push((efB.v ? efB.v + ' ' : '') + pesos(suma) + impB + ' · ' + etiqueta +
           (partes.length ? ' (' + partes.join(', ') + ')' : ''));
       } else {
         f[destino.col] += num(v[destino.campo]);
@@ -381,6 +384,11 @@
       if (kc === 'dias' || kc === 'monto' || kc === 'horas') pideCantidad = true;
     }
     if (!cuanto.length && pideCantidad) cuanto.push('SIN CANTIDAD');
+
+    // Si el bono va libre, Ulises tiene que capturar un BRUTO mayor para que al
+    // empleado le llegue esta cifra. Decirlo aquí es lo que convierte un monto en
+    // una instrucción: sin esto, captura $1,000 brutos y le llegan ~$790.
+    if (v.isr) cuanto.push(v.isr === Cat.LIBRE ? 'LIBRE DE IMPUESTOS' : 'con ISR al empleado');
 
     var s = (verbo ? verbo + ' ' : '') + (cuanto.length ? cuanto.join(' · ') + ' · ' : '') + etiqueta;
 

--- a/modulos/rh/nomina-incidencias/version.json
+++ b/modulos/rh/nomina-incidencias/version.json
@@ -1,10 +1,15 @@
 {
-  "version": "V1.16",
+  "version": "V1.17",
   "fecha": "2026-09-04",
   "modulo": "rh/nomina-incidencias",
   "esquema": "V<mayor>.<menor de dos digitos>. Un incremento de 0.01 por cada merge a main. Al pasar de .99 sube el mayor y el menor vuelve a 00.",
   "ambito": "El CONTADOR es solo de este modulo. finanzas, comercial/machote y operaciones/carga-mo usan el mismo esquema con contadores PROPIOS (ver sus version.json): que aqui vaya en V1.16 y carga-mo en V1.00 es lo correcto, no un desfase — son modulos distintos que avanzan por separado. operaciones/planeacion sigue en 2.4.1; kiosk y confirmar-horas solo con cadena de build.",
   "historial": [
+    {
+      "version": "V1.17",
+      "pr": null,
+      "nota": "El bono ahora declara si va LIBRE DE IMPUESTOS o con ISR a cargo del empleado. No es un dato contable: cambia el monto que Ulises captura. Cuando va libre, el bruto de CONTPAQi es mayor que la cifra prometida porque la empresa absorbe el ISR — medido en la SEM 36, $1,000 libres se capturaron como $1,271.62 o $1,353.33 segun la tasa marginal de cada persona. Sin declararlo, esa diferencia legitima se veia identica a un error de dedo y produjo 7 hallazgos falsos en la pantalla de Ulises. Va como opciones y no como casilla porque las casillas no se exigen (\"no\" es una respuesta) y aqui no contestar no es una opcion: el importe depende de esto. La marca viaja en la instruccion del despacho, pegada al monto."
+    },
     {
       "version": "V1.00",
       "pr": 168,

--- a/operaciones/carga-mo/index.html
+++ b/operaciones/carga-mo/index.html
@@ -9,11 +9,11 @@
      Vx.yy. Se bumpea junto con version.json y con el ?v= de cada script, y el gate
      exige que los tres digan lo mismo: un badge que anuncia una version mientras
      el navegador corre el codigo viejo miente en la peor direccion. -->
-<script>(function(){ window.CMO_VER = 'V1.00'; })();</script>
+<script>(function(){ window.CMO_VER = 'V1.01'; })();</script>
 <script src="../../finanzas/js/auth-fin.js"></script>
 <script src="https://cdnjs.cloudflare.com/ajax/libs/xlsx/0.18.5/xlsx.full.min.js"></script>
-<script src="js/cruce-rh.js?v=V1.00"></script>
-<script src="js/resolver.js?v=V1.00"></script>
+<script src="js/cruce-rh.js?v=V1.01"></script>
+<script src="js/resolver.js?v=V1.01"></script>
 <style>
   :root{ --azul:#1a4480; --ok:#1a7a3a; --warn:#BA7517; --err:#b3261e; --info:#3b5bdb; --bg:#f4f6f9; }
   *{ box-sizing:border-box; }
@@ -642,7 +642,12 @@ function pintarCruceRH(P){
   }
 
   var semSel = (P && P.periodo) ? ('S' + P.periodo.periodo + '/' + (new Date(P.periodo.inicio+'T12:00:00')).getFullYear()) : null;
-  var r = CruceRH.cruzar(RH, (P && P.empleados) || [], semSel);
+  // Los externos por honorarios se pasan en dos mitades: quién ES externo (del
+  // catálogo, aunque no haya facturado esta semana) y quién facturó (lo que el
+  // resolver encontró en el Excel). Sin la primera, alguien que no facturó se
+  // reportaría como si le faltara el código de CONTPAQi.
+  var externos = { personas: (CAT && CAT.trio && CAT.trio.personas) || {}, filas: (P && P.trio) || [] };
+  var r = CruceRH.cruzar(RH, (P && P.empleados) || [], semSel, externos);
   var nInt = CruceRH.contar(r.hallazgos, 'INTEGRIDAD');
   var nRev = CruceRH.contar(r.hallazgos, 'REVISION');
 

--- a/operaciones/carga-mo/js/cruce-rh.js
+++ b/operaciones/carga-mo/js/cruce-rh.js
@@ -50,13 +50,53 @@
     { etiqueta: 'Bono condicionado',          clave: 'BONO' },
     { etiqueta: 'Tiempo extra',               clave: 'HORAS_EXTRAS' },
     { etiqueta: 'Ajuste de sueldo',           clave: 'AJUSTE_EN_SUELDOS' },
-    { etiqueta: 'Descuento de préstamo',      clave: 'PRESTAMO_EMPRESA' },
+    { etiqueta: 'Descuento por préstamo',     clave: 'PRESTAMO_EMPRESA' },
     { etiqueta: 'Descuento de anticipo',      clave: 'PRESTAMO_EMPRESA' },
-    { etiqueta: 'Compensación de deuda',      clave: 'PRESTAMO_EMPRESA' }
+    { etiqueta: 'Compensa contra deuda',      clave: 'PRESTAMO_EMPRESA' }
   ];
+  // ⚠️ Las etiquetas de arriba tienen que existir LETRA POR LETRA en el catálogo de
+  // nómina (modulos/rh/nomina-incidencias/js/catalogo.js). Dos de ellas no existían
+  // —decían 'Descuento DE préstamo' y 'Compensación de deuda' cuando el catálogo dice
+  // 'Descuento POR préstamo' y 'Compensa contra deuda'—, así que esos dos conceptos
+  // NUNCA se cruzaron: RH pedía el descuento, Ulises lo capturaba bien, y el sistema
+  // reportaba 'RH pidió algo que este cruce no sabe comparar'. Una preposición apagó
+  // un control durante todo el tiempo que existió. El gate ahora cruza esta tabla
+  // contra el catálogo real, que es la única forma de que no vuelva a pasar callado.
   // El premio va aparte: no se declara como concepto con cantidad, abre el renglón
   // con la palabra PPA. Su columna en CONTPAQi es esta.
   var CLAVE_PPA = 'PREMIO_ASISTENCIA_PUNTUALIDAD';
+
+  // ── Conceptos que CONTPAQi paga SOLO, como consecuencia de otro ───────────
+  // RH nunca los va a pedir porque no son una decisión suya: son ley. La prima
+  // vacacional es el 25% de las vacaciones (LFT art. 80), y aparece sola en cuanto
+  // se capturan vacaciones. Reclamarla como 'movimiento que RH no pidió' es exigirle
+  // a Magaly que declare una obligación legal — y era el hallazgo que más ruido hacía:
+  // tres INTEGRIDAD que apagaban el botón de enviar una nómina correcta.
+  //
+  // No se ignora: se verifica el porcentaje, que es el control que de verdad importa.
+  // Y una prima SIN vacaciones sigue siendo hallazgo, porque ahí no hay de dónde salga.
+  var DERIVADOS = [
+    { clave: 'PRIMA_VACACIONAL_A_TIEMPO', de: 'VACACIONES_A_TIEMPO',
+      pct: 0.25, nombre: 'prima vacacional', ley: 'LFT art. 80 (25% mínimo)' }
+  ];
+
+  // ── Bono libre de impuestos ───────────────────────────────────────────────
+  // Cuando el bono va libre, la cifra que RH escribe es lo que le LLEGA al empleado y
+  // la que Ulises captura es el BRUTO que lo produce: la empresa absorbe el ISR. Los
+  // dos números son correctos y distintos, así que exigir que sean iguales convierte
+  // el trabajo bien hecho en siete hallazgos.
+  //
+  // Medido en la SEM 36: $1,000 libres se capturaron como $1,271.62 (×1.2716) y como
+  // $1,353.33 (×1.3533) según la persona; Tomás pidió $500 y se capturaron $635.81 —
+  // el MISMO factor que en los de $1,000, o sea estrictamente proporcional. Esos dos
+  // factores son 1/(1−21.36%) y 1/(1−26.1%): tasas marginales reales.
+  //
+  // La banda es deliberadamente ancha. No sirve para adivinar la tasa —eso lo hace
+  // CONTPAQi con la tabla del SAT— sino para cazar los dos errores que sí importan:
+  // capturar el neto como si fuera bruto (factor 1.00, al empleado le llega de menos)
+  // y un dedazo que multiplique el monto. Entre medio, cualquier factor es plausible.
+  var FACTOR_MIN = 1.02;   // por debajo, no se hizo el cálculo inverso
+  var FACTOR_MAX = 1.85;   // por encima, ninguna tasa marginal mexicana lo explica
 
   function norm(s) {
     return ('' + (s === undefined || s === null ? '' : s))
@@ -180,11 +220,17 @@
       var mDias = /([\d.]+)\s*d[ií]as?/i.exec(cuanto);
       var mHoras = /([\d.]+)\s*h\b/i.exec(cuanto);
       var mMonto = /\$\s*([\d,]+(?:\.\d+)?)/.exec(cuanto);
+      // 'libre': el monto es lo que le LLEGA al empleado, no lo que se captura.
+      // 'con_isr': el monto es el bruto y se captura tal cual.
+      // null: la instrucción no lo dice — archivos de antes de que RH lo declarara.
+      // Ese tercer estado NO se trata como 'con_isr': no saber no es saber que no.
+      var libre = /LIBRE DE IMPUESTOS/.test(n) ? true : (/CON ISR AL EMPLEADO/.test(n) ? false : null);
       out.items.push({
         verbo: verbo, concepto: concepto, texto: frase,
         dias:  mDias  ? num(mDias[1]) : null,
         horas: mHoras ? num(mHoras[1]) : null,
         monto: mMonto ? num(mMonto[1].replace(/,/g, '')) : null,
+        libre: libre,
         sin_cantidad: /SIN CANTIDAD/.test(n)
       });
     }
@@ -193,7 +239,18 @@
 
   // ── El cruce ──────────────────────────────────────────────────────────────
   // `empleados` son los del resolver de CONTPAQi (cod, nombre, conceptos{}).
-  function cruzar(despacho, empleados, semanaSeleccionada) {
+  // `trio` son los EXTERNOS que facturan por honorarios: no están en CONTPAQi, así
+  // que Ulises los agrega a mano al Excel con su neto y les hace un .txt aparte para
+  // dispersarles. El resolver ya los reconoce por alias de nombre y les pone su
+  // empleado_id de Odoo; aquí se cruzan por ESE id, que es el mismo `NO EMPLEADO`
+  // que trae el archivo de RH. Cruzar por nombre sería adivinar: Ulises escribe
+  // "FELIPE" y "MANZANAREZ" (con z), Odoo dice "Felipe Pérez Guzmán" y "Manzanares".
+  // `externos` = { personas: {<empleado_id>: {alias:[…]}}, filas: [<lo que el resolver
+  // encontró en el Excel>] }. Los DOS hacen falta y por razones distintas: `personas`
+  // dice quién ES externo —aunque esta semana no haya facturado— y `filas` dice quién
+  // facturó. Sin `personas`, alguien que no facturó se vería como si le faltara el
+  // código de CONTPAQi, que es justo el diagnóstico equivocado.
+  function cruzar(despacho, empleados, semanaSeleccionada, externos) {
     var hallazgos = [], i, j;
     var res = { total_rh: 0, total_contpaqi: 0, cruzados: 0, con_instruccion: 0 };
     if (!despacho || despacho.error) {
@@ -221,17 +278,57 @@
     for (i = 0; i < emps.length; i++) if (emps[i].cod) porCod[('00' + emps[i].cod).slice(-3)] = emps[i];
     var vistos = {};
 
+    // Quién es externo (del catálogo) y quién facturó (del Excel), por empleado_id.
+    var ext0 = externos || {};
+    var esExterno = {}, filaExterno = {}, externosVistos = {};
+    var conocidos = ext0.personas || {};
+    for (var k in conocidos) if (Object.prototype.hasOwnProperty.call(conocidos, k)) esExterno[String(k)] = true;
+    var filasExt = ext0.filas || [];
+    for (i = 0; i < filasExt.length; i++) {
+      if (filasExt[i] && filasExt[i].empleado_id != null) {
+        var idE = String(filasExt[i].empleado_id);
+        esExterno[idE] = true;                 // facturó: es externo aunque falte del catálogo
+        filaExterno[idE] = filasExt[i];
+      }
+    }
+
     for (i = 0; i < despacho.filas.length; i++) {
       var f = despacho.filas[i];
       var quien = (f.codigo3 || '???') + ' ' + f.nombre;
 
-      // 2 · Sin código no hay cruce. Se dice y se sigue: el resto del archivo sí
-      // se puede revisar, y esconderlo sería peor.
+      // 2 · Sin código de CONTPAQi. Hay dos razones muy distintas y confundirlas
+      // manda a Ulises a pedir un dato que nunca va a existir.
       if (!f.codigo3) {
+        var idRh = String(f.no_empleado || '');
+        var ext = esExterno[idRh] ? (filaExterno[idRh] || null) : undefined;
+
+        // (a) Externo por honorarios: NO tiene código porque no va en CONTPAQi.
+        // Cobra en esta nómina, pero por fuera: Ulises le agrega su renglón al final
+        // del Excel con el neto y le hace un .txt aparte para dispersarle. Pedir su
+        // código sería pedir algo que por definición no existe, cada semana.
+        if (ext !== undefined) {
+          externosVistos[idRh] = true;
+          if (ext) {
+            hallazgos.push({ nivel: AVISO, codigo: 'EXTERNO_FACTURO',
+              que: 'Externo por honorarios: cobra fuera de CONTPAQi y su renglón está en el Excel',
+              dato: f.nombre + ' · renglón "' + ext.nombre + '" · neto $' + num(ext.neto).toFixed(2),
+              accion: 'Verifica que ese neto sea el de su factura, y que entre en el .txt de dispersión.' });
+          } else {
+            hallazgos.push({ nivel: AVISO, codigo: 'EXTERNO_SIN_RENGLON',
+              que: 'Externo por honorarios que esta semana no tiene renglón en el Excel',
+              dato: f.nombre + ' · no aparece entre los renglones de honorarios',
+              accion: 'Si facturó, agrégale su renglón con el neto. Si no facturó esta semana, no hay nada que hacer.' });
+          }
+          continue;
+        }
+
+        // (b) Le falta el código de verdad: está en la nómina de CONTPAQi pero su
+        // ficha de Odoo no lo tiene cargado. Eso sí se arregla, y en Odoo.
         hallazgos.push({ nivel: REVISION, codigo: 'RH_SIN_CODIGO',
           que: 'RH mandó una persona sin código de CONTPAQi, no se puede cruzar',
           dato: f.nombre + (f.instruccion ? ' · ' + f.instruccion : ''),
-          accion: 'Pide a RH que le cargue el código en Odoo. Mientras, revisa esta persona a mano.' });
+          accion: 'Si cobra por CONTPAQi, pide que le carguen el código en Odoo. Si cobra por honorarios, ' +
+                  'hay que darla de alta como externa en el catálogo. Mientras, revísala a mano.' });
         continue;
       }
       vistos[f.codigo3] = true;
@@ -260,7 +357,7 @@
       if (f.instruccion && f.instruccion.trim()) res.con_instruccion++;
 
       // 5 · El premio de puntualidad, en sus dos direcciones.
-      var ppaPagado = Math.abs(num(e.conceptos && e.conceptos[CLAVE_PPA])) > 0.005;
+      var ppaPagado = Math.abs(valorDe(e, CLAVE_PPA)) > 0.005;
       if (f.conceptos.ppa && !ppaPagado) {
         hallazgos.push({ nivel: INTEGRIDAD, codigo: 'PPA_NO_PAGADO',
           que: 'RH otorgó el premio de puntualidad y la nómina no lo trae',
@@ -268,7 +365,7 @@
       } else if (!f.conceptos.ppa && ppaPagado) {
         hallazgos.push({ nivel: INTEGRIDAD, codigo: 'PPA_SIN_INSTRUCCION',
           que: 'La nómina paga premio de puntualidad y RH no lo otorgó',
-          dato: quien + ' · $' + num(e.conceptos[CLAVE_PPA]).toFixed(2),
+          dato: quien + ' · $' + valorDe(e, CLAVE_PPA).toFixed(2),
           accion: 'Quítalo o confirma con RH.' });
       }
 
@@ -278,6 +375,21 @@
         var it = f.conceptos.items[j];
         var fila = buscarMapa(it.concepto);
         if (!fila) {
+          // Días trabajados, faltas, permisos: NO tienen columna propia en la lista
+          // de raya. Se reflejan dentro del Sueldo, y el archivo no trae ni los días
+          // ni el sueldo diario, así que este cruce NO PUEDE verificarlos. Decir
+          // 'RH pidió algo que no sé comparar' suena a que falta configurar algo;
+          // lo honesto es decir que no hay contra qué compararlo y qué mirar a mano.
+          // Es AVISO y no REVISIÓN porque no es una sospecha sobre este archivo:
+          // es un límite del layout, y se repite idéntico todas las semanas.
+          if (it.dias !== null) {
+            hallazgos.push({ nivel: AVISO, codigo: 'DIAS_NO_VERIFICABLES',
+              que: 'Días que hay que revisar a mano: la lista de raya no trae columna de días',
+              dato: quien + ' · ' + it.texto,
+              accion: 'Compara el Sueldo de esta persona contra su sueldo diario. ' +
+                      'Si le pagaron la semana completa, el ajuste no se capturó.' });
+            continue;
+          }
           hallazgos.push({ nivel: REVISION, codigo: 'CONCEPTO_NO_CRUZABLE',
             que: 'RH pidió algo que este cruce no sabe comparar contra CONTPAQi',
             dato: quien + ' · ' + it.texto,
@@ -285,17 +397,15 @@
           continue;
         }
         pedido[fila.clave] = true;
-        var val = num(e.conceptos && e.conceptos[fila.clave]);
+        var val = valorDe(e, fila.clave);
         if (Math.abs(val) < 0.005) {
           hallazgos.push({ nivel: INTEGRIDAD, codigo: 'INSTRUCCION_NO_CAPTURADA',
             que: 'RH pidió un movimiento que la nómina no refleja',
             dato: quien + ' · ' + it.texto,
             accion: 'Captúralo en CONTPAQi o confirma con RH que ya no aplica.' });
-        } else if (it.monto !== null && Math.abs(Math.abs(val) - it.monto) > 0.005) {
-          hallazgos.push({ nivel: REVISION, codigo: 'MONTO_DISTINTO',
-            que: 'El monto capturado no es el que pidió RH',
-            dato: quien + ' · RH pidió $' + it.monto.toFixed(2) + ' y la nómina trae $' + Math.abs(val).toFixed(2),
-            accion: 'Corrige el monto o confirma la diferencia con RH.' });
+        } else if (it.monto !== null && (Math.abs(Math.abs(val) - it.monto) > 0.005 || it.libre === true)) {
+          var h = compararMonto(quien, it, Math.abs(val));
+          if (h) hallazgos.push(h);
         }
         if (it.sin_cantidad) {
           hallazgos.push({ nivel: REVISION, codigo: 'RH_SIN_CANTIDAD',
@@ -305,11 +415,38 @@
         }
       }
 
-      // 7 · Y al revés: dinero capturado que RH nunca pidió.
+      // 7 · Lo que CONTPAQi paga solo porque la ley lo obliga.
+      // Se verifica el porcentaje en vez de reclamar la existencia.
+      var derivado = {};
+      for (j = 0; j < DERIVADOS.length; j++) {
+        var D = DERIVADOS[j];
+        var origen = valorDe(e, D.de);
+        var monto  = valorDe(e, D.clave);
+        if (Math.abs(origen) < 0.005) continue;      // sin origen, no es derivado: cae abajo
+        derivado[D.clave] = true;
+        if (Math.abs(monto) < 0.005) {
+          hallazgos.push({ nivel: INTEGRIDAD, codigo: 'DERIVADO_FALTANTE',
+            que: 'La nómina paga ' + D.de.toLowerCase().replace(/_/g, ' ') + ' sin la ' + D.nombre + ' que le corresponde',
+            dato: quien + ' · ' + D.ley,
+            accion: 'Captura la ' + D.nombre + '. Es obligatoria, no depende de que RH la pida.' });
+          continue;
+        }
+        var esperado = r2(Math.abs(origen) * D.pct);
+        if (Math.abs(monto) < esperado - 0.02) {
+          hallazgos.push({ nivel: REVISION, codigo: 'DERIVADO_CORTO',
+            que: 'La ' + D.nombre + ' quedó por debajo del mínimo de ley',
+            dato: quien + ' · $' + Math.abs(monto).toFixed(2) + ' sobre $' + Math.abs(origen).toFixed(2) +
+                  ' es ' + (100 * Math.abs(monto) / Math.abs(origen)).toFixed(1) + '%, y el mínimo es ' +
+                  (100 * D.pct).toFixed(0) + '% (' + D.ley + ')',
+            accion: 'Corrígelo en CONTPAQi antes de mandar.' });
+        }
+      }
+
+      // 8 · Y al revés: dinero capturado que RH nunca pidió.
       for (j = 0; j < MAPA.length; j++) {
         var cl = MAPA[j].clave;
-        if (pedido[cl]) continue;
-        var v2 = num(e.conceptos && e.conceptos[cl]);
+        if (pedido[cl] || derivado[cl]) continue;
+        var v2 = valorDe(e, cl);
         if (Math.abs(v2) < 0.005) continue;
         if (yaReportado(hallazgos, quien, cl)) continue;
         hallazgos.push({ nivel: INTEGRIDAD, codigo: 'CAPTURA_SIN_INSTRUCCION',
@@ -319,7 +456,20 @@
       }
     }
 
-    // 8 · Gente en la nómina que RH nunca listó.
+    // 8b · Un externo facturó y RH no lo listó en la semana. Su monto entra al total
+    // de la nómina y se carga a proyectos igual que el de cualquiera, así que que RH
+    // no lo tenga es un hueco real, no un detalle de forma.
+    for (i = 0; i < filasExt.length; i++) {
+      var fx = filasExt[i];
+      if (!fx || fx.empleado_id == null) continue;
+      if (externosVistos[String(fx.empleado_id)]) continue;
+      hallazgos.push({ nivel: REVISION, codigo: 'EXTERNO_SIN_RH',
+        que: 'El Excel trae un renglón de honorarios de alguien que RH no incluyó en la semana',
+        dato: '"' + fx.nombre + '" · neto $' + num(fx.neto).toFixed(2) + ' (fila ' + fx.fila + ')',
+        accion: 'Confírmalo con RH antes de mandar: su monto entra al total y se carga a proyectos.' });
+    }
+
+    // 9 · Gente en la nómina que RH nunca listó.
     for (i = 0; i < emps.length; i++) {
       var c3 = ('00' + emps[i].cod).slice(-3);
       if (vistos[c3]) continue;
@@ -330,6 +480,65 @@
     }
 
     return { hallazgos: hallazgos, resumen: res };
+  }
+
+  // ── Comparar lo que RH pidió contra lo que se capturó ─────────────────────
+  // Devuelve SIEMPRE un hallazgo: la diferencia existe y se dice. Lo que cambia es
+  // el nivel y la explicación, porque no toda diferencia es un error.
+  function compararMonto(quien, it, capturado) {
+    var factor = it.monto > 0 ? capturado / it.monto : 0;
+
+    // Bono libre: la diferencia es el ISR que absorbe la empresa. Es correcto.
+    if (it.libre === true) {
+      if (factor >= FACTOR_MIN && factor <= FACTOR_MAX) {
+        return { nivel: AVISO, codigo: 'BONO_LIBRE_OK',
+          que: 'Bono libre de impuestos: el bruto capturado es mayor, como debe ser',
+          dato: quien + ' · le llegan $' + it.monto.toFixed(2) + ' y se capturaron $' + capturado.toFixed(2) +
+                ' (×' + factor.toFixed(4) + ', ISR implícito ' + (100 * (1 - 1 / factor)).toFixed(2) + '%)',
+          accion: 'Nada que hacer. Se muestra para que quede la cuenta a la vista.' };
+      }
+      if (factor < FACTOR_MIN) {
+        return { nivel: INTEGRIDAD, codigo: 'BONO_LIBRE_SIN_CALCULAR',
+          que: 'El bono era libre de impuestos y se capturó el monto tal cual',
+          dato: quien + ' · RH pidió que le llegaran $' + it.monto.toFixed(2) + ' y se capturaron $' +
+                capturado.toFixed(2) + ' brutos',
+          accion: 'Calcula el bruto para que el neto sea $' + it.monto.toFixed(2) + '. Así le llega de menos.' };
+      }
+      return { nivel: REVISION, codigo: 'BONO_LIBRE_DESPROPORCIONADO',
+        que: 'El bruto del bono libre es demasiado alto para cualquier tasa de ISR',
+        dato: quien + ' · $' + it.monto.toFixed(2) + ' libres se capturaron como $' + capturado.toFixed(2) +
+              ' (×' + factor.toFixed(4) + ')',
+        accion: 'Revisa el cálculo: ninguna tasa marginal mexicana da ese factor.' };
+    }
+
+    // Sin marca de impuestos no se puede saber cuál de los dos casos es. Se dice la
+    // diferencia y se pide que RH la declare, en vez de afirmar que está mal.
+    if (it.libre === null && capturado > it.monto) {
+      return { nivel: REVISION, codigo: 'MONTO_MAYOR_SIN_DECLARAR',
+        que: 'La nómina capturó más de lo que pidió RH y el archivo no dice si el bono va libre de impuestos',
+        dato: quien + ' · RH pidió $' + it.monto.toFixed(2) + ' y la nómina trae $' + capturado.toFixed(2) +
+              ' (×' + factor.toFixed(4) + ')',
+        accion: 'Si va libre de impuestos, la diferencia es el ISR y está bien: pide a RH que lo marque ' +
+                'en el módulo para que deje de aparecer aquí. Si no, corrige el monto.' };
+    }
+
+    if (Math.abs(capturado - it.monto) <= 0.005) return null;   // coinciden: nada que decir
+
+    return { nivel: REVISION, codigo: 'MONTO_DISTINTO',
+      que: 'El monto capturado no es el que pidió RH',
+      dato: quien + ' · RH pidió $' + it.monto.toFixed(2) + ' y la nómina trae $' + capturado.toFixed(2),
+      accion: 'Corrige el monto o confirma la diferencia con RH.' };
+  }
+
+  // Un concepto de RH puede caer en una percepción (un bono) o en una deducción (un
+  // descuento por préstamo). Buscar solo en percepciones fue lo que hizo que los tres
+  // descuentos de la SEM 36 se reportaran como "RH lo pidió y no aparece" estando
+  // capturados: el dato existía, se estaba mirando la mitad equivocada del renglón.
+  function valorDe(e, clave) {
+    if (!e) return 0;
+    var v = e.conceptos && e.conceptos[clave];
+    if (v === undefined || v === null) v = e.deducciones && e.deducciones[clave];
+    return num(v);
   }
 
   function buscarMapa(concepto) {

--- a/operaciones/carga-mo/js/resolver.js
+++ b/operaciones/carga-mo/js/resolver.js
@@ -399,10 +399,21 @@
     var ded = num(fila[M.TOTAL_DEDUCCIONES]);
     var neto = num(fila[M.NETO]);
 
-    var porColumna = {}, conceptos = {}, aBolsa = [], noCatalogado = [];
+    // `conceptos` son las PERCEPCIONES (lo que se paga) y `deducciones` lo que se
+    // resta. Se mantienen separados a propósito: el reparto a proyectos solo mira
+    // percepciones, y mezclarlas cambiaría los montos. Pero el cruce contra RH sí
+    // necesita las dos —un "descuento por préstamo" que RH pidió vive del lado de
+    // las deducciones—, y sin exponerlas ese control no puede existir.
+    var porColumna = {}, conceptos = {}, deducciones = {}, aBolsa = [], noCatalogado = [];
     var sumaZona = 0, sumaBolsa = 0, sumaNoCat = 0;
     var legacy = { vac: 0, asim: 0 };
     var firmaBaja = [];
+
+    // Solo se LEEN: no entran a ninguna suma ni al reparto. Es un espejo para que
+    // el cruce contra RH pueda ver el otro lado del renglón.
+    Z.deducciones.forEach(function (d) {
+      if (d.clave) deducciones[d.clave] = num(fila[d.col]);
+    });
 
     Z.percepciones.forEach(function (p) {
       var v = num(fila[p.col]);
@@ -484,7 +495,7 @@
       bruto: bruto, deducciones: ded, neto: neto,
       a_repartir: aRepartir,
       a_bolsa: aBolsa, no_catalogado: noCatalogado,
-      conceptos: conceptos, porColumna: porColumna,
+      conceptos: conceptos, deducciones: deducciones, porColumna: porColumna,
       vac: legacy.vac, asim: legacy.asim,
       _src: { total_percepciones_col: M.TOTAL_PERCEPCIONES, total_percepciones_letra: colLetra(M.TOTAL_PERCEPCIONES) }
     };

--- a/operaciones/carga-mo/version.json
+++ b/operaciones/carga-mo/version.json
@@ -1,10 +1,15 @@
 {
-  "version": "V1.00",
+  "version": "V1.01",
   "fecha": "2026-09-04",
   "modulo": "operaciones/carga-mo",
   "esquema": "V<mayor>.<menor de dos digitos>. Un incremento de 0.01 por cada merge a main. Al pasar de .99 sube el mayor y el menor vuelve a 00.",
   "ambito": "El CONTADOR es SOLO de este modulo y arranca en V1.00 aunque el modulo lleve meses en produccion: antes se versionaba con una cadena de build (la ultima fue 20260904-cmo-cruce-rh) y esa numeracion no se puede continuar. rh/nomina-incidencias, finanzas y comercial/machote usan el MISMO esquema con contadores PROPIOS — que aqui diga V1.00 y alla V1.16 es lo correcto, no un desfase.",
   "historial": [
+    {
+      "version": "V1.01",
+      "pr": null,
+      "nota": "Cinco fuentes de falsos positivos, medidas contra la SEM 36 real (30 personas de RH contra 26 renglones de CONTPAQi): 21 hallazgos, 4 de ellos bloqueando el envio de una nomina correcta. Quedaron 15, con UN solo bloqueo y real. (1) El MAPA decia 'Descuento DE prestamo' y 'Compensacion de deuda' cuando el catalogo dice 'Descuento POR prestamo' y 'Compensa contra deuda': dos conceptos que NUNCA se cruzaron. Una preposicion apago un control entero sin un solo error. (2) El resolver solo exponia percepciones, asi que un descuento capturado del lado de las deducciones se daba por no capturado. Ahora expone las dos mitades del renglon. (3) La prima vacacional se reclamaba como 'movimiento que RH no pidio' siendo el 25% de ley (LFT art. 80) que CONTPAQi paga solo: ahora se verifica el porcentaje en vez de exigir que Magaly declare una obligacion legal. (4) El bono libre de impuestos: RH escribe lo que le LLEGA al empleado y Ulises captura el BRUTO; exigir que coincidieran convertia el trabajo bien hecho en 7 hallazgos. (5) Los ajustes de dias no se pueden verificar —la lista de raya no trae ni columna de dias ni sueldo diario— y decirlo es mas util que afirmar que no se capturaron. Ademas: los externos por honorarios se cruzan contra la tabla del trio por el id de Odoo, que el archivo de RH ya trae, en vez de pedir un codigo de CONTPAQi que por definicion no existe; y Esteban (32) se agrego a esa tabla, donde faltaba."
+    },
     {
       "version": "V1.00",
       "pr": null,

--- a/shared/operaciones/contpaqi_conceptos.json
+++ b/shared/operaciones/contpaqi_conceptos.json
@@ -1,6 +1,6 @@
 {
   "_meta": "Catalogo de conceptos CONTPAQi para Carga MO v2. Se lee de main raw EN VIVO por operaciones/carga-mo/ y por el motor n8n. Agregar un alias = PR de una linea, sin tocar HTML ni workflows. Ver docs/operaciones/PARSER_V2.md",
-  "version": "2026.3",
+  "version": "2026.4",
   "_changelog": {
     "2026.2": "Version inicial del catalogo por concepto. Poblada con los conceptos reales de SEM 29/30/31/32 2026 (inventario verificado por Esteban 2026-08-10).",
     "2026.3": "Se retiran del catalogo publico los baselines por empleado y los nombres completos del trio: eran compensacion individual identificable en un repo publico. Los alias del trio se conservan porque sin ellos la fila se descarta en silencio."
@@ -466,6 +466,16 @@
           "FELIPE PEREZ",
           "FELIPE PEREZ GUZMAN"
         ]
+      },
+      "32": {
+        "alias": [
+          "ESTEBAN",
+          "DE LA CRUZ",
+          "ESTEBAN DE LA CRUZ",
+          "DE LA CRUZ CALDERON",
+          "JESUS ESTEBAN DE LA CRUZ CALDERON"
+        ],
+        "_nota": "Tambien cobra por honorarios. Faltaba aqui, asi que su renglon del Excel caeria al puente como fila sin identificar, y en el cruce contra RH aparecia como si le faltara el codigo de CONTPAQi."
       }
     },
     "reglas": {

--- a/tests/gate-cruce-rh.js
+++ b/tests/gate-cruce-rh.js
@@ -15,6 +15,7 @@ const fs = require('fs');
 const RAIZ = path.join(__dirname, '..');
 const Cruce = require(path.join(RAIZ, 'operaciones', 'carga-mo', 'js', 'cruce-rh.js'));
 const Des = require(path.join(RAIZ, 'modulos', 'rh', 'nomina-incidencias', 'js', 'despacho.js'));
+const Cat = require(path.join(RAIZ, 'modulos', 'rh', 'nomina-incidencias', 'js', 'catalogo.js'));
 
 let ok = 0, fail = 0;
 function check(nombre, cond, detalle) {
@@ -195,8 +196,12 @@ seccion('El cruce · concepto por concepto');
   check('y el hallazgo dice QUE pidio, no solo que falta',
     /PAGAR 2 días · Vacaciones/.test(noCap.hallazgos.find(x => x.codigo === 'INSTRUCCION_NO_CAPTURADA').dato));
 
-  const cap = Cruce.cruzar(dVac, [emp('013', 'SOLIS', { VACACIONES_A_TIEMPO: 900 })], 'S36/2026');
-  check('capturadas → sin hallazgo', cap.hallazgos.length === 0, codigos(cap.hallazgos).join(','));
+  // Vacaciones y prima van JUNTAS en la vida real: CONTPAQi paga la prima sola en
+  // cuanto hay vacaciones. El fixture traía las vacaciones peladas, que es un estado
+  // que no existe — y por eso ahora el motor lo caza como prima faltante.
+  const cap = Cruce.cruzar(dVac,
+    [emp('013', 'SOLIS', { VACACIONES_A_TIEMPO: 900, PRIMA_VACACIONAL_A_TIEMPO: 225 })], 'S36/2026');
+  check('capturadas con su prima de ley → sin hallazgo', cap.hallazgos.length === 0, codigos(cap.hallazgos).join(','));
 
   // Movimiento que RH nunca pidio.
   const sobra = Cruce.cruzar(Cruce.parseDespacho(archivoRH([persona({ id: 62, codigo: '013', ppa: { aplica: false } })])),
@@ -210,8 +215,11 @@ seccion('El cruce · concepto por concepto');
   const pBono = persona({ id: 79, codigo: '029', ppa: { aplica: false },
     // con motivo: el catalogo lo exige y sin el la persona sale marcada en REVISAR,
     // que es un hallazgo legitimo y ensuciaria lo que este caso quiere medir.
+    // `isr` entra por la misma razón que `motivo`: el catálogo lo exige, y sin él la
+    // persona sale marcada en REVISAR y ensucia lo que este caso quiere medir.
     declaraciones: [{ tipo: 'bono_productividad', fuente: 'J96',
-                      valores: { monto: 2500, motivo: 'cierre de Topo Chico' } }] });
+                      valores: { monto: 2500, motivo: 'cierre de Topo Chico',
+                                 isr: 'Con ISR a cargo del empleado' } }] });
   const dif = Cruce.cruzar(Cruce.parseDespacho(archivoRH([pBono])),
     [emp('029', 'ROMERO', { BONO: 1500 })], 'S36/2026');
   check('capturado con OTRO monto → se dice, con los dos numeros',
@@ -223,13 +231,77 @@ seccion('El cruce · concepto por concepto');
     [emp('029', 'ROMERO', { BONO: 2500 })], 'S36/2026');
   check('capturado con el monto correcto → sin hallazgo', igual.hallazgos.length === 0, codigos(igual.hallazgos).join(','));
 
+  // ── El bono libre de impuestos ──
+  // RH escribe lo que le LLEGA al empleado; Ulises captura el BRUTO que lo produce.
+  // Exigir que fueran iguales convertía el trabajo bien hecho en siete hallazgos.
+  const FUENTE = Object.keys(Cat.JOURNALS)[0];
+  const pLibre = persona({ id: 79, codigo: '029', ppa: { aplica: false },
+    declaraciones: [{ tipo: 'bono_productividad', fuente: FUENTE,
+      valores: { monto: 1000, motivo: 'PRODUCTIVIDAD', isr: Cat.LIBRE } }] });
+  const dLibre = Cruce.parseDespacho(archivoRH([pLibre]));
+  check('el archivo dice que el bono va libre de impuestos',
+    /LIBRE DE IMPUESTOS/.test(dLibre.filas[0].instruccion), dLibre.filas[0].instruccion);
+  check('y el parser lo lee', dLibre.filas[0].conceptos.items[0].libre === true);
+
+  const brutoOk = Cruce.cruzar(dLibre, [emp('029', 'ROMERO', { BONO: 1271.62 })], 'S36/2026');
+  check('un bruto mayor coherente con el ISR no es un error',
+    Cruce.contar(brutoOk.hallazgos, 'INTEGRIDAD') === 0 && Cruce.contar(brutoOk.hallazgos, 'REVISION') === 0,
+    codigos(brutoOk.hallazgos).join(','));
+  check('y se dice la cuenta, con el ISR implícito',
+    /21\.36%/.test((brutoOk.hallazgos.find(h => h.codigo === 'BONO_LIBRE_OK') || {}).dato || ''),
+    (brutoOk.hallazgos.find(h => h.codigo === 'BONO_LIBRE_OK') || {}).dato);
+
+  // El error que esta regla SÍ tiene que cazar: capturar el neto como si fuera
+  // bruto. Al empleado le llegan ~$790 de los $1,000 que le prometieron.
+  const sinCalcular = Cruce.cruzar(dLibre, [emp('029', 'ROMERO', { BONO: 1000 })], 'S36/2026');
+  check('capturar el neto como bruto SÍ es INTEGRIDAD',
+    tiene(sinCalcular.hallazgos, 'BONO_LIBRE_SIN_CALCULAR') &&
+    sinCalcular.hallazgos.find(h => h.codigo === 'BONO_LIBRE_SIN_CALCULAR').nivel === 'INTEGRIDAD');
+
+  const absurdo = Cruce.cruzar(dLibre, [emp('029', 'ROMERO', { BONO: 10000 })], 'S36/2026');
+  check('y un factor que ninguna tasa explica también se reporta',
+    tiene(absurdo.hallazgos, 'BONO_LIBRE_DESPROPORCIONADO'));
+
+  // Con ISR al empleado, el monto es el bruto y se compara tal cual.
+  const pIsr = persona({ id: 79, codigo: '029', ppa: { aplica: false },
+    declaraciones: [{ tipo: 'bono_productividad', fuente: FUENTE,
+      valores: { monto: 1000, motivo: 'X', isr: 'Con ISR a cargo del empleado' } }] });
+  const dIsr = Cruce.parseDespacho(archivoRH([pIsr]));
+  check('con ISR al empleado el parser NO lo marca libre', dIsr.filas[0].conceptos.items[0].libre === false);
+  const isrDif = Cruce.cruzar(dIsr, [emp('029', 'ROMERO', { BONO: 1271.62 })], 'S36/2026');
+  check('y ahí un bruto distinto SÍ es diferencia de monto', tiene(isrDif.hallazgos, 'MONTO_DISTINTO'),
+    codigos(isrDif.hallazgos).join(','));
+
+  // Archivo viejo, sin la marca: no se puede saber cuál de los dos casos es. Se dice
+  // la diferencia y se pide declararla, en vez de afirmar que está mal. Es el lado
+  // TOLERANTE del contrato, que es el que debe ir primero (CLAUDE.md §8).
+  const viejo = Cruce.parseDespacho(archivoRH([pLibre]).replace(/ · LIBRE DE IMPUESTOS/g, ''));
+  check('sin la marca, el parser no inventa un valor', viejo.filas[0].conceptos.items[0].libre === null);
+  const sinMarca = Cruce.cruzar(viejo, [emp('029', 'ROMERO', { BONO: 1271.62 })], 'S36/2026');
+  check('sin la marca se pide declararlo, no se afirma que está mal',
+    tiene(sinMarca.hallazgos, 'MONTO_MAYOR_SIN_DECLARAR') &&
+    Cruce.contar(sinMarca.hallazgos, 'INTEGRIDAD') === 0);
+
   // Un concepto sin fila en la tabla NO se calla: se dice que no se pudo cruzar.
   // Es la diferencia entre "no encontre problema" y "no supe mirar".
+  // Los conceptos de DÍAS tienen su propio camino: la lista de raya no trae columna
+  // de días ni sueldo diario, así que NO se pueden verificar. Decir 'no sé compararlo'
+  // suena a que falta configurar algo; lo honesto es decir que no hay contra qué.
   const pUsa = persona({ id: 75, codigo: '027', dias_mexico: 2, ppa: { aplica: false },
     declaraciones: [{ tipo: 'trabajo_usa', valores: { dias: 3, so: 'SO1' } }] });
   const usa = Cruce.cruzar(Cruce.parseDespacho(archivoRH([pUsa])), [emp('027', 'SALAZAR', {})], 'S36/2026');
-  check('un concepto fuera de la tabla se declara NO CRUZABLE, no se calla',
-    tiene(usa.hallazgos, 'CONCEPTO_NO_CRUZABLE'), codigos(usa.hallazgos).join(','));
+  check('un ajuste de días se declara NO VERIFICABLE, no "no capturado"',
+    tiene(usa.hallazgos, 'DIAS_NO_VERIFICABLES'), codigos(usa.hallazgos).join(','));
+  check('y es AVISO: es un límite del layout, no una sospecha sobre este archivo',
+    usa.hallazgos.find(h => h.codigo === 'DIAS_NO_VERIFICABLES').nivel === 'AVISO');
+  check('y dice qué mirar a mano',
+    /Sueldo.*sueldo diario/i.test(usa.hallazgos.find(h => h.codigo === 'DIAS_NO_VERIFICABLES').accion),
+    usa.hallazgos.find(h => h.codigo === 'DIAS_NO_VERIFICABLES').accion);
+  const pFuera = persona({ id: 6, codigo: '005', ppa: { aplica: false }, fuente: Object.keys(Cat.JOURNALS)[0],
+    declaraciones: [{ tipo: 'pagado_fts_usa', fuente: Object.keys(Cat.JOURNALS)[0], valores: { monto: 800 } }] });
+  const fuera = Cruce.cruzar(Cruce.parseDespacho(archivoRH([pFuera])), [emp('005', 'X', {})], 'S36/2026');
+  check('un concepto SIN días que no está en la tabla se declara NO CRUZABLE',
+    tiene(fuera.hallazgos, 'CONCEPTO_NO_CRUZABLE'), codigos(fuera.hallazgos).join(','));
 }
 
 seccion('El cruce · lo que RH marco para revisar');
@@ -254,6 +326,87 @@ seccion('Forma de los hallazgos');
   check('los niveles son los tres del resolver',
     r.hallazgos.every(x => ['INTEGRIDAD', 'REVISION', 'AVISO'].indexOf(x.nivel) >= 0));
   check('contar() cuenta por nivel', Cruce.contar(r.hallazgos, 'INTEGRIDAD') >= 1);
+}
+
+seccion('El MAPA contra el catálogo real de nómina');
+{
+  // ⚠️ ESTE ES EL ASSERT QUE FALTABA. El MAPA decía 'Descuento DE préstamo' y
+  // 'Compensación de deuda'; el catálogo dice 'Descuento POR préstamo' y 'Compensa
+  // contra deuda'. Ninguna de las dos calzaba, así que esos conceptos NUNCA se
+  // cruzaron: RH los pedía, Ulises los capturaba bien, y la pantalla reportaba
+  // 'RH pidió algo que este cruce no sabe comparar'. Una preposición apagó un
+  // control entero y no hubo error en ningún lado.
+  const etiquetas = new Set();
+  for (const g of Object.keys(Cat.CATALOGO)) {
+    const items = (Cat.CATALOGO[g] && Cat.CATALOGO[g].items) || {};
+    for (const k of Object.keys(items)) if (items[k].label) etiquetas.add(items[k].label);
+  }
+  const rotas = Cruce.MAPA.filter(m => !etiquetas.has(m.etiqueta)).map(m => m.etiqueta);
+  check('toda etiqueta del MAPA existe LETRA POR LETRA en el catálogo de nómina',
+    rotas.length === 0, rotas.join(' | '));
+
+  // Y las claves tienen que existir del lado de CONTPAQi, o el cruce busca un
+  // concepto que el resolver nunca va a producir.
+  const cat = JSON.parse(fs.readFileSync(path.join(RAIZ, 'shared/operaciones/contpaqi_conceptos.json'), 'utf8'));
+  const claves = new Set(Object.keys(cat.conceptos || {}));
+  const sinClave = Cruce.MAPA.filter(m => !claves.has(m.clave)).map(m => m.clave);
+  check('toda clave del MAPA existe en el catálogo de CONTPAQi', sinClave.length === 0, sinClave.join(' | '));
+  check('la clave del premio también', claves.has(Cruce.CLAVE_PPA), Cruce.CLAVE_PPA);
+}
+
+seccion('Percepciones y deducciones: las dos mitades del renglón');
+{
+  // Un descuento por préstamo vive del lado de las DEDUCCIONES. El cruce solo miraba
+  // percepciones, así que lo daba por no capturado estando capturado — y con la
+  // etiqueta arreglada ese bug habría salido a la luz como un falso INTEGRIDAD.
+  const p = persona({ id: 6, codigo: '005',
+    declaraciones: [{ tipo: 'descuento_prestamo', valores: { monto: 500, pago: 2 } }] });
+  const e = emp('005', 'CRUZ CRISTOBAL LEONEL', {});
+  e.deducciones = { PRESTAMO_EMPRESA: 500 };
+  const r = Cruce.cruzar(Cruce.parseDespacho(archivoRH([p])), [e], 'S36/2026');
+  check('un descuento capturado en deducciones se ve como capturado',
+    !tiene(r.hallazgos, 'INSTRUCCION_NO_CAPTURADA'),
+    (r.hallazgos.find(h => h.codigo === 'INSTRUCCION_NO_CAPTURADA') || {}).dato || '');
+
+  const sinNada = Cruce.cruzar(Cruce.parseDespacho(archivoRH([p])), [emp('005', 'X', {})], 'S36/2026');
+  check('y si de verdad NO está, se sigue reportando',
+    tiene(sinNada.hallazgos, 'INSTRUCCION_NO_CAPTURADA'));
+}
+
+seccion('Lo que CONTPAQi paga solo porque es ley');
+{
+  // RH pide 'Vacaciones'; CONTPAQi paga vacaciones Y prima vacacional, que es el 25%
+  // de ley (LFT art. 80). Reclamar la prima como 'movimiento que RH no pidió' era
+  // exigirle a Magaly que declarara una obligación legal, y apagaba el botón de
+  // enviar con tres INTEGRIDAD sobre una nómina correcta.
+  const p = persona({ id: 25, codigo: '002', dias_mexico: 2,
+    declaraciones: [{ tipo: 'vacaciones', valores: { dias: 3 } }] });
+  const conPrima = Cruce.cruzar(Cruce.parseDespacho(archivoRH([p])),
+    [emp('002', 'CRUZ HERNANDEZ HECTOR', { VACACIONES_A_TIEMPO: 3478, PRIMA_VACACIONAL_A_TIEMPO: 869.5 })], 'S36/2026');
+  check('la prima vacacional del 25% NO se reporta como no pedida',
+    !tiene(conPrima.hallazgos, 'CAPTURA_SIN_INSTRUCCION'),
+    (conPrima.hallazgos.find(h => h.codigo === 'CAPTURA_SIN_INSTRUCCION') || {}).dato || '');
+  check('ni ningún otro hallazgo sobre esa persona', conPrima.hallazgos.length === 0,
+    conPrima.hallazgos.map(h => h.codigo).join(','));
+
+  // Pero SÍ se verifica el porcentaje: es el control que de verdad importa.
+  const corta = Cruce.cruzar(Cruce.parseDespacho(archivoRH([p])),
+    [emp('002', 'X', { VACACIONES_A_TIEMPO: 3478, PRIMA_VACACIONAL_A_TIEMPO: 500 })], 'S36/2026');
+  check('una prima por debajo del 25% de ley SÍ se reporta', tiene(corta.hallazgos, 'DERIVADO_CORTO'));
+  check('y dice el porcentaje real contra el mínimo',
+    /14\.4%.*25%/.test(corta.hallazgos.find(h => h.codigo === 'DERIVADO_CORTO').dato),
+    corta.hallazgos.find(h => h.codigo === 'DERIVADO_CORTO').dato);
+
+  const falta = Cruce.cruzar(Cruce.parseDespacho(archivoRH([p])),
+    [emp('002', 'X', { VACACIONES_A_TIEMPO: 3478 })], 'S36/2026');
+  check('vacaciones SIN prima también se reporta', tiene(falta.hallazgos, 'DERIVADO_FALTANTE'));
+
+  // Prima sin vacaciones no tiene de dónde salir: eso sigue siendo un movimiento
+  // que RH no pidió, y no se debe tapar con la regla de arriba.
+  const p2 = persona({ id: 25, codigo: '002' });
+  const huerfana = Cruce.cruzar(Cruce.parseDespacho(archivoRH([p2])),
+    [emp('002', 'X', { PRIMA_VACACIONAL_A_TIEMPO: 869.5 })], 'S36/2026');
+  check('una prima SIN vacaciones sigue siendo hallazgo', tiene(huerfana.hallazgos, 'CAPTURA_SIN_INSTRUCCION'));
 }
 
 seccion('El calendario del frontend contra el del workflow');


### PR DESCRIPTION
Ulises abrió la pantalla y vio **21 hallazgos, 4 de ellos apagando el botón** de enviar una nómina que estaba bien. Quedan **15, con un solo bloqueo y real**.

Todo medido contra los dos archivos de verdad: las 30 personas que mandó RH contra los 26 renglones de CONTPAQi de la semana 36.

| | antes | después |
|---|---|---|
| INTEGRIDAD (bloquean) | **4** | **1** |
| REVISIÓN | 17 | 2 |
| AVISO | 0 | 12 |

El único que bloquea es real: **CONTPAQi le pagó premio de puntualidad a Erick Belmont ($445.07) y RH no lo autorizó.** Ese es exactamente el trabajo del cruce.

---

## 1 · Una preposición apagó un control entero

El MAPA decía `Descuento DE préstamo` y `Compensación de deuda`. El catálogo de nómina dice `Descuento POR préstamo` y `Compensa contra deuda`.

Ninguna calzaba, así que esos dos conceptos **nunca se cruzaron**: RH los pedía, Ulises los capturaba bien, y la pantalla contestaba *«RH pidió algo que este cruce no sabe comparar»*. No hubo error en ningún lado — solo un control que no existía.

El gate ahora cruza **cada etiqueta contra el catálogo real y cada clave contra el de CONTPAQi**. Es la única forma de que no vuelva a pasar callado.

## 2 · Se miraba la mitad equivocada del renglón

Arreglada la etiqueta, los tres descuentos salieron como *«RH lo pidió y no aparece»* **estando capturados**: el resolver solo exponía percepciones, y un descuento vive del lado de las deducciones. Ahora expone las dos mitades.

Se mantienen en mapas separados a propósito — el reparto a proyectos solo mira percepciones, y mezclarlas cambiaría los montos.

## 3 · La prima vacacional no es una decisión de RH

Es el **25% de ley** (LFT art. 80) que CONTPAQi paga solo en cuanto hay vacaciones. Reclamarla como «movimiento que RH no pidió» era exigirle a Magaly que declarara una obligación legal, y eran tres INTEGRIDAD sobre una nómina correcta.

Ahora se verifica el porcentaje, que es el control que de verdad importa. Los tres casos daban **25.00% exacto**. Una prima *sin* vacaciones sigue siendo hallazgo, y unas vacaciones *sin* prima también.

## 4 · El bono libre de impuestos

RH escribe lo que le **llega** al empleado; Ulises captura el **bruto** que lo produce, porque la empresa absorbe el ISR. Exigir que coincidieran convertía el trabajo bien hecho en siete hallazgos.

Ahora RH lo declara en el módulo y la marca viaja en la instrucción, pegada al monto. Campo obligatorio de dos opciones y **no una casilla**: el importe depende de la respuesta, y las casillas no se exigen porque «no» ya es una respuesta.

Los factores medidos:

```
$1,000 libres  →  $1,271.62   ×1.2716   ISR implícito 21.36%   (Enoc, Leonel)
$1,000 libres  →  $1,353.33   ×1.3533   ISR implícito 26.11%   (César, Rolando)
$1,000 libres  →  $1,354.01   ×1.3540   ISR implícito 26.15%   (Germán, Stephany)
  $500 libres  →    $635.81   ×1.2716   ← el MISMO factor: es proporcional
```

La regla **no adivina la tasa** —eso lo hace CONTPAQi con la tabla del SAT— sino que caza los dos errores que importan: capturar el neto como si fuera bruto (al empleado le llega de menos) y un factor que ninguna tasa explica.

Un archivo sin la marca **no se trata como «con ISR»**: no saber no es saber que no. Se pide declararlo en vez de afirmar que está mal — el lado tolerante del contrato va primero.

## 5 · Los días no se pueden verificar con este layout

La lista de raya no trae columna de días ni sueldo diario, así que «DESCONTAR 2 días» no tiene contra qué compararse. Decirlo, con qué mirar a mano, es más útil que afirmar que no se capturó. Es AVISO y no REVISIÓN porque es un límite del formato y se repite idéntico cada semana.

## Y los externos por honorarios

Carlos, Felipe, Ricardo y Esteban cobran en esta nómina pero no por CONTPAQi: facturan, Ulises les agrega su renglón al final del Excel y les hace un `.txt` aparte para dispersarles. Pedirles «el código de CONTPAQi» era pedir cada semana algo que **por definición no existe**.

El mecanismo ya existía —la tabla del trío— y el cruce no lo sabía. Ahora se cruzan por el **id de Odoo**, que el archivo de RH ya trae en `NO EMPLEADO`: llave exacta, sin adivinar nombres (Ulises escribe `MANZANAREZ` con z y Odoo dice *Manzanares*).

**Esteban (32) faltaba en esa tabla.** Su renglón habría caído al puente como fila sin identificar. Agregado.

Que un externo no facture una semana es AVISO, no hallazgo — lo dice el propio catálogo en `trio.reglas.fila_ausente`.

---

## Test plan

- [x] `gate-cruce-rh` **73 → 97**. Secciones nuevas: el MAPA contra los dos catálogos, las dos mitades del renglón, lo que la ley paga solo, y el bono libre en sus cinco casos (bruto coherente, neto capturado como bruto, factor absurdo, con ISR, y sin la marca).
- [x] **Tres fixtures que empezaron a fallar NO se aflojaron: estaban incompletos.** Pagaban vacaciones sin prima —un estado que no existe en la vida real— y declaraban bonos sin fuente ni impuestos.
- [x] `gate-nomina` 246 · `visual-cargamo` 123 · `visual-nomina` 119.
- [x] Reproducido el antes y el después contra los archivos reales de la SEM 36.
- [x] **Un hueco de mi propia lógica, encontrado al escribir la prueba:** si el bono va libre y el bruto *coincide* con el neto, eso es precisamente el error, y la comparación se saltaba por «los números son iguales».

Versiones: carga-mo **V1.00 → V1.01** · nómina **V1.16 → V1.17** · catálogo de CONTPAQi **v2026.3 → v2026.4** (se lee en vivo de main).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MDYMMPYZdLqWQCVfuZUAC6

---
_Generated by [Claude Code](https://claude.ai/code/session_01MDYMMPYZdLqWQCVfuZUAC6)_