### PR TITLE
feat(comercial/machote) V1.15: los multiplicadores son de cada sección, no de la cotización

### DIFF
--- a/comercial/machote/README.md
+++ b/comercial/machote/README.md
@@ -67,7 +67,7 @@ versión es peor que no tener indicador.
 | `js/pegar.js` | El pegado de tablas: separador, columnas y revisión previa. |
 | `js/almacen.js` | El autoguardado. UNA pieza entre la pantalla y donde viven los datos. |
 | `js/clientes.js` | El catálogo de clientes, leído de Odoo. Guarda el id, pinta el nombre. |
-| `tests/pruebas-navegador.js` | 104 pruebas de navegador. |
+| `tests/pruebas-navegador.js` | 109 pruebas de navegador. |
 
 ## Cómo se calcula el precio
 
@@ -89,6 +89,43 @@ Bajo *margen deseado* el precio es `costo / (1 − margen − comisiones)` y se
 reparte entre secciones **a prorrata del costo**. Por eso mover un multiplicador
 en ese escenario no cambia el precio: sólo cambia el reparto. Es una propiedad
 del machote, no un error, y hay una prueba que la fija.
+
+## Los multiplicadores son de cada sección
+
+Los cuatro —programador, mano de obra, materiales, servicios— **pertenecen a la
+sección**, no a la cotización. Mover el de materiales en `Suministro` no toca el
+de `Instalación`.
+
+No es una preferencia: el suministro y la instalación no se venden con el mismo
+multiplicador, y cuando eran uno solo, **corregir una sección movía el precio de
+todas sin que nadie lo viera**. El campo estaba en la hoja de la sección, así que
+parecía de la sección; el dato estaba en el machote.
+
+**Lo único compartido son las dos comisiones**, FTS y cliente: esas se pactan una
+vez para la cotización entera. Están en la misma tabla, así que la hoja lo dice
+en una línea — dos reglas distintas pegadas una debajo de otra, si no se
+explican, se leen como una sola.
+
+Se resuelven en **tres capas: plantilla ← machote ← sección**, y la de abajo
+manda. Esa capa intermedia es la que sostiene lo ya capturado: una sección sin
+`margenes` propios lee los del machote y muestra exactamente los mismos números
+que mostraba. **No hay nada que migrar y ningún machote cambia de precio.** La
+primera vez que alguien toca un multiplicador, esa sección —y sólo esa— se
+queda con el suyo.
+
+El revisador también cambió de granularidad: los hallazgos de multiplicadores
+dicen **en qué sección**, y el botón «Ir a arreglarlo» abre esa hoja. Mientras
+fueron del machote daba igual; ahora mandar a la primera sección es mandar a la
+equivocada.
+
+**Esto no es una preferencia de diseño: es lo que hace el machote real.** La
+tabla vive en `E1:F5` de **cada hoja de sección**, y ahí los cuatro
+multiplicadores son **valores literales**; las dos comisiones, en `F6`/`F7`, son
+**referencias** a `'DESGLOSE COTIZACION'!B7` y `!B8`. Literal contra referencia
+es exactamente la línea entre «se decide por sección» y «se pacta una vez». Lo
+confirma la fórmula de horas extras, `=$F$3*2`: `$F$3` es la mano de obra **de
+la misma hoja**. Detalle en
+[`docs/comercial/MACHOTE-ESTRUCTURA-REAL.md`](../../docs/comercial/MACHOTE-ESTRUCTURA-REAL.md) §2.2.
 
 ## La pantalla
 

--- a/comercial/machote/js/app.js
+++ b/comercial/machote/js/app.js
@@ -40,7 +40,7 @@
    * 2026-09-03 (por instrucción de Esteban), pero lleva el suyo aparte y va en
    * V1.00. Planeación sigue en `2.4.1` y el kiosko sólo con cadena de build;
    * a esos no se propaga. */
-  const VERSION = 'V1.14';
+  const VERSION = 'V1.15';
   const $  = (s, r) => (r || document).querySelector(s);
   const $$ = (s, r) => Array.prototype.slice.call((r || document).querySelectorAll(s));
   const clon = (x) => JSON.parse(JSON.stringify(x));
@@ -199,6 +199,15 @@
   function setPath(m, path, val) {
     const p = path.split(':');
     if (p[0] === 'nom') { const s = m.secciones.find(x => x.id === p[1]); if (s) s.nombre = val; return; }
+    /* Los multiplicadores son DE LA SECCIÓN, no del machote: `mg:<id>:<clave>`.
+     * Antes se escribían en `m.margenes` y por eso mover uno en una sección
+     * los movía en todas. Lo único que sigue siendo del machote entero son las
+     * dos comisiones, FTS y cliente. */
+    if (p[0] === 'mg') {
+      const s = m.secciones.find(x => x.id === p[1]); if (!s) return;
+      if (!s.margenes) s.margenes = {};
+      s.margenes[p[2]] = sanea(val); return;
+    }
     if (p[0] === 's') {
       const s = m.secciones.find(x => x.id === p[1]); if (!s) return;
       const arr = p[2] === 'mo' ? s.mo : s.partidas;
@@ -490,8 +499,18 @@
       const b = e.target.closest('[data-hoja]');
       if (b) { ST.hoja = b.dataset.hoja; return vMachote(id); }
       if (e.target.closest('[data-nueva]')) {
-        m.secciones.push({ id: 's-' + Date.now(), nombre: 'SECCION ' + (m.secciones.length + 1), mo: [], partidas: [] });
-        ST.hoja = m.secciones[m.secciones.length - 1].id; return vMachote(id);
+        /* Por el motor, no a mano. La sección que armaba esta línea nacía
+         * VACÍA —sin los diez renglones de mano de obra ni los treinta de
+         * materiales— cuando el machote real tiene exactamente diez por
+         * sección; y ahora, además, tiene que nacer con sus propios
+         * multiplicadores. Se descubrió al hacerlos por sección.
+         *
+         * Arranca con los del machote, que es lo que se ve en las demás, y
+         * desde ahí se mueve sin tocar a nadie. */
+        const base = Object.assign({}, C.MARGENES_PLANTILLA, m.margenes || {});
+        const nueva = C.seccionNueva('SECCIÓN ' + (m.secciones.length + 1), m.moneda, base);
+        m.secciones.push(nueva);
+        ST.hoja = nueva.id; tocado(); return vMachote(id);
       }
     };
     pintarHoja(m);
@@ -552,7 +571,10 @@
   function hojaSeccion(m, s, c) {
     const cs = c.secciones.find(x => x.id === s.id) || {};
     const idx = m.secciones.findIndex(x => x.id === s.id);
-    const mg = c.margenes;
+    // Los de ESTA sección, resueltos por el motor. No `c.margenes`, que es la
+    // capa de arranque del machote y era lo que hacía que las cuatro cajas se
+    // vieran iguales en todas las hojas.
+    const mg = cs.margenes || c.margenes;
 
     // Bloque de encabezado: las once filas de la izquierda y la tabla de
     // márgenes de la derecha, tal como están en la hoja.
@@ -572,12 +594,17 @@
       ['% Utilidad Obtenido', pc(cs.margenObtenido)]
     ].map(r => '<tr><td class="et">' + esc(r[0]) + '</td><td class="vl mono calc">' + r[1] + '</td></tr>').join('');
 
+    const mgp = 'mg:' + s.id + ':';
     const der = [
-      ['Programador', 'margenes.programador', mg.programador],
-      ['Mano de obra', 'margenes.mano_obra', mg.mano_obra],
-      ['Materiales', 'margenes.materiales', mg.materiales],
-      ['Servicios', 'margenes.servicios', mg.servicios]
+      ['Programador', mgp + 'programador', mg.programador],
+      ['Mano de obra', mgp + 'mano_obra', mg.mano_obra],
+      ['Materiales', mgp + 'materiales', mg.materiales],
+      ['Servicios', mgp + 'servicios', mg.servicios]
     ].map(r => '<tr><td class="et">' + r[0] + '</td><td>' + celNum(r[1], r[2], 'w70') + '</td></tr>').join('') +
+      // Las comisiones SÍ son del machote entero: se pactan una vez para la
+      // cotización. Por eso siguen sin el prefijo de sección, y por eso se
+      // dice en la pantalla — dos tablas pegadas con reglas distintas, si no
+      // se explica, se leen como una sola.
       '<tr><td class="et">Comision FTS</td><td>' + celPct('comision_fts', m.comision_fts) + '</td></tr>' +
       '<tr><td class="et">Comision CLIENTE</td><td>' + celPct('comision_cliente', m.comision_cliente) + '</td></tr>';
 
@@ -604,7 +631,9 @@
       '</tbody></table></div>' +
       '<div class="blk"><table class="hoja2"><thead><tr><th>Concepto</th><th>Margen de utilidad</th></tr></thead>' +
       '<tbody>' + der + '</tbody></table>' +
-      '<div class="tiny nota">Horas extras = mano de obra × 2 = <strong>' + mg.extra + '</strong>. No se captura, igual que en el Excel.</div>' +
+      '<div class="tiny nota">Los cuatro multiplicadores son <strong>de esta sección</strong>; ' +
+      'las dos comisiones son de toda la cotización.<br>' +
+      'Horas extras = mano de obra × 2 = <strong>' + mg.extra + '</strong>. No se captura, igual que en el Excel.</div>' +
       '</div></div>';
 
     // COSTO MANO DE OBRA — los diez renglones siempre presentes, en sus tres grupos.
@@ -1181,7 +1210,8 @@
         '<div class="wg ' + cls + '"><strong>' + esc(h.titulo) + '</strong>' +
         '<div class="tiny oc">' + esc(h.area) + '</div><div>' + esc(h.detalle) + '</div>' +
         (h.items.length ? '<ul class="tiny">' + h.items.map(i => '<li>' + esc(i) + '</li>').join('') + '</ul>' : '') +
-        '<div class="btnrow"><button class="btn" data-goto="' + esc((h.destino && h.destino.tab) || '') + '">Ir a arreglarlo</button></div>' +
+        '<div class="btnrow"><button class="btn" data-goto="' + esc((h.destino && h.destino.tab) || '') + '"' +
+        ' data-sec="' + esc((h.destino && h.destino.seccion) || '') + '">Ir a arreglarlo</button></div>' +
         '</div>').join('');
 
     $('#vista').innerHTML = '<div class="pad">' +
@@ -1195,7 +1225,12 @@
 
     $$('[data-goto]').forEach(b => b.onclick = () => {
       const t = b.dataset.goto;
-      ST.hoja = (t === 'secc' && m.secciones[0]) ? m.secciones[0].id : 'desglose';
+      // La regla ya sabe EN QUÉ sección está el problema: se abre esa, no la
+      // primera. Con los multiplicadores por sección, "la primera" es casi
+      // siempre la equivocada. Si no la dice, se cae a la primera como antes.
+      const pedida = b.dataset.sec && m.secciones.some(x => x.id === b.dataset.sec)
+        ? b.dataset.sec : (m.secciones[0] && m.secciones[0].id);
+      ST.hoja = (t === 'secc' && pedida) ? pedida : 'desglose';
       location.hash = '#/m/' + id;
     });
   }

--- a/comercial/machote/js/calc.js
+++ b/comercial/machote/js/calc.js
@@ -105,7 +105,7 @@
   /** Una sección en blanco: los diez renglones de mano de obra con su tarifa
    *  de plantilla y las horas en cero, y `PARTIDAS_EN_BLANCO` renglones de
    *  materiales vacíos, listos para llenar hacia abajo como en el Excel. */
-  function seccionNueva(nombre, moneda) {
+  function seccionNueva(nombre, moneda, base) {
     moneda = moneda || 'MXN';
     const mo = ROLES.map(r => ({
       rol: r.id,
@@ -133,7 +133,11 @@
       });
     }
     return { id: 's-' + Date.now() + '-' + Math.round(Math.random() * 1e6),
-             nombre: nombre || 'SECCIÓN 1', mo: mo, partidas: partidas };
+             nombre: nombre || 'SECCIÓN 1',
+             // COPIA, no referencia: dos secciones que compartieran el mismo
+             // objeto volverían al bug que este cambio arregla, y en silencio.
+             margenes: Object.assign({}, MARGENES_PLANTILLA, base || {}),
+             mo: mo, partidas: partidas };
   }
 
   /** Un machote en blanco, con su hoja DESGLOSE (que siempre existe, no es una
@@ -170,7 +174,7 @@
       equipo_operaciones: EQUIPO_OPS_PLANTILLA(),
       equipo_cliente: [{ nombre: 'Contacto cliente 1', pct: 1 }],
       diagnostico: { tipo: '', respuestas: {} },
-      secciones: [seccionNueva('SECCIÓN 1', empresa.moneda)]
+      secciones: [seccionNueva('SECCIÓN 1', empresa.moneda, MARGENES_PLANTILLA)]
     };
   }
 
@@ -197,9 +201,25 @@
     return monto;
   }
 
-  /** Los cuatro multiplicadores vigentes del machote, ya resueltos. */
-  function margenes(m) {
-    const mg = Object.assign({}, MARGENES_PLANTILLA, m.margenes || {});
+  /** Los cuatro multiplicadores vigentes de UNA SECCIÓN, ya resueltos.
+   *
+   *  Se resuelven en tres capas: plantilla ← machote ← sección. Cada sección
+   *  manda sobre las de arriba, así que **mover un multiplicador en una
+   *  sección NO toca a las demás**: es una decisión de esa parte de la obra
+   *  —el suministro no se vende con el mismo multiplicador que la instalación—
+   *  y compartirlos hacía que corregir una sección moviera el precio de todas
+   *  sin que nadie lo viera.
+   *
+   *  Lo que sí es del machote entero son las dos COMISIONES (FTS y cliente):
+   *  esas se pactan una vez para la cotización, no por sección.
+   *
+   *  La capa del machote se queda como el valor de arranque, y es lo que
+   *  mantiene en pie a los machotes capturados ANTES de este cambio: una
+   *  sección sin `margenes` propios sigue leyendo los del machote y muestra
+   *  exactamente los mismos números que mostraba. Nada que migrar. */
+  function margenes(m, s) {
+    const mg = Object.assign({}, MARGENES_PLANTILLA,
+                             (m && m.margenes) || {}, (s && s.margenes) || {});
     // El multiplicador de horas extras no se captura: es el de mano de obra
     // por dos. En el Excel es literalmente =$F$3*2.
     mg.extra = num(mg.mano_obra) * 2;
@@ -208,9 +228,9 @@
 
   /** Una línea de mano de obra: tarifa × personas × horas.
    *  El costo es tridimensional. Tarifa × horas se queda corto. */
-  function costoMo(linea, m) {
+  function costoMo(linea, m, s) {
     const r = ROL[linea.rol];
-    const mg = margenes(m);
+    const mg = margenes(m, s);
     const sinTarifa = vacio(linea.pu);
     const pu = sinTarifa ? 0 : num(linea.pu);
     const costo = aMonedaDoc(pu * num(linea.personas) * num(linea.qty), linea.moneda, m);
@@ -232,8 +252,8 @@
    *  `SO11737` hay una partida "riel" de $200 marcada como Materiales con
    *  margen 1,5 escrito encima de la fórmula, que es de donde salían $20 de
    *  diferencia contra el archivo. Se respeta el valor pisado y se marca. */
-  function costoPartida(linea, m) {
-    const mg = margenes(m);
+  function costoPartida(linea, m, s) {
+    const mg = margenes(m, s);
     const sinPrecio = vacio(linea.pu);
     const pu = sinPrecio ? 0 : num(linea.pu);
     const costo = aMonedaDoc(pu * num(linea.qty), linea.moneda, m);
@@ -251,18 +271,19 @@
   }
 
   function totalSeccion(s, m) {
+    const mgSec = margenes(m, s);
     let costoMoTot = 0, ventaMo = 0, horas = 0, moSinTarifa = 0;
     let costoMat = 0, ventaMat = 0, sinPrecio = 0, sinTipo = 0, sinLink = 0, pisados = 0;
     const monedas = {};
 
     (s.mo || []).forEach(l => {
-      const c = costoMo(l, m);
+      const c = costoMo(l, m, s);
       costoMoTot += c.costo; ventaMo += c.conUtilidad; horas += c.horas;
       if (c.sinTarifa && (num(l.qty) > 0 || num(l.personas) > 0)) moSinTarifa++;
       if (l.moneda) monedas[l.moneda] = 1;
     });
     (s.partidas || []).forEach(l => {
-      const c = costoPartida(l, m);
+      const c = costoPartida(l, m, s);
       costoMat += c.costo; ventaMat += c.conUtilidad;
       if (!c.usada) return;
       if (c.sinPrecio) sinPrecio++;
@@ -274,6 +295,10 @@
 
     return {
       id: s.id, nombre: s.nombre,
+      // Los multiplicadores de ESTA sección. La pantalla los pinta de aquí, no
+      // de los del machote: si los resolviera por su cuenta habría dos lugares
+      // decidiendo el mismo número (§20 regla 4, un solo escritor).
+      margenes: mgSec,
       costoMo: costoMoTot, costoMat, costo: costoMoTot + costoMat,
       ventaMo, ventaMat, venta: ventaMo + ventaMat,
       horas, moSinTarifa, sinPrecio, sinTipo, sinLink, pisados,
@@ -296,6 +321,8 @@
 
   /** El cálculo completo. Única fuente de verdad. */
   function calcular(m) {
+    // Los del MACHOTE, que es la capa de arranque. Los que gobiernan el precio
+    // son los de cada sección, y viajan dentro de `secciones[i].margenes`.
     const mg = margenes(m);
     const secciones = (m.secciones || []).map(s => totalSeccion(s, m));
 

--- a/comercial/machote/js/reglas.js
+++ b/comercial/machote/js/reglas.js
@@ -38,19 +38,43 @@
   const usada = (l) => C.usadaPartida(l);
   const tipoDe = (m) => (G.DEMO.TIPOS_PROYECTO.find(t => t.id === (m.diagnostico || {}).tipo) || null);
 
+  /* La primera sección donde un multiplicador cumple `mal`. Sirve para que el
+   * botón "Ir a arreglarlo" abra la hoja correcta: desde que los
+   * multiplicadores son por sección, mandar al DESGLOSE es mandar a una
+   * pantalla donde no está el campo que hay que tocar. */
+  function seccionConMargen(m, mal) {
+    const base = C.MARGENES_PLANTILLA;
+    const s = (m.secciones || []).find(sec => {
+      const mg = C.margenes(m, sec);
+      return Object.keys(base).some(k => mal(Number(mg[k]), base[k]));
+    });
+    return { tab: 'secc', seccion: s ? s.id : null };
+  }
+
   const REGLAS = [
 
     // ── Márgenes: la tabla que gobierna todo el precio ─────────────────────
     {
       // MACHOTE — programador 4,4 y mano de obra 2,5 no variaron en ninguno de
       // los 8 ejemplares leídos. Si alguien los mueve, es a propósito o es error.
-      destino: () => ({ tab: 'gen' }),
+      destino: (m) => seccionConMargen(m, (v, b) => Math.abs(v - b) > 0.001),
       id: 'margen-fuera-de-plantilla', severidad: 'blanda', area: 'Márgenes',
       titulo: 'Un multiplicador se movió de su valor de plantilla',
+      // Los multiplicadores son POR SECCIÓN, así que se revisan sección por
+      // sección y el hallazgo dice en cuál. Mirar sólo los del machote dejaba
+      // de ver justo el caso que importa: una sección movida y las demás no.
       evaluar: (m) => {
-        const mg = C.margenes(m), base = C.MARGENES_PLANTILLA;
-        const dif = Object.keys(base).filter(k => Math.abs(Number(mg[k]) - base[k]) > 0.001)
-          .map(k => k.replace('_', ' ') + ': ' + mg[k] + ' (plantilla ' + base[k] + ')');
+        const base = C.MARGENES_PLANTILLA;
+        const dif = [];
+        (m.secciones || []).forEach((s, i) => {
+          const mg = C.margenes(m, s);
+          Object.keys(base).forEach(k => {
+            if (Math.abs(Number(mg[k]) - base[k]) > 0.001) {
+              dif.push((s.nombre || ('Sección ' + (i + 1))) + ' · ' +
+                       k.replace('_', ' ') + ': ' + mg[k] + ' (plantilla ' + base[k] + ')');
+            }
+          });
+        });
         if (!dif.length) return null;
         const duros = dif.filter(d => /programador|mano obra/.test(d));
         return { detalle: duros.length
@@ -60,13 +84,20 @@
       }
     },
     {
-      destino: () => ({ tab: 'gen' }),
+      destino: (m) => seccionConMargen(m, (v) => v < 1),
       id: 'margen-invertido', severidad: 'dura', area: 'Márgenes',
       titulo: 'Un multiplicador está por debajo de 1',
       evaluar: (m) => {
-        const mg = C.margenes(m);
-        const mal = Object.keys(C.MARGENES_PLANTILLA).filter(k => Number(mg[k]) < 1)
-          .map(k => k.replace('_', ' ') + ' = ' + mg[k]);
+        const mal = [];
+        (m.secciones || []).forEach((s, i) => {
+          const mg = C.margenes(m, s);
+          Object.keys(C.MARGENES_PLANTILLA).forEach(k => {
+            if (Number(mg[k]) < 1) {
+              mal.push((s.nombre || ('Sección ' + (i + 1))) + ' · ' +
+                       k.replace('_', ' ') + ' = ' + mg[k]);
+            }
+          });
+        });
         return mal.length ? { detalle: 'Un multiplicador menor a 1 vende por debajo del costo.', items: mal } : null;
       }
     },

--- a/comercial/machote/tests/pruebas-navegador.js
+++ b/comercial/machote/tests/pruebas-navegador.js
@@ -175,6 +175,11 @@ let ok = 0, mal = 0;
 
   await paso('el multiplicador de horas extras es mano de obra × 2', async () => {
     const x = await p.evaluate(() => window.MachoteCalc.margenes({ margenes: { mano_obra: 2.5 } }).extra);
+    /* Y con la sección pisando al machote, el de horas extras sigue la de la
+     * sección: es mano de obra × 2, sea de donde sea que salga. */
+    const y = await p.evaluate(() => window.MachoteCalc.margenes(
+      { margenes: { mano_obra: 2.5 } }, { margenes: { mano_obra: 3 } }).extra);
+    if (y !== 6) throw new Error('con sección debía dar 6, dio ' + y);
     if (x !== 5) throw new Error('extra = ' + x);
   });
 
@@ -321,8 +326,9 @@ let ok = 0, mal = 0;
     await p.click('[data-esc="con_utilidad"]'); await p.waitForTimeout(200);
     await hoja('Adecuación');
     const antes = await p.textContent('.fija .mono');
-    await p.fill('[data-cel="margenes.materiales"]', '3.2');
-    await p.dispatchEvent('[data-cel="margenes.materiales"]', 'input');
+    const celMat = '[data-cel^="mg:"][data-cel$=":materiales"]';
+    await p.fill(celMat, '3.2');
+    await p.dispatchEvent(celMat, 'input');
     await p.waitForTimeout(250);
     const desp = await p.textContent('.fija .mono');
     if (antes === desp) throw new Error('no se movió: ' + antes);
@@ -1650,6 +1656,130 @@ let ok = 0, mal = 0;
       throw new Error('perdió la especificación: ' + r.r[0].descripcion);
     if (r.r[2].tipo !== 'Servicios') throw new Error('"Mano de obra" no salió Servicios');
     console.log('    encabezado fuera · precio nuevo · unidad de "1 pza" · especificación dentro');
+  });
+
+  // ── Los multiplicadores, por sección ─────────────────────────────────
+  await paso('mover un multiplicador en una sección NO toca a las demás', async () => {
+    /* Lo que reportó Esteban: "si modifico uno, se modifican en TODAS las
+     * demas secciones". La causa era que vivían en `m.margenes`, uno solo
+     * para toda la cotización. Ahora cada sección tiene los suyos.
+     *
+     * Se mide en el ALMACÉN, no en la pantalla: que otra hoja pinte otro
+     * número podría ser un repintado perezoso; que el archivo tenga dos
+     * valores distintos no se puede fingir. */
+    await ir('#/m/M-1041');
+    const hojas = await p.evaluate(() =>
+      [...document.querySelectorAll('.pestana[data-hoja]')].map(x => x.dataset.hoja));
+    const secs = hojas.filter(h => h !== 'desglose');
+    if (secs.length < 2) throw new Error('el machote de prueba no tiene dos secciones');
+
+    // Sección 1: materiales a 3.9. La pestaña 0 es el DESGLOSE.
+    await p.locator('.pestana').nth(1).click(); await p.waitForTimeout(300);
+    const cel = '[data-cel^="mg:"][data-cel$=":materiales"]';
+    await p.fill(cel, '3.9');
+    await p.dispatchEvent(cel, 'change');
+    await p.waitForTimeout(900);
+
+    // Sección 2: lo que muestra la pantalla
+    await p.locator('.pestana').nth(2).click(); await p.waitForTimeout(350);
+    const enDos = await p.inputValue(cel);
+    if (Number(enDos) === 3.9)
+      throw new Error('la sección 2 se movió con la 1: ' + enDos);
+
+    // Y el almacén, que es la prueba dura
+    const guardado = await p.evaluate(() => {
+      const d = JSON.parse(localStorage.getItem('fts_machote_v1'));
+      const m = d.machotes.find(x => x.id === 'M-1041');
+      return m.secciones.map(s => (s.margenes || {}).materiales === undefined
+        ? 'hereda' : s.margenes.materiales);
+    });
+    if (Number(guardado[0]) !== 3.9)
+      throw new Error('la sección 1 no guardó lo suyo: ' + JSON.stringify(guardado));
+    if (Number(guardado[1]) === 3.9)
+      throw new Error('la sección 2 quedó con el mismo valor: ' + JSON.stringify(guardado));
+    console.log('    sección 1 → 3.9 · sección 2 → ' + enDos + ' · almacén ' + JSON.stringify(guardado));
+  });
+
+  await paso('las comisiones SÍ son de toda la cotización', async () => {
+    /* La otra mitad de lo que pidió: "lo unico compartido es la comision de
+     * fts y del usuario". Una prueba que sólo mirara la separación dejaría
+     * pasar que se separara TAMBIÉN esto, que es justo lo que no debe pasar. */
+    await ir('#/m/M-1041');
+    await p.locator('.pestana').nth(1).click(); await p.waitForTimeout(300);
+    await p.fill('[data-cel="comision_fts"]', '9');
+    await p.dispatchEvent('[data-cel="comision_fts"]', 'change');
+    await p.waitForTimeout(900);
+    await p.locator('.pestana').nth(2).click(); await p.waitForTimeout(350);
+    const enDos = await p.inputValue('[data-cel="comision_fts"]');
+    if (Number(enDos) !== 9)
+      throw new Error('la comisión no se compartió entre secciones: ' + enDos);
+    const guardado = await p.evaluate(() => {
+      const d = JSON.parse(localStorage.getItem('fts_machote_v1'));
+      return d.machotes.find(x => x.id === 'M-1041').comision_fts;
+    });
+    if (Math.abs(Number(guardado) - 0.09) > 1e-9)
+      throw new Error('en el almacén quedó ' + guardado + ', se esperaba 0.09');
+    console.log('    9 % en las dos secciones · almacén 0.09, una sola vez');
+  });
+
+  await paso('el precio de una sección se mueve con SU multiplicador', async () => {
+    /* Que el número quede guardado aparte no basta: tiene que llegar al
+     * precio de esa sección y no al de la otra. Es la diferencia entre
+     * separar el campo y separar el cálculo. */
+    const r = await p.evaluate(() => {
+      const C = window.MachoteCalc;
+      const base = { moneda: 'MXN', margenes: { materiales: 2, servicios: 1.7, mano_obra: 2.5, programador: 4.4 } };
+      const part = () => ([{ qty: 1, pu: 100, tipo: 'Materiales', moneda: 'MXN' }]);
+      const m = Object.assign({}, base, { secciones: [
+        { id: 'a', nombre: 'A', margenes: { materiales: 3 }, mo: [], partidas: part() },
+        { id: 'b', nombre: 'B', mo: [], partidas: part() }
+      ] });
+      const c = C.calcular(m);
+      return { a: c.secciones[0].ventaMat, b: c.secciones[1].ventaMat, total: c.ventaMat };
+    });
+    if (r.a !== 300) throw new Error('la sección con 3 debía vender 300, vendió ' + r.a);
+    if (r.b !== 200) throw new Error('la sección que hereda 2 debía vender 200, vendió ' + r.b);
+    if (r.total !== 500) throw new Error('el total no suma las dos: ' + r.total);
+    console.log('    A (3) → 300 · B (hereda 2) → 200 · total 500');
+  });
+
+  await paso('una sección sin multiplicadores propios hereda los del machote', async () => {
+    /* Los machotes capturados ANTES de este cambio no tienen `margenes` en la
+     * sección. Si heredar fallara, todos mostrarían la plantilla de golpe y
+     * cambiarían de precio solos. Es la prueba de que no hay que migrar nada. */
+    const r = await p.evaluate(() => {
+      const C = window.MachoteCalc;
+      const viejo = { margenes: { materiales: 1.67, servicios: 1.7, mano_obra: 2.5, programador: 4.4 } };
+      const mg = C.margenes(viejo, { nombre: 'sin margenes propios' });
+      return { mat: mg.materiales, ser: mg.servicios };
+    });
+    if (r.mat !== 1.67) throw new Error('no heredó materiales: ' + r.mat);
+    if (r.ser !== 1.7) throw new Error('no heredó servicios: ' + r.ser);
+    console.log('    machote 1.67/1.7 → la sección sin propios muestra 1.67/1.7');
+  });
+
+  await paso('una sección nueva nace completa y con sus multiplicadores', async () => {
+    /* La pestaña `+` armaba la sección a mano y la creaba VACÍA: sin los diez
+     * renglones de mano de obra ni los treinta de materiales. Se descubrió al
+     * hacer los multiplicadores por sección. */
+    await ir('#/m/M-1041');
+    // 900 ms, no 400: el autoguardado espera medio segundo desde la última
+    // tecla. Con 400 el archivo todavía no existía y el `JSON.parse` reventaba
+    // contra un null — la prueba fallaba por la espera, no por la sección.
+    await p.locator('.pestana.mas').click(); await p.waitForTimeout(900);
+    const r = await p.evaluate(() => {
+      const crudo = localStorage.getItem('fts_machote_v1');
+      if (!crudo) throw new Error('el autoguardado no alcanzó a escribir');
+      const d = JSON.parse(crudo);
+      const m = d.machotes.find(x => x.id === 'M-1041');
+      const s = m.secciones[m.secciones.length - 1];
+      return { mo: (s.mo || []).length, part: (s.partidas || []).length,
+               mg: s.margenes ? s.margenes.materiales : null };
+    });
+    if (r.mo !== 10) throw new Error('nació con ' + r.mo + ' renglones de mano de obra, no 10');
+    if (r.part !== 30) throw new Error('nació con ' + r.part + ' partidas, no 30');
+    if (r.mg === null) throw new Error('nació sin multiplicadores propios');
+    console.log('    10 de mano de obra · 30 partidas · materiales ' + r.mg);
   });
 
   // ── El cliente, desde Odoo ───────────────────────────────────────────

--- a/comercial/machote/version.json
+++ b/comercial/machote/version.json
@@ -1,10 +1,15 @@
 {
-  "version": "V1.14",
+  "version": "V1.15",
   "fecha": "2026-09-04",
   "modulo": "comercial/machote",
   "ambito": "El CONTADOR es solo de este modulo. finanzas tambien usa V1.xx desde el 2026-09-03 (instruccion directa de Esteban, corrige el \"no propagar\" del issue #148) pero lleva su propio contador y va en V1.00. operaciones/planeacion sigue en 2.4.1, kiosk y confirmar-horas solo con cadena de build, y siete modulos con un 1.0.0 puesto una vez: a esos no se propaga.",
   "esquema": "V<mayor>.<menor de dos digitos>. Un incremento de 0.01 por cada merge a main. Al pasar de .99 sube el mayor y el menor vuelve a 00.",
   "historial": [
+    {
+      "version": "V1.15",
+      "pr": null,
+      "nota": "Los cuatro multiplicadores son de CADA SECCION, no de la cotizacion entera: mover el de materiales en Suministro ya no mueve el de Instalacion. Lo unico compartido son las dos comisiones, FTS y cliente. Los machotes ya capturados no cambian de precio: una seccion sin multiplicadores propios sigue leyendo los del machote. De paso, la pestaña + creaba secciones VACIAS, sin los diez renglones de mano de obra ni los treinta de materiales"
+    },
     {
       "version": "V1.14",
       "pr": null,

--- a/docs/comercial/MACHOTE-ESTRUCTURA-REAL.md
+++ b/docs/comercial/MACHOTE-ESTRUCTURA-REAL.md
@@ -83,6 +83,25 @@ Comision CLIENTE 0%     (F7, = 'DESGLOSE COTIZACION'!B8)
 **El margen es un MULTIPLICADOR por concepto, no un porcentaje global.** Precio de una
 partida = costo × multiplicador.
 
+**Y la tabla es DE LA HOJA DE SECCIÓN, no del libro.** Está en el rango `E1:F5` de cada
+hoja de sección, y ahí los cuatro multiplicadores son **valores literales**. Las dos
+filas de abajo no: `F6` y `F7` son **referencias** a `'DESGLOSE COTIZACION'!B7` y `!B8`.
+Esa diferencia —literal contra referencia— es la que dice qué se decide por sección y qué
+se pacta una vez para la cotización:
+
+| | dónde vive | alcance |
+|---|---|---|
+| Programador · Mano de obra · Materiales · Servicios | literal en `E1:F5` de **cada hoja** | **por sección** |
+| Comisión FTS · Comisión CLIENTE | referencia al `DESGLOSE` | **de toda la cotización** |
+
+Lo confirma también la fórmula de horas extras, `=$F$3*2`: `$F$3` es la mano de obra **de
+la misma hoja**, no del libro.
+
+⚠️ Lo que esto **no** dice: no se midió si algún ejemplar del acervo tiene de hecho
+valores distintos entre dos secciones del mismo libro. Lo verificado es dónde vive el
+dato y de qué tipo es la celda, que es lo que fija el alcance. La herramienta lo
+reproduce desde V1.15.
+
 Verificado en 12 ejemplares, cinco de ellos cotizaciones de 2026 (SO11737, SO11738, SO11790, SO11836 y el USD de calbee). Lo que **no** varía:
 
 | concepto | valor | ejemplares |


### PR DESCRIPTION
## Lo que se reportó

> «Los multiplicadores que tengo en cada seccion, actualmente **si modifico uno, se modifican en TODAS las demas secciones**. Estos multiplicadores deben ser individuales para cada seccion. **Lo unico compartido es la comision de fts y del usuario**.»

Confirmado y arreglado.

## La causa

El campo estaba en la hoja de la sección, así que **parecía** de la sección. El dato vivía en `m.margenes` — uno solo para toda la cotización. Corregir una sección movía el precio de todas, y no había nada en la pantalla que lo dijera.

## Lo que cambia

Los cuatro —programador, mano de obra, materiales, servicios— pasan a ser **de la sección**. Las dos comisiones siguen siendo **del machote entero**: se pactan una vez para la cotización.

Se resuelven en **tres capas: plantilla ← machote ← sección**, y la de abajo manda.

## Esto no es una preferencia de diseño: es lo que hace el machote real

La evidencia es estructural, y estaba en el acervo sin que nadie la hubiera leído en esta clave. La tabla vive en `E1:F5` de **cada hoja de sección**:

| | dónde vive en el Excel | alcance |
|---|---|---|
| Programador · Mano de obra · Materiales · Servicios | **valor literal** en `E1:F5` de cada hoja | **por sección** |
| Comisión FTS · Comisión CLIENTE | **referencia** `='DESGLOSE COTIZACION'!B7` / `!B8` | de toda la cotización |

Literal contra referencia es exactamente la línea entre «se decide por sección» y «se pacta una vez». Lo confirma la fórmula de horas extras, `=$F$3*2`: `$F$3` es la mano de obra **de la misma hoja**, no del libro.

⚠️ Lo que esto **no** dice: no se midió si algún ejemplar del acervo tiene de hecho valores distintos entre dos secciones del mismo libro. Lo verificado es dónde vive el dato y de qué tipo es la celda, que es lo que fija el alcance. Queda escrito en `docs/comercial/MACHOTE-ESTRUCTURA-REAL.md` §2.2.

## Ningún machote cambia de precio

La capa intermedia —la del machote— es la que sostiene lo ya capturado. Una sección **sin `margenes` propios lee los del machote** y muestra exactamente los mismos números que mostraba. **No hay nada que migrar.** La primera vez que alguien toca un multiplicador, esa sección —y sólo esa— se queda con el suyo.

Hay una prueba dedicada a esto, porque si heredar fallara todos los machotes mostrarían la plantilla de golpe y cambiarían de precio solos.

## El revisador cambió de granularidad

Los hallazgos de multiplicadores ahora dicen **en qué sección**, y el botón «Ir a arreglarlo» abre **esa** hoja. Mientras fueron del machote daba igual; ahora mandar a la primera sección es mandar a la equivocada. (Antes apuntaban a `tab: 'gen'`, que es el DESGLOSE — una hoja donde la tabla de multiplicadores ni siquiera está.)

## Un bug que salió de paso

La pestaña `+` armaba la sección **a mano**, con un objeto literal, y nacía **vacía**: sin los diez renglones de mano de obra ni los treinta de materiales, cuando el machote real tiene exactamente diez por sección en los cinco ejemplares 2026 del acervo. Ahora la arma el motor (`seccionNueva`), que es lo que ya usaba el machote nuevo. Se descubrió porque la sección nueva también tenía que nacer con sus propios multiplicadores.

## Pruebas

`109 pasaron, 0 fallaron.` Cinco nuevas. La central **mide el almacén, no la pantalla**: que otra hoja pinte otro número podría ser un repintado perezoso; que el archivo tenga dos valores distintos no se puede fingir.

```
    sección 1 → 3.9 · sección 2 → 2.5 · almacén [3.9,"hereda"]
✓ mover un multiplicador en una sección NO toca a las demás
    9 % en las dos secciones · almacén 0.09, una sola vez
✓ las comisiones SÍ son de toda la cotización
    A (3) → 300 · B (hereda 2) → 200 · total 500
✓ el precio de una sección se mueve con SU multiplicador
    machote 1.67/1.7 → la sección sin propios muestra 1.67/1.7
✓ una sección sin multiplicadores propios hereda los del machote
    10 de mano de obra · 30 partidas · materiales 2.5
✓ una sección nueva nace completa y con sus multiplicadores
```

La tercera existe porque separar el **campo** y separar el **cálculo** no son lo mismo: comprueba que el multiplicador propio llega al precio de esa sección y no al de la otra.

## Verificado en pantalla

Sobre `M-1041`, cambiando Materiales a `3.9` en la sección 1:

```
Suministro y fabricación  → Materiales 3.9   ·  Comision FTS 5.5 %
Instalación en sitio      → Materiales 2.5   ·  Comision FTS 5.5 %

almacén:
  secciones[0].margenes = { materiales: 3.9 }
  secciones[1].margenes = null            ← hereda, no se enteró
  comision_fts          = 0.055           ← una sola vez, en el machote
```

Y la hoja lo dice, porque son dos tablas pegadas con reglas distintas y sin explicarlo se leen como una sola:

> Los cuatro multiplicadores son **de esta sección**; las dos comisiones son de toda la cotización.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013Qzhio6K8R23HXHnJ2RJ64

---
_Generated by [Claude Code](https://claude.ai/code/session_013Qzhio6K8R23HXHnJ2RJ64)_