### PR TITLE
fix(comercial/machote) V1.16: el multiplicador de la sección llega a los renglones, no sólo al total

### DIFF
--- a/comercial/machote/README.md
+++ b/comercial/machote/README.md
@@ -67,7 +67,7 @@ versión es peor que no tener indicador.
 | `js/pegar.js` | El pegado de tablas: separador, columnas y revisión previa. |
 | `js/almacen.js` | El autoguardado. UNA pieza entre la pantalla y donde viven los datos. |
 | `js/clientes.js` | El catálogo de clientes, leído de Odoo. Guarda el id, pinta el nombre. |
-| `tests/pruebas-navegador.js` | 109 pruebas de navegador. |
+| `tests/pruebas-navegador.js` | 111 pruebas de navegador. |
 
 ## Cómo se calcula el precio
 
@@ -117,6 +117,18 @@ El revisador también cambió de granularidad: los hallazgos de multiplicadores
 dicen **en qué sección**, y el botón «Ir a arreglarlo» abre esa hoja. Mientras
 fueron del machote daba igual; ahora mandar a la primera sección es mandar a la
 equivocada.
+
+⚠️ **El multiplicador de la sección tiene que llegar a los RENGLONES, no sólo al
+total.** En V1.15 no llegaba: la hoja pintaba cada línea llamando al motor **sin
+pasarle la sección**, así que el encabezado sumaba con el multiplicador de la
+sección y las líneas de abajo con el del machote. Dos verdades en la misma
+pantalla, y ninguna prueba lo veía porque todas miraban el motor o el almacén —
+nunca **lo pintado**.
+
+La prueba que lo fija no compara contra un número esperado, sino contra una
+**invariante**: *la suma de los renglones tiene que dar el total de su sección*.
+No necesita saber qué multiplicador le toca a cada renglón, y por eso sigue
+sirviendo cuando la tabla cambie.
 
 **Esto no es una preferencia de diseño: es lo que hace el machote real.** La
 tabla vive en `E1:F5` de **cada hoja de sección**, y ahí los cuatro

--- a/comercial/machote/js/app.js
+++ b/comercial/machote/js/app.js
@@ -40,7 +40,7 @@
    * 2026-09-03 (por instrucción de Esteban), pero lleva el suyo aparte y va en
    * V1.00. Planeación sigue en `2.4.1` y el kiosko sólo con cadena de build;
    * a esos no se propaga. */
-  const VERSION = 'V1.15';
+  const VERSION = 'V1.16';
   const $  = (s, r) => (r || document).querySelector(s);
   const $$ = (s, r) => Array.prototype.slice.call((r || document).querySelectorAll(s));
   const clon = (x) => JSON.parse(JSON.stringify(x));
@@ -651,7 +651,10 @@
       roles.forEach(rol => {
         let i = s.mo.findIndex(l => l.rol === rol.id);
         if (i < 0) { s.mo.push({ rol: rol.id, qty: '', personas: 1, pu: rol.pu, moneda: m.moneda }); i = s.mo.length - 1; }
-        const l = s.mo[i], cl = C.costoMo(l, m), p = 's:' + s.id + ':mo:' + i + ':';
+        // La SECCIÓN va al motor. Sin ella el renglón se calcula con los
+        // multiplicadores del machote y la hoja muestra dos verdades: el total
+        // de arriba con el de la sección, y la línea de abajo con el viejo.
+        const l = s.mo[i], cl = C.costoMo(l, m, s), p = 's:' + s.id + ':mo:' + i + ':';
         const vacia = !(Number(l.qty) > 0);
         // Verde = cantidad Y precio. Con sólo horas, el renglón está a medias y
         // no aporta un peso al total; pintarlo diría "listo" de algo que todavía
@@ -688,7 +691,7 @@
 
     // COSTO MATERIALES Y SERVICIOS
     const filasMat = (s.partidas || []).map((l, j) => {
-      const cl = C.costoPartida(l, m), p = 's:' + s.id + ':partidas:' + j + ':';
+      const cl = C.costoPartida(l, m, s), p = 's:' + s.id + ':partidas:' + j + ':';
       return '<tr' + (C.capturada(l) ? ' class="capturada"' : '') + '>' +
         // Pegar DESDE aquí hacia abajo. Va en la PRIMERA columna, y fija: al
         // final de trece columnas el botón caía fuera de la pantalla —medido:

--- a/comercial/machote/tests/pruebas-navegador.js
+++ b/comercial/machote/tests/pruebas-navegador.js
@@ -1700,6 +1700,120 @@ let ok = 0, mal = 0;
     console.log('    sección 1 → 3.9 · sección 2 → ' + enDos + ' · almacén ' + JSON.stringify(guardado));
   });
 
+  await paso('el multiplicador de la sección llega a los RENGLONES, no sólo al total', async () => {
+    /* El bug de V1.15: `hojaSeccion` llamaba al motor por renglón SIN pasarle
+     * la sección, así que cada línea se calculaba con los multiplicadores del
+     * machote mientras el total de arriba ya usaba los de la sección. La hoja
+     * mostraba DOS VERDADES a la vez y ninguna prueba lo veía, porque todas
+     * miraban el motor o el almacén — nunca lo pintado.
+     *
+     * La comprobación es una invariante que no depende de qué multiplicador
+     * toca a cada renglón: **la suma de los renglones tiene que dar el total
+     * de su propia sección**. Si las líneas usan otro multiplicador, no cuadra. */
+    await ir('#/m/M-1041');
+    await p.locator('.pestana').nth(1).click(); await p.waitForTimeout(300);
+    const cel = '[data-cel^="mg:"][data-cel$=":materiales"]';
+    await p.fill(cel, '3.9');
+    await p.dispatchEvent(cel, 'change');
+    await p.waitForTimeout(600);
+
+    const r = await p.evaluate(() => {
+      const num = (t) => Number(String(t || '').replace(/[^0-9.-]/g, '')) || 0;
+      /* Las DOS tablas de la hoja son `.rejilla.tarjetas` —mano de obra y
+       * materiales—, así que la clase no distingue: hay que buscarlas por lo
+       * que contienen. Pedir sólo la clase agarraba la de mano de obra y la
+       * prueba se caía con "no encontré un renglón de Materiales". */
+      const tabla = (marca) => [...document.querySelectorAll('.rejilla')]
+        .find(t => t.querySelector('[data-cel*=":' + marca + ':"]'));
+
+      const leer = (t) => {
+        const filas = [...t.querySelectorAll('tbody tr')].filter(x => !x.classList.contains('total'));
+        const suma = filas.reduce((a, f) => {
+          const c = f.querySelector('[data-l="Precio con utilidad"]');
+          return a + (c ? num(c.textContent) : 0);
+        }, 0);
+        const tr = t.querySelector('tr.total');
+        const tot = tr.querySelector('[data-l="Con utilidad"]');
+        return { suma: Math.round(suma), total: Math.round(num(tot && tot.textContent)) };
+      };
+
+      // Un renglón de materiales con precio, para leer su multiplicador pintado.
+      const mat = tabla('partidas');
+      if (!mat) return { error: 'no está la tabla de materiales' };
+      let mult = null, linea = null;
+      for (const f of mat.querySelectorAll('tbody tr')) {
+        if (f.classList.contains('total')) continue;
+        const tipo = f.querySelector('[data-cel$=":tipo"]');
+        const pu = f.querySelector('[data-cel$=":pu"]');
+        const pt = f.querySelector('[data-l="Precio total"]');
+        const cu = f.querySelector('[data-l="Precio con utilidad"]');
+        if (tipo && tipo.value === 'Materiales' && pu && num(pu.value) > 0) {
+          const mg = f.querySelector('[data-l="Margen"] input');
+          mult = mg ? (mg.value || mg.placeholder) : null;
+          linea = { costo: num(pt.textContent), conUtilidad: num(cu.textContent) };
+          break;
+        }
+      }
+      return { mat: leer(mat), mult: mult, linea: linea };
+    });
+
+    if (r.error) throw new Error(r.error);
+    if (!r.linea) throw new Error('no encontré un renglón de Materiales con precio');
+    if (Number(r.mult) !== 3.9)
+      throw new Error('el renglón pinta el multiplicador ' + r.mult + ', la sección tiene 3.9');
+    const esperado = Math.round(r.linea.costo * 3.9);
+    if (Math.abs(r.linea.conUtilidad - esperado) > 2)
+      throw new Error('el renglón vende ' + r.linea.conUtilidad + ', con 3.9 debía dar ' + esperado);
+    if (Math.abs(r.mat.suma - r.mat.total) > 2)
+      throw new Error('los renglones suman ' + r.mat.suma + ' y el total dice ' + r.mat.total +
+                      ': la hoja muestra dos verdades');
+    console.log('    renglón × 3.9 = ' + r.linea.conUtilidad +
+                ' · renglones ' + r.mat.suma + ' = total ' + r.mat.total);
+  });
+
+  await paso('en mano de obra el multiplicador pintado también es el de la sección', async () => {
+    /* La otra tabla, por la misma vía y con el mismo descuido: `costoMo`
+     * también se llamaba sin la sección. Aquí el multiplicador se pinta como
+     * texto, no como campo, así que se lee distinto — y por eso se prueba
+     * aparte en vez de confiar en que "es lo mismo". */
+    await ir('#/m/M-1041');
+    await p.locator('.pestana').nth(1).click(); await p.waitForTimeout(300);
+    const cel = '[data-cel^="mg:"][data-cel$=":mano_obra"]';
+    await p.fill(cel, '3.1');
+    await p.dispatchEvent(cel, 'change');
+    await p.waitForTimeout(600);
+
+    const r = await p.evaluate(() => {
+      const num = (t) => Number(String(t || '').replace(/[^0-9.-]/g, '')) || 0;
+      const t = [...document.querySelectorAll('.rejilla')]
+        .find(x => x.querySelector('[data-cel*=":mo:"]'));
+      const filas = [...t.querySelectorAll('tbody tr')]
+        .filter(x => !x.classList.contains('total') && x.querySelector('[data-cel*=":mo:"]'));
+      const mults = [...new Set(filas.map(f => {
+        const c = f.querySelector('[data-l="Margen"]');
+        return c ? c.textContent.trim() : null;
+      }).filter(Boolean))];
+      const suma = filas.reduce((a, f) => {
+        const c = f.querySelector('[data-l="Precio con utilidad"]');
+        return a + (c ? num(c.textContent) : 0);
+      }, 0);
+      const tr = t.querySelector('tr.total');
+      const tds = tr ? [...tr.querySelectorAll('td')].map(x => num(x.textContent)) : [];
+      return { mults, suma: Math.round(suma), tot: Math.max.apply(null, tds.concat([0])) };
+    });
+
+    // Mano de obra 3.1 → horas extras 6.2, y el programador sigue en el suyo.
+    if (r.mults.indexOf('3.1') < 0)
+      throw new Error('ningún renglón pinta 3.1; pinta: ' + JSON.stringify(r.mults));
+    if (r.mults.indexOf('6.2') < 0)
+      throw new Error('las horas extras no siguieron a mano de obra (3.1 × 2 = 6.2): ' +
+                      JSON.stringify(r.mults));
+    if (Math.abs(r.suma - r.tot) > 2)
+      throw new Error('los renglones suman ' + r.suma + ' y el total dice ' + r.tot);
+    console.log('    multiplicadores pintados ' + JSON.stringify(r.mults) +
+                ' · renglones ' + r.suma + ' = total ' + r.tot);
+  });
+
   await paso('las comisiones SÍ son de toda la cotización', async () => {
     /* La otra mitad de lo que pidió: "lo unico compartido es la comision de
      * fts y del usuario". Una prueba que sólo mirara la separación dejaría

--- a/comercial/machote/version.json
+++ b/comercial/machote/version.json
@@ -1,10 +1,15 @@
 {
-  "version": "V1.15",
+  "version": "V1.16",
   "fecha": "2026-09-04",
   "modulo": "comercial/machote",
   "ambito": "El CONTADOR es solo de este modulo. finanzas tambien usa V1.xx desde el 2026-09-03 (instruccion directa de Esteban, corrige el \"no propagar\" del issue #148) pero lleva su propio contador y va en V1.00. operaciones/planeacion sigue en 2.4.1, kiosk y confirmar-horas solo con cadena de build, y siete modulos con un 1.0.0 puesto una vez: a esos no se propaga.",
   "esquema": "V<mayor>.<menor de dos digitos>. Un incremento de 0.01 por cada merge a main. Al pasar de .99 sube el mayor y el menor vuelve a 00.",
   "historial": [
+    {
+      "version": "V1.16",
+      "pr": null,
+      "nota": "El multiplicador de la seccion ya llega a los RENGLONES, no solo al total. En V1.15 la hoja pintaba cada linea llamando al motor SIN pasarle la seccion, asi que el total de arriba usaba el de la seccion y las lineas de abajo el del machote: dos verdades en la misma pantalla. La prueba nueva no compara contra un numero esperado sino contra una invariante -la suma de los renglones tiene que dar el total de su seccion-, que es lo que ninguna prueba miraba"
+    },
     {
       "version": "V1.15",
       "pr": null,


### PR DESCRIPTION
## Lo que se reportó

> «ya estan independientes. pero ahora **el valor que se selecciona en cada seccion, no se aplica en las lineas de abajo** para mano de obra, materiales y servicios.»

Confirmado. **El bug es mío y es de V1.15.**

## La causa

En V1.15 cambié la firma del motor —`costoMo` y `costoPartida` reciben ahora la sección— y actualicé `totalSeccion`, pero **dejé sin tocar las dos llamadas de `app.js` que pintan los renglones**:

```js
// app.js, antes
const cl = C.costoMo(l, m)        // ← falta la sección
const cl = C.costoPartida(l, m)   // ← falta la sección
```

Ahí la sección llegaba `undefined` y las dos funciones caían al fallback: los multiplicadores **del machote**.

Resultado: **el encabezado de la sección sumaba con el multiplicador de la sección y las líneas de abajo con el del machote**. La hoja mostraba dos verdades a la vez.

## Por qué ninguna prueba lo vio

Las cinco pruebas de V1.15 miraban el **motor** (`calcular`, `margenes`) o el **almacén** (`localStorage`). Ninguna miraba **lo pintado**. El motor estaba bien; lo que estaba mal era la llamada desde la vista, y ese camino no tenía cobertura.

Es el mismo modo de falla que ya está escrito en CLAUDE.md §8 —«verificado = ejecutado y observado»— en una superficie nueva: el almacén correcto no prueba la pantalla correcta.

## La prueba que lo fija

No compara contra un número esperado, sino contra una **invariante**:

> la suma de los renglones tiene que dar el total de su sección

No necesita saber qué multiplicador le toca a cada renglón, así que sigue sirviendo cuando la tabla cambie. Si las líneas usan otro multiplicador que el total, no cuadra y punto.

Se prueba en **las dos tablas por separado**, porque el multiplicador se pinta distinto —campo en materiales, texto de sólo lectura en mano de obra— y confiar en que «es lo mismo» es exactamente como se coló este bug.

## Medido

```
    renglón × 3.9 = 31200 · renglones 1502400 = total 1502400
✓ el multiplicador de la sección llega a los RENGLONES, no sólo al total
    multiplicadores pintados ["3.1","4.4","6.2"] · renglones 146568 = total 146568
✓ en mano de obra el multiplicador pintado también es el de la sección

111 pasaron, 0 fallaron.
```

En mano de obra, con la sección en `3.1`: el `6.2` son las **horas extras** siguiendo a la mano de obra de esa sección (`=$F$3*2`), y el `4.4` es el **programador**, que no se tocó. Los tres valores conviviendo en la misma tabla son la prueba de que cada renglón toma el multiplicador que le corresponde, no uno global.

## Nota sobre una prueba

La de materiales falló en el primer intento con *«no encontré un renglón de Materiales con precio»* — **de la prueba, no del código**: las dos tablas de la hoja son `.rejilla.tarjetas`, así que la clase no distingue y mi selector agarró la de mano de obra. Ahora se buscan por lo que contienen (`[data-cel*=":partidas:"]` / `":mo:"`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013Qzhio6K8R23HXHnJ2RJ64

---
_Generated by [Claude Code](https://claude.ai/code/session_013Qzhio6K8R23HXHnJ2RJ64)_