### PR TITLE
Nómina V1.18 · editar una declaración ya capturada, sin volver a teclearla

### DIFF
--- a/modulos/rh/nomina-incidencias/css/nomina.css
+++ b/modulos/rh/nomina-incidencias/css/nomina.css
@@ -133,7 +133,11 @@ input:focus,select:focus{outline:2px solid var(--green-l);border-color:var(--gre
 .item .cuerpo{flex:1 1 auto;min-width:0}
 .item .tit{font-weight:600;font-size:14px}
 .item .det{font-size:12px;color:var(--muted2);margin-top:2px;line-height:1.5}
+.item .acciones{display:flex;gap:2px;flex:0 0 auto}
+.item .editar{background:transparent;border:0;color:var(--muted2);cursor:pointer;font-size:12px;padding:2px 4px}
+.item .editar:hover{color:var(--green-d);text-decoration:underline}
 .item .quitar{background:transparent;border:0;color:var(--red);cursor:pointer;font-size:12px;padding:2px 4px}
+.item.editando{border-color:var(--green);background:var(--green-l)}
 .add{width:100%;border:1px dashed var(--border);background:#fff;border-radius:10px;padding:9px;
   font-size:13px;color:var(--green-d);cursor:pointer}
 .add:hover{border-color:var(--green);background:var(--green-l)}

--- a/modulos/rh/nomina-incidencias/index.html
+++ b/modulos/rh/nomina-incidencias/index.html
@@ -16,7 +16,7 @@
        que se ve si el fetch de version.json no contesta (abrir el archivo por file://,
        Pages cacheando, red caída). Dejarlo atrasado convierte el badge en un falso
        negativo: el código es nuevo y la pantalla jura que es viejo. -->
-  <span class="badge" id="ver-badge">V1.17</span>
+  <span class="badge" id="ver-badge">V1.18</span>
   <button class="badge modo" id="modo-badge" title="Cambiar entre datos reales y modo práctica">REAL</button>
   <span class="sp"></span>
   <span class="guardado" id="guardado"></span>
@@ -108,15 +108,15 @@
      resultado es un badge que dice la version nueva corriendo el codigo viejo, y
      eso manda a buscar los bugs al lugar equivocado. El valor es el MISMO de
      version.json y del badge, y el gate exige que los tres coincidan. -->
-<script src="js/catalogo.js?v=V1.17"></script>
-<script src="js/logica.js?v=V1.17"></script>
-<script src="js/despacho.js?v=V1.17"></script>
-<script src="js/excel.js?v=V1.17"></script>
-<script src="js/indice.js?v=V1.17"></script>
-<script src="js/nom-auth.js?v=V1.17"></script>
-<script src="js/nom-client.js?v=V1.17"></script>
-<script src="js/nom-resolver.js?v=V1.17"></script>
-<script src="js/app.js?v=V1.17"></script>
+<script src="js/catalogo.js?v=V1.18"></script>
+<script src="js/logica.js?v=V1.18"></script>
+<script src="js/despacho.js?v=V1.18"></script>
+<script src="js/excel.js?v=V1.18"></script>
+<script src="js/indice.js?v=V1.18"></script>
+<script src="js/nom-auth.js?v=V1.18"></script>
+<script src="js/nom-client.js?v=V1.18"></script>
+<script src="js/nom-resolver.js?v=V1.18"></script>
+<script src="js/app.js?v=V1.18"></script>
 <script>
 (function () {
   'use strict';

--- a/modulos/rh/nomina-incidencias/js/app.js
+++ b/modulos/rh/nomina-incidencias/js/app.js
@@ -542,29 +542,49 @@
     }
     if (mm.def.no_costo) det.push('no es costo del proyecto: es un préstamo');
 
+    // Editar va ANTES de quitar y en gris: corregir un campo es lo de todos los días
+    // y borrar es lo excepcional. Sin esto, cambiar un solo dato —la clasificación de
+    // impuestos de un bono, por ejemplo— obligaba a borrar el renglón y volver a
+    // capturarlo entero, tirando el motivo, la fuente y el monto ya escritos.
+    var e = esEstado ? '1' : '';
     return '<div class="item"><div class="cuerpo"><div class="tit">' + esc(mm.def.label) + '</div>' +
       '<div class="det">' + esc(det.join(' · ')) + '</div></div>' +
-      '<button class="quitar" data-quitar="' + idx + '" data-est="' + (esEstado ? '1' : '') + '">quitar</button></div>';
+      '<div class="acciones">' +
+      '<button class="editar" data-editar="' + idx + '" data-est="' + e + '">editar</button>' +
+      '<button class="quitar" data-quitar="' + idx + '" data-est="' + e + '">quitar</button></div></div>';
   }
 
   // Formulario de alta: los campos cambian con el tipo elegido. Un formulario fijo con
   // todos los campos de los 26 tipos sería ilegible y pediría datos que no aplican.
-  function formulario(zonaId, soloEstados, alAgregar) {
+  // `previo` (opcional) es la declaración que se está corrigiendo. Cuando viene, el
+  // formulario es el MISMO —una sola definición de cómo se captura cada tipo— pero
+  // arranca lleno y el tipo queda fijo: cambiar el tipo no es editar, es capturar otra
+  // cosa, y los campos de un tipo no significan lo mismo en otro.
+  function formulario(zonaId, soloEstados, alAgregar, previo) {
     var zona = $(zonaId);
     if (!zona) return;
+    var editando = !!previo;
     var opts = '';
     for (var g in Cat.CATALOGO) {
       var G = Cat.CATALOGO[g];
       if (!!G.es_estado !== !!soloEstados) continue;
       opts += '<optgroup label="' + esc(G.titulo) + '">';
-      for (var t in G.items) opts += '<option value="' + t + '">' + esc(G.items[t].label) + '</option>';
+      for (var t in G.items) {
+        var sel = (editando && t === previo.tipo) ? ' selected' : '';
+        opts += '<option value="' + t + '"' + sel + '>' + esc(G.items[t].label) + '</option>';
+      }
       opts += '</optgroup>';
     }
+    var mmP = editando ? Cat.meta(previo.tipo) : null;
     zona.innerHTML = '<div class="box" style="margin-top:9px;border-color:var(--green)">' +
-      '<label for="ntipo">Tipo</label><select id="ntipo">' + opts + '</select>' +
+      (editando
+        ? '<label>Tipo</label><div class="derv" style="margin-top:0">Corrigiendo <b>' +
+          esc((mmP && mmP.def.label) || previo.tipo) + '</b>. Para cambiar de tipo, quita el renglón y captura el nuevo.</div>' +
+          '<select id="ntipo" style="display:none">' + opts + '</select>'
+        : '<label for="ntipo">Tipo</label><select id="ntipo">' + opts + '</select>') +
       '<div id="ncampos"></div>' +
       '<div style="display:flex;gap:8px;margin-top:12px">' +
-      '<button class="btn pri" id="nok">Agregar</button>' +
+      '<button class="btn pri" id="nok">' + (editando ? 'Guardar cambios' : 'Agregar') + '</button>' +
       '<button class="btn" id="ncancel">Cancelar</button></div></div>';
 
     function pintarCampos() {
@@ -607,28 +627,61 @@
       }
       $('ncampos').innerHTML = h;
 
+      // Precarga. Va aquí y no dentro del armado del HTML porque los campos se
+      // repintan cada vez que cambia el tipo, y el valor tiene que sobrevivir a eso.
+      // Solo se precarga si el tipo sigue siendo el de la declaración que se edita:
+      // si el usuario cambiara de tipo, los campos son otros y no hay qué precargar.
+      if (editando && tipo === previo.tipo) {
+        var V = previo.valores || {};
+        if (mm.def.multi) {
+          var R0 = (V.renglones || [])[0] || {};
+          if ($('c_monto')) $('c_monto').value = (R0.monto !== undefined && R0.monto !== null) ? R0.monto : '';
+          if ($('c_so')) $('c_so').value = R0.so || '';
+        } else {
+          var CC = mm.def.campos || [];
+          for (var q = 0; q < CC.length; q++) {
+            var nq = CC[q][0], tq = CC[q][2], eq = $('c_' + nq), vq = V[nq];
+            if (!eq || vq === undefined || vq === null) continue;
+            eq.value = (tq === 'bool') ? (vq === true ? '1' : '') : String(vq);
+          }
+        }
+        if ($('c_fuente') && previo.fuente) $('c_fuente').value = previo.fuente;
+      }
+
       var sel = $('c_fuente');
       if (sel) {
-        sel.addEventListener('change', function () {
+        var pintarDerv = function () {
           var d = Log.derivarFuente(sel.value);
           $('derv').innerHTML = d
             ? 'Empresa: <b>' + esc(d.empresa) + '</b> · Moneda: <b>' + esc(d.moneda) + '</b>'
             : 'La empresa y la moneda se derivan de la fuente.';
-        });
+        };
+        sel.addEventListener('change', pintarDerv);
+        pintarDerv();   // al editar, la fuente ya viene puesta: su derivación se ve desde el inicio
       }
     }
 
     $('ntipo').addEventListener('change', pintarCampos);
     pintarCampos();
 
-    $('ncancel').addEventListener('click', function () { zona.innerHTML = ''; });
+    function cerrarFormulario() {
+      zona.innerHTML = '';
+      if (zona.classList.contains('zona-edicion') && zona.parentNode) zona.parentNode.removeChild(zona);
+      var marcado = $('dbody') && $('dbody').querySelector('.item.editando');
+      if (marcado) marcado.classList.remove('editando');
+    }
+    $('ncancel').addEventListener('click', cerrarFormulario);
     $('nok').addEventListener('click', function () {
       var tipo = $('ntipo').value, mm = Cat.meta(tipo);
       if (!mm) return;
       var reg = { tipo: tipo, valores: {} };
 
       if (mm.def.multi) {
-        reg.valores.renglones = [{ monto: Number($('c_monto').value) || 0, so: $('c_so').value || '' }];
+        // El formulario captura UN renglón. Si la declaración traía más, los demás se
+        // conservan intactos: editar el primero no puede borrar en silencio los otros.
+        var resto = (editando && previo.tipo === tipo)
+          ? ((previo.valores && previo.valores.renglones) || []).slice(1) : [];
+        reg.valores.renglones = [{ monto: Number($('c_monto').value) || 0, so: $('c_so').value || '' }].concat(resto);
       } else {
         var C = mm.def.campos || [];
         for (var i = 0; i < C.length; i++) {
@@ -639,7 +692,7 @@
         }
       }
       if (mm.def.fuente) reg.fuente = $('c_fuente') ? $('c_fuente').value : '';
-      zona.innerHTML = '';
+      cerrarFormulario();
       alAgregar(reg);
     });
   }
@@ -693,6 +746,43 @@
         var p = persona(ACTIVO);
         (est ? p.estados : p.declaraciones).splice(idx, 1);
         SUCIO = true; pintarCajon(); refrescar();
+      });
+    }
+
+    // Editar: el formulario se abre DEBAJO del renglón que se corrige y ese renglón
+    // se resalta. Abrirlo al final de la lista, como el de alta, dejaría a Magaly
+    // adivinando cuál de los cinco bonos está tocando.
+    var es = $('dbody').querySelectorAll('[data-editar]');
+    for (var k = 0; k < es.length; k++) {
+      es[k].addEventListener('click', function (ev) {
+        var idx = Number(ev.currentTarget.getAttribute('data-editar'));
+        var est = ev.currentTarget.getAttribute('data-est') === '1';
+        var p = persona(ACTIVO);
+        var lista = est ? p.estados : p.declaraciones;
+        var previo = lista[idx];
+        if (!previo) return;
+
+        var item = ev.currentTarget.closest('.item');
+        // Un solo editor abierto a la vez: dos formularios llenos con datos de dos
+        // renglones distintos es la forma de guardar uno encima del otro.
+        var abierto = $('dbody').querySelector('.zona-edicion');
+        if (abierto) abierto.parentNode.removeChild(abierto);
+        var previoResaltado = $('dbody').querySelector('.item.editando');
+        if (previoResaltado) previoResaltado.classList.remove('editando');
+
+        var zona = document.createElement('div');
+        zona.id = 'zonaEdit';
+        zona.className = 'zona-edicion';
+        item.parentNode.insertBefore(zona, item.nextSibling);
+        item.classList.add('editando');
+
+        formulario('zonaEdit', est, function (reg) {
+          // Se reemplaza EN SU LUGAR: el orden de los renglones es el que Magaly
+          // capturó y el que sale en el archivo del despacho. Quitar y volver a
+          // agregar mandaría el renglón corregido al final.
+          lista[idx] = reg;
+          SUCIO = true; pintarCajon(); refrescar();
+        }, previo);
       });
     }
   }

--- a/modulos/rh/nomina-incidencias/version.json
+++ b/modulos/rh/nomina-incidencias/version.json
@@ -1,10 +1,15 @@
 {
-  "version": "V1.17",
-  "fecha": "2026-09-04",
+  "version": "V1.18",
+  "fecha": "2026-09-05",
   "modulo": "rh/nomina-incidencias",
   "esquema": "V<mayor>.<menor de dos digitos>. Un incremento de 0.01 por cada merge a main. Al pasar de .99 sube el mayor y el menor vuelve a 00.",
   "ambito": "El CONTADOR es solo de este modulo. finanzas, comercial/machote y operaciones/carga-mo usan el mismo esquema con contadores PROPIOS (ver sus version.json): que aqui vaya en V1.16 y carga-mo en V1.00 es lo correcto, no un desfase — son modulos distintos que avanzan por separado. operaciones/planeacion sigue en 2.4.1; kiosk y confirmar-horas solo con cadena de build.",
   "historial": [
+    {
+      "version": "V1.18",
+      "pr": null,
+      "nota": "Editar una declaracion ya capturada. Antes solo se podia QUITAR y volver a capturar: para cambiar un solo campo —la clasificacion de impuestos que estreno la V1.17, por ejemplo— habia que tirar el monto, el motivo y la fuente ya escritos y teclearlos de nuevo. Ahora cada renglon ofrece 'editar' junto a 'quitar', el formulario abre DEBAJO del renglon que se corrige (no al final de la lista, donde no se sabria cual se esta tocando), ese renglon queda resaltado, y los campos arrancan llenos con la derivacion de la fuente ya a la vista. Es el MISMO formulario del alta, no una copia: una sola definicion de como se captura cada tipo. El tipo queda FIJO al editar —cambiarlo no es corregir, es capturar otra cosa, y los campos de un tipo no significan lo mismo en otro. Se reemplaza en su lugar para no mandar el renglon corregido al final del archivo del despacho, solo hay un editor abierto a la vez, y en un bono de proyecto con varios renglones se conservan los que el formulario no captura."
+    },
     {
       "version": "V1.17",
       "pr": null,

--- a/tests/visual-nomina.js
+++ b/tests/visual-nomina.js
@@ -265,6 +265,61 @@ const VIEWPORTS = [
     check('y se marca que no es costo del proyecto', /no es costo/.test(await page.textContent('#dbody')));
     await page.screenshot({ path: path.join(OUT, nombre + '-3-declarado.png') });
 
+    // ── Editar la declaración que se acaba de capturar ──
+    // Sin esto, corregir UN campo obligaba a borrar el renglón y volver a capturarlo
+    // entero: se tiraba el monto, el plazo y la fuente para cambiar una sola cosa.
+    // Samuel YA traía declaraciones antes de esta prueba, así que el anticipo recién
+    // capturado es el ÚLTIMO renglón, no el índice 0. Apuntar al 0 editaría el bono
+    // que ya tenía — que es justo el error que este botón debe hacer imposible.
+    const nItems = (await page.$$('#dbody .item')).length;
+    const ultimo = String(nItems - 1);
+    check('cada renglón capturado ofrece editar', await page.isVisible('[data-editar="' + ultimo + '"]'));
+    await page.click('[data-editar="' + ultimo + '"]');
+    await page.waitForSelector('#zonaEdit #ntipo', { state: 'attached' });
+
+    check('el editor arranca con el monto ya puesto',
+      (await page.inputValue('#c_monto')) === '3500', await page.inputValue('#c_monto'));
+    check('y con el plazo', (await page.inputValue('#c_plazo')) === '4', await page.inputValue('#c_plazo'));
+    check('y con la fuente que se eligió', (await page.inputValue('#c_fuente')) === 'J122',
+      await page.inputValue('#c_fuente'));
+    check('la derivación de la fuente se ve desde que abre, sin tocar nada',
+      /FTS LLC/.test(await page.textContent('#derv')), await page.textContent('#derv'));
+    check('el tipo queda fijo: corregir no es cambiar de concepto',
+      !(await page.isVisible('#zonaEdit select#ntipo')) &&
+      /Corrigiendo/.test(await page.textContent('#zonaEdit')));
+    check('el botón dice guardar, no agregar',
+      /Guardar cambios/.test(await page.textContent('#zonaEdit #nok')),
+      await page.textContent('#zonaEdit #nok'));
+    check('el renglón que se edita queda resaltado', await page.isVisible('.item.editando'));
+
+    const antesEdit = (await page.$$('#dbody .item')).length;
+    await page.screenshot({ path: path.join(OUT, nombre + '-3b-editando.png') });
+
+    // Cancelar no debe dejar rastro ni tocar el dato.
+    await page.click('#ncancel');
+    await page.waitForTimeout(60);
+    check('cancelar cierra el editor sin dejar hueco', !(await page.$('#zonaEdit')));
+    check('ni renglones resaltados', !(await page.$('.item.editando')));
+    check('y no cambió nada', /3500/.test(await page.textContent('#dbody')),
+      (await page.textContent('#dbody')).slice(0, 90));
+
+    // Ahora sí: corregir el monto y guardar.
+    await page.click('[data-editar="' + ultimo + '"]');
+    await page.waitForSelector('#c_monto');
+    await page.fill('#c_monto', '4200');
+    await page.click('#zonaEdit #nok');
+    await page.waitForTimeout(80);
+    const dTxt = await page.textContent('#dbody');
+    check('el monto corregido queda guardado', /4200/.test(dTxt), dTxt.slice(0, 120));
+    check('y el viejo ya no está', !/3500/.test(dTxt));
+    check('sigue siendo UN renglón, no se duplicó',
+      (await page.$$('#dbody .item')).length === antesEdit,
+      (await page.$$('#dbody .item')).length + ' vs ' + antesEdit);
+    check('el resto del renglón se conservó (plazo y fuente)',
+      /4 semanas|Semanas para pagarlo: 4/.test(dTxt) && /J122/.test(dTxt), dTxt.slice(0, 200));
+    check('el editor se cerró solo al guardar', !(await page.$('#zonaEdit')));
+    await page.screenshot({ path: path.join(OUT, nombre + '-3c-editado.png') });
+
     await page.click('#dcerrar');
     await page.waitForTimeout(60);
     check('el cajón se cierra', !(await page.$('#drawer[open]')));


### PR DESCRIPTION
Antes solo se podía **quitar** y capturar de nuevo. Para cambiar un solo campo —la clasificación de impuestos que estrenó la V1.17, por ejemplo— había que tirar el monto, el motivo y la fuente ya escritos y volver a escribirlos.

Ahora cada renglón ofrece **«editar»** junto a «quitar».

## Las decisiones valen más que el botón

**El formulario abre debajo del renglón que se corrige, y ese renglón queda resaltado.** Abrirlo al final de la lista, como el de alta, dejaría a Magaly adivinando cuál de los cinco bonos está tocando.

**Es el MISMO formulario del alta, con un parámetro más.** Una copia habría significado dos definiciones de cómo se captura cada tipo — y el día que se agregue un campo, como acaba de pasar, una de las dos se queda atrás.

**El tipo queda fijo al editar.** Cambiar «Bono de productividad» por «Vacaciones» no es corregir: es capturar otra cosa, y los campos de un tipo no significan lo mismo en otro. Se dice con todas sus letras en el formulario, con qué hacer en su lugar.

**Se reemplaza en su lugar, no quitar-y-agregar.** El orden de los renglones es el que Magaly capturó y el que sale en el archivo del despacho; corregir uno no debe mandarlo al final.

**Un solo editor abierto a la vez.** Dos formularios llenos con datos de dos renglones distintos es la forma de guardar uno encima del otro.

**En un bono de proyecto con varios renglones**, el formulario captura uno y los demás se conservan intactos. Editar el primero no puede borrar en silencio los otros.

**La derivación de la fuente se pinta al abrir**, no solo al cambiarla: al editar, la fuente ya viene puesta y su empresa/moneda tenían que verse desde el inicio.

**«Cancelar» quita la zona inyectada y apaga el resaltado.** Vaciarla nada más dejaba un hueco y el renglón marcado como si siguiera en edición.

## Test plan

- [x] `visual-nomina` **119 → 167** en tres anchos. Se ejercita en el navegador real: se captura un anticipo, se abre su editor, y se comprueba que arranca con el monto, el plazo y la fuente puestos y la derivación visible; que el tipo no se puede cambiar; que cancelar no deja hueco, ni resaltado, ni toca el dato; y que al guardar el monto cambia, **no se duplica el renglón** y el resto se conserva.
- [x] **La primera corrida falló con `2500` donde esperaba `3500`.** Samuel ya traía declaraciones, así que la recién capturada es la **última**, no la 0. El fallo fue del test —el editor precargaba bien— y editar el renglón equivocado es justo lo que este botón hace imposible.
- [x] `gate-nomina` 246 · `gate-cruce-rh` 97 · `visual-cargamo` 123.
- [x] Revisado a ojo en las capturas de los tres anchos.

Nómina **V1.17 → V1.18**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MDYMMPYZdLqWQCVfuZUAC6

---
_Generated by [Claude Code](https://claude.ai/code/session_01MDYMMPYZdLqWQCVfuZUAC6)_