### PR TITLE
docs(comercial): reversión del lote L3 + mapeo de 5 etapas en el ROADMAP

### DIFF
--- a/docs/comercial/LIMPIEZA-CORRIDA-2026-08-30.md
+++ b/docs/comercial/LIMPIEZA-CORRIDA-2026-08-30.md
@@ -5,11 +5,19 @@ Ejecución de los lotes L1–L4 autorizados en el issue #131, con el workflow
 
 **Resultado: 1,859 leads → 154 vivos.** 1,705 archivados, ninguno borrado.
 
+> ⚠️ **Dos decisiones de esta corrida se revirtieron el 4-sep-2026.** Los ganados
+> volvieron a estar activos y *Qualified* volvió a ser etapa propia. Lo de abajo
+> queda como el registro de lo que pasó el 30-ago; el estado vigente está en
+> [Reversiones — 4-sep-2026](#reversiones--4-sep-2026), al final.
+
 ---
 
 ## Conteos por etapa
 
 De **12 etapas a 4**. Ninguna se borró: las fusionadas quedan vacías.
+
+> Vigente desde el 4-sep-2026: **5 etapas de pipeline + Ganado**. *Qualified* (21)
+> volvió y *Proyecto Ganado* (8) volvió a activo. Ver las reversiones al final.
 
 | Etapa | Antes | Después | Qué pasó |
 |---|---:|---:|---|
@@ -107,3 +115,127 @@ updates mientras las notas siguen pendientes — no confundir "el conteo ya cuad
   por dándole, con el invariante escrito: *estaban `active=true`; restaurar =
   `active:true` + `stage_id` del grupo + `dndole` del grupo + `lost_reason_id:false`*.
 - `dump-pre-limpieza-so-usd-20260829.json.gz` — las 231 SO del universo de L6.
+
+---
+
+## Reversiones — 4-sep-2026
+
+Dos decisiones del 30-ago se revirtieron. Ninguna toca los 1,185 de CANCELADO,
+que se quedan archivados.
+
+### R3 · Se desarchivan los 532 "Proyecto Ganado"
+
+**Qué se revirtió.** El lote L3 archivó 532 leads en etapa *Proyecto Ganado*
+(los 530 que ya estaban ahí más los 2 que L2 fusionó desde *Proyecto Ganado -
+Con PO*). Vuelven a `active=true`, en la misma etapa.
+
+**Por qué.**
+
+1. **Se desviaba de la convención de Odoo:** lo ganado se queda activo, lo
+   cancelado se archiva. Nosotros archivábamos ambos, con lo que el archivado
+   dejó de significar "esto se canceló" y pasó a significar "esto no quiero
+   verlo en la hoja".
+2. **Los ganados son el histórico** que el asistente del machote
+   ([#148](https://github.com/yinyo1/fts-suite/issues/148)) necesita consultar.
+   Archivado los vuelve más difíciles de alcanzar: todo consumidor tiene que
+   acordarse de pedir `active in [true, false]` — el mismo `active_test`
+   implícito que ya mordió en Carga MO (§19 de `CLAUDE.md`).
+
+**La regla que queda.** La etapa decide qué se ve; el archivado se reserva para
+cancelados; **filtrar pipeline vivo es trabajo de la vista**, no del estado
+global del registro. Queda escrita en el ROADMAP (§5.4).
+
+**Cómo se ejecutó.** Por el mismo workflow `comercial/limpieza-2026-08`
+(`buJ1oxU7OpwVCxlk`), con un lote nuevo **`R3`** que **reusa la misma lista
+congelada** `L3.ids` del JSON pineado por SHA `5127bedd` — no re-deriva nada, y
+la acción es la inversa exacta: `active=true`. No toca `stage_id`, ni
+`x_studio_dndole`, ni `lost_reason_id`.
+
+**Verificación previa (antes de escribir).** Los ids salieron del respaldo en
+SharePoint (`rollback-estado-previo-leads-20260829.json`), no de una derivación
+nueva: `por_etapa["8"]` = 530 ids **+** `por_etapa["4"]` = 2 ids (48 y 1398) =
+**532**, idénticos id por id a la lista congelada. Contra Odoo, los 532 estaban
+`active=false` en stage 8 — un solo grupo, sin sobrantes ni faltantes.
+
+**Ejecución.** `87421`, manual, `success`, 00:09:12 → 00:15:55 UTC (6m43s).
+532 desarchivados + 532 notas de chatter. Antes, un dry-run (`87408`) confirmó
+532 ids planeados, una sola nota distinta y **solo tres claves por operación**
+(`_ruta`, `lead_id`, `nota`) — o sea, ningún otro campo en el payload.
+
+Nota de chatter en cada uno:
+
+> `[reversion-2026-09] L3 los había archivado; se desarchivan porque lo ganado se`
+> `queda activo en Odoo y el historial debe seguir consultable.`
+
+### Qualified (21) vuelve como etapa propia
+
+L2 la había fusionado en *Lead Calificado/Por cotizar* (15). Montalvo confirmó
+que **tiene uso real de proceso**, así que vuelve. **Esteban ya había movido los
+leads a mano** antes de esta corrida (`write_date` 2026-09-04 23:32–23:34 UTC =
+17:32 CST): los 9 de la lista —1879, 2080, 2128, 2134, 2153, 2190, 2197, 2198,
+2200— **más un décimo, el 2189** ("Enchaquetado de reactores quimicos"), que
+venía de la etapa 15. CC no escribió nada aquí: solo verificó y reporta.
+
+En Odoo *Qualified* tiene `sequence=3`, o sea va **después** de *Cotizacion
+Enviada* (`sequence=2`), no antes.
+
+### Conteos medidos contra Odoo
+
+Medidos con `odoo_agrupar` sobre `crm.lead`, no leídos del reporte del workflow.
+"Antes" = 2026-09-04 ~23:40 UTC, justo antes de escribir.
+
+| Etapa | Activos antes | Activos después | Archivados antes | Archivados después |
+|---|---:|---:|---:|---:|
+| Prospecto Lead (17) | 23 | 23 | 0 | 0 |
+| Lead Calificado/Por cotizar (15) | 34 | **35** | 0 | 0 |
+| Cotizacion Enviada (5) | 54 | 54 | 2 | 2 |
+| Qualified (21) | 10 | 10 | 0 | 0 |
+| Proyecto Ganado (8) | 0 | **532** | 532 | **0** |
+| Revisar (18) | 44 | 44 | 0 | 0 |
+| CANCELADO (9) | 0 | 0 | 1,185 | 1,185 |
+| **Total** | **165** | **698** | **1,719** | **1,187** |
+
+Los archivados quedan en **1,187**: los 1,185 de CANCELADO más 2 sueltos en
+*Cotizacion Enviada*. Es el número esperado.
+
+**El +1 de la etapa 15 no es de esta corrida.** Es el lead **2224**
+("Reubicación de Chillers entre Posiciones"), creado a las 23:56:37 UTC, en
+medio de la ventana. Se anota para que el delta no quede sin explicar: R3 solo
+tocó ids de la etapa 8.
+
+**Estado de los 532 después** (read-back independiente): los 532 en un solo
+grupo `stage_id=8, active=true`; **`lost_reason_id` vacío en los 532**;
+`x_studio_dndole` intacto (29 Aldo · 40 Angel · 11 Diego · 4 Esteban · 26
+Montalvo · 26 Yusti · 396 sin valor — los valores de ex-FTS siguen ahí porque L4
+solo tocó los leads vivos, no los ganados).
+
+Crudo de tres de ellos, incluidos los 2 que venían de la etapa 4:
+
+```
+id   name                                  active stage_id        dndole  lost_reason_id  write_date (UTC)
+48   Tope de puerta Merik Cedis guadalupe  si     Proyecto Ganado                         2026-09-05 00:09:16
+1398 5S in the Warehouse                   si     Proyecto Ganado  Yusti                  2026-09-05 00:11:47
+2195 Suministro e instalación de injerto…   si     Proyecto Ganado                        2026-09-05 00:12:36
+```
+
+**Lo único no verificado contra Odoo: las notas de chatter.** El MCP de Odoo
+tiene `mail.message` en denylist dura, así que no se pueden leer desde CC. La
+evidencia es el reporte del workflow —el nodo `Odoo - Nota chatter` entregó
+**532 items**, ejecución en `success`, sin error— que es el reporte del proceso,
+no la medición del destino. Spot check para Esteban: abrir el lead 48 en Odoo y
+ver la nota `[reversion-2026-09]` en el chatter.
+
+### Cambio en el workflow
+
+`comercial/limpieza-2026-08` pasó de 13 a 14 nodos. El diff se verificó
+server-side (`get_workflow_versions_diff`) y son exactamente tres cosas:
+
+- nodo nuevo `Odoo - R3 desarchivar` (`crm.lead` update, `active` = `={{ true }}`);
+- `Code - Plan`: dos hunks — `'R3'` agregado a `LOTES` y la rama `R3`. El resto
+  del código quedó byte a byte igual, incluidas las seis reglas del Switch;
+- séptima salida del Switch para `R3`; el fallback `SinEscribir` pasó al índice 7.
+
+Llave de reversa: versión `66d15ff6-5dbc-4962-8971-ce96893d8d61` (la del 30-ago),
+restaurable con `restore_workflow_version`. El workflow sigue **inactivo y sin
+versión publicada** — por eso R3 corrió en modo manual, igual que los lotes del
+30-ago.

--- a/docs/comercial/ROADMAP.md
+++ b/docs/comercial/ROADMAP.md
@@ -95,9 +95,23 @@ Cierran las preguntas abiertas de la auditoría (#130 §6) y son el alcance de l
 
 1. **Etapas: consolidar 12 → 6.** Prospecto · Por cotizar · Cotización enviada · Revisar · Ganado (`is_won`) · Perdido (lost). Las variantes por cliente ("Adiccionales Topo (Monty)", "Cot Enviada Mdlz") se absorben con **tag por cliente, no etapa**. "Proyecto Ganado - Con PO" se fusiona a Ganado.
    > Precisión de implementación (sesión 1): en Odoo "Perdido" **no es una etapa**, es `active=false` + `lost_reason_id`. Son **5 filas de `crm.stage` + el mecanismo lost**, no 6 etapas.
+   >
+   > **Corrección (sesión 3, 4-sep-2026): el mapeo vivo es de 5 etapas de pipeline, no de 4.** La corrida del 30-ago dejó 4 etapas con leads vivos porque fusionó *Qualified* en *Por cotizar* y archivó *Proyecto Ganado*. Montalvo confirmó que **Qualified tiene uso real de proceso**, así que vuelve como etapa propia, y la reversión de L3 devuelve *Proyecto Ganado* a activo. **Este es el mapeo sobre el que se construye la hoja del CRM 1.0** (`sequence` es el orden real en Odoo, no el orden en que se listan aquí):
+   >
+   > | # | Etapa | `stage_id` | `sequence` | Papel |
+   > |---|---|---:|---:|---|
+   > | 1 | Prospecto Lead | 17 | 0 | pipeline |
+   > | 2 | Lead Calificado/Por cotizar | 15 | 1 | pipeline |
+   > | 3 | Cotizacion Enviada | 5 | 2 | pipeline |
+   > | 4 | Qualified | 21 | 3 | pipeline |
+   > | 5 | Revisar | 18 | 9 | pipeline (bandeja de triage) |
+   > | — | Proyecto Ganado | 8 | 5 | **terminal ganado** (`is_won`), activo — no es pipeline vivo |
+   > | — | *Perdido* | — | — | **no es etapa**: `active=false` + `lost_reason_id` (los cancelados conservan `stage_id=9` archivados) |
+   >
+   > Son **5 etapas de pipeline + Ganado + el mecanismo lost**. *Proyecto Ganado* es la única fila con `is_won=true`. Las etapas fusionadas (3, 4, 12, 14, 20) siguen existiendo vacías; ninguna se borró.
 2. **Leads de ex-FTS: reasignar por cartera.** La hoja `06_Clientes-Usuarios` del tracker de SharePoint es la tabla de dueño por cuenta (`comercial/data/clientes-usuarios.csv`). Dueños **vigentes**: Aldo, Montalvo, Esteban. Dueños **no vigentes** en la hoja (Diego, Luis, Rissia) → reparto por cartera vigente (26-ago-2026): Aldo → Magnekon, GRUMA/Mission Foods (fuera de Hayward), Corporate USA, Bridgestone, ABB, GEPP, Budenheim · Montalvo → Nalco, Vertiv, Topo Chico, Johnson Controls/Clarios, Chemtreat, Quimitec, Mondelez, Forza · Ricardo → Hayward y Calbee · Esteban → Robert Barrera y corporativos. Sin dueño vigente ni cartera → etapa Revisar, `dndole` vacío. **Decisión reversible**: se corrige en la primera revisión semanal.
    > Hallazgo de la sesión 1: el universo real son **50 leads**, no 331 — los otros 281 están en CANCELADO o Ganado y los archivan L1/L3.
-3. **Los "Proyecto Ganado" activos se archivan** (won cerrado). La hoja solo muestra pipeline vivo.
+3. ~~**Los "Proyecto Ganado" activos se archivan** (won cerrado). La hoja solo muestra pipeline vivo.~~ **REVERTIDA (sesión 3, 4-sep-2026).** Los 532 leads que L3 archivó se desarchivaron; se quedan **activos** en la etapa *Proyecto Ganado*. Dos razones: (a) se desviaba de la convención de Odoo —lo ganado se queda activo, lo cancelado se archiva— y nosotros archivábamos ambos; (b) los ganados son el histórico que el asistente del machote ([#148](https://github.com/yinyo1/fts-suite/issues/148)) necesita consultar, y archivado los vuelve más difíciles de alcanzar. La intención original —que la hoja muestre solo pipeline vivo— sigue en pie, pero se resuelve en la vista, no en el estado global del registro: ver §5.4.
 4. **Login comercial separado de Finanzas: sí.** Usuarios iniciales: Esteban, Aldo, Montalvo, Ricardo, Pablo. Se construye en sesión 2 (ver §5.2).
 5. **Carpetas:** el módulo se queda en `comercial/` con `core/` y `crm/`. `app/` se reserva para una migración general del Suite.
 6. **`x_studio_dndole` se queda como selection en 1.0.** Se depura (fuera ex-FTS) y se agregan los valores faltantes de los 5 usuarios.
@@ -105,6 +119,16 @@ Cierran las preguntas abiertas de la auditoría (#130 §6) y son el alcance de l
 8. **Watchdog al equipo hasta la sesión 5.** Antes, watchdog v2 (señal `mail.message`, no `write_date`) en canary solo a Esteban.
 9. **Las `sale.order` de FTS MX marcadas en USD se corrigen en la sesión 1**, universo histórico completo (las no canceladas), como lote aparte con dry-run.
    > Hallazgo de la sesión 1: **solo la etiqueta de moneda está mal, los montos ya están en pesos** (SO5989 marcada USD $44,240.21 ↔ su factura posteada INV1688 en MXN por exactamente 44,240.21). La corrección cambia `currency_id` y **no convierte montos**. La causa raíz (de dónde sale el default USD) sigue abierta y el problema está acelerando: 76 de 190 casos son de 2026.
+
+## 5.4 Regla: la etapa decide qué se ve; el archivado se reserva para cancelados
+
+Establecida en la sesión 3 (4-sep-2026) al revertir L3. Aplica a todo `crm.lead`:
+
+- **La etapa es lo que decide qué se ve.** El estado de un lead se expresa con `stage_id` (y con `is_won` para el terminal ganado), no apagándolo.
+- **El archivado (`active=false`) se reserva para cancelados**, junto con `lost_reason_id`. Es el mecanismo *lost* de Odoo y no debe usarse como filtro de visibilidad.
+- **Filtrar pipeline vivo es trabajo de la vista**, no del registro. La hoja del CRM 1.0 excluye *Proyecto Ganado* con un filtro por etapa; el lead sigue activo y consultable por cualquier otro consumidor.
+
+El costo de romper esta regla ya se pagó: archivar los ganados los sacó del alcance del histórico que consulta el asistente del machote (#148), a cambio de una limpieza visual que la vista podía dar gratis. **Un registro se archiva por lo que le pasó, no por quién no quiere verlo.**
 
 ## 5.2 Punto transversal: identidad
 


### PR DESCRIPTION
Documentación de las dos reversiones ejecutadas hoy sobre la limpieza del 30-ago (#131). **Solo docs** — la escritura a Odoo ya ocurrió, esto la deja registrada.

## Qué se revirtió en Odoo

**R3 — los 532 "Proyecto Ganado" vuelven a estar activos.** El lote L3 los había archivado. Dos razones: se desviaba de la convención de Odoo (lo ganado se queda activo, lo cancelado se archiva; nosotros archivábamos ambos) y los ganados son el histórico que el asistente del machote (#148) necesita consultar.

**Qualified (21) vuelve como etapa propia.** L2 la había fusionado en 15. Montalvo confirmó que tiene uso real de proceso. Esteban ya había movido los leads a mano antes de esta corrida; CC solo verificó y reporta.

Los 1,185 de CANCELADO **no se tocaron**.

## Cambios en este PR

- `docs/comercial/LIMPIEZA-CORRIDA-2026-08-30.md` — sección nueva **Reversiones — 4-sep-2026**: qué se revirtió, por qué, cómo se ejecutó, los conteos antes/después medidos contra Odoo, el crudo de tres registros, y el diff del workflow. Aviso arriba del documento para que nadie lea los conteos del 30-ago como estado vigente.
- `docs/comercial/ROADMAP.md` — corrige el documento rector (#127):
  - decisión 1: el mapeo vivo es de **5 etapas de pipeline, no de 4**, con la tabla de `stage_id` y `sequence` leídos de Odoo — es la base sobre la que se construye la hoja del CRM 1.0;
  - decisión 3 (archivar los ganados): marcada **REVERTIDA**;
  - **§5.4 nueva**: la etapa decide qué se ve; el archivado se reserva para cancelados; filtrar pipeline vivo es trabajo de la vista.

## Conteos medidos contra Odoo

| | Antes | Después |
|---|---:|---:|
| Activos | 165 | **698** |
| Archivados | 1,719 | **1,187** |

Los 1,187 son los 1,185 de CANCELADO más 2 sueltos en *Cotizacion Enviada*. Desglose por etapa en el documento.

## Verificación

- Los 532 ids salieron del respaldo en SharePoint (`por_etapa["8"]` = 530 **+** `por_etapa["4"]` = 2), idénticos id por id a la lista congelada del repo. Contra Odoo, los 532 estaban `active=false` en stage 8 antes de escribir — sin sobrantes ni faltantes.
- Read-back independiente después: los 532 en un solo grupo `stage_id=8, active=true`, `lost_reason_id` vacío en los 532, `x_studio_dndole` intacto.
- **No verificado contra Odoo:** las notas de chatter — `mail.message` está en denylist dura del MCP. La evidencia es el reporte del workflow (532 items, ejecución en `success`). Spot check en el documento.

## Cambio en el workflow (fuera de este PR)

`comercial/limpieza-2026-08` (`buJ1oxU7OpwVCxlk`) pasó de 13 a 14 nodos: un lote **`R3`** que reusa la misma lista congelada `L3.ids` del JSON pineado por SHA y aplica la acción inversa. El diff se verificó server-side y son exactamente el nodo nuevo, dos hunks en `Code - Plan` y la séptima salida del Switch. Llave de reversa: versión `66d15ff6-5dbc-4962-8971-ce96893d8d61`. Sigue inactivo y sin versión publicada.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018yVb4vawBnV7VRsumDG6oi