### PR TITLE
feat(comercial/machote) V1.17: respaldo — lo capturado deja de poder perderse

### DIFF
--- a/comercial/machote/README.md
+++ b/comercial/machote/README.md
@@ -67,7 +67,8 @@ versión es peor que no tener indicador.
 | `js/pegar.js` | El pegado de tablas: separador, columnas y revisión previa. |
 | `js/almacen.js` | El autoguardado. UNA pieza entre la pantalla y donde viven los datos. |
 | `js/clientes.js` | El catálogo de clientes, leído de Odoo. Guarda el id, pinta el nombre. |
-| `tests/pruebas-navegador.js` | 111 pruebas de navegador. |
+| `js/respaldo.js` | Exportar e importar. La fusión que nunca pisa. |
+| `tests/pruebas-navegador.js` | 117 pruebas de navegador. |
 
 ## Cómo se calcula el precio
 
@@ -237,6 +238,62 @@ y leerla entera.
 En teléfono la marca es el **borde** de la tarjeta, no el fondo: un fondo verde
 detrás de once campos etiquetados no se lee.
 
+## Respaldo
+
+**Lo capturado vive sólo en el navegador de cada quien.** Nadie más lo ve, y se pierde si
+se limpian los datos del sitio. Hasta que el machote guarde en el servidor (#140), la
+protección es exportar.
+
+Al pie de la pantalla de inicio, dos gestos:
+
+- **Exportar todo** — baja `machotes-<persona>-<fecha>-<hora>.json` con el almacén completo
+  más quién exportó, cuándo y desde qué navegador. Un clic, un archivo, sin herramientas de
+  desarrollador. Persona y momento van en el nombre para que dos exportaciones del mismo
+  día no se confundan al juntarlas.
+- **Importar** — vuelve a meter ese archivo.
+
+### Importar no puede destruir
+
+**Si un `id` ya existe, el entrante NO lo pisa:** entra al lado como copia marcada
+(`_copia_de`, y «(importado)» en el nombre) y alguien decide después.
+
+No es prudencia de más. Un importador que reemplaza convierte un respaldo en un arma:
+basta equivocarse de archivo para perder el trabajo del día, y quien lo aprieta cree que
+se está protegiendo. En el peor caso quedan dos machotes y sobra uno — eso se arregla; lo
+otro no.
+
+Y un archivo que no se entiende **no toca nada**: se rechaza entero y se dice por qué.
+Aplicar la mitad de un archivo roto deja un estado que nadie pidió.
+
+⚠️ **El sobre del respaldo no es el formato del almacén.** `fts_machote_v1` y su
+`{v, guardado_at, machotes, handoff}` no se tocaron: hay capturas reales adentro y
+cambiarlos las orfanaría. El archivo que se descarga es un envoltorio aparte que lleva el
+almacén tal cual en `datos`.
+
+### Quién capturó
+
+El machote nuevo estampa `creado_por` y `creado_por_nombre` **del token de la sesión**.
+Hasta V1.16 el campo existía y quedaba vacío en **todo** machote real, así que lo capturado
+no decía de quién era — y sin autor, el almacén compartido no sabe de quién es cada
+machote.
+
+⚠️ Del lado del navegador la sesión llama al usuario **`actor`**, no `sub`. Es el mismo
+dato —`auth/suite-login` firma `sub` y responde `actor`— pero buscar `ses.sub` devuelve
+`undefined` sin fallar.
+
+A los machotes que ya nacieron sin autor **no se les inventa uno**: quedan vacíos y se
+resuelven al importar, donde sí se sabe quién mandó el archivo.
+
+### Subir al servidor: no se construyó
+
+Un tercer botón mandaría el archivo solo, sin elegirlo a mano, a SharePoint por n8n.
+**Está bloqueado:** la credencial de Microsoft Graph de n8n **no tiene permiso de
+SharePoint** — contestó `403 accessDenied` al intentar leer el sitio, con el token OAuth ya
+obtenido, así que no es la credencial sino el permiso de la app. Falta `Sites.Selected` o
+`Sites.ReadWrite.All` con admin consent. Detalle en el issue #213.
+
+Mientras tanto **Exportar ya resuelve el respaldo**; subir sólo convierte dos pasos en uno.
+
 ## Autoguardado
 
 No hay botón de guardar, y no debe haberlo. Cada cambio —una cifra, el nombre de
@@ -245,6 +302,12 @@ la última tecla; y al cambiar de pantalla, al cambiar de pestaña del navegador
 al cerrar, lo pendiente se guarda de inmediato. Un punto de color en la barra
 superior dice en cuál de los tres estados está: **guardado**, **sin guardar**,
 **guardando**.
+
+**Y cuando deja de poder guardar, lo dice fuerte.** El punto de color es honesto pero se
+puede mirar sin verlo mientras se captura; a partir del momento en que el navegador ya no
+acepta guardar, todo lo que se teclee se pierde al cerrar. Por eso aparece una barra que
+tapa el pie de la pantalla, con **Exportar ahora** al lado —avisar sin dar salida es sólo
+asustar— y que se retira sola cuando el guardado vuelve a funcionar.
 
 ⚠️ **Hoy guarda en el NAVEGADOR, no en un servidor.** Lo que se captura en una
 laptop no lo ve nadie más, y se pierde si se limpian los datos del sitio. Sirve

--- a/comercial/machote/css/machote.css
+++ b/comercial/machote/css/machote.css
@@ -655,3 +655,38 @@ th .hint { font-weight: 400; text-transform: none; opacity: .75; }
   table.rejilla.tarjetas td.acc, table.rejilla.tarjetas th.acc { position: static; }
   table.rejilla.tarjetas td.descol, table.rejilla.tarjetas th.descol { min-width: 0; width: auto; }
 }
+
+/* ── Respaldo (V1.17) ─────────────────────────────────────────────────────
+ * El bloque del pie de la lista, y la barra que aparece cuando el navegador
+ * deja de guardar. */
+.wg.respaldo .btnrow { padding: 10px 0; }
+
+/* `Importar` es un <label> que envuelve un <input type=file>: el input nativo
+ * no se puede estilar y se ve distinto en cada sistema. El label le da la
+ * misma forma que a los demás botones, y el input queda oculto pero
+ * ALCANZABLE con el teclado — `display:none` lo sacaría del tabulador. */
+.btn.archivo { position: relative; overflow: hidden; }
+.btn.archivo input[type="file"] {
+  position: absolute; inset: 0; opacity: 0; width: 100%; cursor: pointer;
+}
+
+/* No se está guardando. Tapa el pie de la pantalla a propósito: es lo único
+ * de la interfaz que se pone encima del trabajo, porque a partir de aquí todo
+ * lo que se teclee se pierde. */
+.nogda {
+  position: fixed; left: 0; right: 0; bottom: 0; z-index: 60;
+  background: var(--rojo); color: #fff;
+  padding: 12px 14px; font-size: 13.5px; line-height: 1.45;
+  display: flex; gap: 12px; align-items: center; justify-content: space-between;
+  flex-wrap: wrap; box-shadow: 0 -6px 18px rgba(0, 0, 0, .18);
+}
+.nogda-b { display: flex; gap: 8px; flex-shrink: 0; }
+.nogda .btn { background: #fff; border-color: #fff; color: var(--rojo); }
+.nogda .btn.fantasma { background: transparent; color: #fff; }
+
+@media (max-width: 560px) {
+  /* En teléfono el texto y los botones apilados: en una fila los botones
+   * quedarían de 40 px y el aviso se leería a medias. */
+  .nogda { flex-direction: column; align-items: stretch; }
+  .nogda-b .btn { flex: 1; }
+}

--- a/comercial/machote/index.html
+++ b/comercial/machote/index.html
@@ -38,6 +38,7 @@
 <script src="js/reglas.js"></script>
 <script src="js/pegar.js"></script>
 <script src="js/clientes.js"></script>
+<script src="js/respaldo.js"></script>
 <script src="js/app.js"></script>
 </body>
 </html>

--- a/comercial/machote/js/almacen.js
+++ b/comercial/machote/js/almacen.js
@@ -74,11 +74,47 @@
     try { localStorage.removeItem(LLAVE); } catch (e) { /* nada que hacer */ }
   }
 
+  /* ── El sobre del respaldo ────────────────────────────────────────────
+   *
+   * ⚠️ NO es el formato del almacén. `fts_machote_v1` y su sobre
+   * `{v, guardado_at, machotes, handoff}` **no se tocan** — hay capturas
+   * reales adentro y cambiarlos las orfanaría. Esto es un envoltorio APARTE,
+   * para el archivo que se descarga: lleva el almacén tal cual en `datos` y
+   * le agrega quién lo exportó, que es lo que el archivo necesita saber y el
+   * almacén no.
+   *
+   * Por qué el navegador va dentro: si alguien capturó en la laptop y en el
+   * teléfono son dos archivos parciales, y al juntarlos hay que poder decir
+   * cuál vino de dónde. */
+  function sobre(sesion) {
+    return {
+      formato: 'fts-machote-respaldo',
+      v: 1,
+      exportado_at: new Date().toISOString(),
+      exportado_por: (sesion && sesion.actor) || '',
+      exportado_por_nombre: (sesion && sesion.nombre) || '',
+      navegador: (typeof navigator !== 'undefined' && navigator.userAgent) || '',
+      datos: leer() || { v: 1, machotes: [], handoff: {} }
+    };
+  }
+
+  /** Saca la lista de machotes de un archivo. Acepta el sobre de exportar y
+   *  también el crudo del almacén, porque quien pegue un respaldo a mano no
+   *  tiene por qué saber la diferencia. */
+  function machotesDe(obj) {
+    if (!obj) return null;
+    if (obj.datos && Array.isArray(obj.datos.machotes)) return obj.datos.machotes;
+    if (Array.isArray(obj.machotes)) return obj.machotes;
+    return null;
+  }
+
   G.MachoteAlmacen = {
     nombre: 'navegador',
     disponible: function () { return VIVO; },
     leer: leer,
     escribir: escribir,
-    olvidar: olvidar
+    olvidar: olvidar,
+    sobre: sobre,
+    machotesDe: machotesDe
   };
 })(window);

--- a/comercial/machote/js/app.js
+++ b/comercial/machote/js/app.js
@@ -40,7 +40,7 @@
    * 2026-09-03 (por instrucción de Esteban), pero lleva el suyo aparte y va en
    * V1.00. Planeación sigue en `2.4.1` y el kiosko sólo con cadena de build;
    * a esos no se propaga. */
-  const VERSION = 'V1.16';
+  const VERSION = 'V1.17';
   const $  = (s, r) => (r || document).querySelector(s);
   const $$ = (s, r) => Array.prototype.slice.call((r || document).querySelectorAll(s));
   const clon = (x) => JSON.parse(JSON.stringify(x));
@@ -86,14 +86,40 @@
       : 'Se guarda solo, en este navegador. Todavia no viaja a ningun servidor.';
   }
 
+  /* El pulso es un punto de color: dice la verdad, pero se puede mirar sin
+   * verlo mientras se captura. Cuando el guardado DEJA de funcionar eso no
+   * alcanza — a partir de ahí todo lo que se teclee se pierde al cerrar, y
+   * quien captura no tiene por qué adivinarlo.
+   *
+   * Esta barra tapa parte de la pantalla a propósito y no se va sola. Trae el
+   * exportar al lado porque avisar sin dar salida es solo asustar. */
+  function avisarNoGuarda() {
+    if ($('#noGuarda')) return;                       // ya está puesta
+    const b = document.createElement('div');
+    b.id = 'noGuarda'; b.className = 'nogda';
+    b.setAttribute('role', 'alert');
+    b.innerHTML =
+      '<span><strong>No se está guardando.</strong> Este navegador ya no acepta guardar ' +
+      '(modo privado, o se llenó el espacio). Lo que captures se pierde al cerrar.</span>' +
+      '<span class="nogda-b"><button class="btn" id="ngExp">Exportar ahora</button>' +
+      '<button class="btn fantasma" id="ngX">Entendido</button></span>';
+    document.body.appendChild(b);
+    $('#ngExp').onclick = () => exportarRespaldo();
+    $('#ngX').onclick = () => b.remove();
+  }
+  function quitarAvisoNoGuarda() { const b = $('#noGuarda'); if (b) b.remove(); }
+
   /** Guarda ya, sin esperar el retardo. Devuelve si de verdad quedo. */
   function guardarYa() {
-    if (!A || !A.disponible()) { ST.pulso = 'sin-almacen'; pintarPulso(); return false; }
+    if (!A || !A.disponible()) { ST.pulso = 'sin-almacen'; pintarPulso(); avisarNoGuarda(); return false; }
     if (_reloj) { clearTimeout(_reloj); _reloj = null; }
     ST.pulso = 'guardando'; pintarPulso();
     const ok = A.escribir({ machotes: ST.machotes, handoff: ST.handoff });
     ST.pulso = ok ? 'guardado' : 'sin-almacen';
     pintarPulso();
+    // Se avisa al fallar y se retira al volver a funcionar: una alerta que se
+    // queda cuando el problema pasó enseña a ignorarla.
+    if (ok) quitarAvisoNoGuarda(); else avisarNoGuarda();
     return ok;
   }
 
@@ -305,6 +331,52 @@
     return q.toLowerCase().split(/\s+/).filter(Boolean).every(w => t.indexOf(w) >= 0);
   }
 
+  /* El respaldo va al PIE de la pantalla de inicio, no arriba: no es lo que
+   * alguien viene a hacer, pero tiene que estar donde se encuentre sin
+   * preguntar. Y dice en una línea por qué existe, porque un botón de exportar
+   * sin explicación parece opcional. */
+  function respaldoHTML() {
+    const n = ST.machotes.length;
+    return '<h3 style="margin-top:22px">Respaldo</h3>' +
+      '<div class="wg respaldo">' +
+      '<div class="tiny nota">Lo capturado vive <strong>sólo en este navegador</strong>: no lo ve ' +
+      'nadie más y se pierde si se limpian los datos del sitio. <strong>Exporta y manda el ' +
+      'archivo</strong> hasta que el machote guarde en el servidor.</div>' +
+      '<div class="btnrow">' +
+      '<button class="btn primario" id="bExportar">Exportar todo (' + n + ')</button>' +
+      '<label class="btn archivo">Importar…<input type="file" id="fImportar" ' +
+      'accept="application/json,.json"></label>' +
+      '</div>' +
+      '<div class="tiny">Importar <strong>nunca pisa</strong>: si un machote ya existe, el del ' +
+      'archivo entra al lado marcado como copia.</div></div>';
+  }
+
+  /** Baja el respaldo y lo dice. Vive aquí y no en `respaldo.js` porque
+   *  necesita la sesión y el toast, que son de la pantalla. */
+  function exportarRespaldo() {
+    const S = G.SuiteAuth, ses = (S && S.getSession()) || {};
+    const r = G.MachoteRespaldo.exportar(ses);
+    if (!r.ok) { toast('No se pudo exportar: ' + (r.error || 'desconocido')); return; }
+    toast('Bajó ' + r.nombre + ' · ' + r.machotes + ' machote(s)');
+  }
+
+  /** Importa un archivo elegido por la persona. NUNCA pisa: lo que ya existe
+   *  se queda, y el entrante entra al lado marcado como copia. */
+  function importarRespaldo(archivo) {
+    const lector = new FileReader();
+    lector.onload = () => {
+      const r = G.MachoteRespaldo.importarTexto(String(lector.result), ST.machotes);
+      if (!r.ok) { toast(r.error); return; }
+      ST.machotes = r.lista;
+      guardarYa();
+      render();
+      const de = r.de ? ' de ' + r.de : '';
+      toast(r.nuevos + ' nuevo(s) y ' + r.copias + ' copia(s)' + de + '. No se pisó nada.');
+    };
+    lector.onerror = () => toast('No se pudo leer el archivo.');
+    lector.readAsText(archivo);
+  }
+
   function vHome() {
     top('Machote y órdenes', 'Comercial · prototipo', 'DEMO', null, true);
     $('#fija').innerHTML = '';
@@ -369,7 +441,18 @@
       buscador +
       (visibles.length ? filas : vacio) +
       '<h3 style="margin-top:22px">Estación 3.0 · confirmar la orden</h3>' + ords +
+      respaldoHTML() +
       '<div class="ver">versión <strong>' + VERSION + '</strong></div></div>';
+
+    $('#bExportar').onclick = () => exportarRespaldo();
+    $('#fImportar').onchange = (e) => {
+      const f = e.target.files && e.target.files[0];
+      // Se limpia el input para que elegir DOS VECES el mismo archivo vuelva
+      // a disparar el evento; si no, el segundo intento no hace nada y parece
+      // que la importación falló.
+      e.target.value = '';
+      if (f) importarRespaldo(f);
+    };
 
     // Se repinta sólo la lista al teclear, no la vista: repintar entera mata
     // el foco del buscador a media palabra.
@@ -433,10 +516,17 @@
       // `cliente_id` queda en null: NUNCA se bloquea por eso.
       const txtCliente = $('#n-cliente').value.trim();
       const hit = G.Clientes ? G.Clientes.resolver(txtCliente) : null;
+      /* QUIÉN lo captura, del token. Ojo con el nombre del campo: del lado
+       * del navegador la sesión lo llama `actor`, no `sub` — es el mismo dato
+       * (`auth/suite-login` firma `sub` y responde `actor`), pero buscar
+       * `ses.sub` devolvería undefined sin fallar. */
+      const S = G.SuiteAuth, ses = (S && S.getSession()) || {};
       const m = C.machoteNuevo({
         nombre: nombre,
         cliente: hit ? hit.nombre : txtCliente,
         cliente_id: hit ? hit.id : null,
+        creado_por: ses.actor || '',
+        creado_por_nombre: ses.nombre || ses.actor || '',
         so: $('#n-so').value.trim() || null,
         empresa_id: Number($('#n-empresa').value)
       });

--- a/comercial/machote/js/calc.js
+++ b/comercial/machote/js/calc.js
@@ -156,6 +156,16 @@
       // `cliente` queda como respaldo para cuando Odoo no conteste, y como
       // el único dato de los machotes que nacieron antes del catálogo.
       cliente: d.cliente || '',
+      /* QUIÉN lo capturó, del token de la sesión. Hasta V1.16 esto quedaba
+       * vacío en TODO machote real —`vNuevo()` no lo pasaba— y por eso lo
+       * capturado hoy no dice de quién es. Es requisito del almacén
+       * compartido: sin autor, Postgres no sabe de quién es cada machote.
+       *
+       * A los que ya nacieron sin él NO se les inventa uno: quedan vacíos y
+       * se resuelven al importar, donde sí se sabe quién mandó el archivo. */
+      creado_por: d.creado_por || '',
+      creado_por_nombre: d.creado_por_nombre || '',
+      creado_at: d.creado_at || new Date().toISOString(),
       cliente_id: (typeof d.cliente_id === 'number') ? d.cliente_id : null,
       so: d.so || null,
       estado: 'borrador',

--- a/comercial/machote/js/respaldo.js
+++ b/comercial/machote/js/respaldo.js
@@ -1,0 +1,126 @@
+/* ═══ Machote · el respaldo ═══
+ *
+ * V1.17 · issue #213. Mientras el almacén sea el navegador, esto es lo único
+ * que impide que lo capturado se pierda sin aviso.
+ *
+ * Tres gestos, y cada uno existe por una razón distinta:
+ *   - **Exportar**  baja un archivo. Es el rescate de lo ya capturado y la red
+ *     de seguridad permanente: sirve igual cuando exista Postgres.
+ *   - **Importar**  vuelve a meter ese archivo. FUSIONA, nunca reemplaza.
+ *   - **Subir**     mandaría el archivo solo, sin elegirlo a mano. NO SE
+ *     CONSTRUYÓ: la credencial de Microsoft Graph de n8n no tiene permiso de
+ *     SharePoint (403 accessDenied, verificado 2026-09-06). Ver #213.
+ *
+ * ── La regla que gobierna importar ───────────────────────────────────────
+ * **Importar no puede destruir.** Ni un machote, ni un renglón, ni un campo.
+ * Si un `id` ya existe, el entrante NO lo pisa: entra al lado como copia
+ * marcada y alguien decide después. Un importador que reemplaza convierte un
+ * respaldo en un arma: basta equivocarse de archivo para perder el trabajo del
+ * día, y quien lo aprieta cree que está protegiéndose.
+ *
+ * En el peor caso quedan dos machotes y sobra uno. Eso se arregla; lo otro no.
+ */
+(function (G) {
+  'use strict';
+
+  var A = G.MachoteAlmacen;
+
+  function dosDig(n) { return (n < 10 ? '0' : '') + n; }
+
+  /** `machotes-montalvo-20260906-1432.json` — persona y momento en el nombre,
+   *  para que dos exportaciones del mismo día no se confundan al juntarlas. */
+  function nombreArchivo(sesion) {
+    var d = new Date();
+    var quien = (sesion && sesion.actor) ? String(sesion.actor).replace(/[^a-z0-9._-]/gi, '') : 'sin-usuario';
+    return 'machotes-' + quien + '-' +
+      d.getFullYear() + dosDig(d.getMonth() + 1) + dosDig(d.getDate()) + '-' +
+      dosDig(d.getHours()) + dosDig(d.getMinutes()) + '.json';
+  }
+
+  /** Descarga el respaldo. Devuelve `{ok, nombre, machotes, bytes}` o `{ok:false}`.
+   *
+   *  El `revokeObjectURL` no es cosmético: sin él el blob se queda en memoria
+   *  toda la sesión, y aquí puede pesar cientos de KB. */
+  function exportar(sesion) {
+    if (!A) return { ok: false, error: 'SIN_ALMACEN' };
+    var s = A.sobre(sesion);
+    var txt = JSON.stringify(s, null, 2);
+    var nombre = nombreArchivo(sesion);
+    try {
+      var blob = new Blob([txt], { type: 'application/json' });
+      var url = URL.createObjectURL(blob);
+      var a = document.createElement('a');
+      a.href = url; a.download = nombre;
+      document.body.appendChild(a); a.click(); a.remove();
+      setTimeout(function () { URL.revokeObjectURL(url); }, 1000);
+    } catch (e) {
+      return { ok: false, error: String(e && e.message || e) };
+    }
+    return { ok: true, nombre: nombre,
+             machotes: (s.datos.machotes || []).length,
+             bytes: txt.length };
+  }
+
+  /** Fusiona `entrantes` sobre `actuales` SIN pisar.
+   *
+   *  Devuelve `{lista, nuevos, copias}`. `lista` es nueva; no se muta la que
+   *  entró, para que quien llama decida si la adopta.
+   *
+   *  El id de la copia lleva sufijo estable dentro de la misma importación
+   *  (`-imp<algo>-1`, `-2`…) en vez de `Date.now()` por renglón: importar
+   *  cincuenta en el mismo milisegundo generaría ids repetidos, que es
+   *  exactamente el problema que se está evitando. */
+  function fusionar(actuales, entrantes, sello) {
+    var lista = (actuales || []).slice();
+    var vivos = {}, i;
+    for (i = 0; i < lista.length; i++) vivos[lista[i].id] = true;
+
+    var marca = sello || ('imp' + Date.now().toString(36).slice(-4));
+    var nuevos = 0, copias = 0;
+
+    for (i = 0; i < (entrantes || []).length; i++) {
+      var m = entrantes[i];
+      if (!m || !m.id) continue;                    // sin id no se puede fusionar
+      if (!vivos[m.id]) { lista.push(m); vivos[m.id] = true; nuevos++; continue; }
+
+      // Ya existe: entra AL LADO, marcado, sin tocar al que estaba.
+      var c = JSON.parse(JSON.stringify(m));
+      copias++;
+      c._copia_de = m.id;
+      c._importado_at = new Date().toISOString();
+      var base = m.id + '-' + marca + '-' + copias, k = 0;
+      while (vivos[base]) { k++; base = m.id + '-' + marca + '-' + copias + '.' + k; }
+      c.id = base;
+      c.nombre = (c.nombre || 'Sin nombre') + ' (importado)';
+      lista.push(c); vivos[c.id] = true;
+    }
+    return { lista: lista, nuevos: nuevos, copias: copias };
+  }
+
+  /** Lee el texto de un archivo y lo fusiona. Nunca lanza: devuelve el porqué.
+   *
+   *  Si el archivo no se entiende, **no se toca nada**. Un importador que
+   *  aplica la mitad de un archivo roto deja un estado que nadie pidió. */
+  function importarTexto(txt, actuales) {
+    var obj;
+    try { obj = JSON.parse(txt); }
+    catch (e) { return { ok: false, error: 'Ese archivo no es un JSON válido.' }; }
+
+    var entrantes = A ? A.machotesDe(obj) : null;
+    if (!entrantes) {
+      return { ok: false, error: 'El archivo no trae una lista de machotes. ' +
+               '¿Es el .json que bajó "Exportar todo"?' };
+    }
+    var r = fusionar(actuales, entrantes);
+    return { ok: true, lista: r.lista, nuevos: r.nuevos, copias: r.copias,
+             total: entrantes.length,
+             de: obj.exportado_por_nombre || obj.exportado_por || '' };
+  }
+
+  G.MachoteRespaldo = {
+    exportar: exportar,
+    fusionar: fusionar,
+    importarTexto: importarTexto,
+    nombreArchivo: nombreArchivo
+  };
+})(window);

--- a/comercial/machote/tests/pruebas-navegador.js
+++ b/comercial/machote/tests/pruebas-navegador.js
@@ -2076,6 +2076,187 @@ let ok = 0, mal = 0;
     } finally { await f.close(); }
   });
 
+  // ── Respaldo (V1.17) ─────────────────────────────────────────────────
+  await paso('el autor se estampa al crear, del token', async () => {
+    /* Hasta V1.16 `analista` quedaba vacío en TODO machote real porque
+     * `vNuevo()` no lo pasaba: lo capturado no decía de quién era. Es
+     * requisito del almacén compartido, no un adorno. */
+    await ir('#/nuevo');
+    await p.waitForTimeout(320);
+    await p.fill('#n-nombre', 'ZZ con autor');
+    await p.click('#n-crear');
+    await p.waitForTimeout(900);
+    const m = await p.evaluate(() => JSON.parse(localStorage.getItem('fts_machote_v1'))
+      .machotes.find(x => x.nombre === 'ZZ con autor'));
+    if (!m) throw new Error('no se creó');
+    if (m.creado_por !== 'zz.prueba')
+      throw new Error('creado_por: ' + JSON.stringify(m.creado_por));
+    if (m.creado_por_nombre !== 'ZZ Prueba')
+      throw new Error('creado_por_nombre: ' + JSON.stringify(m.creado_por_nombre));
+    if (!m.creado_at) throw new Error('sin creado_at');
+    console.log('    ' + m.creado_por + ' · ' + m.creado_por_nombre);
+  });
+
+  await paso('exportar y reimportar el mismo archivo no duplica ni pierde', async () => {
+    /* La prueba central del rescate. Se exporta, se vuelve a importar EL MISMO
+     * contenido, y tiene que dar copias marcadas — no duplicados silenciosos
+     * ni, peor, un reemplazo. Se mide sobre el motor de fusión, que es donde
+     * vive la regla; el botón se prueba aparte. */
+    /* El almacén tiene que TENER algo, o esto fusiona cero contra cero y pasa
+     * en vacío — un `0 → 0` se ve idéntico a un éxito (CLAUDE.md §9). Se crea
+     * un machote de verdad primero, que además dispara el autoguardado. */
+    await ir('#/nuevo');
+    await p.waitForTimeout(320);
+    await p.fill('#n-nombre', 'ZZ para exportar');
+    await p.click('#n-crear');
+    await p.waitForTimeout(900);
+    await p.evaluate(() => { location.hash = '#/'; });
+    await p.waitForTimeout(300);
+
+    const r = await p.evaluate(() => {
+      const R = window.MachoteRespaldo, A = window.MachoteAlmacen;
+      const sobre = A.sobre({ actor: 'zz.prueba', nombre: 'ZZ Prueba' });
+      const actuales = sobre.datos.machotes;
+      const entrantes = A.machotesDe(sobre);
+      const f = R.fusionar(actuales, entrantes);
+      // Ninguno de los originales puede haber cambiado de id ni desaparecido.
+      const idsAntes = actuales.map(m => m.id);
+      const sobreviven = idsAntes.every(id => f.lista.some(m => m.id === id));
+      return { antes: actuales.length, despues: f.lista.length,
+               nuevos: f.nuevos, copias: f.copias, sobreviven,
+               idsUnicos: new Set(f.lista.map(m => m.id)).size === f.lista.length };
+    });
+    if (!(r.antes > 0))
+      throw new Error('el almacén estaba vacío: la prueba habría pasado en vacío');
+    if (!r.sobreviven) throw new Error('se perdió un machote original');
+    if (r.nuevos !== 0) throw new Error('contó ' + r.nuevos + ' como nuevos; eran los mismos');
+    if (r.copias !== r.antes) throw new Error('copias ' + r.copias + ' ≠ ' + r.antes);
+    if (r.despues !== r.antes * 2) throw new Error('total ' + r.despues);
+    if (!r.idsUnicos) throw new Error('generó ids repetidos');
+    console.log('    ' + r.antes + ' → ' + r.despues + ' · ' + r.copias +
+                ' copias, 0 perdidos, ids únicos');
+  });
+
+  await paso('importar un id existente crea copia y NO pisa', async () => {
+    /* La regla dura: importar no puede destruir. Se importa un machote con un
+     * id que ya existe pero con el nombre cambiado; el original tiene que
+     * seguir intacto y el entrante entrar al lado. */
+    await ir('#/');
+    const r = await p.evaluate(() => {
+      const R = window.MachoteRespaldo;
+      const actuales = [
+        { id: 'M-X', nombre: 'EL BUENO', cliente: 'A' },
+        { id: 'M-Y', nombre: 'otro', cliente: 'B' }
+      ];
+      const entrantes = [
+        { id: 'M-X', nombre: 'EL DEL ARCHIVO', cliente: 'Z' },
+        { id: 'M-NUEVO', nombre: 'no existía', cliente: 'C' }
+      ];
+      const f = R.fusionar(actuales, entrantes);
+      const orig = f.lista.find(m => m.id === 'M-X');
+      const copia = f.lista.find(m => m._copia_de === 'M-X');
+      return { total: f.lista.length, nuevos: f.nuevos, copias: f.copias,
+               origNombre: orig && orig.nombre, origCliente: orig && orig.cliente,
+               copiaId: copia && copia.id, copiaNombre: copia && copia.nombre,
+               tieneNuevo: f.lista.some(m => m.id === 'M-NUEVO') };
+    });
+    if (r.origNombre !== 'EL BUENO')
+      throw new Error('PISÓ el original: ahora dice ' + r.origNombre);
+    if (r.origCliente !== 'A') throw new Error('cambió el cliente del original');
+    if (!r.copia_id && !r.copiaId) throw new Error('no creó la copia');
+    if (r.copiaId === 'M-X') throw new Error('la copia reusó el id');
+    if (!/importado/.test(r.copiaNombre || '')) throw new Error('la copia no está marcada');
+    if (!r.tieneNuevo) throw new Error('perdió el que sí era nuevo');
+    if (r.nuevos !== 1 || r.copias !== 1) throw new Error(JSON.stringify(r));
+    console.log('    original intacto "' + r.origNombre + '" · copia ' + r.copiaId);
+  });
+
+  await paso('un archivo que no se entiende no toca nada', async () => {
+    /* Aplicar la mitad de un archivo roto deja un estado que nadie pidió. */
+    await ir('#/');
+    const r = await p.evaluate(() => {
+      const R = window.MachoteRespaldo;
+      const actuales = [{ id: 'M-X', nombre: 'intacto' }];
+      return {
+        basura: R.importarTexto('esto no es json', actuales),
+        jsonAjeno: R.importarTexto('{"hola":1}', actuales),
+        siguen: actuales.length
+      };
+    });
+    if (r.basura.ok) throw new Error('aceptó basura');
+    if (r.jsonAjeno.ok) throw new Error('aceptó un JSON sin machotes');
+    if (!/JSON válido/.test(r.basura.error)) throw new Error('no explica: ' + r.basura.error);
+    if (!/lista de machotes/.test(r.jsonAjeno.error)) throw new Error('no explica: ' + r.jsonAjeno.error);
+    if (r.siguen !== 1) throw new Error('tocó la lista');
+    console.log('    rechaza y explica, sin tocar nada');
+  });
+
+  await paso('los dos botones de respaldo están y se alcanzan', async () => {
+    await ir('#/');
+    const r = await p.evaluate(() => {
+      const b = document.querySelector('#bExportar');
+      const f = document.querySelector('#fImportar');
+      const lab = f && f.closest('label');
+      const rb = b && b.getBoundingClientRect();
+      const rl = lab && lab.getBoundingClientRect();
+      return { hayB: !!b, hayF: !!f, txt: b && b.textContent,
+               altoB: rb && Math.round(rb.height), altoL: rl && Math.round(rl.height),
+               acepta: f && f.getAttribute('accept') };
+    });
+    if (!r.hayB || !r.hayF) throw new Error('faltan los controles');
+    if (!/Exportar todo \(\d+\)/.test(r.txt || '')) throw new Error('el botón dice: ' + r.txt);
+    if (r.altoB < 44 || r.altoL < 44)
+      throw new Error('no se alcanzan con el pulgar: ' + r.altoB + ' / ' + r.altoL + ' px');
+    if (!/json/.test(r.acepta || '')) throw new Error('el input no filtra .json');
+    console.log('    ' + r.txt + ' · ' + r.altoB + ' y ' + r.altoL + ' px de alto');
+  });
+
+  await paso('cuando el guardado falla, el aviso tapa y no se puede ignorar', async () => {
+    /* El pulso dice la verdad pero se puede no ver. Esto no. */
+    const q = await b.newPage({ viewport: { width: 380, height: 780 } });
+    try {
+      await q.addInitScript(() => {
+        try {
+          localStorage.clear();
+          localStorage.setItem('fts_suite_session', JSON.stringify({
+            token: 'x.y.z', actor: 'zz.prueba', nombre: 'ZZ Prueba',
+            scopes: ['comercial:read'], exp: Math.floor(Date.now() / 1000) + 3600
+          }));
+        } catch (e) {}
+        const o = window.fetch;
+        window.fetch = function (u) {
+          if (String(u).indexOf('/comercial/clientes') >= 0) {
+            return Promise.resolve({ ok: true, json: () => Promise.resolve({ ok: true, clientes: [] }) });
+          }
+          return o.apply(this, arguments);
+        };
+      });
+      await q.goto(BASE); await q.waitForTimeout(400);
+      // El almacén deja de aceptar, como en modo privado o al llenarse.
+      await q.evaluate(() => { localStorage.setItem = function () { throw new Error('QuotaExceeded'); }; });
+      await q.evaluate(() => { location.hash = '#/nuevo'; }); await q.waitForTimeout(400);
+      await q.fill('#n-nombre', 'ZZ sin almacen');
+      await q.click('#n-crear');
+      await q.waitForTimeout(700);
+      const r = await q.evaluate(() => {
+        const n = document.querySelector('#noGuarda');
+        if (!n) return { hay: false };
+        const c = n.getBoundingClientRect();
+        return { hay: true, rol: n.getAttribute('role'), txt: n.textContent,
+                 abajo: Math.round(c.bottom) >= window.innerHeight - 2,
+                 ancho: Math.round(c.width) >= window.innerWidth - 2,
+                 exporta: !!document.querySelector('#ngExp') };
+      });
+      if (!r.hay) throw new Error('no avisó nada');
+      if (r.rol !== 'alert') throw new Error('no se anuncia como alerta');
+      if (!/No se está guardando/.test(r.txt)) throw new Error('no lo dice: ' + r.txt.slice(0, 80));
+      if (!/se pierde/.test(r.txt)) throw new Error('no dice la consecuencia');
+      if (!r.abajo || !r.ancho) throw new Error('no tapa: no llega a los bordes');
+      if (!r.exporta) throw new Error('avisa pero no da salida');
+      console.log('    barra a lo ancho, con "Exportar ahora" al lado');
+    } finally { await q.close(); }
+  });
+
   // ── El gate ──────────────────────────────────────────────────────────
   await paso('sin sesión, el libro no se alcanza a ver', async () => {
     // Pagina LIMPIA, sin la sesion sembrada: debe mandar al login.

--- a/comercial/machote/version.json
+++ b/comercial/machote/version.json
@@ -1,10 +1,15 @@
 {
-  "version": "V1.16",
-  "fecha": "2026-09-04",
+  "version": "V1.17",
+  "fecha": "2026-09-06",
   "modulo": "comercial/machote",
   "ambito": "El CONTADOR es solo de este modulo. finanzas tambien usa V1.xx desde el 2026-09-03 (instruccion directa de Esteban, corrige el \"no propagar\" del issue #148) pero lleva su propio contador y va en V1.00. operaciones/planeacion sigue en 2.4.1, kiosk y confirmar-horas solo con cadena de build, y siete modulos con un 1.0.0 puesto una vez: a esos no se propaga.",
   "esquema": "V<mayor>.<menor de dos digitos>. Un incremento de 0.01 por cada merge a main. Al pasar de .99 sube el mayor y el menor vuelve a 00.",
   "historial": [
+    {
+      "version": "V1.17",
+      "pr": null,
+      "nota": "Respaldo: lo capturado deja de poder perderse. Exportar baja un .json con todo mas quien exporto y cuando; importar fusiona por id y NUNCA pisa -lo que ya existe se queda y el entrante entra al lado como copia marcada-; el machote nuevo estampa quien lo capturo, del token, que hasta V1.16 quedaba vacio en todo machote real; y cuando el navegador deja de guardar aparece una barra que tapa el pie de la pantalla con Exportar al lado, en vez de un punto de color facil de ignorar. Subir al servidor NO se construyo: la credencial de Graph de n8n no tiene permiso de SharePoint -403 accessDenied-, ver issue #213"
+    },
     {
       "version": "V1.16",
       "pr": null,

--- a/docs/comercial/prototipos/respaldo-v117.html
+++ b/docs/comercial/prototipos/respaldo-v117.html
@@ -1,0 +1,198 @@
+<!doctype html>
+<meta charset="utf-8">
+<title>Prototipo · respaldo del machote (V1.17)</title>
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<style>
+  :root { --tinta:#1f2430; --gris:#5b6472; --linea:#e3e6eb; --fondo:#fff;
+          --azul:#1f4e79; --verde:#2e7d32; --ambar:#b26a00; --rojo:#b3261e; }
+  * { box-sizing:border-box }
+  body { margin:0; font:15px/1.5 -apple-system,Segoe UI,Roboto,sans-serif;
+         color:var(--tinta); background:#f6f7f9 }
+  .caja { max-width:760px; margin:0 auto; padding:18px }
+  h1 { font-size:19px; margin:0 0 4px }
+  h2 { font-size:15px; margin:22px 0 8px; padding-top:16px; border-top:1px solid var(--linea) }
+  .sub { color:var(--gris); font-size:13px; margin:0 0 16px }
+  .tarjeta { background:var(--fondo); border:1px solid var(--linea); border-radius:10px;
+             padding:14px; margin-bottom:12px }
+  .btnrow { display:flex; gap:8px; flex-wrap:wrap }
+  button { min-height:44px; padding:0 16px; border-radius:8px; border:1px solid var(--linea);
+           background:var(--fondo); color:var(--tinta); font:inherit; cursor:pointer }
+  button.primario { background:var(--azul); border-color:var(--azul); color:#fff; font-weight:600 }
+  button:disabled { opacity:.5; cursor:not-allowed }
+  .tiny { font-size:12.5px; color:var(--gris) }
+  .n-ok { color:var(--verde) } .n-warn { color:var(--ambar) } .n-bad { color:var(--rojo) }
+  pre { background:#f2f4f7; border:1px solid var(--linea); border-radius:8px; padding:10px;
+        overflow:auto; font-size:12px; margin:8px 0 0 }
+  table { border-collapse:collapse; width:100%; font-size:13.5px; margin-top:8px }
+  th,td { text-align:left; padding:6px 8px; border-bottom:1px solid var(--linea) }
+  th { background:#f2f4f7; font-size:12px; text-transform:uppercase; letter-spacing:.03em }
+  .cp { background:#fff8e1 }
+  .aviso { border-left:3px solid var(--ambar); background:#fffbf0; padding:10px 12px;
+           border-radius:0 8px 8px 0; font-size:13.5px; margin:10px 0 }
+  .bloq { border-left:3px solid var(--rojo); background:#fdf2f1 }
+  label.arch { display:inline-flex; align-items:center; min-height:44px; padding:0 16px;
+               border:1px solid var(--linea); border-radius:8px; background:var(--fondo); cursor:pointer }
+  input[type=file] { display:none }
+</style>
+
+<div class="caja">
+  <h1>Prototipo · respaldo del machote</h1>
+  <p class="sub">V1.17 · issue #213. Archivo suelto, sin servidor: se abre con doble clic y no toca
+  el machote real. Los datos de abajo son de mentiras, para probar el gesto.</p>
+
+  <div class="tarjeta">
+    <strong>Lo que hay ahora mismo</strong>
+    <div id="estado" class="tiny"></div>
+    <table id="tabla"></table>
+  </div>
+
+  <h2>1 · Exportar</h2>
+  <div class="tarjeta">
+    <p class="tiny">Baja un <code>.json</code> con todo lo capturado, más quién exportó y cuándo.
+    Un clic, un archivo. Es lo que cada quien manda por Teams.</p>
+    <div class="btnrow"><button class="primario" id="bExp">Exportar todo</button></div>
+    <div id="expOut"></div>
+  </div>
+
+  <h2>2 · Importar</h2>
+  <div class="tarjeta">
+    <p class="tiny">Fusiona por <code>id</code> y <strong>nunca pisa</strong>: si el id ya existe,
+    entra como <em>copia</em> marcada. Importar no puede destruir nada.</p>
+    <div class="btnrow">
+      <label class="arch">Elegir archivo…<input type="file" id="fImp" accept="application/json,.json"></label>
+      <button id="bDup">Probar: importar lo mismo otra vez</button>
+    </div>
+    <div id="impOut"></div>
+  </div>
+
+  <h2>3 · Subir al servidor</h2>
+  <div class="tarjeta">
+    <div class="aviso bloq"><strong>Bloqueado, y no se construyó.</strong> La credencial de
+    Microsoft Graph de n8n <strong>no tiene permiso de SharePoint</strong>: contestó
+    <code>403 accessDenied</code> al intentar leer el sitio. El token OAuth sí se obtuvo, así que
+    no es la credencial — es el permiso de la app. Detalle y qué falta en Azure, en el issue #213.</div>
+    <div class="btnrow"><button disabled>Subir al servidor</button></div>
+    <p class="tiny">Mientras tanto, <strong>Exportar</strong> ya resuelve el respaldo: baja el
+    archivo y mándalo por Teams. Esto solo convierte dos pasos en uno.</p>
+  </div>
+
+  <h2>4 · Cuando el guardado falla</h2>
+  <div class="tarjeta">
+    <p class="tiny">Hoy el pulso se queda en «sin guardar» y es fácil no verlo mientras se captura.
+    Así se ve el aviso nuevo:</p>
+    <div class="btnrow"><button id="bFalla">Simular que el navegador ya no deja guardar</button></div>
+  </div>
+</div>
+
+<script>
+/* ── El demo. Nada de esto toca el machote real: vive en memoria. ── */
+var SESION = { actor: 'montalvo', nombre: 'Francisco Montalvo' };
+var datos = { v:1, guardado_at:new Date().toISOString(), handoff:{}, machotes:[
+  { id:'M-1041', nombre:'Paso de gato antiderrapante', cliente:'Cliente A',
+    creado_por:'montalvo', creado_por_nombre:'Francisco Montalvo', estado:'borrador' },
+  { id:'M-1042', nombre:'Adecuaciones de toma sanitaria', cliente:'Cliente B',
+    creado_por:'montalvo', creado_por_nombre:'Francisco Montalvo', estado:'revision' },
+  { id:'M-0900', nombre:'Capturado antes de V1.17', cliente:'Cliente C',
+    creado_por:'', creado_por_nombre:'', estado:'borrador' }
+]};
+
+function pintar(){
+  document.getElementById('estado').textContent =
+    datos.machotes.length + ' machotes en memoria.';
+  var f = datos.machotes.map(function(m){
+    return '<tr' + (m._copia_de ? ' class="cp"' : '') + '><td><code>' + m.id + '</code></td><td>' +
+      m.nombre + '</td><td>' + (m.creado_por_nombre ||
+        '<span class="n-warn">— sin autor —</span>') + '</td><td class="tiny">' +
+      (m._copia_de ? 'copia de ' + m._copia_de : '') + '</td></tr>';
+  }).join('');
+  document.getElementById('tabla').innerHTML =
+    '<tr><th>id</th><th>nombre</th><th>capturó</th><th></th></tr>' + f;
+}
+
+/* ── EXPORTAR ── el sobre lleva quién y cuándo; el contenido va tal cual. ── */
+function sobre(){
+  return { formato:'fts-machote-respaldo', v:1,
+           exportado_at:new Date().toISOString(),
+           exportado_por:SESION.actor, exportado_por_nombre:SESION.nombre,
+           navegador:navigator.userAgent, datos:datos };
+}
+function nombreArchivo(){
+  var d = new Date(), p = function(n){ return String(n).padStart(2,'0'); };
+  return 'machotes-' + (SESION.actor||'sin-usuario') + '-' + d.getFullYear() +
+         p(d.getMonth()+1) + p(d.getDate()) + '-' + p(d.getHours()) + p(d.getMinutes()) + '.json';
+}
+document.getElementById('bExp').onclick = function(){
+  var txt = JSON.stringify(sobre(), null, 2);
+  var a = document.createElement('a');
+  a.href = URL.createObjectURL(new Blob([txt], {type:'application/json'}));
+  a.download = nombreArchivo();
+  document.body.appendChild(a); a.click(); a.remove();
+  setTimeout(function(){ URL.revokeObjectURL(a.href); }, 1000);
+  document.getElementById('expOut').innerHTML =
+    '<p class="tiny n-ok">Bajó <strong>' + a.download + '</strong> · ' +
+    datos.machotes.length + ' machotes · ' + txt.length.toLocaleString() + ' bytes</p>' +
+    '<pre>' + txt.slice(0,340).replace(/</g,'&lt;') + '\n…</pre>';
+};
+
+/* ── IMPORTAR ── fusión que NUNCA pisa. ──
+ * Si el id ya existe se le da uno nuevo y se marca de dónde vino. Nada se
+ * reemplaza y nada se borra: en el peor caso quedan dos y alguien decide. */
+function fusionar(entrantes){
+  var vivos = {}, n = { nuevos:0, copias:0 };
+  datos.machotes.forEach(function(m){ vivos[m.id] = true; });
+  entrantes.forEach(function(m){
+    if (vivos[m.id]) {
+      var c = JSON.parse(JSON.stringify(m));
+      c._copia_de = m.id;
+      c.id = m.id + '-imp' + Date.now().toString(36).slice(-4) + (n.copias || '');
+      c.nombre = (c.nombre || 'Sin nombre') + ' (importado)';
+      datos.machotes.push(c); vivos[c.id] = true; n.copias++;
+    } else { datos.machotes.push(m); vivos[m.id] = true; n.nuevos++; }
+  });
+  return n;
+}
+function importar(txt){
+  var out = document.getElementById('impOut');
+  try {
+    var s = JSON.parse(txt);
+    var lista = (s && s.datos && s.datos.machotes) || (s && s.machotes);
+    if (!Array.isArray(lista)) throw new Error('el archivo no trae una lista de machotes');
+    var antes = datos.machotes.length, n = fusionar(lista);
+    pintar();
+    out.innerHTML = '<p class="tiny n-ok">' + antes + ' → ' + datos.machotes.length +
+      ' · <strong>' + n.nuevos + '</strong> nuevos, <strong>' + n.copias +
+      '</strong> como copia. Nada se pisó.</p>';
+  } catch(e){
+    out.innerHTML = '<p class="tiny n-bad">No se pudo leer: ' + String(e.message) +
+      '. <strong>No se tocó nada.</strong></p>';
+  }
+}
+document.getElementById('fImp').onchange = function(ev){
+  var f = ev.target.files && ev.target.files[0]; if (!f) return;
+  var r = new FileReader();
+  r.onload = function(){ importar(String(r.result)); };
+  r.readAsText(f); ev.target.value = '';
+};
+document.getElementById('bDup').onclick = function(){
+  importar(JSON.stringify(sobre()));
+};
+
+/* ── EL AVISO cuando ya no se puede guardar ── */
+document.getElementById('bFalla').onclick = function(){
+  if (document.getElementById('barraFalla')) return;
+  var b = document.createElement('div');
+  b.id = 'barraFalla';
+  b.style.cssText = 'position:fixed;left:0;right:0;bottom:0;z-index:99;background:#b3261e;' +
+    'color:#fff;padding:12px 14px;font-size:14px;display:flex;gap:10px;align-items:center;' +
+    'justify-content:space-between;flex-wrap:wrap';
+  b.innerHTML = '<span><strong>No se está guardando.</strong> Este navegador ya no acepta ' +
+    'guardar. Exporta ahora para no perder lo capturado.</span>' +
+    '<span style="display:flex;gap:8px"><button id="bfExp" style="min-height:40px">Exportar ahora</button>' +
+    '<button id="bfX" style="min-height:40px;background:transparent;color:#fff;border-color:#fff">Entendido</button></span>';
+  document.body.appendChild(b);
+  document.getElementById('bfExp').onclick = function(){ document.getElementById('bExp').click(); };
+  document.getElementById('bfX').onclick = function(){ b.remove(); };
+};
+
+pintar();
+</script>


### PR DESCRIPTION
Issue #213. Montalvo, Ricardo y Esteban capturan machotes reales contra `localStorage`, sin respaldo y sin autor. **Esta versión no toca Postgres**: su único objetivo es que lo capturado no se pueda perder sin aviso.

**La condición dura se respetó:** `fts_machote_v1` y su sobre `{v, guardado_at, machotes, handoff}` **no se tocaron**. El archivo que se descarga es un envoltorio aparte que lleva el almacén tal cual en `datos`.

---

## A · El autor, del token

`creado_por`, `creado_por_nombre` y `creado_at` al crear. Hasta V1.16 el campo existía y quedaba **vacío en todo machote real** porque `vNuevo()` no lo pasaba — lo capturado no decía de quién era. Es requisito del almacén compartido, no un adorno.

⚠️ **Del lado del navegador la sesión llama al usuario `actor`, no `sub`.** Es el mismo dato (`auth/suite-login` firma `sub` y responde `actor`), pero buscar `ses.sub` devolvería `undefined` **sin fallar**.

A los que ya nacieron sin autor **no se les inventa uno**: quedan vacíos y se resuelven al importar, donde sí se sabe quién mandó el archivo.

## B · Exportar

Baja `machotes-<persona>-<fecha>-<hora>.json` con el almacén completo más quién exportó, cuándo y desde qué navegador. Un clic, un archivo, sin herramientas de desarrollador.

Persona y momento van en el nombre para que dos exportaciones del mismo día no se confundan al juntarlas. El navegador va dentro porque si alguien capturó en laptop **y** teléfono son dos archivos parciales, y al fusionarlos hay que poder decir cuál vino de dónde.

## D · Importar no puede destruir

**Si un `id` ya existe, el entrante NO lo pisa:** entra al lado como copia marcada (`_copia_de`, «(importado)» en el nombre) y alguien decide después.

No es prudencia de más. Un importador que reemplaza **convierte un respaldo en un arma**: basta equivocarse de archivo para perder el trabajo del día, y quien lo aprieta cree que se está protegiendo. En el peor caso quedan dos machotes y sobra uno — eso se arregla; lo otro no.

Y un archivo que no se entiende **no toca nada**: se rechaza entero y se dice por qué. Aplicar la mitad de un archivo roto deja un estado que nadie pidió.

Detalle: el id de la copia lleva sufijo **estable dentro de la misma importación** (`-imp<x>-1`, `-2`…) en vez de `Date.now()` por renglón — importar cincuenta en el mismo milisegundo generaría ids repetidos, que es justo el problema que se está evitando.

## E · Cuando el guardado falla

El pulso es honesto pero se puede mirar sin verlo mientras se captura. A partir del momento en que el navegador ya no acepta guardar, **todo lo que se teclee se pierde al cerrar**.

Ahora aparece una barra que **tapa el pie de la pantalla**, con **Exportar ahora** al lado —avisar sin dar salida es sólo asustar— y que **se retira sola** cuando el guardado vuelve a funcionar: una alerta que se queda cuando el problema pasó enseña a ignorarla.

## C · Subir al servidor — **NO se construyó**

La credencial `Microsoft Graph - sales` de n8n **no tiene permiso de SharePoint**. Sonda de solo lectura (ejecución **88810**, workflow archivado):

```json
{"hubo_error": true,
 "mensaje": "403 - {\"error\":{\"code\":\"accessDenied\",\"message\":\"Access denied\"}}"}
```

**El token OAuth sí se obtuvo** — si la credencial estuviera mal, el error sería `Failed to acquire OAuth2 access token` y fallaría antes de llegar a Graph (CLAUDE.md §17). Fue **Graph** quien contestó 403: no es la credencial, es el permiso de la app. Ni siquiera puede **leer** el sitio.

Falta en Azure `Sites.Selected` (recomendado, acotado al sitio) o `Sites.ReadWrite.All`, con admin consent. **No inventé otro destino.** Mientras tanto **Exportar ya resuelve el respaldo**; subir sólo convierte dos pasos en uno.

---

## Pruebas — `117 pasaron, 0 fallaron`

Seis nuevas:

```
    zz.prueba · ZZ Prueba
✓ el autor se estampa al crear, del token
    5 → 10 · 5 copias, 0 perdidos, ids únicos
✓ exportar y reimportar el mismo archivo no duplica ni pierde
    original intacto "EL BUENO" · copia M-X-impibwv-1
✓ importar un id existente crea copia y NO pisa
    rechaza y explica, sin tocar nada
✓ un archivo que no se entiende no toca nada
    Exportar todo (4) · 44 y 44 px de alto
✓ los dos botones de respaldo están y se alcanzan
    barra a lo ancho, con "Exportar ahora" al lado
✓ cuando el guardado falla, el aviso tapa y no se puede ignorar
```

⚠️ **Una de ellas pasó primero EN VACÍO.** La de exportar/reimportar reportó `0 → 0 · 0 copias`: el almacén estaba vacío y fusionó cero contra cero — un resultado que **se ve idéntico a un éxito**, que es exactamente el modo de falla de CLAUDE.md §9. Se corrigió creando un machote de verdad antes y exigiendo `antes > 0`. Ahora mide `5 → 10`.

## Medido en pantalla

```
1280px → aviso 1280×76  · tapa el pie · botones en fila
 380px → aviso  380×147 · tapa el pie · botones apilados a lo ancho
respaldo: "Exportar todo (4)" y "Importar…" a 44 px de alto en las dos anchuras
```

## Prototipo

`docs/comercial/prototipos/respaldo-v117.html` — archivo suelto, se abre con doble clic, no toca el machote real. Prueba exportar, importar (incluido «importar lo mismo otra vez») y el aviso, con datos de mentiras. El tercer botón aparece deshabilitado con la razón.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013Qzhio6K8R23HXHnJ2RJ64

---
_Generated by [Claude Code](https://claude.ai/code/session_013Qzhio6K8R23HXHnJ2RJ64)_