### PR TITLE
fix(po-radar): una orden real de Calbee salía al 72% por dos defectos del scorer (#142)

### DIFF
--- a/docs/po-radar/MVP-WORKFLOW.md
+++ b/docs/po-radar/MVP-WORKFLOW.md
@@ -53,6 +53,11 @@ Todo lo ajustable vive en el nodo `Set - config`, en texto plano, sin tocar cód
 | `reset_estado` | `false` | borra la memoria de dedupe. Solo para pruebas |
 | `hora_latido` | `18` | hora CST del corte diario (§7) |
 
+Los pesos de etapa 1 y las señales negativas están en el nodo `Code - Etapa 1`; cada una lleva su
+comentario con la corrida que la originó. La regla que las ordena: **una frase de entrega explícita
+gana aunque el correo hable de facturas; el encabezado por asunto cede ante cualquier negativa** —
+el porqué está en §5.6.
+
 **El solape de 90 minutos es deliberado.** La dedupe absorbe lo que se repita; un hueco, en cambio,
 pierde una orden de compra para siempre. Se elige el error barato.
 
@@ -78,7 +83,8 @@ hacia el de perder una orden.
 
 ## 4. Lo que se rompió al probarlo
 
-Seis corridas contra correo real. Cada una destapó algo que el diseño no había previsto:
+Seis corridas de prueba contra correo real, más el primer fallo real en operación (§5.6). Cada una
+destapó algo que el diseño no había previsto:
 
 **El modo `dry` no era dry (corrida 85362).** No había nada entre `Code - Build sendMail` y
 `HTTP - sendMail`: la bandera `_dry` se calculaba y nadie la leía. La primera prueba "en seco" mandó
@@ -108,6 +114,32 @@ remitente**, que es un dato duro del sobre, más una marca por `conversationId` 
 porque todas las pruebas anteriores cayeron, por casualidad, en ventanas con al menos un candidato; y
 las ventanas sin candidatos son **la mayoría**. Lo destapó la prueba del latido, no una prueba del
 detector. Ahora Resumen toma Decidir dentro de un `try` y, si no corrió, lee su propio `$input`.
+
+**Una orden real de Calbee salió al 72% y no llegó al grupo (corrida 91585, 8-sep).** Es el primer
+fallo detectado por el uso, no por una prueba, y son **dos** defectos del scorer sumados. El desglose
+crudo de etapa 1 fue `score: 30 · senales: [buzon_rol, folio, adjunto, externo, neg_factura]`, y con
+`confianza 0.96` eso da `0.6×96 + 0.4×35 = 72`. Para cruzar 90 con esa confianza hacía falta un
+score de **81**; tenía 35.
+
+*Defecto 1 — el pie de página de la orden la castigó.* El cuerpo decía, literal: `Please remit all
+invoice to ap@calbeeamerica.com`. Eso indica **a dónde mandar la factura de FTS** y es texto estándar
+de casi toda orden de compra; el `\binvoice\b` que se había agregado para callar los avisos de Ariba
+lo mordió y restó 25. **Mencionar una factura no es ser una factura.** Ahora ese pie se recorta antes
+de evaluar las señales negativas, con el verbo por delante y con `\b`, para que `Sent - Invoice
+INV171` y `has been submitted` —que sí son avisos de factura— sigan penalizados.
+
+*Defecto 2 — el asunto de portal no contaba como entrega.* `FTS Full Technology Systems LLC Purchase
+Order 2989 for Calbee America` es un encabezado con folio y **sin verbo**: no matchea ninguna frase
+de `ENTREGA`, que es una lista de actos de entrega (*"sent a new purchase order"*, *"orden de compra
+standard"*). Cuando la orden la emite un ERP o un portal, **el asunto ES el acto de entrega**. Nueva
+señal `acto_entrega_asunto` (+35), que exige la forma deletreada más el folio — un `PO` suelto es
+demasiado común en respuestas y facturas que solo citan el número.
+
+*Y el freno que el arreglo necesitaba.* La primera versión del parche regaló los +35 a una `Factura
+A-123 de la Orden de Compra 4567` y a una `Remision - Purchase Order 8899`: ambas traen el folio en
+el asunto sin ser órdenes. Por eso `acto_entrega_asunto` **cede ante cualquier señal negativa**,
+mientras que una frase de entrega explícita gana igual (una orden real sí habla de facturas). Lo
+destapó el arnés, no el diseño.
 
 **Los adjuntos se perdían y nadie se enteraba (85545).** El mismo correo devolvía 0 adjuntos en dos
 corridas y 2 adjuntos en otra. No era intermitencia: era **`429 ApplicationThrottled` de Graph**, y
@@ -149,7 +181,7 @@ del **comprador**, que es justamente el error caro que FASE A midió y que el pr
 Las otras dos copias de esa misma orden — una del buzón automático del cliente y otra reenviada a
 mano por una persona de su equipo — quedaron como `duplicado_folio` y no se reenviaron.
 
-## 6. Dos formatos de orden probados, no uno
+## 6. Tres formatos de orden probados, no uno
 
 El detector no está calibrado a un solo cliente. Se probó contra los dos canales por los que llegan
 órdenes reales, y los dos salen al 96%:
@@ -158,6 +190,7 @@ El detector no está calibrado a un solo cliente. Se probó contra los dos canal
 |---|---|---|---|---|
 | ERP del cliente (GEPP) | `FYI: BEPUSA - Orden de Compra Standard 2688378, 0` | 2688378 | 96% | 2, PDF de 44,347 caracteres |
 | Plataforma de compras (Ariba/GRUMA) | `GRUMA sent a new Purchase Order 7500314675` | 7500314675 | 96% | 2, PDF de 3,290 caracteres |
+| Portal Concur (Calbee) | `FTS Full Technology Systems LLC Purchase Order 2989 for Calbee America` | 2989 | 96% *(tras el arreglo de §5.6; salió al 72%)* | 4 |
 
 En la ventana de 100 correos del 10-13 de agosto, ya con el aviso de Ariba silenciado: **12
 candidatos, 1 orden reenviada, 0 probables, 0 falsos positivos.**


### PR DESCRIPTION
Primer fallo detectado por el **uso**, no por una prueba. La orden `2989` de Calbee (124,628 USD, vía portal Concur) se reenvió al buzón de Esteban marcada PROBABLE al **72%** en vez de irse directo al grupo.

## El desglose crudo — corrida `91585`

```
score 30 · senales [buzon_rol, folio, adjunto, externo, neg_factura]
confianza 0.96  →  precisión = 0.6×96 + 0.4×35 = 72
```

```
buzon_rol   +15   (concursolutions.com está en la lista de plataformas)
folio       +15   ("Purchase Order 2989" en el asunto)
adjunto     +20
externo      +5
neg_factura −25   ← ❌
acto_entrega  0   ← ❌ nunca disparó
                 ────
                  30   (+5 de bono por nombre de adjunto → 35)
```

Con `confianza 0.96`, cruzar 90 exigía **score ≥ 81**. Tenía 35. Dos defectos sumados:

### 1. El pie de página de la orden la castigó

El cuerpo dice, literal: `Please remit all invoice to ap@calbeeamerica.com`. Eso indica **a dónde mandar la factura de FTS** y es texto estándar de casi toda orden de compra. El `\binvoice\b` que se agregó para callar los avisos de Ariba lo mordió: −25.

**Mencionar una factura no es ser una factura.** Ahora ese pie se recorta antes de evaluar las negativas; el verbo va delante y con `\b` para que `Sent - Invoice INV171` y `has been submitted` —que sí son avisos de factura— sigan penalizados.

### 2. El asunto de portal no contaba como entrega

`FTS Full Technology Systems LLC Purchase Order 2989 for Calbee America` es un encabezado con folio y **sin verbo**: no matchea ninguna frase de `ENTREGA`, que es una lista de *actos* de entrega. Cuando la orden la emite un ERP o un portal, **el asunto ES el acto de entrega**.

Nueva señal `acto_entrega_asunto` (+35), que exige la forma deletreada más el folio — un `PO` suelto es demasiado común en respuestas y facturas que solo citan el número.

### Y el freno que el arreglo necesitaba

La primera versión del parche le regalaba los +35 a `Factura A-123 de la Orden de Compra 4567` y a `Remision - Purchase Order 8899`: ambas traen el folio en el asunto sin ser órdenes. Por eso `acto_entrega_asunto` **cede ante cualquier señal negativa**, mientras que una frase de entrega explícita gana igual (una orden real sí habla de facturas). **Lo destapó el arnés, no el diseño.**

## Verificación

Arnés que corre el **código real** del nodo (no una reimplementación), con la confianza real del clasificador, sobre 12 casos:

| Caso | Antes | Después |
|---|---|---|
| **Calbee (el caso)** | 30 · `neg_factura` | **90** · `acto_entrega_asunto` |
| GEPP ERP | 90 | 90 |
| GRUMA Ariba | 90 | 90 |
| PO Concur, otro cliente | 55 | **90** |
| Ariba aviso factura (`Sent - Invoice`) | descartado | descartado |
| Ariba factura enviada | descartado | descartado |
| Ariba digest diario | descartado | descartado |
| Boletín con año / OTP Tesla | descartado | descartado |
| Cotización citando PO | 25 | 25 |
| Factura ES citando OC | descartado | descartado |
| Remisión citando PO | descartado | descartado |

**Cero regresiones. Cero llamadas nuevas al clasificador.**

```
Calbee:  ANTES  score 35 → precisión 72%
         DESPUÉS score 95 → precisión 96%   (umbral grupo = 90)
```

**Read-back:** sha256 del nodo descargado del server idéntico al archivo probado (`729c6a19b4b17a5f28e237dfce8561d2655056e99ce0ab31cf926faebc9cd6a4`), y el arnés vuelto a correr contra ese código descargado.

**Publicado:** `active: true` · `triggerCount: 1` · `activeVersionId == versionId == 79ac72d3-41be-4a6d-b00c-6c9e500626b4`.

⚠️ El primer `update_workflow` dejó el cambio como **borrador** (`versionId ≠ activeVersionId`) — sin el `publish` posterior, el read-back del nodo habría dicho "correcto" mientras seguía corriendo la versión vieja.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ft5VcRcbHtCUtgUwU73a5e

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ft5VcRcbHtCUtgUwU73a5e)_