### PR TITLE
feat(comercial/machote) V1.22: dirección ve los machotes del equipo en sólo lectura, y el sincronizador pasa a lista blanca

### DIFF
--- a/comercial/machote/css/machote.css
+++ b/comercial/machote/css/machote.css
@@ -1166,3 +1166,23 @@ tr.desg-cuadre .malo { color: var(--rojo); font-weight: 700; }
    ancho — pero tampoco compite con el título. */
 .tb-ver { font-size: 10.5px; color: var(--suave); font-variant-numeric: tabular-nums;
           flex: 0 0 auto; letter-spacing: .01em; }
+
+/* ── Trabajo AJENO · sólo lectura (V1.22) ─────────────────────────────────
+ * Dirección ve los machotes del equipo, y los ve SIN poder editarlos. Lo que
+ * de verdad lo impide vive en el servidor —el dueño sale del token, y
+ * `empujarUno` rechaza lo ajeno—; esto es para que se NOTE, porque una
+ * pantalla idéntica a la editable invita a teclear encima. */
+.pill.aj { background: #eef2ff; color: #3730a3; }
+
+.aviso-ajeno { margin: -4px 0 12px; padding: 10px 12px; border-radius: 10px;
+               background: #eef2ff; border: 1px solid #c7d2fe; color: #1e1b4b;
+               font-size: 13px; line-height: 1.5; }
+
+/* La hoja trabada: los campos ya van `disabled` desde JS —esto sólo lo hace
+   visible—. El cursor de «no» es lo que contesta «¿por qué no puedo escribir?»
+   antes de que la persona lo pregunte. */
+.libro.solo-lectura .hoja, .libro.solo-lectura #hoja { opacity: .92; }
+.libro.solo-lectura input:disabled,
+.libro.solo-lectura select:disabled,
+.libro.solo-lectura textarea:disabled { background: var(--papel); cursor: not-allowed; }
+.libro.solo-lectura .pestana { opacity: 1; }   /* moverse entre hojas SÍ se puede */

--- a/comercial/machote/js/almacen.js
+++ b/comercial/machote/js/almacen.js
@@ -673,6 +673,10 @@
     bajar: bajar,
     esAjeno: esAjeno,
     empujar: empujar,
+    /* Se exporta para que la prueba pueda apretar el SEGUNDO candado —el de
+     * `empujarUno`— sin pasar por la lista. Un candado que no se puede probar
+     * por separado es un candado que nadie sabe si sigue puesto. */
+    empujarUno: empujarUno,
     historial: historial,
     idServidor: idServidor,
     esDemo: esDemo,

--- a/comercial/machote/js/almacen.js
+++ b/comercial/machote/js/almacen.js
@@ -154,14 +154,15 @@
 
   /** Cuántos machotes están escritos aquí pero todavía no en el servidor.
    *  Los ejemplos NO cuentan: nunca se van a subir (`empujarUno` los rechaza),
-   *  así que contarlos dejaría el pulso en «sin guardar» para siempre. */
+   *  así que contarlos dejaría el pulso en «sin guardar» para siempre. Lo
+   *  AJENO tampoco: no es de quien mira y no le toca a él guardarlo. */
   function pendientes(machotes) {
     var lista = machotes || ((leerLocal() || {}).machotes) || [];
     var s = leerSync(), n = 0;
     for (var i = 0; i < lista.length; i++) {
       var m = lista[i];
       if (!m || !m.id) continue;
-      if (esDemo(m)) continue;
+      if (esDemo(m) || esAjeno(m)) continue;
       var meta = s[m.id];
       if (!meta || meta.huella !== huella(m)) n++;
     }
@@ -253,12 +254,34 @@
    * Se comprueba con una prueba dedicada. */
   function esDemo(m) { return !!(m && m._demo === true); }
 
+  /* Un machote AJENO es de otra persona y llegó porque quien mira tiene el
+   * scope `comercial:admin`. Dirección revisa, no edita el trabajo de otro.
+   *
+   * NO SE GUARDA EN `fts_machote_v1`. Esa llave significa «lo mío», y meter
+   * ahí lo de los demás rompería tres cosas a la vez:
+   *   · el `id_local` choca —Ricardo también tiene un M-1041— y el de otro
+   *     pisaría el propio al fundirse;
+   *   · `empujarUno` lo volvería a subir, y el servidor le pone de dueño a
+   *     QUIEN MANDA, así que el trabajo de Ricardo acabaría a nombre de
+   *     Esteban;
+   *   · se quedaría ahí para siempre, también el día que a alguien le quiten
+   *     el scope.
+   * Por eso los ajenos viven SÓLO en memoria, mientras dura la pantalla. */
+  function esAjeno(m) { return !!(m && m._ajeno === true); }
+
   function empujarUno(m, ses, motivo) {
     /* Segundo candado, además de no meterla en la lista: si mañana alguien
      * llama a `empujarUno` directo, la demo sigue sin llegar al servidor. */
     if (esDemo(m)) {
       return Promise.resolve({ ok: false, error: 'ES_DEMO',
         mensaje: 'Los machotes de demostración no se suben al servidor.' });
+    }
+    /* Mismo candado para el trabajo ajeno. No debería llegar aquí —ni entra a
+     * la lista local ni lo recorre `empujar`— pero el día que alguien llame a
+     * esto directo, subirlo lo pondría a nombre de quien manda. */
+    if (esAjeno(m)) {
+      return Promise.resolve({ ok: false, error: 'ES_AJENO',
+        mensaje: 'Ese machote es de otra persona: se puede ver, no guardar.' });
     }
     var s = leerSync();
     var meta = s[m.id] || { version: 0 };
@@ -314,7 +337,7 @@
     for (var i = 0; i < lista.length; i++) {
       var m = lista[i];
       if (!m || !m.id) continue;
-      if (esDemo(m)) continue;                       // la demo no viaja
+      if (esDemo(m) || esAjeno(m)) continue;         // ni la demo ni lo de otro viajan
       var meta = s[m.id];
       if (!meta || meta.huella !== huella(m)) falta.push(m);
     }
@@ -369,12 +392,29 @@
       for (i = 0; i < lista.length; i++) if (lista[i] && lista[i].id) porId[lista[i].id] = i;
 
       var nuevos = 0, refrescados = 0, conservados = 0;
+      /* Lo AJENO se aparta aquí y no vuelve a tocar el almacén local. Va en su
+       * propia lista, en memoria, y la pantalla la pinta al lado de la propia.
+       * El porqué está en `esAjeno`. */
+      var ajenos = [];
 
       for (i = 0; i < r.machotes.length; i++) {
         var fila = r.machotes[i];
         if (!fila || !fila.id_local || !fila.documento) continue;
 
         var doc = machoteDesdeFila(fila);
+
+        if (fila.ajeno === true) {
+          /* El id de PANTALLA de un ajeno es el uuid del servidor, no su
+           * `id_local`: dos personas pueden tener el mismo `M-1041` y con el
+           * id_local se abrirían una a la otra. */
+          doc.id = fila.id;
+          doc._ajeno = true;
+          doc._dueno = fila.dueno || null;
+          doc._dueno_nombre = fila.dueno_nombre || null;
+          doc._version_servidor = fila.version;
+          ajenos.push(doc);
+          continue;
+        }
 
         var pos = porId[fila.id_local];
         if (pos === undefined) {
@@ -407,6 +447,7 @@
 
       return { ok: true, bajados: r.machotes.length, nuevos: nuevos,
                refrescados: refrescados, conservados: conservados,
+               es_admin: r.es_admin === true, ajenos: ajenos,
                machotes: lista, handoff: local.handoff || {}, cache_ok: quedo };
     });
   }
@@ -457,7 +498,7 @@
      * subir» eternamente y «Subir ahora» nunca podría bajar el número — un
      * pendiente que no se puede resolver es peor que no avisar. */
     var todos = machotes || ((leerLocal() || {}).machotes) || [];
-    var lista = todos.filter(function (m) { return !esDemo(m); });
+    var lista = todos.filter(function (m) { return !esDemo(m) && !esAjeno(m); });
     var demos = todos.length - lista.length;
     var ses = sesion();
 
@@ -475,9 +516,15 @@
           ids_pendientes: lista.map(function (m) { return m.id; }) };
       }
 
+      /* Los AJENOS se descartan antes de indexar. La franja habla de LO MÍO, y
+       * el índice va por `id_local`, que NO es único entre personas: Ricardo
+       * también tiene un `M-1041`. Sin este filtro, con el scope de dirección
+       * el machote de otro casaría con el propio y la franja diría «a salvo»
+       * de algo que en el servidor está a nombre de alguien más. */
       var enServidor = {}, i;
       for (i = 0; i < r.machotes.length; i++) {
         var f = r.machotes[i];
+        if (f && f.ajeno === true) continue;
         if (f && f.id_local) enServidor[f.id_local] = f;
       }
 
@@ -624,6 +671,7 @@
     // Asíncrono: el servidor.
     escribir: escribir,
     bajar: bajar,
+    esAjeno: esAjeno,
     empujar: empujar,
     historial: historial,
     idServidor: idServidor,

--- a/comercial/machote/js/app.js
+++ b/comercial/machote/js/app.js
@@ -40,7 +40,7 @@
    * 2026-09-03 (por instrucción de Esteban), pero lleva el suyo aparte y va en
    * V1.00. Planeación sigue en `2.4.1` y el kiosko sólo con cadena de build;
    * a esos no se propaga. */
-  const VERSION = 'V1.21';
+  const VERSION = 'V1.22';
   const $  = (s, r) => (r || document).querySelector(s);
   const $$ = (s, r) => Array.prototype.slice.call((r || document).querySelectorAll(s));
   const clon = (x) => JSON.parse(JSON.stringify(x));
@@ -54,6 +54,10 @@
   const ST = {
     verVacios: false,
     machotes: _guardado ? _guardado.machotes : clon(D.MACHOTES),
+    /* Trabajo de OTRAS personas, en memoria y nada más. Llega sólo con el
+     * scope `comercial:admin` y nunca se escribe en `fts_machote_v1`. */
+    ajenos: [],
+    esAdmin: false,
     ordenes:  clon(D.ORDENES),
     handoff: _guardado ? (_guardado.handoff || {}) : {},
     confirmadas: {},
@@ -244,7 +248,10 @@
    *  vendió: si desaparece, desaparece la única explicación de por qué el
    *  precio fue ese. Lo que se hace con él es cambiarle el estado, no borrarlo.
    *  En creación y En revisión sí se borran: ahí todavía no hay historia. */
-  const borrable = (m) => !((D.ESTADOS[m && m.estado] || {}).sin_borrar);
+  /* Un machote AJENO no se borra ni se edita: dirección revisa, no reescribe
+   * el trabajo de otro. Si quiere partir de él, que lo duplique a su nombre. */
+  const borrable = (m) => !((D.ESTADOS[m && m.estado] || {}).sin_borrar) &&
+                          !(m && m._ajeno === true);
 
   const esc = (s) => String(s === null || s === undefined ? '' : s)
     .replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;').replace(/"/g, '&quot;');
@@ -259,7 +266,12 @@
     : (x * 100).toFixed(2).replace(/\.00$/, '') + '%';
   const nn = (x) => (x === null || x === undefined || x === '') ? '' : x;
 
-  const mach  = (id) => ST.machotes.find(m => m.id === id);
+  /* Busca en las dos listas: la propia (que vive en el navegador) y la de
+   * trabajo AJENO (que sólo vive en memoria, y sólo si quien mira tiene el
+   * scope de dirección). Ver `esAjeno` en almacen.js. */
+  const mach  = (id) => ST.machotes.find(m => m.id === id) ||
+                        ST.ajenos.find(m => m.id === id);
+  const ajeno = (m) => !!(m && m._ajeno === true);
   const orden = (id) => ST.ordenes.find(o => o.id === id);
   const hoff  = (id) => ST.handoff[id] || (ST.handoff[id] = { entregables: {}, notas: '' });
 
@@ -528,13 +540,19 @@
     const ses = (G.SuiteAuth && G.SuiteAuth.getSession()) || null;
     const yo = (ses && ses.actor) || '';
     const yoNom = (ses && ses.nombre) || yo;
-    const duenoDe = (m) => (m && (m.autor || m.dueno)) || yo;
+    /* En un ajeno el dueño lo dice el servidor (`_dueno`), no el documento:
+     * el `autor` de adentro es de quien guardó esa versión, que puede ser otro. */
+    const duenoDe = (m) => (m && (m._dueno || m.autor || m.dueno)) || yo;
     const nombreDe = (a) => (a === yo ? yoNom : a);
 
     /* El universo de personas sale de los DATOS, no de una lista escrita a
      * mano: el día que entre alguien nuevo aparece solo. */
+    /* El universo de la lista son los PROPIOS más los AJENOS. Los ajenos sólo
+     * existen con el scope de dirección; sin él la lista es la de siempre. */
+    const universo = ST.machotes.concat(ST.ajenos || []);
+
     const personas = [];
-    ST.machotes.forEach(m => {
+    universo.forEach(m => {
       const d = duenoDe(m);
       if (d && personas.indexOf(d) < 0) personas.push(d);
     });
@@ -547,7 +565,7 @@
       (f.moneda === '' || (m.moneda || 'MXN') === f.moneda) &&
       coincide(m, ST.busca);
 
-    const visibles = ST.machotes.filter(pasa);
+    const visibles = universo.filter(pasa);
 
     /* La entrada al tablero de dirección sólo se ofrece a quien tiene la
      * llave. Un enlace visible para todos, que a casi todos les contestara
@@ -561,17 +579,21 @@
     const encabezado =
       '<div class="enc">' +
         '<h2>Machotes</h2>' +
-        '<div class="cuenta">' + (visibles.length === ST.machotes.length
-          ? ST.machotes.length + (ST.machotes.length === 1 ? ' cotización' : ' cotizaciones')
-          : visibles.length + ' de ' + ST.machotes.length) + '</div>' +
+        '<div class="cuenta">' + (visibles.length === universo.length
+          ? universo.length + (universo.length === 1 ? ' cotización' : ' cotizaciones')
+          : visibles.length + ' de ' + universo.length) + '</div>' +
         '<div class="acc">' +
           (esDireccion ? '<a class="btn fantasma" href="#/control">Control</a>' : '') +
           /* Dice «todo» y dice CUÁNTOS a propósito. Con filtros en pantalla —y el
            * de persona puesto de arranque— «Exportar» a secas se lee como «exporta
            * lo que estoy viendo», que es justo lo que NO hace. El número es la
            * comprobación de un vistazo de que el respaldo lleva todo. */
+          /* Cuenta `ST.machotes`, NO el universo: el respaldo se lleva lo TUYO.
+           * Meter en tu archivo el trabajo de otros sería sacarlo de donde su
+           * dueño lo puede gobernar. Por eso este número puede ser menor que
+           * el del encabezado cuando se está viendo con el scope de dirección. */
           '<button class="btn fantasma" id="bExportar" title="Baja un archivo con TODO lo '
-            + 'capturado, no sólo lo que muestran los filtros">Exportar todo ('
+            + 'capturado POR TI, no sólo lo que muestran los filtros">Exportar todo ('
             + ST.machotes.length + ')</button>' +
           '<label class="btn fantasma archivo" title="Nunca pisa lo que ya existe">Importar' +
             '<input type="file" id="fImportar" accept="application/json,.json"></label>' +
@@ -617,7 +639,9 @@
       return '<tr class="rw" data-mid="' + esc(m.id) + '">' +
         '<td><div class="nm"><a href="#/m/' + esc(m.id) + '">' + esc(m.nombre) + '</a>' +
           (dm ? ' <span class="pill" title="Ejemplo que trae la aplicación. No se guarda en el servidor.">ejemplo</span>' : '') +
-          '</div><div class="sub">' + esc(cli(m)) + (m.so ? ' · ' + esc(m.so) : '') + ' · ' + esc(m.id) + '</div></td>' +
+          (ajeno(m) ? ' <span class="pill aj" title="Trabajo de otra persona. Se abre en lectura: no se edita ni se borra.">sólo lectura</span>' : '') +
+          '</div><div class="sub">' + esc(cli(m)) + (m.so ? ' · ' + esc(m.so) : '') +
+          (ajeno(m) ? '' : ' · ' + esc(m.id)) + '</div></td>' +
         '<td class="quien-td sub" title="' + esc(nombreDe(duenoDe(m))) + '">' +
           esc(nombreDe(duenoDe(m))) + '</td>' +
         '<td><span class="pill" style="background:' + edo(m).color + '20;color:' + edo(m).color + '">' +
@@ -643,6 +667,7 @@
         '<a class="item" href="#/m/' + esc(m.id) + '">' +
         '<div class="grow"><strong>' + esc(m.nombre) + '</strong>' +
           (dm ? ' <span class="pill">ejemplo</span>' : '') +
+          (ajeno(m) ? ' <span class="pill aj">sólo lectura</span>' : '') +
           '<div class="tiny">' + esc(cli(m)) + (m.so ? ' · ' + esc(m.so) : '') + ' · ' +
           esc(nombreDe(duenoDe(m))) + '</div></div>' +
         '<div class="right"><span class="chip" style="background:' + edo(m).color + '">' +
@@ -854,14 +879,27 @@
     // abierta de la anterior deja al analista en una sección que no pidió.
     if (ST.libroAbierto !== id) { ST.hoja = 'desglose'; ST.libroAbierto = id; }
     const c = C.calcular(m);
-    top(cli(m), m.id + (m.so ? ' · ' + m.so : ''), null, '#/');
+    const soloLectura = ajeno(m);
+    top(cli(m), soloLectura
+      ? ('de ' + (m._dueno_nombre || m._dueno || 'otra persona'))
+      : (m.id + (m.so ? ' · ' + m.so : '')), null, '#/');
 
     const hojas = [{ id: 'desglose', label: 'DESGLOSE COTIZACIÓN' }]
       .concat(m.secciones.map(s => ({ id: s.id, label: s.nombre || 'SECCIÓN' })));
     if (!hojas.some(h => h.id === ST.hoja)) ST.hoja = 'desglose';
 
+    /* AVISO ARRIBA, ANTES DE LA HOJA. Un machote ajeno se ve igual que el
+     * propio, así que si no se dice, alguien teclea encima creyendo que es
+     * suyo y pierde el rato: los campos están bloqueados y no va a entender
+     * por qué. El aviso dice de quién es y qué puede hacer en su lugar. */
     $('#vista').innerHTML =
-      '<div class="libro">' +
+      (soloLectura
+        ? '<div class="aviso-ajeno">Esta cotización es de <strong>' +
+          esc(m._dueno_nombre || m._dueno || 'otra persona') + '</strong>. ' +
+          'La estás viendo en <strong>sólo lectura</strong>: se puede revisar, no editar. ' +
+          'Si quieres partir de ella, duplícala a tu nombre.</div>'
+        : '') +
+      '<div class="libro' + (soloLectura ? ' solo-lectura' : '') + '">' +
       '<div class="hojas" id="hojas">' + hojas.map((h, i) =>
         '<button class="pestana' + (h.id === ST.hoja ? ' on' : '') +
         (i > C.MAX_SECCIONES ? ' fuera' : '') + '" data-hoja="' + esc(h.id) + '"' +
@@ -906,6 +944,27 @@
     const c = C.calcular(m);
     $('#hoja').innerHTML = hojaHTML(m, c);
     enlazar(m);
+    trabarSiEsAjeno(m);
+  }
+
+  /* Traba la hoja cuando el machote es de otra persona.
+   *
+   * Va AQUÍ y no en cada sitio que pinta porque `pintarHoja` es el único punto
+   * por el que pasa toda la hoja — el mismo criterio que el filtro de la demo
+   * en `empujar`. Un camino nuevo que repinte queda cubierto solo.
+   *
+   * Esto NO es la seguridad: la seguridad es que el servidor no deja guardar
+   * un machote ajeno (`empujarUno` lo rechaza, y de todos modos el dueño lo
+   * pone el token). Esto es para que nadie pierda el rato tecleando encima de
+   * algo que no se va a guardar. */
+  function trabarSiEsAjeno(m) {
+    if (!m || m._ajeno !== true) return;
+    const hoja = $('#hoja'); if (!hoja) return;
+    hoja.querySelectorAll('input, select, textarea, button').forEach(el => {
+      el.disabled = true;
+      el.setAttribute('aria-disabled', 'true');
+      if (!el.title) el.title = 'Es de otra persona: sólo lectura.';
+    });
   }
 
   /** Refresca SÓLO los derivados, sin repintar.
@@ -1718,7 +1777,14 @@
        * servidor trajo machotes, o esta persona ya tenía capturado aquí. Si
        * las dos están vacías, se queda la demo — que es lo que espera quien
        * abre la página por primera vez. */
-      if (Array.isArray(r.machotes) && (r.machotes.length || _hayCaptura)) {
+      /* Lo ajeno entra aparte y NO se persiste. Si el servidor todavía no
+       * manda `ajenos` —la versión publicada vieja— esto queda en [] y la
+       * pantalla se comporta exactamente como antes. Tolerante primero: es la
+       * regla anti-trabón de CLAUDE.md §8. */
+      ST.ajenos = Array.isArray(r.ajenos) ? r.ajenos : [];
+      ST.esAdmin = r.es_admin === true;
+
+      if (Array.isArray(r.machotes) && (r.machotes.length || _hayCaptura || ST.ajenos.length)) {
         ST.machotes = r.machotes;
         ST.handoff = r.handoff || ST.handoff;
         render();

--- a/comercial/machote/js/app.js
+++ b/comercial/machote/js/app.js
@@ -543,7 +543,12 @@
     /* En un ajeno el dueño lo dice el servidor (`_dueno`), no el documento:
      * el `autor` de adentro es de quien guardó esa versión, que puede ser otro. */
     const duenoDe = (m) => (m && (m._dueno || m.autor || m.dueno)) || yo;
-    const nombreDe = (a) => (a === yo ? yoNom : a);
+    /* El nombre REAL, no el usuario. La columna se llama «Responsable» y para
+     * los ajenos salía `francisco.montalvo` — justo las personas que dirección
+     * necesita identificar de un vistazo. El servidor manda `dueno_nombre`. */
+    const nombresAjenos = {};
+    (ST.ajenos || []).forEach(m => { if (m._dueno) nombresAjenos[m._dueno] = m._dueno_nombre || m._dueno; });
+    const nombreDe = (a) => (a === yo ? yoNom : (nombresAjenos[a] || a));
 
     /* El universo de personas sale de los DATOS, no de una lista escrita a
      * mano: el día que entre alguien nuevo aparece solo. */
@@ -579,8 +584,14 @@
     const encabezado =
       '<div class="enc">' +
         '<h2>Machotes</h2>' +
+        /* Con ajenos en pantalla la cuenta dice CUÁNTAS SON TUYAS. Sin eso,
+         * «4 cotizaciones» al lado de «Exportar todo (1)» se lee como un error
+         * de la aplicación en vez de como lo que es: el respaldo se lleva lo
+         * tuyo, y tuya hay una. */
         '<div class="cuenta">' + (visibles.length === universo.length
-          ? universo.length + (universo.length === 1 ? ' cotización' : ' cotizaciones')
+          ? universo.length + (universo.length === 1 ? ' cotización' : ' cotizaciones') +
+            ((ST.ajenos || []).length ? ' · ' + ST.machotes.length + ' tuya' +
+              (ST.machotes.length === 1 ? '' : 's') : '')
           : visibles.length + ' de ' + universo.length) + '</div>' +
         '<div class="acc">' +
           (esDireccion ? '<a class="btn fantasma" href="#/control">Control</a>' : '') +
@@ -656,7 +667,9 @@
           '<button class="ico" data-hist="' + esc(m.id) + '" title="Ver el historial de versiones">🕘</button>' +
           (borrable(m)
             ? '<button class="ico" data-borrar="' + esc(m.id) + '" title="Eliminar machote">×</button>'
-            : '<span class="ico candado" title="Enviado a Odoo: no se borra, sólo cambia de estado">🔒</span>') +
+            : '<span class="ico candado" title="' + (ajeno(m)
+                ? 'Es de otra persona: se puede ver, no borrar.'
+                : 'Enviado a Odoo: no se borra, sólo cambia de estado') + '">🔒</span>') +
         '</div></td></tr>';
     };
 
@@ -681,7 +694,9 @@
         '<button class="ico" data-hist="' + esc(m.id) + '" title="Ver el historial de versiones">🕘</button>' +
         (borrable(m)
           ? '<button class="ico peligro borrar" data-borrar="' + esc(m.id) + '" title="Eliminar machote">×</button>'
-          : '<span class="ico candado" title="Enviado a Odoo: no se borra, sólo cambia de estado">🔒</span>') +
+          : '<span class="ico candado" title="' + (ajeno(m)
+              ? 'Es de otra persona: se puede ver, no borrar.'
+              : 'Enviado a Odoo: no se borra, sólo cambia de estado') + '">🔒</span>') +
         '</div>';
     };
 
@@ -1503,7 +1518,12 @@
       /* El paso siguiente al machote: pasarlo a orden. Es un CASCARÓN —lo
        * dice en su propia cabecera— y por eso el botón va en secundario, al
        * lado de Revisar, sin robarle el lugar al que sí hace algo. */
-      (G.MachoteOrden
+      /* «Pasar a orden» NO se ofrece sobre trabajo ajeno. La barra vive FUERA
+       * de `#hoja`, así que `trabarSiEsAjeno` no la alcanza —lo cazó la
+       * captura, no el diff—: quedaba un botón vivo para convertir en orden la
+       * cotización de otro. «Revisar» sí se queda: es de sólo lectura y es
+       * justo para lo que dirección abre un machote ajeno. */
+      (G.MachoteOrden && !ajeno(m)
         ? '<button class="btn fantasma" id="btnOrden" title="Ver cómo se pasaría a orden de venta">Pasar a orden</button>'
         : '') +
       '<a class="btn" href="#/rev/' + m.id + '">Revisar</a></div>';

--- a/comercial/machote/tests/pruebas-navegador.js
+++ b/comercial/machote/tests/pruebas-navegador.js
@@ -3360,10 +3360,19 @@ let ok = 0, mal = 0;
         localStorage.removeItem('fts_machote_v1');
         localStorage.removeItem('fts_machote_sync_v1');
       } catch (e) {}
-      const doc = (nom) => ({
-        nombre: nom, cliente: 'Cliente X', estado: 'borrador', moneda: 'MXN',
-        margenes: {}, secciones: [{ id: 's1', nombre: 'SECCIÓN 1', mo: [], partidas: [] }]
-      });
+      /* El documento se clona de la DEMO —que es un machote válido y completo—
+       * y sólo se le cambia el nombre. Un machote inventado a mano aquí pinta
+       * una hoja sin campos, y entonces la prueba de «está trabado» no probaría
+       * nada: no habría nada que trabar. Se evalúa perezosamente porque
+       * `window.DEMO` todavía no existe cuando corre este guion. */
+      const doc = (nom) => {
+        const base = (window.DEMO && window.DEMO.MACHOTES && window.DEMO.MACHOTES[0]) || null;
+        const d = base ? JSON.parse(JSON.stringify(base))
+                       : { estado: 'borrador', moneda: 'MXN', margenes: {}, secciones: [] };
+        d.nombre = nom; d.estado = 'borrador';
+        delete d._demo;          // llega del servidor: ya no es un ejemplo
+        return d;
+      };
       window.__guard = [];
       const orig = window.fetch;
       window.fetch = function (u, o) {
@@ -3399,6 +3408,18 @@ let ok = 0, mal = 0;
   await paso('dirección ve el trabajo del equipo, marcado y sin poder tocarlo', async () => {
     const q = await paginaConAjenos();
     try {
+      /* Al entrar se ve SÓLO lo propio, también con el scope de dirección: es
+       * la decisión de Esteban y el pie lo anuncia. Lo de los demás está a un
+       * clic, y ese clic es el que se da aquí. */
+      const alEntrar = await q.$$eval('tr.rw', f => f.map(x => x.textContent.indexOf('Lo de Ricardo') >= 0));
+      if (alEntrar.some(Boolean))
+        throw new Error('al entrar ya enseñaba lo de otro: el filtro propio no se respetó');
+      const pie = (await q.textContent('#vista')).replace(/\s+/g, ' ');
+      if (!/Viendo sólo lo tuyo/i.test(pie))
+        throw new Error('no avisa que hay un filtro puesto');
+
+      await q.selectOption('#fPersona', ''); await q.waitForTimeout(320);
+
       const r = await q.evaluate(() => {
         const filas = [...document.querySelectorAll('tr.rw')];
         const busca = (t) => filas.find(f => f.textContent.indexOf(t) >= 0);

--- a/comercial/machote/tests/pruebas-navegador.js
+++ b/comercial/machote/tests/pruebas-navegador.js
@@ -3342,6 +3342,158 @@ let ok = 0, mal = 0;
     } finally { await ctx.close(); }
   });
 
+  /* ── V1.22 · dirección ve el trabajo del equipo, en sólo lectura ───────
+   *
+   * El servidor decide el ALCANCE (con `comercial:admin` devuelve los de
+   * todos) y eso se prueba contra la base, no aquí. Lo que se prueba aquí es
+   * lo otro: que la pantalla trate el trabajo ajeno como AJENO — que no lo
+   * meta en el almacén de uno, que no lo suba, y que no deje teclearlo. */
+  const paginaConAjenos = async () => {
+    const q = await b.newPage({ viewport: { width: 1280, height: 900 } });
+    await q.addInitScript(() => {
+      try {
+        localStorage.setItem('fts_suite_session', JSON.stringify({
+          token: 'prueba.prueba.prueba', actor: 'esteban.delacruz',
+          nombre: 'Jesus Esteban De La Cruz', empleado_id: 32,
+          scopes: ['comercial:read', 'comercial:admin'],
+          exp: Math.floor(Date.now() / 1000) + 3600, debe_cambiar_password: false }));
+        localStorage.removeItem('fts_machote_v1');
+        localStorage.removeItem('fts_machote_sync_v1');
+      } catch (e) {}
+      const doc = (nom) => ({
+        nombre: nom, cliente: 'Cliente X', estado: 'borrador', moneda: 'MXN',
+        margenes: {}, secciones: [{ id: 's1', nombre: 'SECCIÓN 1', mo: [], partidas: [] }]
+      });
+      window.__guard = [];
+      const orig = window.fetch;
+      window.fetch = function (u, o) {
+        const s = String(u);
+        if (s.indexOf('/comercial/machotes-leer') >= 0) {
+          return Promise.resolve({ ok: true, json: () => Promise.resolve({
+            ok: true, modo: 'lista', actor: 'esteban.delacruz', es_admin: true,
+            total: 2, duenos: ['esteban.delacruz', 'ricardo.hernandez'],
+            machotes: [
+              { id: 'uuid-mio', id_local: 'M-MIO-1', documento: doc('Lo mio'),
+                dueno: 'esteban.delacruz', dueno_nombre: 'Jesus Esteban De La Cruz',
+                ajeno: false, version: 1, versiones: 1, estado: 'borrador' },
+              { id: 'uuid-de-ricardo', id_local: 'M-1041', documento: doc('Lo de Ricardo'),
+                dueno: 'ricardo.hernandez', dueno_nombre: 'Ricardo Alan Hernandez',
+                ajeno: true, version: 3, versiones: 3, estado: 'revision' }
+            ] }) });
+        }
+        if (s.indexOf('/comercial/machote-guardar') >= 0) {
+          var c = {}; try { c = JSON.parse((o && o.body) || '{}'); } catch (e) {}
+          window.__guard.push(c);
+          return Promise.resolve({ ok: true, json: () => Promise.resolve({
+            ok: true, machote_id: 'x', id_local: c.id_local, dueno: 'esteban.delacruz',
+            version: 1, versiones: 1, autor: 'esteban.delacruz' }) });
+        }
+        if (s.indexOf('/comercial/clientes') >= 0) return new Promise(function () {});
+        return orig.apply(this, arguments);
+      };
+    });
+    await q.goto(BASE); await q.waitForTimeout(1600);
+    return q;
+  };
+
+  await paso('dirección ve el trabajo del equipo, marcado y sin poder tocarlo', async () => {
+    const q = await paginaConAjenos();
+    try {
+      const r = await q.evaluate(() => {
+        const filas = [...document.querySelectorAll('tr.rw')];
+        const busca = (t) => filas.find(f => f.textContent.indexOf(t) >= 0);
+        const mio = busca('Lo mio'), aj = busca('Lo de Ricardo');
+        return {
+          salen_los_dos: !!mio && !!aj,
+          el_ajeno_se_marca: !!(aj && aj.querySelector('.pill.aj')),
+          el_ajeno_no_se_borra: !!(aj && !aj.querySelector('[data-borrar]')),
+          el_mio_si_se_borra: !!(mio && mio.querySelector('[data-borrar]')),
+          dice_de_quien: !!(aj && /Ricardo/.test(aj.textContent)),
+          /* LO IMPORTANTE: el trabajo de otro NO entra al almacén de uno. */
+          en_el_almacen: (JSON.parse(localStorage.getItem('fts_machote_v1') || '{"machotes":[]}')
+            .machotes || []).map(m => m.nombre)
+        };
+      });
+      if (!r.salen_los_dos) throw new Error('no salieron los dos machotes');
+      if (!r.el_ajeno_se_marca) throw new Error('el ajeno no se distingue del propio');
+      if (!r.el_ajeno_no_se_borra) throw new Error('le dejó el botón de borrar al ajeno');
+      if (!r.el_mio_si_se_borra) throw new Error('se llevó de más: el propio ya no se borra');
+      if (!r.dice_de_quien) throw new Error('no dice de quién es');
+      if (r.en_el_almacen.indexOf('Lo de Ricardo') >= 0)
+        throw new Error('GUARDÓ trabajo ajeno en fts_machote_v1: ' + JSON.stringify(r.en_el_almacen));
+      if (r.en_el_almacen.indexOf('Lo mio') < 0)
+        throw new Error('perdió lo propio: ' + JSON.stringify(r.en_el_almacen));
+      console.log('    en el almacén sólo ' + JSON.stringify(r.en_el_almacen));
+    } finally { await q.close(); }
+  });
+
+  await paso('el machote ajeno se abre TRABADO y nunca se sube', async () => {
+    const q = await paginaConAjenos();
+    try {
+      await q.evaluate(() => { location.hash = '#/m/uuid-de-ricardo'; });
+      await q.waitForTimeout(500);
+      const r = await q.evaluate(() => {
+        const campos = [...document.querySelectorAll('#hoja input, #hoja select, #hoja textarea')];
+        return {
+          avisa: !!document.querySelector('.aviso-ajeno'),
+          campos: campos.length,
+          sueltos: campos.filter(c => !c.disabled).length
+        };
+      });
+      if (!r.avisa) throw new Error('no avisa que es de otra persona');
+      if (!r.campos) throw new Error('no pintó la hoja: la prueba no probaría nada');
+      if (r.sueltos) throw new Error(r.sueltos + ' de ' + r.campos + ' campos siguen editables');
+
+      // Y aunque se fuerce el empujón, no viaja.
+      const g = await q.evaluate(async () => {
+        const A = window.MachoteAlmacen;
+        const aj = { id: 'uuid-de-ricardo', nombre: 'Lo de Ricardo', _ajeno: true,
+                     secciones: [], margenes: {} };
+        const r1 = await A.empujar([aj]);
+        const r2 = await A.empujarUno(aj, { token: 't' }, null).catch(e => ({ error: 'lanzó' }));
+        return { subidos: r1 && r1.subidos, uno: r2 && r2.error,
+                 llamadas: (window.__guard || []).length };
+      });
+      if (g.llamadas) throw new Error('llamó al servidor ' + g.llamadas + ' vez(ces) con lo ajeno');
+      if (g.uno !== 'ES_AJENO') throw new Error('empujarUno no lo rechazó: ' + g.uno);
+      console.log('    hoja trabada · ' + r.campos + ' campos · 0 llamadas al servidor · ' + g.uno);
+    } finally { await q.close(); }
+  });
+
+  await paso('el sincronizador de configuración NO se lleva lo del machote', async () => {
+    /* La fuga que esto cierra: `shared/ops-config.json` está COMMITEADO en un
+     * repo público, y hasta hoy el sincronizador barría toda llave `fts_*`.
+     * La captura comercial de tres personas se iba en la siguiente subida. */
+    const q = await b.newPage({ viewport: { width: 1280, height: 900 } });
+    try {
+      /* Se carga el archivo REAL —no una copia— en una página en blanco y se
+       * ejerce su API. Si alguien cambia la lista, esto lo caza. */
+      await q.goto(BASE);
+      await q.addScriptTag({ path: path.resolve(__dirname, '..', '..', '..', 'shared', 'config-sync.js') });
+      const r = await q.evaluate(() => {
+        const sensibles = ['fts_machote_v1', 'fts_machote_sync_v1', 'fts_suite_session',
+          'fts_fin_session', 'fts_mi_perfil_session', 'fts_comercial_hmac', 'fts_employees',
+          'fts_session', 'ops_sync_password', 'ops_kiosk_master_pin', 'ops_kiosk_field_pin'];
+        sensibles.forEach(k => localStorage.setItem(k, 'SECRETO-' + k));
+        localStorage.setItem('ops_n8n_url', 'https://n8n.example');
+        localStorage.setItem('key_claude', 'sk-de-mentiras');
+        const cfg = window.ConfigSync.collectOpsKeys();
+        return { llaves: Object.keys(cfg).sort(),
+                 coladas: sensibles.filter(k => k in cfg),
+                 trae_config: ('ops_n8n_url' in cfg) && ('key_claude' in cfg),
+                 fuera: window.ConfigSync.sinSincronizar() };
+      });
+      if (r.coladas.length)
+        throw new Error('se colaron al repo público: ' + r.coladas.join(', '));
+      if (!r.trae_config)
+        throw new Error('se llevó de más: dejó de sincronizar la configuración real');
+      if (r.fuera.indexOf('fts_machote_v1') < 0)
+        throw new Error('no reporta que el machote se queda fuera');
+      console.log('    sincroniza ' + r.llaves.length + ' · deja fuera ' + r.fuera.length +
+                  ' (incluido fts_machote_v1)');
+    } finally { await q.close(); }
+  });
+
   await paso('sin errores de consola propios del prototipo', async () => {
     if (errs.length) throw new Error(errs.slice(0, 4).join(' | '));
     if (delEntorno.length) console.log('   (' + delEntorno.length +

--- a/comercial/machote/tests/pruebas-navegador.js
+++ b/comercial/machote/tests/pruebas-navegador.js
@@ -3458,10 +3458,18 @@ let ok = 0, mal = 0;
         return {
           avisa: !!document.querySelector('.aviso-ajeno'),
           campos: campos.length,
-          sueltos: campos.filter(c => !c.disabled).length
+          sueltos: campos.filter(c => !c.disabled).length,
+          /* La barra fija vive FUERA de `#hoja`: se comprueba aparte porque el
+           * trabado de la hoja no la alcanza. */
+          pasar_a_orden: !!document.querySelector('#btnOrden'),
+          revisar: !!document.querySelector('.fija a[href^="#/rev/"]')
         };
       });
       if (!r.avisa) throw new Error('no avisa que es de otra persona');
+      if (r.pasar_a_orden)
+        throw new Error('deja «Pasar a orden» sobre trabajo ajeno');
+      if (!r.revisar)
+        throw new Error('quitó «Revisar», que es justo para lo que se abre uno ajeno');
       if (!r.campos) throw new Error('no pintó la hoja: la prueba no probaría nada');
       if (r.sueltos) throw new Error(r.sueltos + ' de ' + r.campos + ' campos siguen editables');
 

--- a/comercial/machote/version.json
+++ b/comercial/machote/version.json
@@ -1,10 +1,15 @@
 {
-  "version": "V1.21",
-  "fecha": "2026-09-08",
+  "version": "V1.22",
+  "fecha": "2026-09-09",
   "modulo": "comercial/machote",
   "ambito": "El CONTADOR es solo de este modulo. finanzas tambien usa V1.xx desde el 2026-09-03 (instruccion directa de Esteban, corrige el \"no propagar\" del issue #148) pero lleva su propio contador y va en V1.00. operaciones/planeacion sigue en 2.4.1, kiosk y confirmar-horas solo con cadena de build, y siete modulos con un 1.0.0 puesto una vez: a esos no se propaga.",
   "esquema": "V<mayor>.<menor de dos digitos>. Un incremento de 0.01 por cada merge a main. Al pasar de .99 sube el mayor y el menor vuelve a 00.",
   "historial": [
+    {
+      "version": "V1.22",
+      "pr": null,
+      "nota": "Direccion ve los machotes del equipo, y los ve en SOLO LECTURA. Hasta hoy comercial/machotes-leer devolvia unicamente los del dueno del token, asi que el filtro de persona de V1.21 prometia algo que no podia cumplir: Montalvo y Ricardo habian subido 9 machotes que Esteban no veia. Ahora, con el scope comercial:admin, la lectura abarca a todos y cada renglon dice de quien es. El ALCANCE sale del TOKEN, nunca del cuerpo: un usuario normal que mande dueno o es_admin en el cuerpo recibe exactamente lo mismo que sin mandarlos, y cambiar el payload del token invalida la firma. El trabajo ajeno NO se guarda en fts_machote_v1 -esa llave significa lo mio-: vive solo en memoria, no cuenta como pendiente, no se exporta y no se puede subir, porque el servidor le pondria de dueno a quien manda. Se abre con la hoja trabada y un aviso que dice de quien es. Ademas: el sincronizador de configuracion deja de barrer todas las llaves fts_ y pasa a lista blanca, asi que la captura comercial ya no puede acabar en el repo publico; y el ciclo de envio quedo cerrado de punta a punta contra Graph."
+    },
     {
       "version": "V1.21",
       "pr": null,

--- a/docs/comercial/SINCRONIZADOR-LISTA-BLANCA.md
+++ b/docs/comercial/SINCRONIZADOR-LISTA-BLANCA.md
@@ -1,0 +1,93 @@
+# El sincronizador de configuración pasa a lista blanca
+
+**9-sep-2026 · issue #140 · V1.22**
+
+`shared/config-sync.js` no es un archivo del módulo comercial. Se toca desde aquí porque
+la fuga que tenía se llevaba, entre otras cosas, **la captura comercial de tres personas**.
+
+## Lo que pasaba
+
+`collectOpsKeys()` recorría **todo** `localStorage` y se llevaba cada llave que empezara
+por `ops_`, `key_` o `fts_`, excluyendo cuatro. Lo recolectado se cifra y se escribe en
+**`shared/ops-config.json`, que está commiteado en un repositorio PÚBLICO**.
+
+La lista negra tenía cuatro entradas: `ops_sync_password`, `ops_last_sync`, `fts_session`
+y `fts_master_hash`. **No** estaban excluidas, entre otras:
+
+| llave | qué es |
+|---|---|
+| `fts_machote_v1` | las cotizaciones del equipo, **con costos y comisiones** |
+| `fts_machote_sync_v1` | qué se subió y en qué versión |
+| `fts_suite_session` | el JWT de la sesión |
+| `fts_fin_session` · `fts_mi_perfil_session` · `fts_iperc_session` | otras sesiones |
+| `fts_comercial_hmac` | un HMAC |
+| `fts_employees` | datos de empleados (§20 #7: datos personales no van a repo público) |
+
+## Lo que NO pasó
+
+**No hay fuga consumada.** El blob de hoy dice `updated: 2026-04-18T17:19:38.375Z` y el
+archivo tiene **un solo commit** (`4254782`, 17-ago-2026). Las llaves del machote no
+existían entonces: `fts_machote_v1` aparece por primera vez el **3-sep-2026**
+(`a3b39e7`, V1.07). `fts_fin_session` y `fts_suite_session` son igualmente posteriores al
+18-abr. Y `fts_session` —la vieja de FTSAuth, que sí es anterior— **estaba excluida**.
+
+O sea: el archivo publicado no contiene ninguna de ellas. El riesgo era **hacia adelante**,
+en la próxima sincronización que alguien hiciera.
+
+## El cambio
+
+De lista negra a **lista blanca**: `PERMITIDAS` enumera lo que se sincroniza, y
+`collectOpsKeys()` pide exactamente eso en vez de recorrer `localStorage`.
+
+Lo que importa no es la precisión, es el **modo de fallo** (CLAUDE.md §9): olvidar una
+llave de configuración cuesta volver a teclearla en el otro dispositivo; olvidar una de
+datos costaba publicarla. Se rompe hacia el lado soportable.
+
+## Qué se sigue sincronizando
+
+- **Backend**: `ops_n8n_url`, `ops_odoo_url`, `ops_odoo_db`, `ops_demo_mode`, `ops_migrated`
+- **Kiosko**: geocercas (`ops_kiosk_geolocations`, `ops_geo_sync_timestamp`), `ops_kiosk_stages`,
+  `ops_kiosk_company_id`, los cuatro de reconocimiento facial, `ops_kiosk_field_photo`,
+  los cuatro de notificación
+- **Tablero y planeación**: `ops_dash_*` (4), `ops_plan_*` (5)
+- **Llaves de API que este panel administra a propósito**: `key_claude`, `key_groq`,
+  `key_openrouter`, `key_gemini`, `key_github_token`, `key_odoo_api`, `ops_github_token`
+
+Los cuatro `key_*` y el token de GitHub siguen dentro **porque administrarlos es lo que hace
+este panel**: sacarlos rompería su función. Es una decisión distinta de la fuga, y sigue
+abierta — el PAT en claro está reportado desde la sesión 4 y Esteban decidió revocarlo
+después.
+
+## Qué DEJA de sincronizarse, y a quién le puede doler
+
+Todo lo demás. En concreto, lo que existe hoy en el repo y ya no viaja:
+
+| llave | consecuencia de que ya no viaje |
+|---|---|
+| `fts_machote_v1` / `fts_machote_sync_v1` | **ninguna**: el machote se sincroniza solo, contra Postgres. Esto era pura fuga. |
+| `fts_suite_session`, `fts_fin_session`, `fts_mi_perfil_session`, `fts_iperc_session` | ninguna: una sesión no debe viajar entre dispositivos, se vuelve a entrar. |
+| `fts_employees`, `fts_iperc_learned`, `fts_iperc_client` | datos de trabajo; si algún módulo dependía de que viajaran, hay que darles su propio almacén server-side, no el archivo público. |
+| `fts_system_prompt`, `fts_openrouter_key`, `fts_groq_key`, `fts_gemini_key`, `fts_api_key`, `fts_gh_token` | **sí puede doler**: son ajustes/llaves de las pantallas de IA. Ahora se teclean por dispositivo. Sus gemelos `key_*` sí siguen sincronizando, así que en la mayoría de los casos hay un camino que ya funciona. |
+| `ops_kiosk_master_pin`, `ops_kiosk_field_pin`, `ops_master_pin`, `ops_api_key` | PINes de personas. Se configuran por dispositivo a propósito. |
+| `ops_last_sync`, `ops_sync_password` | ya estaban fuera. |
+
+**El cambio no borra nada.** `load()` sólo hace `setItem`: una llave que deje de
+sincronizarse se queda como esté en cada navegador, no se pierde ni se pisa.
+
+## Cómo se sabe qué se está quedando fuera
+
+`ConfigSync.sinSincronizar()` devuelve la lista, y `save()` la escribe en la consola al
+guardar. Una lista blanca que silenciosamente deja de llevar algo es tan mala como la
+lista negra que se llevaba de más: en los dos casos nadie se entera.
+
+**Para agregar una llave**: métela en `PERMITIDAS`, en su grupo, y sólo si es
+**configuración** del panel de operaciones. Nunca datos de trabajo, ni sesiones, ni PINes,
+ni nada que identifique a una persona.
+
+## Prueba
+
+`comercial/machote/tests/pruebas-navegador.js` →
+*«el sincronizador de configuración NO se lleva lo del machote»*: siembra las once llaves
+sensibles más dos de configuración, carga el `config-sync.js` **real**, llama a
+`collectOpsKeys()` y exige que no se cuele ninguna de las once **y** que las dos de
+configuración sí estén — porque una lista blanca vacía también pasaría la primera mitad.

--- a/shared/config-sync.js
+++ b/shared/config-sync.js
@@ -104,24 +104,79 @@
 
     // Recolecta todas las keys ops_*, key_* y fts_* del localStorage
     // Excluye keys de auth/sesión locales que NO deben subirse a GitHub
-    collectOpsKeys(){
-      const config = {};
-      const EXCLUDE = new Set([
-        'ops_sync_password',  // password local, no se cifra a sí mismo
-        'ops_last_sync',      // timestamp local
-        'fts_session',        // sesión activa (auth-suite)
-        'fts_master_hash'     // hash temporal del primer login master
-      ]);
+    /* ── LISTA BLANCA. Antes era lista negra, y por eso había que cambiarla.
+     *
+     * Hasta el 9-sep-2026 esto barría TODA llave `ops_*`, `key_*` y `fts_*` y
+     * excluía cuatro. El archivo que produce, `shared/ops-config.json`, está
+     * COMMITEADO en un repo PÚBLICO. O sea: cada llave nueva que estrenara
+     * cualquier módulo del Suite entraba sola, cifrada, al repo público — sin
+     * que nadie lo decidiera.
+     *
+     * Y ya había pasado: `fts_machote_v1` (las cotizaciones del equipo, con
+     * costos y comisiones), `fts_suite_session` (el JWT), `fts_fin_session`,
+     * `fts_mi_perfil_session`, `fts_comercial_hmac` y `fts_employees` NO
+     * estaban excluidas. Nada se filtró todavía —el blob es del 18-abr-2026 y
+     * el machote no existía hasta el 3-sep— pero la siguiente sincronización
+     * se lo llevaba.
+     *
+     * El cifrado es honesto (AES-256-GCM + PBKDF2-SHA256 100k). El problema no
+     * era el cifrado: era el ALCANCE. Una contraseña elegida por una persona
+     * protegiendo, en un archivo público y PARA SIEMPRE, la captura comercial
+     * de tres personas.
+     *
+     * Con lista blanca el modo de fallo se invierte, que es lo único que
+     * importa: olvidar una llave de configuración cuesta volver a teclearla en
+     * el otro dispositivo; olvidar una de datos costaba publicarla. Se rompe
+     * hacia el lado soportable (CLAUDE.md §9).
+     *
+     * PARA AGREGAR UNA LLAVE: métela abajo, en su grupo, y sólo si es
+     * CONFIGURACIÓN del panel de operaciones. Nunca datos de trabajo, ni
+     * sesiones, ni PINes de personas, ni nada que identifique a alguien.
+     * `sinSincronizar()` te dice qué se está quedando fuera. */
+    PERMITIDAS: [
+      // Dónde vive el backend
+      'ops_n8n_url', 'ops_odoo_url', 'ops_odoo_db', 'ops_demo_mode', 'ops_migrated',
+      // Kiosko: geocercas y ajustes de la pantalla
+      'ops_kiosk_geolocations', 'ops_geo_sync_timestamp', 'ops_kiosk_stages',
+      'ops_kiosk_company_id', 'ops_kiosk_face_enabled', 'ops_kiosk_face_required',
+      'ops_kiosk_face_threshold', 'ops_kiosk_face_models_url', 'ops_kiosk_field_photo',
+      'ops_kiosk_notify_email', 'ops_kiosk_notify_email_fallback',
+      'ops_kiosk_notify_wa', 'ops_kiosk_notify_wa_webhook',
+      // Tablero y planeación: umbrales y horarios
+      'ops_dash_refresh', 'ops_dash_alerta_sin_checar', 'ops_dash_alerta_fuera_zona',
+      'ops_dash_alerta_extra', 'ops_plan_hora_entrada', 'ops_plan_hora_salida',
+      'ops_plan_hora_limite', 'ops_plan_recordatorio', 'ops_plan_wa_webhook',
+      // Llaves de API que este panel administra a propósito
+      'key_claude', 'key_groq', 'key_openrouter', 'key_gemini',
+      'key_github_token', 'key_odoo_api', 'ops_github_token'
+    ],
+
+    /* Lo que HAY en este navegador y NO se sincroniza. No es un aviso de
+     * error: es la lista de lo que se queda aquí a propósito. Se enseña al
+     * guardar para que el cambio no sea invisible — una lista blanca que
+     * silenciosamente deja de llevar algo es igual de mala que la negra. */
+    sinSincronizar(){
+      const fuera = [];
+      const ok = new Set(this.PERMITIDAS);
       for(let i = 0; i < localStorage.length; i++){
         const key = localStorage.key(i);
         if(!key) continue;
-        if(EXCLUDE.has(key)) continue;
-        const isOps = key.indexOf('ops_') === 0;
-        const isKey = key.indexOf('key_') === 0;
-        const isFts = key.indexOf('fts_') === 0;
-        if(isOps || isKey || isFts){
-          config[key] = localStorage.getItem(key);
+        if(ok.has(key)) continue;
+        if(key.indexOf('ops_') === 0 || key.indexOf('key_') === 0 || key.indexOf('fts_') === 0){
+          fuera.push(key);
         }
+      }
+      return fuera.sort();
+    },
+
+    collectOpsKeys(){
+      const config = {};
+      /* Nada de recorrer `localStorage`: se pide EXACTAMENTE lo permitido. Es
+       * la diferencia entre «todo menos esto» y «sólo esto», y es toda la
+       * corrección. */
+      for(const key of this.PERMITIDAS){
+        const v = localStorage.getItem(key);
+        if(v !== null) config[key] = v;
       }
       return config;
     },
@@ -129,6 +184,14 @@
     // Guardar toda la config cifrada en GitHub
     async save(token, password){
       const config = this.collectOpsKeys();
+      /* Lo que se queda fuera se DICE, no se calla. Una lista blanca que deja
+       * de llevar algo en silencio es tan mala como la lista negra que se
+       * llevaba de más: en los dos casos nadie se entera. */
+      const fuera = this.sinSincronizar();
+      if(fuera.length){
+        try{ console.info('[config-sync] NO se sincronizan ' + fuera.length +
+          ' llave(s), se quedan en este navegador: ' + fuera.join(', ')); }catch(e){}
+      }
       // Incluir el token cifrado para poder recuperarlo en otros dispositivos
       config['_github_token'] = token;
 


### PR DESCRIPTION
Sesión 5 del issue #140. Reporte completo con los crudos en el issue.

## A · Dirección ve el trabajo del equipo

El filtro de persona de V1.21 prometía algo que no podía cumplir: filtraba sobre una lista que sólo tenía lo propio. Medido en la base: Montalvo (3) y Ricardo (6) tenían **9 machotes** que Esteban no veía.

Con `comercial:admin` la lectura abarca a todos. **El alcance sale del TOKEN, nunca del cuerpo** — probado contra el endpoint vivo: un usuario normal mandando `dueno`, `actor`, `es_admin:true` y `scopes:[…admin]` en el cuerpo recibe **exactamente las mismas 6 filas**.

⚠️ **La mitad del servidor está GUARDADA pero NO PUBLICADA** (`versionId 2700ae77` ≠ `activeVersionId bb0667a5`). La herramienta se llama «publish (**activate**) a workflow» y la sesión tenía prohibido activar workflows, así que no la forcé. Hace falta un clic en n8n.

**Por eso el frontend va tolerante primero** (§8 anti-trabón): si el servidor no manda `ajenos`, la lista se comporta exactamente como antes. Mergear esto sin publicar aquello no traba nada.

### El trabajo ajeno no se guarda en `fts_machote_v1`

Salió al construirlo y habría sido feo. `bajar()` fundía en el almacén local todo lo que devolviera el servidor; con el alcance de dirección eso rompía tres cosas: el `id_local` choca (Ricardo también tiene `M-1041`…`M-1044`), `empujarUno` lo volvería a subir y el servidor le pone de dueño **a quien manda** (el trabajo de Ricardo a nombre de Esteban), y se quedaría ahí para siempre.

Los ajenos viven **sólo en memoria**: no se persisten, no cuentan como pendiente, no se exportan, no se suben (dos candados, como la demo), y su id de pantalla es el uuid del servidor.

Se abren en lectura: aviso de quién es, hoja trabada, sin borrar, sin «Pasar a orden».

## B · El ciclo de envío

Un correo real a `sales@fts.mx` (y a nadie más — el candado es del servidor): `http_graph 202`, PDF de Odoo 204 KB, `responder_a` resuelto del `empleado_id` firmado en el token.

**Hallazgo:** **0 de 17** machotes tienen `odoo_so_id`, así que el camino `machote_id → PDF → correo` no se puede ejercitar con datos reales todavía. Las dos ramas de la marca se probaron con el código HTTP inyectado sobre los nodos de producción: **500 → no escribe** (2→2), **202 → escribe** `version 3, estado 'enviado'`.

## C · El sincronizador, de lista negra a lista blanca

`shared/config-sync.js` barría toda llave `ops_*`/`key_*`/`fts_*` hacia `shared/ops-config.json`, **commiteado en un repo público**. No estaban excluidas `fts_machote_v1`, `fts_suite_session`, `fts_employees` y varias más.

**No hay fuga consumada** — el blob es del 18-abr y `fts_machote_v1` no existe hasta el 3-sep. El riesgo era hacia adelante.

Alcance y consecuencias por llave en `docs/comercial/SINCRONIZADOR-LISTA-BLANCA.md`. `load()` sólo hace `setItem`, así que nada se borra.

## D · Los dos endpoints encendidos

`cotizacion`: 12 ejecuciones, todas `success`. `clientes`: 0 ejecuciones — lo llamé para no caer en la trampa del `insertadas: 0`, y responde `200 · ok · 250 clientes`.

## Pruebas

**155 pasaron, 0 fallaron** sobre el head ya fusionado con `main` (152 heredadas + 3 nuevas). Capturas a 380 y 1280 revisadas, sin `pageerror`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013Qzhio6K8R23HXHnJ2RJ64

---
_Generated by [Claude Code](https://claude.ai/code/session_013Qzhio6K8R23HXHnJ2RJ64)_