### PR TITLE
S1 watchdogs: config sin ruido + digest semanal + redacción de snapshots (#220)

### DIFF
--- a/docs/n8n-workflows/s1-semaforo/Code-MAIN.js
+++ b/docs/n8n-workflows/s1-semaforo/Code-MAIN.js
@@ -1,0 +1,163 @@
+// -- Code - MAIN - S1 (2026-09-09, issue #220) --------------------------------
+// S1 NO CAMBIA NINGUN CALCULO. Lo que se agrega:
+//   (1) GUARDA DE VACIO en todos los nodos Odoo. Causa raiz del bug de 12 semanas:
+//       alwaysOutputData:true + onError:continueRegularOutput hacen que un search vacio
+//       devuelva [{}] y sea indistinguible de un search exitoso. Ahora cada nodo declara
+//       su llave esperada; si no llega ni una fila utilizable se levanta un diagnostico
+//       que el correo IMPRIME. Un fallback silencioso deja de ser posible.
+//   (2) `ev` (identidad de evento) en cada bandera, para que buildEmail pueda reportar
+//       un evento UNA vez en lugar de todos los dias que dure en la ventana de 30.
+//   (3) `tramo` del contador, para clasificar delta sin que el renglon "cambie" a diario.
+// color_b / dias_sin_seguimiento SIGUEN calculandose y viajan en la fila: el semaforo B
+// se retira del REPORTE, no del computo (S3 puede necesitarlo). Umbrales intactos.
+let _r = $('HTTP - load config').first().json;
+const cfg = (_r && _r.config) ? _r : JSON.parse(_r.data || _r.body || (typeof _r === 'string' ? _r : JSON.stringify(_r)));
+const C = cfg.config, STG = cfg.stages, MAT = cfg.materiales_overrides || {}, EXCL = cfg.excluidos || [];
+const SEQ = {1:0,2:1,5:2,3:3,7:4,13:8,8:9,4:10,6:11};
+const COM = C.comercial_whitelist_partner_ids || [], WD = C.watchdog_author_partner_id;
+const FF = cfg.integridad.fecha_fin_field_id, FS = cfg.integridad.stage_field_id;
+const AP = C.ap_confirmacion || {};
+const OBS = cfg.observacion || {};
+const NR = cfg.nota_repetida || {};
+const SIMIL = (NR.umbral_similitud != null) ? NR.umbral_similitud : 0.85;
+const RACHA_MIN = (NR.racha_minima != null) ? NR.racha_minima : 2;
+const SA = cfg.sin_avance || {};
+const SA_DIAS = (SA.dias_en_stage_min != null) ? SA.dias_en_stage_min : 60;
+const HOLD_ST = (cfg.banderas && cfg.banderas.hold_sin_fecha_stages) || [];
+const hoyISO = String($('Set - hoy').first().json.hoy || '').slice(0,10);
+// --- GUARDA DE VACIO (S1) ----------------------------------------------------
+// `llave` es un campo que TODA fila legitima de ese nodo trae. Si ninguna fila la
+// tiene, el search vino vacio (o el nodo fallo y onError lo dejo pasar como dato).
+const _diag = [];
+function rowsOf(nodo, llave, critico){
+  let all = [];
+  try { all = $(nodo).all(); } catch(e){
+    _diag.push({nodo:nodo, problema:'no se pudo leer el nodo', detalle:String(e.message).slice(0,120), critico:!!critico});
+    return [];
+  }
+  const out = [];
+  for(const it of all){
+    const j = it.json;
+    if(j && typeof j === 'object' && j[llave] !== undefined) out.push(j);
+  }
+  if(!out.length){
+    _diag.push({nodo:nodo, problema:'devolvio 0 filas utilizables (llave "'+llave+'" ausente)',
+                items_crudos:all.length, critico:!!critico});
+  }
+  return out;
+}
+const R_PROJ  = rowsOf('Odoo - getAll projects','id',true);
+const R_SO    = rowsOf('Odoo - getAll SO','id',false);
+const R_PART  = rowsOf('Odoo - getAll partners','id',false);
+const R_TERM  = rowsOf('Odoo - getAll termlines','payment_id',false);
+const R_M94   = rowsOf('Odoo - getAll msg94','res_id',true);
+const R_MCOM  = rowsOf('Odoo - getAll msgComment','res_id',false);
+const R_TMSG  = rowsOf('Odoo - getAll trackedMsgs','res_id',false);
+const R_TVAL  = rowsOf('Odoo - getAll trackingVals','field_id',false);
+const R_ATT   = rowsOf('Odoo - getAll attachments','id',false);
+// --- TZ ----------------------------------------------------------------------
+// Toda la aritmetica de dias opera en hora de MONTERREY (UTC-6, sin DST desde 2022).
+// El contenedor n8n corre en UTC; settings.timezone del workflow NO aplica a
+// getHours()/setDate() de un Code node, por eso se normaliza a mano.
+const TZO = (C.tz_offset_hours != null ? C.tz_offset_hours : -6);
+function mtyWall(ds){ if(!ds) return null; const s=String(ds);
+  const iso = s.replace(' ','T') + (/([Zz]|[+-]\d\d:?\d\d)$/.test(s) ? '' : 'Z');
+  const t = Date.parse(iso); if(isNaN(t)) return null;
+  return new Date(t + TZO*3600000); }
+function dayStart(d){ const x=new Date(d); x.setHours(0,0,0,0); return x; }
+const today = mtyWall($('Set - hoy').first().json.hoy);
+const todayDay = dayStart(today);
+const m2o = v => Array.isArray(v)?v[0]:v;
+const isWE = x => x.getDay()===6 || x.getDay()===0;
+function nextBizDay(d){ const x=dayStart(d); do { x.setDate(x.getDate()+1); } while(C.excluir_findes && isWE(x)); return x; }
+// Dias habiles TRANSCURRIDOS desde el dia de la nota: hoy=0, ayer habil=1, viernes->lunes=1.
+function bizDays(ds){ const w=mtyWall(ds); if(!w) return null;
+  let c=nextBizDay(w), n=0; while(c <= todayDay){ n++; c=nextBizDay(c); } return n; }
+function lastBy(rows, filt){ const m={}; for(const r of rows){ if(filt && !filt(r)) continue;
+  const rid=r.res_id; if(!m[rid] || new Date(r.date) > new Date(m[rid].date)) m[rid]=r; } return m; }
+const lastStageMsg = lastBy(R_M94);
+// --- Notas: normalizacion, GUARD de vacias, y deteccion de repetidas --------
+function normNota(h){ return String(h==null?'':h)
+  .replace(/<[^>]*>/g,' ').replace(/&nbsp;/gi,' ').replace(/&amp;/gi,'&')
+  .normalize('NFD').replace(/[\u0300-\u036f]/g,'')
+  .toLowerCase().replace(/\s+/g,' ').trim(); }
+function bigr(s){ const g=new Set(); for(let i=0;i<s.length-1;i++) g.add(s.slice(i,i+2)); return g; }
+function simil(a,b){ if(a===b) return 1; if(!a.length||!b.length) return 0;
+  const A=bigr(a), B=bigr(b); let x=0; for(const k of A) if(B.has(k)) x++;
+  return (2*x)/(A.size+B.size); }
+const notasProj = {}, vaciasProj = {};
+for(const m of R_MCOM){
+  if(m==null || m.res_id==null) continue;
+  if(m2o(m.author_id) === WD) continue;
+  const t = normNota(m.body);
+  if(!t){ vaciasProj[m.res_id] = (vaciasProj[m.res_id]||0)+1; continue; }
+  (notasProj[m.res_id] = notasProj[m.res_id]||[]).push({ date:m.date, t }); }
+const lastComment = {}, rachaProj = {};
+for(const k of Object.keys(notasProj)){
+  const arr = notasProj[k].sort((a,b)=> new Date(a.date) - new Date(b.date));
+  lastComment[k] = arr[arr.length-1];
+  let r=1; for(let i=arr.length-1; i>0; i--){ if(simil(arr[i].t, arr[i-1].t) >= SIMIL) r++; else break; }
+  rachaProj[k] = r; }
+const matSO = {}; for(const s of R_SO){ matSO[s.id] = (C.materiales_values||[]).includes(s.x_studio_product_type); }
+const termDays = {}; for(const t of R_TERM){ const k=m2o(t.payment_id); termDays[k]=Math.max(termDays[k]||0, Number(t.nb_days)||0); }
+const partnerTerm = {}; for(const p of R_PART){ partnerTerm[p.id] = p.property_payment_term_id ? m2o(p.property_payment_term_id) : null; }
+const trkByMsg = {}; for(const t of R_TVAL){ trkByMsg[m2o(t.mail_message_id)] = t; }
+const flagsByProj = {}; function addFlag(rid,f){ (flagsByProj[rid]=flagsByProj[rid]||[]).push(f); }
+// `ev`: identidad del EVENTO. Para banderas de evento (cambio de fecha / de stage) es el
+// id del mail.message, que es unico e inmutable -> el correo lo reporta UNA vez, no los
+// ~21 dias que el evento vive en la ventana de 30. Para banderas de ESTADO el ev describe
+// el estado, y se deduplica por firma (si el estado sigue igual, no se repite).
+for(const m of R_TMSG){ const t=trkByMsg[m.id]; if(!t) continue; const au=m2o(m.author_id); const aun=Array.isArray(m.author_id)?m.author_id[1]:''; const fid=m2o(t.field_id);
+  if(fid===FF && t.old_value_datetime && !COM.includes(au)) addFlag(m.res_id,{tipo:'fecha_fin', ev:'fecha_fin|'+m.id, detalle:'Fecha fin movida por '+aun+' (fuera de Comercial): '+String(t.old_value_datetime).slice(0,10)+' -> '+String(t.new_value_datetime).slice(0,10), fecha:m.date});
+  if(fid===FS && SEQ[t.new_value_integer]!=null && SEQ[t.old_value_integer]!=null && SEQ[t.new_value_integer] < SEQ[t.old_value_integer]) addFlag(m.res_id,{tipo:'stage_atras', ev:'stage_atras|'+m.id, detalle:'Stage regresado '+t.old_value_char+' -> '+t.new_value_char+' por '+aun, fecha:m.date}); }
+const attMime = {}; for(const a of R_ATT){ attMime[a.id]= a.mimetype||''; }
+function norm(s){ return String(s||'').replace(/<[^>]*>/g,' ').normalize('NFD').replace(/[\u0300-\u036f]/g,'').toLowerCase(); }
+const apTpl = norm(AP.template);
+const apOk = {};
+for(const m of R_MCOM){ if(apTpl && norm(m.body).includes(apTpl)){ const hasImg=(m.attachment_ids||[]).some(a=>(attMime[a]||'').startsWith('image/')); if(!AP.requiere_imagen || hasImg) apOk[m.res_id]=true; } }
+function colorOf(d,r){ if(d==null||r==null) return 'verde'; if(d>=r) return 'rojo'; if(d>=Math.max(r-1,1)) return 'amarillo'; return 'verde'; }
+function rojoCredito(p){ const t=partnerTerm[m2o(p.partner_id)]; const d=(t&&termDays[t]!=null)?termDays[t]:C.credit_fallback_days; return d + C.credit_extra_days; }
+// tramo del contador: el renglon solo "cambia" al cruzar de tramo, no cada 24 h.
+function tramo(d){ if(d==null) return '?'; if(d===0) return '0'; if(d<=5) return '1-5'; if(d<=15) return '6-15'; if(d<=30) return '16-30'; return '>30'; }
+const ORD={verde:0,amarillo:1,rojo:2}; const out=[];
+for(const p of R_PROJ){ const sid=m2o(p.stage_id); if(sid==null||EXCL.includes(sid)) continue; const sc=STG[String(sid)]; if(!sc) continue;
+  const esMat = p.sale_order_id ? !!matSO[m2o(p.sale_order_id)] : false;
+  const ls=lastStageMsg[p.id];
+  // FUENTE del contador A, explicita en la fila. Con msg94 vacio esto dice 'create_date'
+  // en el 100% de los casos, y el correo lo IMPRIME (issue #220 error #1).
+  const fuenteA = ls ? 'stage_msg' : (p.create_date ? 'create_date' : 'ninguna');
+  const diasEnStage = ls?bizDays(ls.date):(p.create_date?bizDays(p.create_date):null);
+  const lc=lastComment[p.id];
+  const sinNotaValida = !lc;
+  const diasSinSeg = lc?bizDays(lc.date):(p.create_date?bizDays(p.create_date):null);
+  const oEn = (esMat && MAT[sid] && MAT[sid].en_stage) ? MAT[sid].en_stage : sc.en_stage;
+  const oSeg = (esMat && MAT[sid] && MAT[sid].sin_seguimiento) ? MAT[sid].sin_seguimiento : sc.sin_seguimiento;
+  let colA;
+  if(oEn.modo==='due_date'){ if(!p.date){ colA=colorOf(diasEnStage, C.in_progress_fallback_dias); } else { const due=new Date(p.date); const ama=new Date(due.getTime()-(C.in_progress_amarillo_dias_habiles||3)*86400000); colA = today>=due?'rojo':(today>=ama?'amarillo':'verde'); } }
+  else if(oEn.modo==='credito'){ colA=colorOf(diasEnStage, rojoCredito(p)); }
+  else { colA=colorOf(diasEnStage, oEn.rojo_dias); }
+  const evalSeg = o => (o.modo==='credito') ? colorOf(diasSinSeg, rojoCredito(p)) : colorOf(diasSinSeg, o.rojo_dias);
+  const colBNuevo = evalSeg(oSeg);
+  const enObs = (OBS.stages||[]).includes(sid) && (!OBS.hasta || hoyISO <= OBS.hasta);
+  const oPrev = enObs ? ((OBS.sin_seguimiento_previo||{})[String(sid)] || oSeg) : oSeg;
+  let colB = enObs ? evalSeg(oPrev) : colBNuevo;
+  // El color combinado se sigue calculando (no cambia ningun umbral) pero el REPORTE
+  // de S1 usa color_a. Ver issue #220 S2.3: el semaforo B lleva 11 corridas en 0% verde
+  // y su verde es inalcanzable por construccion (exige nota de hoy antes de las 08:00).
+  let col = ORD[colA]>=ORD[colB]?colA:colB;
+  if(p.last_update_status==='off_track') col='rojo'; else if(p.last_update_status==='at_risk' && col==='verde') col='amarillo';
+  // colorA con el override de last_update_status, que es el que S1 reporta
+  let colAr = colA;
+  if(p.last_update_status==='off_track') colAr='rojo'; else if(p.last_update_status==='at_risk' && colAr==='verde') colAr='amarillo';
+  if((AP.aplica_stages||[]).includes(sid) && !apOk[p.id]) addFlag(p.id,{tipo:'ap_sin_confirmacion', ev:'ap_sin_confirmacion|estado', detalle:'En plazo de credito SIN confirmacion AP documentada (falta log note + pantallazo)'});
+  if(vaciasProj[p.id]) addFlag(p.id,{tipo:'nota_vacia', ev:'nota_vacia|'+vaciasProj[p.id], detalle:vaciasProj[p.id]+' log note(s) sin contenido en el chatter - no cuentan como seguimiento'});
+  if(HOLD_ST.includes(sid)){ const fr=p.date;
+    if(!fr) addFlag(p.id,{tipo:'hold_sin_fecha_vigente', ev:'hold_sin_fecha|vacia', detalle:'En Hold SIN fecha de reactivacion capturada'});
+    else if(String(fr) < hoyISO) addFlag(p.id,{tipo:'hold_sin_fecha_vigente', ev:'hold_sin_fecha|'+fr, detalle:'En Hold con fecha de reactivacion VENCIDA ('+fr+')'}); }
+  const racha = rachaProj[p.id] || 0;
+  const sinAvance = (racha >= RACHA_MIN) && ((diasEnStage != null && diasEnStage > SA_DIAS) || colA !== 'verde');
+  out.push({ json:{ id:p.id, name:p.name, stage_id:sid, stage:sc.label, grupo:sc.grupo, cliente: p.partner_id?p.partner_id[1]:'', es_materiales:esMat, dias_en_stage:diasEnStage, dias_sin_seguimiento:diasSinSeg, color_a:colA, color_a_rep:colAr, color_b:colB, color:col, banderas: flagsByProj[p.id]||[], sin_nota_valida:sinNotaValida, racha_nota:(rachaProj[p.id]||0), sin_avance:sinAvance, en_observacion:enObs, color_b_nuevo:colBNuevo, fuente_a:fuenteA, tramo_a:tramo(diasEnStage), project_date:(p.date||null), _diag:_diag, link_odoo:'https://serviciosfts.odoo.com/web#id='+p.id+'&model=project.project&view_type=form' } }); }
+// Si NO hay proyectos, el diagnostico tiene que sobrevivir: sin esto un fallo del nodo 1
+// devolveria [] y el correo saldria vacio y "correcto", que es el modo de falla que S1 mata.
+if(!out.length) return [{ json:{ _solo_diag:true, _diag:_diag } }];
+return out;

--- a/docs/n8n-workflows/s1-semaforo/Code-buildEmail.js
+++ b/docs/n8n-workflows/s1-semaforo/Code-buildEmail.js
@@ -6,7 +6,7 @@
 //   1. SEMAFORO B RETIRADO DEL REPORTE. Llevaba 11 corridas en 0% verde contra una meta
 //      impresa de >=90%, y su verde es inalcanzable por construccion: rojo_dias=2 =>
 //      amarillo=1 => verde exige dias_sin_seguimiento=0, o sea una nota escrita hoy antes
-//      de las 08:00, que es cuando sale el correo. Ademas med?a el dia de la semana: los
+//      de las 08:00, que es cuando sale el correo. Ademas media el dia de la semana: los
 //      19 renglones de Operaciones del 8-sep traian "2d" identico. Se sigue CALCULANDO en
 //      Code - MAIN (viaja en color_b) pero no se reporta.
 //   2. SOLO EL DELTA. Firma por proyecto en staticData; un renglon sin cambio no se
@@ -16,8 +16,15 @@
 //      En proceso"; 18 de un solo cambio de fecha). Ahora cada evento se reporta el dia
 //      que se ve y se recuerda en staticData.
 //   4. GUARDA DE VACIO visible: si un search vino vacio, el correo lo dice.
-//   5. La seccion de integridad se llama CAMBIOS FUERA DE COMERCIAL, no "posible
-//      manipulacion": lo que marca es trabajo normal de Operaciones y Administracion.
+//   5. Las banderas se reparten por NATURALEZA: autoria (fecha_fin / stage_atras) va a
+//      CAMBIOS FUERA DE COMERCIAL -no "posible manipulacion", que acusa a quien hace el
+//      trabajo-; calidad de dato (nota_vacia / hold_sin_fecha_vigente) va a DATOS QUE NO
+//      CUADRAN, que es lo que realmente son.
+//   6. DIGEST DE LUNES (adicion a S1). El delta esconde lo que esta mal y no cambia:
+//      en la prueba quedaron 14 proyectos "sin cambio" contados solo al pie, y ahi iba
+//      MAGNEKON con $1.28M vencidos, el renglon que motivo la auditoria. Los lunes sale
+//      ademas el ESTADO COMPLETO de todos los vigilados. Mismo workflow, misma metrica,
+//      mismos umbrales: solo cambia QUE se imprime segun el dia.
 const _cf = $('HTTP - load config').first().json;
 const cfg = (_cf && _cf.config) ? _cf : JSON.parse(_cf.data || _cf.body || (typeof _cf==='string'?_cf:JSON.stringify(_cf)));
 const C = cfg.config;
@@ -112,7 +119,14 @@ const semana = sd.history.filter(h=> new Date(h.fecha) >= mondayOf(today));
 const aPctNow = rows.length?Math.round(aAll.V/rows.length*100):0;
 function pctV(list,k){ if(!list.length) return 0; return Math.round(list.reduce((a,h)=>a+(h.total?(h[k]/h.total):0),0)/list.length*100); }
 const kpiSem = (semana.length<4) ? {modo:'simple', aPct:aPctNow, dias:semana.length} : {modo:'prom', aPct:pctV(semana,'aV'), dias:semana.length};
-const esLunes = today.getDay()===1;
+// Dia(s) en que sale el digest de estado completo. Sale de la config VIVA para poder
+// ejercitarlo un dia cualquiera sin tocar codigo (asi se probo antes de publicar), y
+// para que Esteban pueda pedirlo otro dia editando el JSON. Si la config no trae la
+// llave -que es el caso de main hoy- el default es LUNES: el lado tolerante primero
+// (regla anti-trabon), la config vieja sigue funcionando sin cambios.
+// getDay(): 0=domingo, 1=lunes ... 6=sabado.
+const DIGEST_DIAS = Array.isArray(C.digest_dias) ? C.digest_dias : [1];
+const esLunes = DIGEST_DIAS.includes(today.getDay());
 
 // ---- render -----------------------------------------------------------------
 const ACC = { rojo:'&#8627; Avanza de stage o documenta por que sigue aqui (Log note)',
@@ -165,6 +179,36 @@ function secResueltos(arr){
   for(const r of arr) h+='<li>&#9989; '+escN(r.name)+' &middot; salio de la lista</li>';
   return h+'</ul>';
 }
+// ---- DIGEST DE LUNES --------------------------------------------------------
+// Reportar solo el delta tiene un costo: lo que esta mal pero NO cambia desaparece del
+// correo. En la corrida de prueba quedaron 14 proyectos "sin cambio" contados solo al
+// pie, y ahi iba MAGNEKON con $1.28M vencidos - el renglon que motivo la auditoria #220.
+// Con delta puro se vuelve a sepultar, ahora por silencio en vez de por ruido. Por eso
+// los LUNES sale ademas el estado COMPLETO de todos los proyectos vigilados. No cambia
+// ningun calculo ni ningun umbral: es la misma metrica, solo cambia QUE se imprime segun
+// el dia de la semana.
+function secDigest(subset){
+  let h='<h3 style="color:#0078D4;margin:18px 0 4px">&#128203; ESTADO COMPLETO DE LA SEMANA ['+subset.length+']</h3>';
+  h+='<p style="margin:2px 0;font-size:12px;color:#666">Todos los proyectos vigilados, hayan cambiado o no. De martes a viernes el correo trae solo lo que cambio.</p>';
+  if(!subset.length) return h+'<p style="color:#888;margin:2px 0">- ninguno -</p>';
+  const GR=[['rojo','&#128308;','#c62828','Rojo'],['amarillo','&#128993;','#b35900','Amarillo'],['verde','&#128994;','#2e7d32','Verde']];
+  for(const g of GR){
+    const arr=subset.filter(r=>r.color_a_rep===g[0]).slice().sort((x,y)=>(y.dias_en_stage||0)-(x.dias_en_stage||0));
+    h+='<p style="margin:10px 0 2px;color:'+g[2]+'"><b>'+g[1]+' '+g[3]+' ['+arr.length+']</b></p>';
+    if(!arr.length){ h+='<p style="color:#888;margin:2px 0;font-size:13px">- ninguno -</p>'; continue; }
+    h+='<ul style="font-size:13px;margin:2px 0;padding-left:18px">';
+    for(const r of arr){
+      h+='<li style="margin-bottom:3px"><b>'+escN(r.name,45)+'</b> ('+escN(r.cliente,28)+') &middot; '+esc(r.stage)+
+         ' &middot; <b>'+dE(r)+'d</b>'+
+         (r.project_date?(' &middot; compromiso '+esc(String(r.project_date).slice(0,10))):'')+
+         (r.sin_avance?' &middot; <span style="color:#8e24aa">&#128260; nota repetida</span>':'')+
+         ((r.banderas||[]).length?(' &middot; <span style="color:#8e24aa">&#128681;'+r.banderas.length+'</span>'):'')+
+         ' &middot; '+lnk(r)+'</li>';
+    }
+    h+='</ul>';
+  }
+  return h;
+}
 function buildMsg(subset, grupoLabel, to){
   const nu=NUEVO.filter(r=>r.grupo===grupoLabel), em=EMPEORO.filter(r=>r.grupo===grupoLabel);
   const me=MEJORO.filter(r=>r.grupo===grupoLabel), ig=IGUAL.filter(r=>r.grupo===grupoLabel);
@@ -179,10 +223,10 @@ function buildMsg(subset, grupoLabel, to){
   const res=RESUELTOS.filter(x=>x.grupo===grupoLabel || x.grupo===null);
   const aC=cntA(subset);
   const hay = nu.length||em.length||me.length||sa.length||flg.length||flgDato.length||res.length||diagNuevo;
-  // GUARDA DE VACIO. Sin nada que decir no se manda correo... salvo el LUNES, que sale un
-  // latido corto con el KPI. Asi el silencio nunca es ambiguo (un watchdog que muere en
-  // silencio es el Hallazgo #14) sin volver al correo diario que nadie lee. La alerta de
-  // latido perdido propiamente dicha es S7.
+  // GUARDA DE VACIO. Sin nada que decir no se manda correo... salvo el LUNES, que
+  // SIEMPRE sale con el digest de estado completo. Asi el silencio nunca es ambiguo (un
+  // watchdog que muere en silencio es el Hallazgo #14) sin volver al correo diario que
+  // nadie lee. La alerta de latido perdido propiamente dicha es S7.
   if(!hay && !esLunes) return null;
   const soloLatido = !hay;
   let html='<meta charset="utf-8"><div style="font-family:Arial,sans-serif;color:#222;font-size:14px">';
@@ -190,16 +234,18 @@ function buildMsg(subset, grupoLabel, to){
   html+='<div style="background:#f4f6f8;border-radius:8px;padding:8px 12px;margin:8px 0">';
   html+='<p style="margin:0 0 4px"><b>'+subset.length+' proyectos vigilados</b> &middot; '+
         '&#128309; ESTANCAMIENTO EN STAGE: &#128994; '+aC.V+' verde &middot; &#128993; '+aC.A+' amarillo &middot; &#128308; '+aC.R+' rojo</p>';
-  html+='<p style="margin:0;font-size:12px;color:#666">Este correo reporta <b>lo que cambio</b> desde el correo anterior. '+
-        'Los '+ig.length+' renglones sin cambio no se imprimen: se cuentan al pie.</p></div>';
+  html+= esLunes
+    ? '<p style="margin:0;font-size:12px;color:#666"><b>Lunes:</b> ademas del delta va el <b>estado completo</b> de los '+subset.length+' proyectos vigilados, mas abajo.</p></div>'
+    : '<p style="margin:0;font-size:12px;color:#666">Este correo reporta <b>lo que cambio</b> desde el correo anterior. Los '+ig.length+' renglones sin cambio no se imprimen: se cuentan al pie. El <b>lunes</b> sale el estado completo.</p></div>';
   if(soloLatido){
     html+='<p style="margin:10px 0"><b>Sin cambios</b> desde el correo anterior: ningun proyecto entro, empeoro ni se resolvio, y no hay banderas nuevas.</p>';
+    html+=secDigest(subset);
     html+=secDatos(subset, []);
     html+='<hr style="margin:16px 0 8px"><p style="font-size:12px;color:#666"><b>'+ig.length+' proyectos en condicion estable.</b><br>';
     html+='&#128202; <b>KPI semanal</b> ('+(kpiSem.modo==='simple'?('arranque, dia '+kpiSem.dias):('promedio '+kpiSem.dias+' dias'))+'): estancamiento <b>'+kpiSem.aPct+'%</b> verde (meta &ge;90%)<br>';
     html+='Latido: corrida '+esc(fechaStr)+' 08:00 CST.</p></div>';
     const toL = Array.isArray(to) ? to : String(to).split(',').map(x=>x.trim()).filter(Boolean);
-    return { message:{ subject:'[Semaforo '+grupoLabel+'] '+fb+' - sin cambios', body:{contentType:'HTML',content:html}, toRecipients: toL.map(a=>({emailAddress:{address:a}})) }, saveToSentItems:true };
+    return { message:{ subject:'[Semaforo '+grupoLabel+'] '+fb+' - estado semanal (sin cambios)', body:{contentType:'HTML',content:html}, toRecipients: toL.map(a=>({emailAddress:{address:a}})) }, saveToSentItems:true };
   }
   html+=sec('&#127381; NUEVO HOY','#c62828',nu,'&#127381;');
   html+=sec('&#128200; EMPEORO (cruzo de tramo)','#e65100',em,'&#128200;');
@@ -212,6 +258,7 @@ function buildMsg(subset, grupoLabel, to){
     for(const x of flg) html+='<li>&#128681; <b>'+escN(x.r.name,50)+'</b>: '+esc(x.f.detalle)+'</li>';
     html+='</ul>'; }
   html+=secDatos(subset, flgDato);
+  if(esLunes) html+=secDigest(subset);
   html+='<hr style="margin:16px 0 8px"><p style="font-size:12px;color:#666">';
   html+='<b>'+ig.length+' proyectos en condicion estable</b> (sin cambio de tramo ni banderas nuevas) - no se imprimen para que lo que cambio se vea.<br>';
   if(esLunes) html+='&#128202; <b>KPI semanal</b> ('+(kpiSem.modo==='simple'?('arranque, dia '+kpiSem.dias):('promedio '+kpiSem.dias+' dias'))+'): estancamiento <b>'+kpiSem.aPct+'%</b> verde (meta &ge;90%)<br>';
@@ -224,6 +271,7 @@ function buildMsg(subset, grupoLabel, to){
   if(res.length) partes.push(res.length+' resuelto'+(res.length>1?'s':''));
   if(flg.length) partes.push(flg.length+' cambio'+(flg.length>1?'s':'')+' fuera de Comercial');
   if(flgDato.length) partes.push(flgDato.length+' dato'+(flgDato.length>1?'s':'')+' por revisar');
+  if(esLunes) partes.push('estado semanal');
   if(diag.length) partes.push('REVISAR MEDICION');
   const subj='[Semaforo '+grupoLabel+'] '+fb+' - '+(partes.length?partes.join(' '+E(183)+' '):'sin cambios');
   const toList = Array.isArray(to) ? to : String(to).split(',').map(s=>s.trim()).filter(Boolean);

--- a/docs/n8n-workflows/s1-semaforo/Code-buildEmail.js
+++ b/docs/n8n-workflows/s1-semaforo/Code-buildEmail.js
@@ -1,0 +1,240 @@
+// -- Code - buildEmail - S1 (2026-09-09, issue #220) --------------------------
+// S1 NO MUEVE NINGUN UMBRAL. Si un renglon desaparece es por (a) deduplicacion,
+// (b) el semaforo B retirado del reporte, o (c) destinatarios. Nunca por un calculo.
+//
+// Lo que cambia respecto de la version previa:
+//   1. SEMAFORO B RETIRADO DEL REPORTE. Llevaba 11 corridas en 0% verde contra una meta
+//      impresa de >=90%, y su verde es inalcanzable por construccion: rojo_dias=2 =>
+//      amarillo=1 => verde exige dias_sin_seguimiento=0, o sea una nota escrita hoy antes
+//      de las 08:00, que es cuando sale el correo. Ademas med?a el dia de la semana: los
+//      19 renglones de Operaciones del 8-sep traian "2d" identico. Se sigue CALCULANDO en
+//      Code - MAIN (viaja en color_b) pero no se reporta.
+//   2. SOLO EL DELTA. Firma por proyecto en staticData; un renglon sin cambio no se
+//      imprime, se cuenta al pie. Aparece la seccion SE RESOLVIO, que antes no existia.
+//   3. BANDERAS UNA VEZ POR EVENTO. La consulta de tracking mira 30 dias, asi que un
+//      cambio de stage se reportaba ~21 veces (133 apariciones de "Stage regresado Hold ->
+//      En proceso"; 18 de un solo cambio de fecha). Ahora cada evento se reporta el dia
+//      que se ve y se recuerda en staticData.
+//   4. GUARDA DE VACIO visible: si un search vino vacio, el correo lo dice.
+//   5. La seccion de integridad se llama CAMBIOS FUERA DE COMERCIAL, no "posible
+//      manipulacion": lo que marca es trabajo normal de Operaciones y Administracion.
+const _cf = $('HTTP - load config').first().json;
+const cfg = (_cf && _cf.config) ? _cf : JSON.parse(_cf.data || _cf.body || (typeof _cf==='string'?_cf:JSON.stringify(_cf)));
+const C = cfg.config;
+// GUARDA DE FORMA (se conserva de la version previa). La config se lee EN VIVO del repo;
+// si ese fetch trae algo a medio propagar, un 404 o rate-limit, C queda undefined. Antes
+// eso reventaba mas abajo y el error viajaba como DATO hasta Graph, que devolvia 400 y
+// tambien lo trataba como dato: la ejecucion salia VERDE sin enviar nada (lunes 17-ago).
+const _falta = [];
+if (!C || typeof C !== "object") _falta.push("config");
+else {
+  if (typeof C.modo_prueba === "undefined") _falta.push("config.modo_prueba");
+  if (!C.alert_recipient_default) _falta.push("config.alert_recipient_default");
+  if (!C.recipients_por_grupo || typeof C.recipients_por_grupo !== "object") _falta.push("config.recipients_por_grupo");
+}
+if (_falta.length) { throw new Error("Config del semaforo incompleta o no cargada - faltan: " + _falta.join(", ") + ". El correo NO se envio. Revisa HTTP - load config (lee sla_stages.json en vivo del repo)."); }
+
+const todo = $('Code - MAIN').all().map(i=>i.json);
+const soloDiag = todo.length===1 && todo[0]._solo_diag;
+const rows = soloDiag ? [] : todo;
+const diag = (todo[0] && todo[0]._diag) ? todo[0]._diag : [];
+const hoy = $('Set - hoy').first().json.hoy;
+const today = new Date(hoy);
+const fechaStr = hoy.slice(0,10);
+const MES_EN = ['Jan','Feb','Mar','Apr','May','Jun','Jul','Aug','Sep','Oct','Nov','Dec'];
+const fb = fechaStr.slice(8,10)+'/'+MES_EN[parseInt(fechaStr.slice(5,7),10)-1]+'/'+fechaStr.slice(0,4);
+
+const esc = v => Array.from(String(v==null?'':v)).map(function(ch){ var cp=ch.codePointAt(0); if(ch==='&')return '&amp;'; if(ch==='<')return '&lt;'; if(ch==='>')return '&gt;'; if(ch==='"')return '&quot;'; return cp>127?('&#'+cp+';'):ch; }).join('');
+const escN = (v,n) => { const s=String(v==null?'':v); return esc(s.length>(n||60) ? s.slice(0,(n||60))+'...' : s); };
+const lnk = r => '<a href="'+r.link_odoo+'">abrir</a>';
+const dE = r => (r.dias_en_stage==null?'?':r.dias_en_stage);
+
+// ---- estado previo (staticData) ---------------------------------------------
+// CAVEAT heredado: staticData solo PERSISTE en runs de produccion (Schedule activo), no en
+// Manual Trigger. En una corrida manual se LEE el estado de la ultima corrida de produccion
+// y no se escribe, asi que probar no contamina la linea base.
+const sd = $getWorkflowStaticData('global');
+const prevA  = sd.s1_prevA  || {};   // { id: firma }
+const prevEv = sd.s1_prevEv || {};   // { evKey: 'YYYY-MM-DD' }
+const nextA  = {};
+const nextEv = {};
+
+const TR = {'0':0,'1-5':1,'6-15':2,'16-30':3,'>30':4,'?':0};
+const ORD = {verde:0, amarillo:1, rojo:2};
+const firmaDe = r => r.color_a_rep+'|'+r.tramo_a+'|'+(r.sin_avance?'sa':'-');
+const rankDe  = r => ORD[r.color_a_rep]*10 + (TR[r.tramo_a]||0);
+const rankFirma = f => { const p=String(f).split('|'); return (ORD[p[0]]||0)*10 + (TR[p[1]]||0); };
+
+// banderas: separa EVENTOS nuevos de los ya reportados
+for(const r of rows){
+  r._flagsNuevas = [];
+  for(const f of (r.banderas||[])){
+    const k = r.id+'|'+(f.ev||f.tipo);
+    nextEv[k] = fechaStr;
+    if(prevEv[k] === undefined) r._flagsNuevas.push(f);
+  }
+}
+// poda: no dejar crecer staticData sin limite (los eventos viven 30 dias en la consulta)
+const corteEv = new Date(today.getTime() - 60*86400000).toISOString().slice(0,10);
+for(const k of Object.keys(prevEv)){ if(prevEv[k] >= corteEv && nextEv[k]===undefined) nextEv[k]=prevEv[k]; }
+
+const enLista = r => r.color_a_rep!=='verde' || r.sin_avance || (r.banderas||[]).length>0;
+for(const r of rows){ if(enLista(r)) nextA[r.id] = firmaDe(r); }
+
+const diagFirma = diag.map(d=>d.nodo).sort().join(',');
+const diagNuevo = diagFirma !== (sd.s1_diagFirma || '');
+// clasificacion
+const NUEVO=[], EMPEORO=[], IGUAL=[], MEJORO=[];
+for(const r of rows){
+  if(!enLista(r)) continue;
+  const f = firmaDe(r), p = prevA[r.id];
+  if(p===undefined) NUEVO.push(r);
+  else if(rankDe(r) > rankFirma(p)) EMPEORO.push(r);
+  else if(rankDe(r) < rankFirma(p)) MEJORO.push(r);
+  else IGUAL.push(r);
+}
+const vivos = new Set(rows.filter(enLista).map(r=>String(r.id)));
+const nombrePrev = sd.s1_nombres || {}, grupoPrev = sd.s1_grupos || {};
+const RESUELTOS = Object.keys(prevA).filter(id=>!vivos.has(String(id)))
+  .map(id=>({ id:Number(id), name:nombrePrev[id] || ('proyecto '+id), grupo:grupoPrev[id] || null }));
+const nextNombres = {}, nextGrupos = {};
+for(const r of rows){ if(enLista(r)){ nextNombres[r.id]=r.name; nextGrupos[r.id]=r.grupo; } }
+
+// ---- KPI: SOLO semaforo A. B se retira del reporte --------------------------
+const cntA = a => ({ total:a.length, V:a.filter(r=>r.color_a_rep==='verde').length, A:a.filter(r=>r.color_a_rep==='amarillo').length, R:a.filter(r=>r.color_a_rep==='rojo').length });
+const aAll = cntA(rows);
+const bAll = { V:rows.filter(r=>r.color_b==='verde').length, A:rows.filter(r=>r.color_b==='amarillo').length, R:rows.filter(r=>r.color_b==='rojo').length };
+sd.history = (sd.history||[]).filter(h=>h.fecha!==fechaStr);
+sd.history.push({ fecha:fechaStr, total:rows.length, aV:aAll.V,aA:aAll.A,aR:aAll.R, bV:bAll.V,bA:bAll.A,bR:bAll.R });
+sd.history = sd.history.slice(-45);
+function mondayOf(d){ const x=new Date(d); const g=(x.getDay()+6)%7; x.setDate(x.getDate()-g); x.setHours(0,0,0,0); return x; }
+const semana = sd.history.filter(h=> new Date(h.fecha) >= mondayOf(today));
+const aPctNow = rows.length?Math.round(aAll.V/rows.length*100):0;
+function pctV(list,k){ if(!list.length) return 0; return Math.round(list.reduce((a,h)=>a+(h.total?(h[k]/h.total):0),0)/list.length*100); }
+const kpiSem = (semana.length<4) ? {modo:'simple', aPct:aPctNow, dias:semana.length} : {modo:'prom', aPct:pctV(semana,'aV'), dias:semana.length};
+const esLunes = today.getDay()===1;
+
+// ---- render -----------------------------------------------------------------
+const ACC = { rojo:'&#8627; Avanza de stage o documenta por que sigue aqui (Log note)',
+              amarillo:'&#8627; Se acerca al limite: mueve el stage o documenta' };
+function fila(r, prefijo){
+  let h='<li style="margin-bottom:7px">'+prefijo+' <b>'+escN(r.name)+'</b> ('+escN(r.cliente,40)+') &middot; '+esc(r.stage);
+  h+='<br>'+(r.color_a_rep==='rojo'?'&#128308;':'&#128993;')+' en stage <b>'+dE(r)+'d</b> (tramo '+esc(r.tramo_a)+')';
+  if(r.project_date) h+=' &middot; fecha compromiso '+esc(String(r.project_date).slice(0,10));
+  h+=' &middot; '+lnk(r);
+  if((r._flagsNuevas||[]).length){ h+='<br>'; for(const f of r._flagsNuevas) h+='<span style="color:#8e24aa">&#128681; '+esc(f.detalle)+'</span><br>'; }
+  else h+='<br>';
+  h+='<span style="color:'+(r.color_a_rep==='rojo'?'#c62828':'#b35900')+'">'+ACC[r.color_a_rep==='rojo'?'rojo':'amarillo']+'</span></li>';
+  return h;
+}
+function sec(titulo, color, arr, prefijo){
+  let h='<h3 style="color:'+color+';margin:14px 0 4px">'+titulo+' ['+arr.length+']</h3>';
+  if(!arr.length) return h+'<p style="color:#888;margin:2px 0">- ninguno -</p>';
+  arr=arr.slice().sort((x,y)=>(y.dias_en_stage||0)-(x.dias_en_stage||0));
+  h+='<ul style="font-size:13px;margin:4px 0;padding-left:18px">';
+  for(const r of arr) h+=fila(r,prefijo);
+  return h+'</ul>';
+}
+function secSinAvance(arr){
+  let h='<h3 style="color:#8e24aa;margin:14px 0 4px">&#128260; SEGUIMIENTO SIN AVANCE (la nota se repite) ['+arr.length+']</h3>';
+  if(!arr.length) return h+'<p style="color:#888;margin:2px 0">- ninguno -</p>';
+  h+='<ul style="font-size:13px;margin:4px 0;padding-left:18px">';
+  for(const r of arr.slice().sort((x,y)=>(y.racha_nota||0)-(x.racha_nota||0)))
+    h+='<li style="margin-bottom:6px"><b>'+escN(r.name)+'</b> ('+escN(r.cliente,40)+') &middot; '+esc(r.stage)+
+       '<br>&#128260; <b>'+(r.racha_nota||0)+' notas seguidas practicamente iguales</b> &middot; en stage <b>'+dE(r)+'d</b> &middot; '+lnk(r)+
+       '<br><span style="color:#8e24aa">&#8627; La nota se esta repitiendo: documenta que CAMBIO o mueve el stage</span></li>';
+  return h+'</ul>';
+}
+const ES_AUTORIA = t => t==='fecha_fin' || t==='stage_atras';
+function secDatos(subset, flagsDato){
+  const items=[];
+  for(const x of (flagsDato||[])) items.push('<b>'+escN(x.r.name,50)+'</b>: '+esc(x.f.detalle));
+  for(const d of diag) items.push('<b>'+esc(d.nodo)+'</b>: '+esc(d.problema)+(d.critico?' <b style="color:#c62828">(CRITICO)</b>':''));
+  const nCd = subset.filter(r=>r.fuente_a==='create_date').length;
+  if(nCd) items.push('<b>'+nCd+' de '+subset.length+' proyectos</b> miden "dias en stage" desde <code>create_date</code>, no desde la entrada al stage: no hay ningun <code>mail.message</code> con <code>subtype_id=94</code>. <b>El numero de arriba es la EDAD del proyecto.</b> Ver issue #220 error #1 - se corrige en S6.');
+  let h='<h3 style="color:#00695c;margin:14px 0 4px">&#128295; DATOS QUE NO CUADRAN / NO SE PUDO MEDIR ['+items.length+']</h3>';
+  if(!items.length) return h+'<p style="color:#888;margin:2px 0">- nada -</p>';
+  h+='<ul style="font-size:13px;margin:4px 0;padding-left:18px">';
+  for(const t of items) h+='<li style="margin-bottom:4px">'+t+'</li>';
+  return h+'</ul>';
+}
+function secResueltos(arr){
+  let h='<h3 style="color:#2e7d32;margin:14px 0 4px">&#9989; SE RESOLVIO desde el correo anterior ['+arr.length+']</h3>';
+  if(!arr.length) return h+'<p style="color:#888;margin:2px 0">- ninguno -</p>';
+  h+='<ul style="font-size:13px;margin:4px 0;padding-left:18px">';
+  for(const r of arr) h+='<li>&#9989; '+escN(r.name)+' &middot; salio de la lista</li>';
+  return h+'</ul>';
+}
+function buildMsg(subset, grupoLabel, to){
+  const nu=NUEVO.filter(r=>r.grupo===grupoLabel), em=EMPEORO.filter(r=>r.grupo===grupoLabel);
+  const me=MEJORO.filter(r=>r.grupo===grupoLabel), ig=IGUAL.filter(r=>r.grupo===grupoLabel);
+  const sa=nu.concat(em).filter(r=>r.sin_avance);
+  // separa por NATURALEZA de la bandera, no por novedad:
+  //   autoria (fecha_fin / stage_atras) -> CAMBIOS FUERA DE COMERCIAL
+  //   calidad de dato (nota_vacia / hold_sin_fecha_vigente) -> DATOS QUE NO CUADRAN
+  const flg=[], flgDato=[];
+  for(const r of subset) for(const f of (r._flagsNuevas||[])){
+    if(ES_AUTORIA(f.tipo)) flg.push({r:r,f:f}); else flgDato.push({r:r,f:f});
+  }
+  const res=RESUELTOS.filter(x=>x.grupo===grupoLabel || x.grupo===null);
+  const aC=cntA(subset);
+  const hay = nu.length||em.length||me.length||sa.length||flg.length||flgDato.length||res.length||diagNuevo;
+  // GUARDA DE VACIO. Sin nada que decir no se manda correo... salvo el LUNES, que sale un
+  // latido corto con el KPI. Asi el silencio nunca es ambiguo (un watchdog que muere en
+  // silencio es el Hallazgo #14) sin volver al correo diario que nadie lee. La alerta de
+  // latido perdido propiamente dicha es S7.
+  if(!hay && !esLunes) return null;
+  const soloLatido = !hay;
+  let html='<meta charset="utf-8"><div style="font-family:Arial,sans-serif;color:#222;font-size:14px">';
+  html+='<h2 style="color:#0078D4;margin:0">Semaforo '+esc(grupoLabel)+' - '+fb+'</h2>';
+  html+='<div style="background:#f4f6f8;border-radius:8px;padding:8px 12px;margin:8px 0">';
+  html+='<p style="margin:0 0 4px"><b>'+subset.length+' proyectos vigilados</b> &middot; '+
+        '&#128309; ESTANCAMIENTO EN STAGE: &#128994; '+aC.V+' verde &middot; &#128993; '+aC.A+' amarillo &middot; &#128308; '+aC.R+' rojo</p>';
+  html+='<p style="margin:0;font-size:12px;color:#666">Este correo reporta <b>lo que cambio</b> desde el correo anterior. '+
+        'Los '+ig.length+' renglones sin cambio no se imprimen: se cuentan al pie.</p></div>';
+  if(soloLatido){
+    html+='<p style="margin:10px 0"><b>Sin cambios</b> desde el correo anterior: ningun proyecto entro, empeoro ni se resolvio, y no hay banderas nuevas.</p>';
+    html+=secDatos(subset, []);
+    html+='<hr style="margin:16px 0 8px"><p style="font-size:12px;color:#666"><b>'+ig.length+' proyectos en condicion estable.</b><br>';
+    html+='&#128202; <b>KPI semanal</b> ('+(kpiSem.modo==='simple'?('arranque, dia '+kpiSem.dias):('promedio '+kpiSem.dias+' dias'))+'): estancamiento <b>'+kpiSem.aPct+'%</b> verde (meta &ge;90%)<br>';
+    html+='Latido: corrida '+esc(fechaStr)+' 08:00 CST.</p></div>';
+    const toL = Array.isArray(to) ? to : String(to).split(',').map(x=>x.trim()).filter(Boolean);
+    return { message:{ subject:'[Semaforo '+grupoLabel+'] '+fb+' - sin cambios', body:{contentType:'HTML',content:html}, toRecipients: toL.map(a=>({emailAddress:{address:a}})) }, saveToSentItems:true };
+  }
+  html+=sec('&#127381; NUEVO HOY','#c62828',nu,'&#127381;');
+  html+=sec('&#128200; EMPEORO (cruzo de tramo)','#e65100',em,'&#128200;');
+  html+=secResueltos(res);
+  if(me.length) html+=sec('&#128201; MEJORO (sigue en la lista)','#2e7d32',me,'&#128201;');
+  html+=secSinAvance(sa);
+  html+='<h3 style="margin:14px 0 4px">&#128681; CAMBIOS FUERA DE COMERCIAL ['+flg.length+']</h3>';
+  if(!flg.length) html+='<p style="color:#888;margin:2px 0">- ninguno nuevo -</p>';
+  else { html+='<p style="margin:2px 0;font-size:12px;color:#666">Cada evento se reporta <b>una sola vez</b>, el dia que se detecta. No es una acusacion de manipulacion: es un cambio de fecha o de stage hecho por alguien fuera de Comercial.</p><ul style="font-size:13px;margin:4px 0;padding-left:18px">';
+    for(const x of flg) html+='<li>&#128681; <b>'+escN(x.r.name,50)+'</b>: '+esc(x.f.detalle)+'</li>';
+    html+='</ul>'; }
+  html+=secDatos(subset, flgDato);
+  html+='<hr style="margin:16px 0 8px"><p style="font-size:12px;color:#666">';
+  html+='<b>'+ig.length+' proyectos en condicion estable</b> (sin cambio de tramo ni banderas nuevas) - no se imprimen para que lo que cambio se vea.<br>';
+  if(esLunes) html+='&#128202; <b>KPI semanal</b> ('+(kpiSem.modo==='simple'?('arranque, dia '+kpiSem.dias):('promedio '+kpiSem.dias+' dias'))+'): estancamiento <b>'+kpiSem.aPct+'%</b> verde (meta &ge;90%)<br>';
+  html+='El semaforo de <b>falta de seguimiento</b> se retiro del reporte en S1 (issue #220): llevaba 11 corridas en 0% verde y su verde era inalcanzable por construccion. Se sigue calculando.<br>';
+  html+='Latido: corrida '+esc(fechaStr)+' 08:00 CST.</p></div>';
+  const E=String.fromCodePoint;
+  const partes=[];
+  if(nu.length) partes.push(nu.length+' nuevo'+(nu.length>1?'s':''));
+  if(em.length) partes.push(em.length+' empeoro');
+  if(res.length) partes.push(res.length+' resuelto'+(res.length>1?'s':''));
+  if(flg.length) partes.push(flg.length+' cambio'+(flg.length>1?'s':'')+' fuera de Comercial');
+  if(flgDato.length) partes.push(flgDato.length+' dato'+(flgDato.length>1?'s':'')+' por revisar');
+  if(diag.length) partes.push('REVISAR MEDICION');
+  const subj='[Semaforo '+grupoLabel+'] '+fb+' - '+(partes.length?partes.join(' '+E(183)+' '):'sin cambios');
+  const toList = Array.isArray(to) ? to : String(to).split(',').map(s=>s.trim()).filter(Boolean);
+  return { message:{ subject:subj, body:{ contentType:'HTML', content:html }, toRecipients: toList.map(a=>({ emailAddress:{ address:a } })) }, saveToSentItems:true };
+}
+// persistir estado DESPUES de construir (si truena arriba, no se pierde la linea base)
+sd.s1_prevA = nextA; sd.s1_prevEv = nextEv; sd.s1_nombres = nextNombres; sd.s1_grupos = nextGrupos;
+sd.s1_diagFirma = diagFirma;
+const out=[];
+if (C.modo_prueba) { const m=buildMsg(rows, "Operaciones + Admin", C.alert_recipient_default); if(m) out.push({json:m}); }
+else { for (const g of ["Operaciones","Admin"]) { const sub = rows.filter(r => r.grupo === g);
+  const to = (C.recipients_por_grupo || {})[g] || C.alert_recipient_default;
+  const m = buildMsg(sub, g, to); if(m) out.push({json:m}); } }
+return out;

--- a/docs/n8n-workflows/s1-semaforo/Code-buildSnapshot.js
+++ b/docs/n8n-workflows/s1-semaforo/Code-buildSnapshot.js
@@ -1,0 +1,52 @@
+// -- Code - buildSnapshot - S1 (2026-09-09, issue #220) ------------------------
+// El snapshot se PUBLICA a un repo PUBLICO (yinyo1/fts-suite sirve Pages), asi que
+// aqui es donde se decide que sale. Tres cambios respecto de la version previa:
+//
+//   1. REDACCION DE `cliente` EN ORIGEN (regla transversal CLAUDE.md sec.20 #7: datos personales
+//      nunca a repo publico). El campo viene de partner_id[1] de Odoo y en varios
+//      partners trae "<RAZON SOCIAL>, <NOMBRE DE LA PERSONA DE CONTACTO>". Se corta
+//      en la PRIMERA coma: queda la razon social, se va el nombre. Es un corte
+//      conservador -una razon social del tipo "ACME, S.A. de C.V." pierde el sufijo-
+//      y ese es el lado correcto en el que fallar.
+//      RIESGO ACEPTADO CONSCIENTEMENTE: los 8 nombres que YA estan en los snapshots
+//      historicos del repo NO se limpian. Borrarlos del archivo no los borra del
+//      historial de git, asi que esto NO queda resuelto, queda asumido.
+//   2. `_diag` SUBE al nivel del snapshot. Code - MAIN lo adjunta a CADA fila (el
+//      mismo array repetido 35 veces); aqui se guarda una sola vez.
+//   3. Se quitan de cada fila los campos internos del correo (`_diag`,
+//      `_flagsNuevas`): son estado de render, no medicion.
+//
+// Lo que NO cambia: ningun umbral, ningun calculo, ninguna fila. El snapshot sigue
+// siendo el registro completo de lo medido -por eso el digest de lunes puede
+// reconstruirse desde aqui-.
+const hoy = ($('Set - hoy').first().json.hoy||'').slice(0,10);
+const raw = $('Code - MAIN').all().map(i=>i.json);
+const soloDiag = raw.length===1 && raw[0]._solo_diag;
+const diag = (raw[0] && raw[0]._diag) ? raw[0]._diag : [];
+const rows = soloDiag ? [] : raw;
+
+function redactCliente(v){
+  const s = String(v==null ? '' : v);
+  const i = s.indexOf(',');
+  return (i > 0 ? s.slice(0, i) : s).trim();
+}
+const proyectos = rows.map(function(r){
+  const o = {};
+  for(const k of Object.keys(r)){
+    if(k === '_diag' || k === '_flagsNuevas') continue;
+    o[k] = r[k];
+  }
+  o.cliente = redactCliente(r.cliente);
+  return o;
+});
+
+const snap = {
+  fecha: hoy,
+  total: proyectos.length,
+  por_color: proyectos.reduce(function(a,r){ a[r.color]=(a[r.color]||0)+1; return a; },{}),
+  _redaccion: 'campo cliente cortado en la primera coma (repo publico)',
+  _diag: diag,
+  proyectos: proyectos
+};
+const content = Buffer.from(JSON.stringify(snap,null,2)).toString('base64');
+return [{ json:{ fecha:hoy, message:'chore(semaforo): snapshot '+hoy, content } }];

--- a/docs/n8n-workflows/s1-semaforo/README.md
+++ b/docs/n8n-workflows/s1-semaforo/README.md
@@ -1,0 +1,33 @@
+# S1 · cuerpos de los Code nodes de `ops/watchdog-semaforo` (issue #220)
+
+Copia fiel de los dos `jsCode` que S1 desplegó en el **borrador** del workflow
+`29eaGe2wkS98lRMU`. Están aquí para que el cambio sea revisable en un diff: por el
+MCP de n8n el código se manda como un string completo, así que sin esto el único
+lugar donde vive es dentro del workflow.
+
+| Archivo | Nodo n8n |
+|---|---|
+| `Code-MAIN.js` | `Code - MAIN` |
+| `Code-buildEmail.js` | `Code - buildEmail` |
+
+## Estado al cerrar S1 (2026-09-09 15:01 UTC)
+
+- **Borrador** (`versionId 88ed2eed-6711-4771-b21d-86c4bac0ab5c`): este código, con la
+  URL de config apuntando a `main`.
+- **Versión ACTIVA** (`activeVersionId a3781e87-e476-4d23-a891-d11e240e82a8`): el código
+  PREVIO. Producción sigue corriendo lo de antes.
+- **Llave de reversa:** `a3781e87-e476-4d23-a891-d11e240e82a8`, que además es la versión
+  activa hoy. `restore_workflow_version` sobre ese id deshace todo.
+
+⚠️ **Hallazgo de método que corrige a CLAUDE.md §17 quirk #2:** `update_workflow` del MCP
+`n8n_FTS` escribe el **borrador**, no la versión activa. Tras el edit queda
+`versionId != activeVersionId` y **producción sigue corriendo el código viejo** hasta que
+alguien llame `publish_workflow`. §17 dice que este MCP «escribe · preserva active ✓» —
+cierto, pero incompleto: preserva `active` porque *no toca la versión activa en absoluto*.
+El read-back del flag `active` (regla dura de §3) **no basta** para saber si un cambio está
+vivo; hay que comparar `versionId` contra `activeVersionId`.
+
+## Sin secretos
+
+Ninguno de los dos nodos lee `$env` ni contiene credenciales. Las credenciales de Odoo,
+GitHub y Graph viven en los nodos HTTP/Odoo por referencia de id, no en el código.

--- a/docs/n8n-workflows/s1-semaforo/README.md
+++ b/docs/n8n-workflows/s1-semaforo/README.md
@@ -1,6 +1,6 @@
 # S1 · cuerpos de los Code nodes de `ops/watchdog-semaforo` (issue #220)
 
-Copia fiel de los dos `jsCode` que S1 desplegó en el **borrador** del workflow
+Copia fiel de los tres `jsCode` que S1 dejó **publicados** en el workflow
 `29eaGe2wkS98lRMU`. Están aquí para que el cambio sea revisable en un diff: por el
 MCP de n8n el código se manda como un string completo, así que sin esto el único
 lugar donde vive es dentro del workflow.
@@ -9,25 +9,86 @@ lugar donde vive es dentro del workflow.
 |---|---|
 | `Code-MAIN.js` | `Code - MAIN` |
 | `Code-buildEmail.js` | `Code - buildEmail` |
+| `Code-buildSnapshot.js` | `Code - buildSnapshot` |
 
-## Estado al cerrar S1 (2026-09-09 15:01 UTC)
+## Estado publicado (2026-09-09 19:52 UTC)
 
-- **Borrador** (`versionId 88ed2eed-6711-4771-b21d-86c4bac0ab5c`): este código, con la
-  URL de config apuntando a `main`.
-- **Versión ACTIVA** (`activeVersionId a3781e87-e476-4d23-a891-d11e240e82a8`): el código
-  PREVIO. Producción sigue corriendo lo de antes.
-- **Llave de reversa:** `a3781e87-e476-4d23-a891-d11e240e82a8`, que además es la versión
-  activa hoy. `restore_workflow_version` sobre ese id deshace todo.
+- **Versión ACTIVA = borrador**: `versionId == activeVersionId ==`
+  `2aac86ca-732e-4aab-9208-68f1e9458777`. `active:true` · `triggerCount:1` ·
+  `availableInMCP:true` · `timezone Etc/UTC`. Producción corre este código.
+- **Llave de reversa al S1 sin digest:** `88ed2eed-6711-4771-b21d-86c4bac0ab5c`
+  (la versión que estuvo activa entre las 15:01 y las 19:52 UTC del 9-sep).
+  `restore_workflow_version` sobre ese id quita el digest y la redacción y deja
+  el S1 original.
+- **Llave de reversa al pre-S1:** `a3781e87-e476-4d23-a891-d11e240e82a8`.
 
-⚠️ **Hallazgo de método que corrige a CLAUDE.md §17 quirk #2:** `update_workflow` del MCP
-`n8n_FTS` escribe el **borrador**, no la versión activa. Tras el edit queda
-`versionId != activeVersionId` y **producción sigue corriendo el código viejo** hasta que
-alguien llame `publish_workflow`. §17 dice que este MCP «escribe · preserva active ✓» —
-cierto, pero incompleto: preserva `active` porque *no toca la versión activa en absoluto*.
-El read-back del flag `active` (regla dura de §3) **no basta** para saber si un cambio está
-vivo; hay que comparar `versionId` contra `activeVersionId`.
+## Lo que agregó esta tanda
+
+1. **Digest de estado completo** en `Code - buildEmail` (función `secDigest`).
+   Sale los días que diga `config.digest_dias` de `sla_stages.json` — producción
+   `[1]` = lunes; el resto de la semana el correo sigue siendo delta puro. Si la
+   llave falta, el código asume `[1]`, así que la config vieja sigue sirviendo sin
+   cambios (lado tolerante primero). **Ningún umbral se movió.**
+   El día del digest el correo **siempre** sale: la rama de "sin cambios" dejó de
+   ser un latido corto y ahora trae el estado completo.
+2. **Redacción del campo `cliente`** en `Code - buildSnapshot`, cortando en la
+   primera coma antes de publicar al repo público. Los 8 nombres de contacto que
+   ya están en los snapshots históricos **NO se limpian**: riesgo aceptado
+   conscientemente, no resuelto — borrarlos del archivo no los borra del
+   historial de git.
+3. `_diag` sube al nivel del snapshot en vez de repetirse en cada fila, y las
+   filas ya no llevan `_diag` ni `_flagsNuevas`. Es **preventivo**: `_diag` lo
+   introdujo S1 en `Code - MAIN`, así que ningún snapshot publicado lo llegó a
+   cargar.
+
+## Prueba en vivo antes de publicar (ejecución `92620`)
+
+`2026-09-09 16:45:48 UTC`, `success` en 9.2 s, contra `sla_stages.TEST.json` de la
+rama con `digest_dias:[3]` para forzar el digest un miércoles.
+
+- `HTTP - Enviar correo (Graph)` → output `{}` = **202**, un solo correo a
+  `estebandelacruz@fts.mx` (`modo_prueba:true`).
+- Asunto: `[Semaforo Operaciones + Admin] 09/Sep/2026 - 1 cambio fuera de
+  Comercial · 6 datos por revisar · estado semanal · REVISAR MEDICION`.
+- `ESTADO COMPLETO DE LA SEMANA [35]` → 🔴 24 · 🟡 0 · 🟢 11, por días desc,
+  encabezando SO7723 (MAGNEKON) con 402d.
+- `Code - buildSnapshot` 9 ms; el snapshot decodificado trae `total:35`,
+  `_diag` en la raíz, **0** filas con `_diag`/`_flagsNuevas` y **0** clientes con
+  coma — 10 razones sociales publicadas, ningún nombre de persona.
+
+⚠️ **Límite del `modo_prueba` que conviene saber:** con `modo_prueba:true` el
+grupo se llama `"Operaciones + Admin"` y las filas traen `grupo` `"Operaciones"` o
+`"Admin"`, así que **las secciones de delta salen todas en 0 por construcción**
+(el filtro por grupo no calza) y el pie dice "0 proyectos en condición estable".
+No es una regresión: es el modo prueba. El delta se validó aparte con un harness
+local contra los snapshots reales del 4/7/8-sep.
+
+## Hallazgo anotado, NO perseguido (backlog)
+
+**El PUT del snapshot solo puede CREAR, nunca actualizar, y falla en silencio.**
+`HTTP - PUT snapshot (GitHub)` manda `{message, content, branch}` sin `sha`, así
+que si el archivo del día ya existe GitHub responde **422** (`"sha" wasn't
+supplied`) y `onError:continueRegularOutput` lo convierte en dato → el nodo
+reporta `success`. Crudo de la ejecución `92620`:
+
+```
+HTTP - PUT snapshot (GitHub) · executionStatus: "success"
+  json.error.status  = 422
+  json.error.message = 422 - {"message":"Invalid request.\n\n\"sha\" wasn't supplied.", ...}
+```
+
+En la cadencia normal (una corrida a las 08:00) es invisible e inofensivo: el
+archivo no existe todavía y el PUT lo crea. Pero significa que **cualquier
+re-corrida del mismo día deja el snapshot viejo**, con un check verde encima. Es
+la misma clase de fallo que la regla "el 200 no prueba la escritura"
+(CLAUDE.md §8), del lado contrario: un 422 disfrazado de éxito. El arreglo es
+leer el `sha` con un GET previo y mandarlo en el PUT.
+
+Consecuencia práctica de hoy: la prueba **no tocó `main`**, y la redacción del
+`cliente` se verá en el repo a partir de la corrida del jueves 10-sep 08:00 CST.
 
 ## Sin secretos
 
-Ninguno de los dos nodos lee `$env` ni contiene credenciales. Las credenciales de Odoo,
-GitHub y Graph viven en los nodos HTTP/Odoo por referencia de id, no en el código.
+Ninguno de los tres nodos lee `$env` ni contiene credenciales. Las credenciales
+de Odoo, GitHub y Graph viven en los nodos HTTP/Odoo por referencia de id, no en
+el código.

--- a/docs/watchdogs/AUDITORIA-2026-09.md
+++ b/docs/watchdogs/AUDITORIA-2026-09.md
@@ -1,0 +1,946 @@
+# Auditoría de watchdogs — operaciones y administración (septiembre 2026)
+
+**Sesión de investigación. No se construyó ni se modificó nada:** cero writes a Odoo, cero
+ediciones de workflow, cero correos enviados. Todo lo de abajo es lectura.
+
+- **Fecha de la auditoría:** 2026-09-09 (05:00–05:30 UTC = 2026-09-08 23:00–23:30 CST)
+- **Alcance pedido:** `ops/watchdog-semaforo` + el watchdog de administración, más inventario
+  de los otros tres.
+- **Hallazgo de encuadre, antes de cualquier detalle:** *no existe un "watchdog de
+  administración" aparte.* `fin/watchdog-captura` (`hckccUkyaAItBmbU`) vigila la **captura
+  bancaria** (Jeeves ↔ journal 61 ↔ Chase), no cuentas por cobrar. Los cuatro errores
+  reportados como "Administración" (días en stage, plazos de crédito, clientes sin plazo,
+  fecha comercial) **viven todos en `ops/watchdog-semaforo`**, en su grupo `Admin`: el
+  mismo workflow manda dos correos distintos, uno a Operaciones y otro a Admin, y la lógica
+  de crédito está en `Code - MAIN` del semáforo. Esto importa para el plan: son **un solo
+  workflow que arreglar**, no dos.
+
+---
+
+## PASO 1 · Estado actual
+
+### 1.1 Inventario de los cinco watchdogs
+
+Leído con `search_workflows` (2026-09-09 05:05 UTC):
+
+| Workflow | ID | Activo | triggerCount | Nodos | Creado | Último cambio | Legible por MCP |
+|---|---|---|---|---|---|---|---|
+| `ops/watchdog-semaforo` | `29eaGe2wkS98lRMU` | ✅ sí | 1 | 29 | 2026-06-18 | 2026-08-30 | sí |
+| `fin/watchdog-captura` | `hckccUkyaAItBmbU` | ✅ sí | 1 | 22 | 2026-08-12 | **2026-09-09 04:49** | sí |
+| `ops/watchdog-mo (W1-W5 Fase 1.5)` | `RBxoREDTfehELmyr` | ✅ sí | 1 | ? | 2026-07-09 | 2026-07-17 | **no** |
+| `rh/watchdog/sin-checkin` | `Q19zFeJQytSfBjdb` | ✅ sí | 1 | ? | 2026-06-20 | 2026-06-20 | **no** |
+| `comercial/watchdog-enviadas (T2 canary)` | `hJNTUd8E57W4rfjU` | ❌ no | 0 | 7 | 2026-07-16 | 2026-08-31 | sí |
+
+⚠️ **Límite de esta auditoría, declarado:** `ops/watchdog-mo` y `rh/watchdog/sin-checkin`
+tienen `availableInMCP: false`, así que **no pude leer su JSON ni sus ejecuciones**
+(`get_workflow_details` → *"Workflow is not available in MCP"*). Este contenedor tampoco
+tiene la API key de n8n (`~/.claude.json` → `mcpServers: []`), así que el camino alterno del
+PUT directo (CLAUDE.md §17 quirk #3) no estaba disponible. Lo que digo de esos dos sale de
+`docs/operaciones/FASE15_CUENTAS_WATCHDOGS.md`, `docs/rh/WATCHDOG_SIN_CHECKIN.md` y sus
+configs en `shared/` — **documentación, no lectura del workflow**. Para cerrarlos hace falta
+que Esteban prenda *MCP access* en la tarjeta de cada uno.
+
+### 1.2 `ops/watchdog-semaforo` — 29 nodos
+
+**Trigger y horario real.** Dos triggers: `Manual Trigger` y
+`Schedule (Lun-Vie 8am CST)` con `cronExpression: "0 14 * * 1-5"`.
+`settings.timezone = "Etc/UTC"` → **14:00 UTC = 08:00 CST, L-V**. Verificado contra las
+ejecuciones reales, que arrancan todas a `14:00:00.xxx` UTC. El horario **sí** es el que
+dice el nombre.
+
+**Cadena de nodos** (lineal, sin ramas hasta el final):
+
+```
+Manual / Schedule → Set - hoy → HTTP - load config → Odoo - getAll projects → Code - prep
+  → Odoo - getAll SO       → Code - col1
+  → Odoo - getAll partners → Code - col2
+  → Odoo - getAll termlines→ Code - col3
+  → Odoo - getAll msg94    → Code - col4
+  → Odoo - getAll msgComment → Code - col5
+  → Odoo - getAll trackedMsgs → Code - extractIds
+  → Odoo - getAll trackingVals → Code - col6
+  → Odoo - getAll attachments → Code - MAIN → Code - col-main
+                                                ├→ Code - buildLogNotes → Odoo - CREATE log note
+                                                ├→ Code - buildSnapshot → HTTP - PUT snapshot (GitHub)
+                                                └→ Code - buildEmail    → HTTP - Enviar correo (Graph)
+```
+
+Los `Code - colN` son todos `return [{ json:{ ok:true } }];` — colapsadores para que el
+`getAll` siguiente corra una sola vez. Nueve nodos de los 29 son plomería.
+
+**Config viva:** `HTTP - load config` lee
+`https://raw.githubusercontent.com/yinyo1/fts-suite/main/shared/operaciones/sla_stages.json`
+en cada corrida. Cambiar umbrales o destinatarios = editar + push a main, sin re-importar.
+
+**Las consultas exactas a Odoo:**
+
+| # | Modelo | Dominio | Campos |
+|---|---|---|---|
+| 1 | `project.project` | `stage_id in [1,2,5,3,7,13]` · `partner_id != false` · `is_internal_project != true` · `is_fsm != true` | id, name, stage_id, sale_order_id, partner_id, date, last_update_status, create_date |
+| 2 | `sale.order` | `id in soIds` | id, `x_studio_product_type` |
+| 3 | `res.partner` | `id in partnerIds` | id, `property_payment_term_id` |
+| 4 | `account.payment.term.line` | **sin dominio** (todas) | payment_id, nb_days |
+| 5 | `mail.message` | `model=project.project` · `res_id in projIds` · **`subtype_id = 94`** | res_id, date, author_id |
+| 6 | `mail.message` | `model=project.project` · `res_id in projIds` · `message_type = comment` | res_id, date, author_id, body, attachment_ids |
+| 7 | `mail.message` | `model=project.project` · `res_id in projIds` · `date >= hoy−30d` | res_id, author_id, date, tracking_value_ids |
+| 8 | `mail.tracking.value` | `id in trkIds` | field_id, old/new_value_integer, old/new_value_datetime, old/new_value_char, mail_message_id |
+| 9 | `ir.attachment` | `id in attIds` | id, mimetype |
+
+**Qué campo de fecha se usa para cada métrica** (esto es la raíz de casi todo):
+
+- **Semáforo A — "estancamiento en stage"** = `bizDays(último mail.message subtype 94)`,
+  y **si no hay ninguno → `bizDays(project.create_date)`**.
+- **Semáforo B — "falta de seguimiento"** = `bizDays(último mail.message message_type=comment
+  cuyo autor ≠ watchdog y cuyo body normalizado no queda vacío)`, y si no hay ninguna →
+  `bizDays(project.create_date)` con la bandera `sin_nota_valida`.
+- **`bizDays`** cuenta días hábiles **transcurridos** (hoy = 0, ayer hábil = 1), en hora de
+  Monterrey vía offset manual `tz_offset_hours: -6`, porque `settings.timezone` no aplica a
+  `getHours()` dentro de un Code node.
+- **Modo `credito`** (stage 13): el rojo se calcula como
+  `nb_days(property_payment_term_id del partner del proyecto) + credit_extra_days(7)`, con
+  `credit_fallback_days = 30` si el partner no trae término. Es decir: **el plazo de crédito
+  se saca del cliente, no de la factura**, y se aplica sobre `dias_en_stage`.
+- **Modo `due_date`** (stage 2 In Progress): compara `today` contra `project.date`
+  (fecha compromiso), amarillo 3 días naturales antes.
+- **Color final** = el peor de A y B, y `last_update_status` puede empeorarlo
+  (`off_track` → rojo, `at_risk` → amarillo).
+
+**Umbrales vigentes** (`sla_stages.json` v1.2, 2026-08-09):
+
+| stage_id | label | grupo | A (en_stage) | B (sin_seguimiento) |
+|---|---|---|---|---|
+| 1 | To Do | Operaciones | fijo 1d | fijo 2d |
+| 2 | In Progress | Operaciones | `due_date` sobre `project.date` (fallback 30d) | fijo 2d |
+| 5 | Hold | Operaciones | fijo 30d | fijo 2d |
+| 3 | Done Operations | **Admin** | fijo 2d | fijo 2d |
+| 7 | Admin - In progress | **Admin** | fijo 14d | fijo 2d |
+| 13 | En plazo de credito | **Admin** | `credito` | fijo 2d |
+
+Amarillo = `max(rojo − 1, 1)`. Excluidos: stages 8 (Complete TOTAL), 4 (Canceled), 6
+(Templates). Overrides de materiales (`x_studio_product_type = 'MRO'`) para stages 1 y 2.
+
+**Banderas de integridad:**
+- `fecha_fin`: cambió `project.date` (field_id 24700) y el autor **no** está en
+  `comercial_whitelist_partner_ids: [306]`.
+- `stage_atras`: `sequence(stage nuevo) < sequence(stage viejo)` (field_id 24714).
+- `ap_sin_confirmacion`: en stage 13 sin un comment que contenga el texto
+  `"CONFIRMACIÓN AP CLIENTE - en plazo de pago"` **y** una imagen adjunta.
+- `nota_vacia`, `hold_sin_fecha_vigente`.
+
+**Plantilla del correo** (`Code - buildEmail`). Asunto:
+`[Semaforo <grupo>] DD/Mon/AAAA - 🔴🔴 N criticos · 🔵 N estancados · 📝 N sin nota`.
+Cuerpo, en este orden fijo:
+
+1. Cabecera con total de proyectos y los dos semáforos (verde/amarillo/rojo de A y de B).
+2. `🔴🔴 CRITICOS — doble rojo` (A rojo **y** B rojo).
+3. `🔄 SEGUIMIENTO SIN AVANCE` (racha de notas casi idénticas ≥ 2).
+4. `🔵 SOLO ESTANCADOS` (A rojo, B no).
+5. `📝 SOLO SIN SEGUIMIENTO` (B rojo, A no).
+6. `🟡 AMARILLOS — preventivo`.
+7. `🔬 NUEVO CRITERIO — EN OBSERVACION` (bloque temporal, ver 1.6).
+8. `🚩 INTEGRIDAD / posible manipulacion`.
+9. KPI semanal (solo lunes) y cierre mensual (solo los días 1–3).
+
+**El correo se manda siempre**, para los dos grupos, aunque no haya ni un renglón: las
+secciones vacías imprimen `- ninguno -`. No hay guarda de vacío. (Los otros watchdogs sí la
+tienen — ver 1.7.)
+
+**DESTINATARIOS DE HOY** (leídos de `shared/operaciones/sla_stages.json` en main,
+`config.recipients_por_grupo`, con `modo_prueba: false`):
+
+- **Semáforo Operaciones** → `felipe@fts.mx`, `gibran@fts.mx`, `mateo@fts.mx`,
+  `estebandelacruz@fts.mx`, `info_comercialFTS@fts.mx`
+- **Semáforo Admin** → `erick@fts.mx`, `gerardo@fts.mx`, `carolina@fts.mx`,
+  `estebandelacruz@fts.mx`, `info_comercialFTS@fts.mx`
+
+Confirmado contra el encabezado real de un correo entregado (18-ago, vía Graph):
+`Para: Erick Belmont; Gerardo Lozano; Carolina Lugo; Jesus Esteban De La Cruz; Info_comercialFTS`.
+
+**Escrituras del semáforo** (no es read-only puro):
+- `Odoo - CREATE log note`: `mail.message` con `subtype_id=2`, `message_type=notification`,
+  **`author_id=3`** (Esteban), solo cuando el estado cambió vs la corrida previa
+  (`staticData.estadoPrev`).
+- `HTTP - PUT snapshot (GitHub)`: `shared/operaciones/semaforo_snapshots/AAAA-MM-DD.json`
+  a main, todos los días.
+
+### 1.3 `fin/watchdog-captura` — 22 nodos
+
+**Trigger:** `A - Schedule 08:15 CST` con `cronExpression: "15 8 * * 1-5"` y
+`settings.timezone = "America/Monterrey"`. **Es el único de los cinco que escribe el cron en
+hora local** en vez de su equivalente UTC. Verificado contra ejecuciones: arrancan a
+`14:15:00` UTC = 08:15 CST. Funciona hoy, pero depende de que `settings.timezone` sobreviva
+— y CLAUDE.md §18 lección #1 documenta que n8n **lo descarta al importar**. Si alguien
+re-importa este workflow, el cron se va al TZ de la instancia (`America/New_York`) y corre a
+las 07:15 CST sin avisar.
+
+**Qué vigila:** la captura bancaria del **journal 61** (Jeeves Tarjeta de Crédito) y las
+cuentas Chase de los journals **122** (cheques, cuenta GL 1557) y **123** (tarjeta, GL 1558).
+Nada que ver con cuentas por cobrar.
+
+**Consultas:**
+
+| # | Modelo / fuente | Filtro | Para qué |
+|---|---|---|---|
+| 3 | Jeeves MCP `list_transactions` | `startDate = hoy−30d`, `transactionStatuses:['settled']` | fuente de verdad externa |
+| 4 | `account.bank.statement.line` | `journal_id = 61` · `date >= hoy−30d` | emparejar contra Jeeves |
+| 5 | `mail.message` | `model=account.journal` · `res_id=61` · `body like %CBRUN%` · `date >= hoy` | ¿corrió la captura? |
+| 6 | `mail.message` | `model=account.journal` · `res_id=61` · `body like %CBWATCH%` | auto-vigilancia + tendencia |
+| 7 | `account.online.account` | sin dominio | balance de Plaid |
+| 7d | `account.online.link` | sin dominio | `state` del enlace bancario |
+| 8 | `account.move.line` | `account_id in [1557,1558]` · `parent_state=posted` | suma del GL |
+| 8d | `account.bank.statement.line` | `journal_id in [122,123]` · `create_date >= hoy−30d` | frescura real de captura |
+
+**Fechas y umbrales:** ventana 30 días; `GRACIA_DIAS = 3` (los últimos 3 días CST no
+alertan, por el lag de liquidación p95 2.6d); `UMBRAL_LAG = 20`;
+`UMBRAL_HORAS_SIN_CBRUN = 3`; `UMBRAL_DIAS_HABILES_SIN_WATCH = 2`;
+`TOLERANCIA_DELTA = 0.01`. La frescura de captura se mide con **`create_date` de la última
+línea bancaria** (no con `last_sync` de Plaid — eso se corrigió el 2026-09-09), con gracia
+**por journal**: 3 días para el 122, 4 para el 123. El delta se compara contra un
+`delta_esperado` constante y medido: **224,977.63** para el 122 (saldo inicial nunca
+contabilizado) y **0** para el 123.
+
+**15 tipos de alerta:** `FALTANTES_NUEVAS`, `LAG_CERCA_DE_VENTANA`, `RECHAZOS_EN_INSERT`,
+`CONTEO_NO_CONFIABLE`, `SIN_CBRUN`, `CAPTURA_SIN_RESPIRAR`, `WATCHDOG_SIN_LATIDO`,
+`JEEVES_SIN_RESPUESTA`, `MATCHER_FALLO`, `LINK_DESCONECTADO`, `CHASE_SYNC_RANCIO`,
+`CHASE_DELTA_DERIVO`, `CHASE_LECTURA_FALLO`, `CAPTURA_LECTURA_FALLO`,
+`CUENTA_SIN_MAPEO_GL`.
+
+**Plantilla:** asunto `[Watchdog captura] ALERTA — <tipos> — AAAA-MM-DD` (u `ok`). Cuerpo:
+un bloque rojo por alerta con título en español y tabla propia, luego una tabla `Estado`
+(rango evaluado, conteos Jeeves/Odoo, CBRUN, y un bloque por cuenta online), luego
+`Cuarentena` (4 pérdidas conocidas por colisión de hash v1) y `Avisos`.
+
+**DESTINATARIO DE HOY:** `DESTINATARIOS = ['estebandelacruz@fts.mx']` — **uno solo, y
+hardcodeado en el Code node `1 - Code config`, no en un JSON de config.** Es el único de los
+cinco cuyos destinatarios no se pueden cambiar sin editar el workflow.
+
+**Escrituras:** `10 - Odoo CREATE CBWATCH` deja un `mail.message` (`author_id=3`,
+`subtype_id=2`) en el chatter del journal 61 **en cada corrida, haya alerta o no**. El correo
+solo sale si `hay_alerta` (nodo `IF - hay alerta?`). Sí tiene guarda de vacío.
+
+**Higiene, a favor:** este workflow **sí** trae `retryOnFail: true, maxTries: 3` en el nodo
+de Graph. El semáforo no.
+
+### 1.4 Los otros tres (por documentación, no por lectura del JSON)
+
+- **`ops/watchdog-mo`** (`RBxoREDTfehELmyr`, activo). W1–W5 de Fase 1.5: checkout sin cuenta
+  ni proyecto, horas sin confirmar, reasignación cross-depto, doble confirmación. Cron
+  `0 15 * * 1-5` + `timezone UTC` = 9 AM CST. Config
+  `shared/operaciones/watchdogs_mo.json`: `canary: false`, W1–W5 todos `true`.
+  **Destinatarios:** `estebandelacruz@fts.mx`, `felipe@fts.mx`, `ana.acevedo@fts.mx`,
+  `magaly@fts.mx`. Riesgo documentado en FASE15 §Parte 11: su filtro depende de **dos textos
+  literales** (`Correccion de atribucion` + `panel Confirmar Horas`) que escribe
+  `corregir-bolsa`; si alguien cambia el texto, W3/W4 se van a 0 **sin lanzar error**.
+- **`rh/watchdog/sin-checkin`** (`Q19zFeJQytSfBjdb`, activo). Empleados activos sin checkin
+  ≥ 5 días hábiles. Cron `0 14 * * 1-5` + tz UTC. **Destinatarios:** `estebandelacruz@fts.mx`,
+  `magaly@fts.mx`, `ana.acevedo@fts.mx` (hardcodeados en el Code). Guarda de vacío: si 0
+  empleados, no manda correo. **Contradicción documental:** `docs/rh/WATCHDOG_SIN_CHECKIN.md`
+  dice *"🔴 inactivo → solo falta Publish"* y n8n reporta `active: true, triggerCount: 1`.
+  El doc está stale; el workflow lleva **2 meses y medio corriendo sin que nadie lo haya
+  vuelto a tocar** (último cambio 2026-06-20).
+- **`comercial/watchdog-enviadas`** (`hJNTUd8E57W4rfjU`, **inactivo**, `triggerCount: 0`).
+  Cotizaciones `state=sent` sin movimiento, medido desde **`write_date`** — limitación que el
+  propio código documenta: *"write_date mide la última vez que cualquier proceso tocó
+  cualquier campo, NO la última vez que un vendedor le dio seguimiento"*, y 60 órdenes
+  comparten el mismo `write_date` de una escritura masiva. **Destinatario:** solo
+  `estebandelacruz@fts.mx` (`canary: true`). **Contradicción inversa a la de RH:**
+  `shared/comercial/watchdog_enviadas.json` dice `"activo": true` y el workflow está apagado.
+
+### 1.5 Cómo se conectan con el resto de la suite
+
+**De qué leen:**
+- Semáforo: `project.project`, `sale.order`, `res.partner`, `account.payment.term.line`,
+  `mail.message`, `mail.tracking.value`, `ir.attachment` de Odoo + su config de GitHub raw.
+- Captura: Jeeves MCP + `account.bank.statement.line`, `account.online.account/link`,
+  `account.move.line`, `mail.message` de Odoo.
+
+**Qué depende de sus salidas — la respuesta corta es: nada automatizado.**
+- Los **snapshots** (`shared/operaciones/semaforo_snapshots/`, 60 archivos, 1.3 MB) **no
+  tienen ningún consumidor de código**. `grep` en todo el repo: las únicas referencias están
+  en `CLAUDE.md`, `docs/operaciones/SEMAFORO_WATCHDOG.md`,
+  `docs/comercial/AUDITORIA-2026-08.md` y `docs/comercial/AUDITORIA-SESION-2.md` — todos
+  documentos. El frontend `operaciones/semaforo/` y el endpoint `ops/semaforo` siguen
+  pendientes (CLAUDE.md §18 pendientes #4 y #5). **Hoy el snapshot es un archivo
+  write-only** — que es justo lo que hizo posible esta auditoría, así que su valor es real,
+  pero nadie lo lee en automático.
+- El **CBWATCH** en el chatter del journal 61 lo lee **el propio watchdog de captura** en la
+  corrida siguiente (auto-vigilancia + serie de tendencia). Es el único caso de una salida de
+  watchdog consumida por código.
+- Los **log notes** que el semáforo escribe en el chatter de cada proyecto no los lee nadie.
+  Y hay un acoplamiento latente ahí: el semáforo escribe con `author_id = 3` (Esteban) pero
+  filtra las notas ajenas por `watchdog_author_partner_id = 2`. Hoy no se auto-alimenta
+  **solo porque escribe con `message_type = notification`** y la consulta de seguimiento pide
+  `message_type = comment`. `watchdog_author_partner_id: 2` es config muerta, y si alguien
+  cambiara ese `message_type`, el watchdog empezaría a contar sus propias notas como
+  seguimiento humano.
+
+**Lógica compartida con comercial / rentabilidad:** no hay código compartido, hay
+**patrón copiado**. `docs/rh/WATCHDOG_SIN_CHECKIN.md` lo dice explícito ("el watchdog reusa
+el nodo Graph + la misma credencial + el mismo Schedule"), y `comercial/SUPUESTOS.md` dice
+que clonó `ops/watchdog-mo`. Consecuencias:
+- **Los cinco mandan por la misma credencial** `Microsoft Graph - sales`
+  (`Mh5kBNduMzOl3nzT`) **desde el mismo remitente** `sales@fts.mx`. Es la única credencial
+  de Microsoft en la instancia (verificado en `docs/po-radar/AUDITORIA-2026-08.md`): un
+  límite de esa app es un límite de todo el correo del sistema.
+- Con la rentabilidad (Frente A) **no comparten nada**, y ahí hay un hueco: el semáforo
+  decide "en plazo de crédito" sin mirar una sola factura, mientras
+  `project/archive-budget-cierre` (Frente B) **sí** calcula AR y AP por analítica con
+  `amount_residual`. Dos automatizaciones sobre el mismo proyecto, una con noción de cobranza
+  y la otra sin ella.
+
+### 1.6 Bloque "EN OBSERVACION": una excepción que ya caducó
+
+`sla_stages.json` → `observacion: { stages: [13], hasta: "2026-08-24" }`. El mecanismo está
+bien diseñado (caduca solo, sin tocar nada). Pero **caducó hace 11 días hábiles** y el efecto
+de su caducidad es medible y grande: el stage 13 pasó de puntuar con el criterio de crédito a
+puntuar con la regla de nota diaria. En los snapshots, el rojo de B en el grupo Admin salta de
+**1 el 21-ago a 18 el 24-ago**. Nadie recalibró después del salto.
+
+### 1.7 Reglas duplicadas o contradictorias entre los cinco
+
+| Tema | Semáforo | Captura | MO | RH | Comercial |
+|---|---|---|---|---|---|
+| Base de la cuenta de días | días **hábiles** desde nota/creación | días **naturales** CST desde `create_date` de línea | (n/d) | días **hábiles** desde `check_in` | días **naturales** desde `write_date` |
+| Cron | `0 14` + tz `Etc/UTC` | **`15 8` + tz `America/Monterrey`** | `0 15` + tz UTC | `0 14` + tz UTC | `45 14` + tz UTC |
+| Nombre del modo prueba | `modo_prueba` | (no tiene) | `canary` (redirige todo + `[CANARY]`) | (no tiene) | `canary` (solo a Esteban) |
+| Destinatarios | JSON en main, por grupo | **hardcoded en el Code** | JSON en main | hardcoded en el Code | JSON en main |
+| Guarda de vacío | **NO — siempre manda 2 correos** | sí (`IF - hay alerta?`) | sí (guards por bloque) | sí (0 filas → `[]`) | sí (0 filas → `[]`) |
+| Reintento del envío | no | **sí, 3 intentos** | no | no | no |
+| Fallback si el config no carga | **muere y falla en rojo** (deliberado, tras el 17-ago) | n/d | muere en silencio | n/d | **degrada a defaults + banner** |
+| `active` real vs documentado | coincide | coincide | coincide | **doc dice inactivo, está activo** | **config dice activo, está apagado** |
+
+Contradicciones que valen la pena nombrar:
+
+1. **Tres convenciones de horario en cinco workflows.** Cuatro escriben el cron en UTC
+   (defensa contra el bug de §18: n8n descarta `settings.timezone` al importar); el de
+   captura lo escribe en hora local y confía en el `timezone`. Las dos estrategias son
+   defendibles; **tenerlas mezcladas no**, porque la defensa de una es exactamente el
+   supuesto que rompe a la otra.
+2. **Tres nombres para "no le pegues al equipo todavía"**: `modo_prueba`, `canary`
+   (redirigir), `canary` (recortar destinatarios).
+3. **Dos direcciones de drift entre config y realidad** — RH activo con doc que lo cree
+   apagado, comercial apagado con config que lo cree activo. Ninguna de las dos se detecta
+   sola.
+4. **Solo el semáforo manda sin tener nada que decir.** Los otros cuatro se callan cuando no
+   hay hallazgos. Esa asimetría es, por sí sola, una de las causas de que el semáforo se lea
+   como ruido: es el único que aparece todos los días haga falta o no.
+
+---
+
+## PASO 2 · Histórico real de correos
+
+### 2.1 Fuentes y su límite
+
+- **Ejecuciones en n8n:** solo **10–11 por workflow**, la más vieja del 2026-08-26. La
+  retención es de 14 días (`EXECUTIONS_DATA_MAX_AGE=336`, CLAUDE.md §14). **No sirve para el
+  histórico**, y eso ya está documentado como regla (§9: el historial de ejecuciones no prueba
+  ausencia de corridas).
+- **Snapshots en el repo:** `shared/operaciones/semaforo_snapshots/`, **60 archivos** del
+  2026-06-17 al 2026-09-08. Cada archivo = una corrida = **2 correos**. Esta es la fuente
+  buena, y es exacta porque el snapshot y el correo se construyen del mismo
+  `Code - MAIN`, en ramas hermanas.
+- **Buzón de Esteban vía Graph:** corrobora la entrega real y da los asuntos. Usada para
+  cruzar.
+
+### 2.2 Cuántos correos, con qué frecuencia
+
+**Semáforo:** 59 días hábiles entre el 2026-06-18 y el 2026-09-08. Hay snapshot de **58**.
+
+- **Falta 1 día entero:** `2026-07-10` (jueves). No hay snapshot → esa corrida no llegó a
+  `Code - col-main`.
+- **2 corridas produjeron snapshot con error en vez de datos**, las dos con el mismo
+  mensaje crudo:
+  `{"error": "Cannot read properties of undefined (reading 'comercial_whitelist_partner_ids') [line 4]"}`
+  → **2026-06-17** (la primera corrida de su vida) y **2026-08-17** (el lunes que documenta
+  el comentario de `Code - buildEmail`: *"la ejecucion salia VERDE sin enviar nada"*). El
+  buzón confirma que el 17-ago **no llegó ningún** `[Semaforo …]`, y que el 18-ago sí.
+- **Total entregado: ≈ 114 correos** (57 corridas buenas × 2 grupos) en 12 semanas,
+  **2 por día hábil**.
+
+**Captura:** desde su go-live (2026-08-12) hasta el 2026-09-08 hay 20 días hábiles. En el
+buzón hay **17 correos**, y **todos dicen `ALERTA`**. Ni uno solo con `ok`. La secuencia de
+tipos, leída de los asuntos:
+
+| Fecha | Tipos en el asunto |
+|---|---|
+| 08-12 | `FALTANTES_NUEVAS` |
+| 08-17 | `FALTANTES_NUEVAS, RECHAZOS_EN_INSERT, CHASE_SYNC_RANCIO, CHASE_SYNC_RANCIO` |
+| 08-18 | `FALTANTES_NUEVAS, RECHAZOS_EN_INSERT, CHASE_SYNC_RANCIO, CHASE_SYNC_RANCIO` |
+| 08-19 | `CHASE_SYNC_RANCIO, CHASE_SYNC_RANCIO` |
+| 08-20 | `CHASE_SYNC_RANCIO, CHASE_SYNC_RANCIO` |
+| 08-21 · 24 · 25 · 26 | `LINK_DESCONECTADO` (4 días seguidos) |
+| 08-27 · 28 · 31 · 09-01 | `CHASE_SYNC_RANCIO` (4 días seguidos) |
+| 09-03 | `CHASE_DELTA_DERIVO` |
+| 09-04 | `CHASE_SYNC_RANCIO, CHASE_DELTA_DERIVO` |
+| 09-07 · 09-08 | `CHASE_SYNC_RANCIO` |
+
+Dos lecturas:
+- El asunto **repetía el mismo tipo dos veces** el 17–20 de agosto (una alerta por cuenta,
+  sin deduplicar). Hoy ya deduplica.
+- **`LINK_DESCONECTADO` × 4 y `CHASE_SYNC_RANCIO` × 4** son el mismo hecho gritado cuatro
+  veces. Y `CHASE_DELTA_DERIVO` el 3-sep (0.00 → −62.53) y otra vez el 4-sep (−62.53 → 0.00)
+  es **el mismo hueco transitorio alertado en las dos direcciones** — el propio código lo
+  reconoce ahora: *"ALERTO LAS DOS VECES por el mismo hueco transitorio… Nada se habia
+  perdido"*. Ese comentario, y el cambio a `delta_esperado` + gracia por journal, es del
+  **2026-09-09 04:49 UTC**, o sea de anteayer/hoy: **el ruido de captura ya está atendido en
+  parte**, y esta auditoría solo puede medir el antes.
+
+### 2.3 Cuántos renglones traía cada correo y cómo evolucionó
+
+Renglones = entradas en las cuatro secciones accionables (críticos + solo estancados +
+solo sin nota + amarillos). Promedio por correo:
+
+| Ventana | Grupo | Corridas | Renglones/correo | Críticos | Solo est. | Solo nota | Amarillos | Banderas |
+|---|---|---|---|---|---|---|---|---|
+| 18-jun → 15-jul | Operaciones | 19 | **8.1** | 2.0 | 2.1 | 3.5 | 0.5 | 2.6 |
+| 18-jun → 15-jul | Admin | 19 | **14.6** | 5.4 | 8.4 | 0.8 | 0.0 | 11.5 |
+| 11-ago → 8-sep | Operaciones | 20 | **16.4** | 4.7 | 3.0 | 5.0 | 3.8 | 7.8 |
+| 11-ago → 8-sep | Admin | 20 | **10.6** | 5.6 | 3.5 | 1.3 | 0.1 | 9.7 |
+
+El volumen de Operaciones **se duplicó** (8.1 → 16.4). El de Admin bajó de 14.6 a 10.6 pero
+su carga de banderas se mantuvo en ~10 por correo.
+
+**El indicador que más importa: el semáforo B ya no produce verdes.**
+
+| Fecha | B verde | B amarillo | B rojo |
+|---|---|---|---|
+| 2026-08-25 | 15 | 0 | 11 |
+| 2026-08-26 | **0** | 20 | 6 |
+| 2026-08-27 | **0** | 3 | 23 |
+| 2026-08-28 | **0** | 0 | 26 |
+| 2026-08-31 | **0** | 7 | 26 |
+| 2026-09-01 | **0** | 6 | 27 |
+| 2026-09-02 | **0** | 15 | 19 |
+| 2026-09-03 | **0** | 3 | 31 |
+| 2026-09-04 | **0** | 0 | **34 de 34** |
+| 2026-09-07 | **0** | 20 | 15 |
+| 2026-09-08 | **0** | 0 | **35 de 35** |
+
+**Once corridas seguidas con cero verdes, y dos de ellas con el 100 % de la cartera en rojo.**
+La meta escrita en el propio correo es *"≥90 % verde"*. Medido: **0 %**.
+
+Y no es que el equipo haya dejado de trabajar. Es aritmética: `rojo_dias = 2` → amarillo =
+`max(2−1,1) = 1` → **verde exige `dias_sin_seguimiento = 0`, o sea una nota escrita hoy
+antes de las 08:00 CST**, que es cuando sale el correo. Verificado empíricamente sobre los
+pares `(dias_sin_seguimiento, color_b)` de los snapshots: el 2026-08-25, los 15 verdes
+tienen **todos** `dias_sin_seguimiento = 0`; no hay un solo verde con 1. **El verde del
+semáforo B es inalcanzable por construcción para quien trabaje en horario de oficina.**
+
+### 2.4 Qué porcentaje de los renglones se repite día tras día
+
+Midiendo "el mismo proyecto en la misma sección que en la corrida anterior":
+**678 de 1,184 = 57.3 %**. Pero ese número está *deprimido* por un artefacto: el semáforo B
+oscila con el día de la semana, así que los proyectos brincan de sección sin que cambie nada
+en el mundo. La medida sin artefacto es la de estancamiento (A), y ahí:
+
+**En 58 corridas se observaron 71 cambios de stage y CERO reinicios de `dias_en_stage`.**
+La métrica nunca bajó, ni una vez, para ningún proyecto (ver PASO 3, error #1).
+
+Concentración del volumen: **28 proyectos aparecen en ≥ 20 de las 58 corridas y aportan
+941 de 1,231 renglones = 76 % de todo lo que se ha mandado.** 16 proyectos aparecen en ≥ 30
+corridas (54 % del volumen). 3 proyectos aparecen en ≥ 50 (14 %).
+
+### 2.5 Los renglones más repetidos de toda la historia
+
+`runsA` = corridas con `color_a = rojo`. `rachaA` = corridas rojas consecutivas hasta hoy.
+
+| runsA | rachaA | visto | id | Proyecto | Stage hoy | "días en stage" hoy |
+|---|---|---|---|---|---|---|
+| **58/58** | **58** | 58 | 2327 | SO11511 · Válvula lavado de botellas — BEBIDAS PURIFICADAS | En plazo de credito | 100 |
+| **58/58** | **58** | 58 | 101 | SO7723 · Integración con sensor de nivel — MAGNEKON (Juventino Hernández) | En plazo de credito | **401** |
+| 57/58 | 47 | 58 | 213 | SO11037 · Distribución eléctrica luminarias Cabina de Flejadora — JOHNSON CONTROLS | **Hold** | **266** |
+| 32 | 29 | 46 | 2305 | SO11557 · Enchaquetado — Mission Foods | (salió) | 123 |
+| 32 | 32 | 32 | 2298 | SO11631 · BSH | En plazo de credito | 114 |
+| 31 | 29 | 58 | 241 | SO11290 · Test loop ingeniería Mexicali — Nalco | En plazo de credito | 203 |
+| 30 | 28 | 58 | 160 | SO10300 · Techo de Magnekon | En plazo de credito | 330 |
+| 28 | 28 | 47 | 2356 | SO11773 · **ELECTRICAL DUMP STATION DALLAS 2** — Mission Foods | In Progress | 48 |
+| 28 | 28 | 47 | 2355 | SO11673 · **Póliza de matto Compresor Houston** — Mission Foods | In Progress | 48 |
+| 27 | 27 | 27 | 2304 | SO11646 · BSH | En plazo de credito | 104 |
+| 25 | 16 | 52 | 2353 | SO11779 · Reparación motores de rampa — BEBIDAS PURIFICADAS | En plazo de credito | 53 |
+| 21 | 0 | 52 | 2352 | SO11699 · **Sensores en ductos** — Bridgestone | In Progress | 53 |
+| 15 | 0 | 58 | 506 | SO11492 · Ductos de aire área de chips — Mission Foods | In Progress | 187 |
+
+**Tres proyectos llevan 58 de 58 corridas en el correo** — desde el primer día que el
+watchdog existe. Dos de ellos con racha ininterrumpida de 58. Eso son ~116 apariciones
+individuales en el buzón de cinco personas, por tres proyectos, sin que la alerta haya
+producido un cambio de estado. Y los cuatro casos que el equipo reportó como falsos
+positivos (Luminarias, Sensores, Dallas, Compresor) están todos en esta tabla.
+
+**Las banderas se comportan igual o peor.** Total en 58 corridas: 911 banderas, de 5 tipos:
+
+| Veces | Tipo | Texto más repetido |
+|---|---|---|
+| 509 | `ap_sin_confirmacion` | "En plazo de credito SIN confirmacion AP documentada (falta log note + pantallazo)" |
+| 265 | `stage_atras` | **133×** "Stage regresado Hold → En proceso por **OPERACIONES FTS-YIN**" |
+| 86 | `nota_vacia` | 82× "1 log note(s) sin contenido en el chatter" |
+| 33 | `hold_sin_fecha_vigente` | "En Hold con fecha de reactivacion VENCIDA" |
+| 18 | `fecha_fin` | 18× "Fecha fin movida por **Jesus Esteban De La Cruz** (no Comercial)" |
+
+El mecanismo del ruido de banderas es estructural: la consulta 7 pide
+`date >= hoy − 30 días`, así que **un cambio de stage se vuelve a marcar todos los días
+durante 30 días** (~21 correos). Las 18 apariciones de "Fecha fin movida por Jesus Esteban
+De La Cruz" son **un solo cambio**, hecho por el CEO, marcado como sospechoso 18 veces —
+porque `comercial_whitelist_partner_ids` solo contiene al partner 306.
+
+Y `ap_sin_confirmacion` disparó hoy en **8 de 8** proyectos del stage 13: es el 100 % de su
+población. Un control que marca a todo el mundo no discrimina nada.
+
+---
+
+## PASO 3 · Los ocho errores reportados por el equipo
+
+### Antes de los ocho: la mejor evidencia de todas ya la escribió el equipo
+
+El 2026-08-19 a las 14:37 UTC (08:37 CST), **Erick Belmont** contestó el `[Semaforo Admin]`
+del 18-ago punto por punto (`internetMessageId`
+`<BN0PR22MB2768FFC8053C335111D887D5D6A52@BN0PR22MB2768.namprd22.prod.outlook.com>`, con
+copia a Felipe y Gerardo). Extractos textuales:
+
+> **SO7723 · 🔴 en stage 386d** — "Se ha dado seguimiento pero esté proyecto no han ido para
+> calar el sensor para que Juventino nos de el VoBo y se proceda a terminar ese proyecto y ya
+> tenemos cobrado el 90% de todo el proyecto."
+
+> **SO10300 · 🔴 315d** — "Se ha mandado correo, se busca por teléfono pero hasta que hablamos
+> con seriedad con las de recepción responden y no nos dan cita… y así es el juego con
+> Magnekon."
+
+> **SO11290 · 🔴 188d** — "Se envío factura apenas el **15 de agosto** a cliente por
+> instrucciones de Operaciones, aunque entre el 3 y el 15 se estuvo solicitando el GR."
+
+> **SO11511 · 🔴 85d** — "La factura **INV 1996** fue enviada, pero no se ha hecho comentarios
+> debido a que esta tiene un plazo de **120 días** y fue timbrada y remitida en su momento
+> **13 de mayo** y no le vemos sentido a estar comente y comente sino hasta que se acerque el
+> vencimiento, salvo mejor opinión."
+
+> **SO11779 · 🔴 38d** — "Se cargo la factura el 21 de julio y son 120 días de crédito
+> entonces sucede lo mismo que el proyecto anterior."
+
+> **SO11748 · 🔴 14d** — "Ayer se mandó la factura del 10% final del proyecto… si no había
+> avance es porque apenas lo terminaron, entonces por eso en estos 14 días no se puso notas."
+
+Y cerró: *"si gustas podemos tener una reunión de todo el equipo (Comercial, Operaciones y
+Finanzas) con la finalidad de que entendamos y veamos que podemos mejorar de este tipo de
+situaciones."*
+
+Eso es un destinatario explicando, con nombres y fechas, que **siete de siete renglones no
+eran accionables por él**. Es el mejor argumento de esta auditoría y no lo escribí yo.
+
+### 3.1 Administración
+
+#### Error #1 — "Cuenta mal los días en stage" · ✅ EXISTE · es el bug raíz de todo
+
+**Dónde vive:** `29eaGe2wkS98lRMU` → nodo **`Code - MAIN`**, dos líneas:
+
+```js
+const lastStageMsg = lastBy('Odoo - getAll msg94');
+...
+const ls=lastStageMsg[p.id];
+const diasEnStage = ls ? bizDays(ls.date) : (p.create_date ? bizDays(p.create_date) : null);
+```
+
+**Qué pasa:** el nodo `Odoo - getAll msg94` busca `mail.message` con `subtype_id = 94`
+("Project Stage Changed") y **no existe ni uno**. Crudo de la ejecución **90897**
+(2026-09-08T14:00:00Z, la corrida que generó el correo de ayer), nodo `Odoo - getAll msg94`:
+
+```json
+"data": { "main": [ [ { "json": {}, "pairedItem": [ { "item": 0, "input": 0 } ] } ] ] }
+```
+
+Un solo item vacío — lo que `alwaysOutputData: true` produce cuando el search no devuelve
+nada. Con `lastStageMsg` vacío, **el `else` se ejecuta siempre** y `dias_en_stage` mide
+**días hábiles desde `project.create_date`**, es decir **la edad del proyecto**.
+
+**Comprobado sobre los 35 proyectos del snapshot de ayer** (`create_date` leído de Odoo,
+días hábiles calculados aparte): **34 de 35 coinciden exactamente** con
+`bizDays(create_date → 2026-09-08)`. El único que falla (2375) falla por **un** día, y falla
+del lado correcto: su `create_date` es `2026-09-02 05:50:36 UTC` = `2026-09-01 23:50 CST`,
+así que en hora de Monterrey son 5 días hábiles y no 4 — o sea que aplicando el mismo
+`tz_offset_hours` del workflow, **coinciden 35 de 35.**
+
+| id | Stage | `dias_en_stage` | `bizDays(create_date)` |
+|---|---|---|---|
+| 101 | En plazo de credito | 401 | 401 |
+| 121 | In Progress | 371 | 371 |
+| 160 | En plazo de credito | 330 | 330 |
+| 213 | **Hold** | 266 | 266 |
+| 241 | En plazo de credito | 203 | 203 |
+| 2327 | En plazo de credito | 100 | 100 |
+| … | … | (34/35 exactos) | … |
+
+**El caso reportado, reproducido:** el proyecto **241** (SO11290, Nalco) se movió de stage
+tres veces en agosto — los snapshots lo muestran en `Done Operations` el 06-ago,
+`Admin - In progress` el 07-ago y `En plazo de credito` desde el 11-ago — y su contador
+siguió: **180, 181, 182, 183, 184, 185, 186, 188…** sin reiniciarse nunca. El 18-ago marcó
+**188d**, que es exactamente lo que reportó el equipo y lo que Erick citó en su correo.
+188 días hábiles desde `create_date 2025-11-27` = 188. La factura real (INV2013) es del
+**2026-08-05** con vencimiento **2026-10-04**.
+
+**Y no es una regresión: nació roto.** En las 58 corridas, `dias_en_stage` **nunca bajó para
+ningún proyecto**, ni una sola vez, mientras se observaban **71 cambios de stage**. Ejemplos
+crudos de la serie:
+
+```
+2026-06-22  id=2337  To Do -> Hold                          dias  4 ->  5   (no reinicio)
+2026-06-30  id=2337  Hold -> In Progress                    dias 10 -> 11   (no reinicio)
+2026-08-07  id=2337  In Progress -> Done Operations          dias 38 -> 39   (no reinicio)
+2026-06-23  id= 225  Done Operations -> En plazo de credito  dias 173 -> 174 (no reinicio)
+2026-08-03  id= 241  In Progress -> Done Operations          dias 176 -> 177 (no reinicio)
+```
+
+`docs/operaciones/SEMAFORO_WATCHDOG.md` línea 42 dice que en el diseño (2026-06-17) sí se
+leyó un subtype-94. Hoy no hay ninguno, y el primer snapshot con datos (18-jun, un día
+después) ya venía sin reinicios. Sea que el subtype se desactivó, que cambió de id o que la
+lectura de diseño fue de otra cosa, **el efecto observable es que la métrica A nunca
+funcionó en producción.**
+
+**Por qué nadie lo detectó en 12 semanas:** el nodo tiene `alwaysOutputData: true` **y**
+`onError: continueRegularOutput`. Un search vacío es indistinguible de un search exitoso, el
+`else` es un fallback silencioso, y el número que sale **se ve razonable** (crece un día por
+día hábil, como debería). Es el Hallazgo #14 de CLAUDE.md — *feature en bypass silencioso* —
+en una superficie nueva: **una métrica en bypass silencioso**.
+
+**Dificultad de arreglo: MEDIA.** Dos partes. (a) Averiguar en Odoo cuál es hoy el subtype
+real del cambio de stage, o dejar de depender del chatter: `project.project` no tiene
+`date_last_stage_update` (re-confirmado en el doc §48), así que las alternativas son leer
+`mail.tracking.value` del campo 24714 — que el workflow **ya consulta** para la bandera
+`stage_atras`, con lo cual el dato está en la mano — o pedir un campo Studio que estampe la
+fecha de entrada al stage. (b) Recalibrar los umbrales, porque llevan 12 semanas calibrados
+contra un número que significaba otra cosa. **Y un guard:** si el search de la métrica
+vuelve vacío, el correo tiene que **decirlo**, no caer al fallback.
+
+#### Error #2 — "No cuenta ni desde emisión ni desde envío" · ✅ EXISTE
+
+**Dónde vive:** `Code - MAIN`, función `rojoCredito` + el modo `credito` del stage 13:
+
+```js
+function rojoCredito(p){
+  const t = partnerTerm[m2o(p.partner_id)];
+  const d = (t && termDays[t] != null) ? termDays[t] : C.credit_fallback_days;
+  return d + C.credit_extra_days;
+}
+...
+else if (oEn.modo === 'credito') { colA = colorOf(diasEnStage, rojoCredito(p)); }
+```
+
+Tres defectos encadenados en cuatro líneas:
+
+1. El plazo se compara contra **`diasEnStage`**, que por el error #1 es **la edad del
+   proyecto**. Nada que ver con la factura.
+2. El plazo se saca de **`res.partner.property_payment_term_id`** (el default del cliente),
+   no del término de la factura emitida.
+3. `termDays` se construye con **`Math.max`** sobre todas las líneas del término
+   (`termDays[t]=Math.max(termDays[t]||0, Number(it.json.nb_days)||0)`), así que un término
+   escalonado (30/60/90) se colapsa al plazo más largo.
+
+**Sobre el caso reportado.** "SO 1150011" no existe con ese folio; por los 120 días que
+menciona el reporte y por lo que escribió Erick, el caso es **SO11511** (proyecto 2327,
+Válvula para lavado de botellas, BEBIDAS PURIFICADAS) — y/o **SO11557** (proyecto 2305), que
+el 18-ago aparecía con "120d en stage". Lo documento para los dos, porque los dos
+contradicen al watchdog. Crudo de `account.move` (posted, `out_invoice`):
+
+```
+name    invoice_origin partner_id            invoice_date invoice_date_due invoice_payment_term_id amount_residual payment_state
+INV1996 (vacío)        BEBIDAS PURIFICADAS   2026-05-13   2026-09-10       120 Days                123,424.00      not_paid
+INV2006 SO11779        BEBIDAS PURIFICADAS   2026-07-20   2026-11-17       120 Days FTS 2024        14,469.84      not_paid
+INV2013 SO11290        Nalco de Mexico       2026-08-05   2026-10-04       60 Days FTS 2024        184,126.80      not_paid
+INV2022 SO11832        BEBIDAS PURIFICADAS   2026-08-18   2026-12-16       120 Days FTS 2024        86,452.48      not_paid
+INV172  SO11557        GRUMA CORP DBA MISSION FOODS 2026-07-15 2026-07-15   30 days                       0.00      in_payment
+INV171  SO11789        Corporate USA         2026-07-10   2026-07-10       30 days                       0.00      in_payment
+```
+
+INV1996 es la factura que Erick citó por número: emitida **13-may** (coincide con "timbrada
+y remitida el 13 de mayo"), término **"120 Days"**, y **vence el 2026-09-10 — mañana.**
+El watchdog la lleva marcando en rojo **58 corridas seguidas** con "100 días en stage",
+cuando la factura **no había vencido ni un día**.
+
+**Y aquí está lo importante para la decisión del PASO 4: Odoo ya tiene la respuesta.**
+`account.move.invoice_date_due` está poblado y correcto en todas, calculado por Odoo con el
+término **de la factura** (`invoice_payment_term_id`: "120 Days", "120 Days FTS 2024",
+"60 Days FTS 2024", "30 days", "15 day"). El watchdog **no lee `account.move` en absoluto**.
+
+**Dificultad: MEDIA.** El dato existe; hay que ir por él. La parte fina es el vínculo
+proyecto → factura: `invoice_origin` es texto y **falla justo en los dos casos más
+marcados** — INV1996 (SO11511) lo trae **vacío**, y para SO7723 (proyecto 101, el de 401
+días) no hay ninguna factura con ese origen aunque Erick diga que está cobrado al 90 %.
+`sale.order.invoice_status` tampoco sirve: SO10917 dice `to invoice` teniendo INV1989 de
+$558,014.52 **pagada**. El camino confiable es `sale.order.invoice_ids` / las líneas, o
+partner + monto, y hay que probarlo antes de confiar en él.
+
+#### Error #3 — "Hay clientes sin plazo de crédito configurado" · ✅ EXISTE
+
+**Dónde vive:** el `credit_fallback_days: 30` + `credit_extra_days: 7` de `sla_stages.json`,
+consumidos por `rojoCredito`. Sin ninguna señal en el correo de que se está usando el
+fallback.
+
+**Crudo de `res.partner`** para los 18 partners que la corrida 90897 leyó
+(`Code - prep.partnerIds`):
+
+```
+id   name                                property_payment_term_id  parent_id                     is_company
+897  BEBIDAS PURIFICADAS                 (vacío)                                                 si
+880  Bridgestone México                  (vacío)                                                 si
+1978 Ruben Robledo                       (vacío)                   Bridgestone México
+2269 CONMET DE MEXICO                    (vacío)                                                 si
+2242 Omar De la Garza                    (vacío)                   Calbee America Incorporated
+2049 GRUMA CORP DBA MISSION FOODS        (vacío)                                                 si
+900  JOHNSON CONTROLS ENTERPRISES MEXICO 90 Days FTS 2024                                        si
+1143 Lau Industries de Mexico            30 Days FTS 2024                                        si
+895  MAGNEKON S.A. DE C.V.               (vacío)                                                 si
+896  Juventino Hernandez                 (vacío)                   MAGNEKON S.A. DE C.V.
+1630 Mission Foods                       (vacío)                                                 si
+1585 Mission Foods                       (vacío)                                                 si
+2263 Daniel Sanudo                       (vacío)                   Mission Foods
+2326 Martín Infante                      (vacío)                   Mission Foods, Mission Foods
+1907 Robert Barrera                      (vacío)                   Mission Foods
+94   Nalco de Mexico                     60 Days FTS 2024                                        si
+289  Misael Constantino                  60 Days FTS 2024          Nalco de Mexico
+2237 Tito Everardo Ordaz                 60 Days FTS 2024          Nalco de Mexico
+```
+
+**5 de 18 tienen término. 13 no** — y entre los que no están BEBIDAS PURIFICADAS (la de los
+120 días reales), Mission Foods, MAGNEKON, Bridgestone, Calbee, GRUMA y CONMET. Todos esos
+se evalúan con **37 días** (30 + 7).
+
+**Un agravante que no estaba reportado:** `rojoCredito` lee el término del `partner_id` **del
+proyecto**, que muchas veces es un **contacto hijo**, no la empresa. Seis de los 18 son
+contactos. Los hijos de Nalco heredan el término porque alguien se los puso a mano
+(289, 2237); los de Mission Foods, Bridgestone, Calbee y Magnekon no. Así que **incluso si
+mañana se configuran los términos en todas las empresas, los proyectos apuntados a un
+contacto seguirían cayendo al fallback**, porque el código no sube por `parent_id`.
+
+**Dificultad: BAJA en código, MEDIA en datos.** El fallback con `parent_id` son dos líneas.
+Marcar el renglón como *"plazo asumido, no configurado"* en el correo es una línea. Capturar
+los 13 términos en Odoo es trabajo de Gerardo/Erick. **Y si se adopta
+`invoice_date_due` (error #2), este error desaparece solo**: la factura trae su propio
+término y Odoo ya calculó el vencimiento.
+
+#### Error #4 — "No distingue fecha comercial de fecha de proyecto" (caso Hernán) · ✅ EXISTE
+
+El "Hernán" del reporte es **Juventino Hernández** (`res.partner` id **896**, contacto de
+MAGNEKON S.A. DE C.V.), el cliente de los dos proyectos Magnekon más marcados: **101**
+(SO7723, 401 días, 58/58 corridas) y **160** (SO10300, 330 días). Es el mismo del que Erick
+escribió *"no han ido para calar el sensor para que Juventino nos de el VoBo"*.
+
+**Dónde vive:** en que el semáforo solo conoce **dos** fechas por proyecto —
+`create_date` (que por el error #1 es la que usa siempre para A) y `project.date` (la fecha
+compromiso, que usa para el modo `due_date` del stage 2) — y **ninguna de las dos es la fecha
+que el negocio considera oficial**. No hay campo, ni lectura, ni concepto de "fecha
+comercial acordada con el cliente". El caso Hernán (arranque el 19-ago sin importar firma ni
+portal) **no es expresable hoy** en la config: `sla_stages.json` no tiene ningún lugar donde
+poner una fecha de inicio por proyecto o por cliente.
+
+Y el hueco es visible en los datos: los tres proyectos Magnekon activos (101, 160, 343)
+tienen `date` = 2025-12-23, 2026-07-31 y 2026-10-30, todas ajenas a un arranque el 19-ago.
+
+**Dificultad: MEDIA-ALTA**, y es mitad decisión de negocio. Requiere (a) decidir dónde vive
+la fecha oficial — campo Studio en `sale.order`/`project.project`, o override por cliente en
+`sla_stages.json` — (b) quién la captura y (c) que el semáforo la prefiera sobre las demás.
+Antes de tocar código hay que cerrar la pregunta de la fuente de verdad (PASO 4).
+
+### 3.2 Operaciones
+
+#### Error #5 — "Falsa alerta de integridad por posible manipulación" · ✅ EXISTE
+
+**Dónde vive:** `sla_stages.json` → `config.comercial_whitelist_partner_ids: [306]`, y en
+`Code - MAIN`:
+
+```js
+if(fid===FF && t.old_value_datetime && !COM.includes(au))
+  addFlag(m.res_id,{tipo:'fecha_fin', detalle:'Fecha fin movida por '+aun+' (no Comercial)', fecha:m.date});
+if(fid===FS && SEQ[t.new_value_integer]!=null && SEQ[t.old_value_integer]!=null
+   && SEQ[t.new_value_integer] < SEQ[t.old_value_integer])
+  addFlag(m.res_id,{tipo:'stage_atras', detalle:'Stage regresado '+t.old_value_char+' -> '+t.new_value_char+' por '+aun, fecha:m.date});
+```
+
+La whitelist tiene **un solo partner**. Todo lo demás es "posible manipulación". Los textos
+crudos más repetidos en 58 corridas confirman exactamente lo que reportó el equipo:
+
+```
+133×  Stage regresado Hold -> En proceso por OPERACIONES FTS-YIN
+ 24×  Stage regresado Admin - In progress -> Done Operations por Administracion FTS-YIN
+ 22×  Stage regresado Complete TOTAL (Gera) -> En proceso por OPERACIONES FTS-YIN
+ 22×  Stage regresado Admin - In progress -> Hold por OPERACIONES FTS-YIN
+ 22×  Stage regresado En plazo de credito -> Admin - In progress por OPERACIONES FTS-YIN
+ 18×  Fecha fin movida por Jesus Esteban De La Cruz (no Comercial)
+```
+
+Los dos usuarios que hacen el trabajo real — **OPERACIONES FTS-YIN** y **Administracion
+FTS-YIN** — están fuera de la whitelist, y **el propio CEO** también: sus 18 apariciones
+son **un solo cambio de fecha**, marcado 18 veces como sospechoso.
+
+**Hay un segundo mecanismo de ruido, independiente de la whitelist:** la consulta
+`Odoo - getAll trackedMsgs` filtra `date >= hoy − 30 días` (`Code - prep`:
+`corte = hoy − 30*86400000`), y **no hay deduplicación por evento**. Un cambio de stage
+entra al correo **todos los días hábiles durante 30 días naturales ≈ 21 correos**. De ahí
+salen los 133: no son 133 movimientos, son un puñado de movimientos × 21 días cada uno.
+
+**Dificultad: BAJA.** Tres cosas, todas chicas: (a) meter a la whitelist los partners de
+Operaciones, Administración y el CEO — o mejor, invertir la regla y marcar solo lo que
+**nadie autorizado** hizo; (b) reportar el evento **una sola vez**, el día que ocurre (hay
+`staticData` ya en uso para esto en `Code - buildLogNotes`); (c) renombrar la sección:
+"posible manipulación" acusa, y lo que se está viendo es trabajo normal.
+
+#### Error #6 — "Alertas de proyectos que ya no se pueden mover" (Luminarias) · ✅ EXISTE
+
+**El caso:** proyecto **213**, `SO11037 - Distribucion Electrica luminarias Cabina de
+Flejadora`, JOHNSON CONTROLS. Crudo de `project.project`:
+
+```
+id   stage_id  create_date          date        partner_id                           last_update_status
+213  Hold      2025-09-01 21:26:55  2026-07-30  JOHNSON CONTROLS ENTERPRISES MEXICO  on_track
+```
+
+Hoy marca **266 días** (el reporte decía 252; son los mismos días hábiles corridos desde
+entonces). Aparece en **58 de 58 corridas**, con racha roja de 47, y además con bandera
+`hold_sin_fecha_vigente` porque su `date` de reactivación (2026-07-30) está vencida — 33
+apariciones de esa bandera en el histórico.
+
+**Dónde vive el error:** en que **no existe ninguna condición terminal**. El dominio del
+nodo 1 excluye los stages 8/4/6, y punto. El semáforo no sabe si un proyecto está facturado,
+cobrado, o si el stage en que está admite movimiento. `Code - MAIN` no consulta
+`account.move` ni `amount_residual` — nada de cobranza entra al cálculo.
+
+**Sobre "ya estaba facturado", con honestidad:** la evidencia es indirecta y contradictoria,
+y eso es en sí mismo el hallazgo. `sale.order.SO11037` dice `invoice_status: "to invoice"` y
+no hay `account.move` con `invoice_origin = 'SO11037'`. Pero sus SOs hermanas de luminarias
+para el mismo cliente **sí** están facturadas y pagadas: `INV1988` (SO11504 "Adicional de
+proyecto luminarias", 92,945.00, `paid`) e `INV1989` (SO10917 "Instalación de alumbrado en
+recicladora clarios", 558,014.52, `paid`) — y SO10917 **también** dice `to invoice`, lo que
+prueba que ese campo no es confiable aquí. **No puedo afirmar desde Odoo que SO11037 esté
+facturada**, y no la voy a afirmar. Lo que sí queda probado es lo que importa: **el watchdog
+no tiene forma de saberlo, así que alerta igual.**
+
+**Dificultad: BAJA-MEDIA.** Definir estados terminales en config (por stage, y por "AR = 0")
+es directo, y el patrón de leer AR por analítica **ya existe y está en producción** en
+`project/archive-budget-cierre` (`RW7KnoeEzYLvavI0`): `account.move.line` +
+`analytic_distribution 'in' [cuenta]` + `parent_state=posted` + `amount_residual != 0`. Es
+código que copiar, no que inventar.
+
+#### Error #7 — "Alertas por causas externas" (rigging del compresor en aduanas) · ✅ EXISTE
+
+**Los casos:** hay **dos** proyectos de compresor/rigging y conviene no confundirlos:
+
+```
+id   name                                                      stage        date        partner
+2358 SO11233 - Rigging compresor - Lau Industries de Mexico     In Progress  2026-09-30  Lau Industries
+2355 SO11673 - Poliza de matto para Compresor Houston TX        In Progress  2026-07-31  Mission Foods
+```
+
+El de **aduanas** es el rigging: **2358** (SO11233, Lau Industries), 41 días, visto en 28 de
+58 corridas, hoy en `SOLO_SIN_SEGUIMIENTO` con bandera `fecha_fin`. El **2355** (Póliza de
+mantenimiento Compresor Houston) es otro, y lleva **36 corridas con racha roja de 28**
+porque su `project.date` venció el 31-jul.
+
+**Dónde vive:** en que **no hay ningún estado de "esperando a un tercero"**. Los stages
+disponibles son To Do / In Progress / Hold / Done Operations / Admin-In progress / En plazo
+de credito. `Hold` sería el candidato natural, pero castiga (`rojo_dias: 30`) y además
+levanta `hold_sin_fecha_vigente` si no se captura una fecha de reactivación — y cuando el
+bloqueo es una aduana, **no hay fecha que capturar**. `sla_stages.json` tampoco tiene ningún
+campo tipo "pausar hasta" o "bloqueado por tercero".
+
+El resultado práctico es perverso: la única salida que el equipo tiene para un bloqueo
+externo es mover a Hold, y Hold le genera **otra** alerta. Se ve en los datos: el proyecto
+**2361** (SO11791 Calbee, Hold) trae hoy `hold_sin_fecha_vigente` **y** `nota_vacia`.
+
+**Dificultad: BAJA en código, MEDIA en proceso.** Un `motivo_espera` + `esperando_hasta`
+(por proyecto, en un JSON del repo o en un campo Studio) que **saque el renglón de las
+secciones rojas** y lo mande a un bloque "En espera de terceros", con reaparición al vencer
+la fecha, es poco código. Lo que cuesta es acordar quién declara la espera y con qué
+evidencia — porque un "esperando al cliente" sin caducidad es la manera más fácil de apagar
+el watchdog por la puerta de atrás.
+
+#### Error #8 — "Fechas desactualizadas en sistema" (Sensores, Electrical Dump Station Dallas) · ✅ EXISTE
+
+**Los dos casos, crudos de `project.project`:**
+
+```
+id   name                                                  stage        date        create_date
+2352 SO11699 - Instalacion mecanica y electrica de Sensores  In Progress  2026-12-31  2026-06-25
+2356 SO11773 - ELECTRICAL DUMP STATION DALLAS 2              In Progress  2026-07-31  2026-07-02
+```
+
+Los dos están en stage 2, cuyo `en_stage` es `modo: due_date` sobre `project.date`. Y
+producen **el error opuesto cada uno**:
+
+- **2356 (Dallas)**: `date = 2026-07-31`, **vencida hace 6 semanas** → `color_a` rojo todos
+  los días. **28 corridas con racha roja de 28.** La fecha no se movió; la alerta no informa
+  nada nuevo desde el 1-ago.
+- **2352 (Sensores)**: `date = 2026-12-31`, una fecha de relleno a fin de año → `color_a`
+  **verde** con 53 días en stage. **Racha roja: 0.** El semáforo A lo declara sano. Y
+  `sla_stages.json` documenta este caso exacto en `banderas._hold_sin_fecha_vigente`:
+  *"proy 2352 con fecha 31-ago pero su propia nota decía 'se reanudan en diciembre 2026' —
+  ninguna automatización caza esa contradicción."*
+
+**Dónde vive:** en que `project.date` es un campo **sin dueño y sin verificación**. La única
+defensa que existe es la bandera `fecha_fin` (que se dispara al cambiarla, y que por el error
+#5 acusa a quien hace el trabajo), y `hold_sin_fecha_vigente`, que solo aplica al stage 5.
+Para el stage 2 **nada** valida que la fecha compromiso sea creíble: ni que no esté vencida
+hace meses, ni que no sea un 31-dic de relleno.
+
+**Dificultad: BAJA.** Es una bandera nueva de coherencia: *"fecha compromiso vencida hace
+más de N días y sin actualizar"* + *"fecha sospechosa de relleno (fin de mes/año a más de M
+meses)"*. Se calcula con datos que el workflow **ya trae** (`project.date` está en el nodo 1)
+y no requiere ninguna consulta nueva. La parte que no es código: que alguien sea responsable
+de mantener la fecha.
+
+### 3.3 Un noveno hallazgo, no reportado, que probablemente sea el de mayor impacto diario
+
+**El semáforo B ya no es un semáforo: es un calendario.** El correo de **Operaciones** del
+2026-09-08, los 19 proyectos, columna `dias_sin_seguimiento`:
+
+```
+CRITICO   id= 121 SO9428   In Progress  stage=371d  nota=2d
+CRITICO   id= 212 SO10337  In Progress  stage=267d  nota=2d
+CRITICO   id= 213 SO11037  Hold         stage=266d  nota=2d
+SOLO_NOTA id= 343 SO11261  In Progress  stage=199d  nota=2d
+SOLO_NOTA id= 506 SO11492  In Progress  stage=187d  nota=2d
+CRITICO   id=2302 SO11547  In Progress  stage=137d  nota=2d
+CRITICO   id=2349 SO11762  In Progress  stage= 59d  nota=2d
+SOLO_NOTA id=2352 SO11699  In Progress  stage= 53d  nota=2d
+CRITICO   id=2356 SO11773  In Progress  stage= 48d  nota=2d
+CRITICO   id=2355 SO11673  In Progress  stage= 48d  nota=2d
+SOLO_NOTA id=2358 SO11233  In Progress  stage= 41d  nota=2d
+SOLO_NOTA id=2359 SO11771  In Progress  stage= 32d  nota=2d
+SOLO_NOTA id=2361 SO11791  Hold         stage= 27d  nota=2d
+CRITICO   id=2362 SO11842  In Progress  stage= 22d  nota=2d
+CRITICO   id=2363 SO11833  In Progress  stage= 21d  nota=2d
+SOLO_NOTA id=2369 SO11862  In Progress  stage=  7d  nota=2d
+SOLO_NOTA id=2368 SO11861  In Progress  stage=  7d  nota=2d
+SOLO_NOTA id=2375 SO11498  In Progress  stage=  5d  nota=2d
+CRITICO   id=2376 SO11860  To Do        stage=  2d  nota=2d
+```
+
+**19 de 19 con exactamente 2 días.** El lunes 07-sep, 20 proyectos tenían exactamente 1 día
+(amarillos). El equipo de Operaciones escribe sus notas **en una tanda el viernes**, así que
+el semáforo B marca amarillo a todos el lunes y rojo a todos de martes a viernes. **La
+métrica ya no distingue proyectos: distingue días de la semana.** Con `rojo_dias = 2` y el
+correo a las 08:00, el sistema no tiene ningún estado que premie a quien cumple.
+
+Y en el otro grupo la misma regla produce el efecto contrario: **9 de los 16 renglones de
+Admin de ayer son proyectos `Done Operations` de 7 a 16 días de vida**, todos marcados
+`CRITICO` (stage 3 tiene `en_stage: 2d` y `sin_seguimiento: 2d`, así que un proyecto es
+crítico a los 2 días hábiles de llegar ahí). Cinco de ellos —2370, 2371, 2372, 2373, 2374—
+se crearon **el mismo día** (28-ago, carga de materiales) y llegan como **cinco incidentes
+críticos independientes** con números idénticos.
+
+---
+
+## Anexo · Lo que quedó fuera y por qué
+
+1. **`ops/watchdog-mo` y `rh/watchdog/sin-checkin` no se leyeron** (`availableInMCP: false`).
+   Todo lo dicho de ellos es de documentación. Para cerrarlo: prender MCP access en la
+   tarjeta de cada workflow.
+2. **No pude consultar `mail.message` ni `mail.message.subtype` por el MCP de Odoo**
+   (denylist dura / fuera de allowlist). La prueba de que no hay subtype-94 salió del **crudo
+   de la ejecución 90897**, que es evidencia directa pero **no responde qué es hoy el subtype
+   94** ni si cambió de id. Esa pregunta queda abierta y es el primer paso del fix del error #1.
+3. **Un salto sin explicar en la serie:** el proyecto 343 pasó de 147 a 165 días entre el
+   21-jul y el 22-jul (+18 en una corrida), coincidiendo con un cambio de stage
+   `En plazo de credito → In Progress`. No lo perseguí (CLAUDE.md §8: un hallazgo se anota,
+   no se persigue). Queda anotado.
+4. **Observación de higiene, no bloqueante:** los 60 snapshots (1.3 MB) se commitean a diario
+   a un repo **público** y contienen nombres de **contactos de clientes** ("Mission Foods,
+   Daniel Sanudo", "MAGNEKON S.A. DE C.V., Juventino Hernandez", y 6 más). No hay correos ni
+   teléfonos (verificado con `grep`), así que no es una filtración de datos de contacto, pero
+   sí son nombres de empleados de clientes publicados sin necesidad — y el consumidor de esos
+   archivos hoy es **nadie**. Anotado para el backlog.

--- a/docs/watchdogs/PROPUESTA.md
+++ b/docs/watchdogs/PROPUESTA.md
@@ -1,0 +1,693 @@
+# Propuesta de rediseño de los watchdogs — septiembre 2026
+
+Documento de propuesta. **Nada de lo de aquí está construido.** La evidencia que lo sostiene
+está en [`AUDITORIA-2026-09.md`](AUDITORIA-2026-09.md); aquí solo se decide qué hacer con
+ella.
+
+---
+
+## 0. La vara
+
+> El objetivo de un watchdog es dar seguimiento a **anomalías**. Una anomalía es algo que
+> cambió, que se salió de rango, o que alguien puede accionar hoy. Un estado que lleva 252
+> días igual no es una anomalía, es una **condición**.
+
+Traducida a una prueba que se puede aplicar renglón por renglón, en ese orden:
+
+1. **¿Cambió algo desde el correo anterior?** Si el renglón es idéntico al de ayer, no es
+   noticia.
+2. **¿Se salió de un rango que alguien pactó?** No "lleva mucho tiempo", sino *pasó una fecha
+   comprometida, un vencimiento de factura, un plazo acordado*. Sin fecha pactada no hay
+   rango, y sin rango no hay "salirse".
+3. **¿Alguien de la lista de destinatarios puede hacer algo hoy?** Si la acción es de un
+   tercero, del calendario o de nadie, el renglón no va en ese correo.
+
+Un renglón necesita **al menos una de las tres**. Hoy el semáforo no exige ninguna: le basta
+que un contador cruce un umbral, y ese contador (por el error #1) mide la edad del proyecto.
+
+**El número que resume el problema:** de los 1,231 renglones enviados en 12 semanas, **76 %
+provienen de 28 proyectos vistos en 20 o más de las 58 corridas**. Tres proyectos aparecieron
+en **58 de 58**. Eso no es vigilancia, es una suscripción.
+
+---
+
+## 1. Qué debe entrar al correo y qué no
+
+### Entra
+
+| # | Señal | Por qué pasa la vara | Dato que la calcula |
+|---|---|---|---|
+| E1 | **Factura vencida y no pagada** | Se salió de un rango pactado por el cliente | `account.move.invoice_date_due < hoy` **y** `amount_residual != 0` |
+| E2 | **Factura que vence en ≤ 5 días hábiles** | Accionable hoy, y solo hoy sirve | `invoice_date_due` dentro de la ventana |
+| E3 | **Fecha compromiso del proyecto vencida** | Se salió de un rango que pactó FTS | `project.date < hoy` |
+| E4 | **Transición de stage ocurrida ayer** | Cambió | `mail.tracking.value` del día |
+| E5 | **Proyecto que entró a un stage nuevo y no salió en su plazo** | Se salió de rango — *con la métrica arreglada* | fecha real de entrada al stage |
+| E6 | **Fecha compromiso incoherente** (vencida hace >15 días hábiles, o de relleno a fin de año) | Cambió el mundo y el dato no | `project.date` vs hoy |
+| E7 | **Espera de tercero que ya caducó** | Volvió a ser nuestro | `esperando_hasta < hoy` |
+| E8 | **El watchdog no pudo medir** (search vacío, config no cargó, Odoo falló) | Es lo único que nadie más va a notar | guards explícitos |
+
+### No entra
+
+| Sale | Por qué |
+|---|---|
+| Proyectos con N días en un stage **sin fecha pactada** | No hay rango del cual salirse. Es una condición. |
+| **Todo renglón idéntico al del correo anterior** | No cambió nada |
+| **Ausencia de log note como falta en sí misma** | Ver §2.3: mide un ritual, no el proyecto |
+| Facturas **no vencidas** | Erick ya lo dijo: *"no le vemos sentido a estar comente y comente sino hasta que se acerque el vencimiento"* |
+| Proyectos con **AR = 0** (cobrados) | Terminados. Ver §5 |
+| Bloqueos declarados de tercero, **dentro de su vigencia** | Ver §4 |
+| Cambios de stage y de fecha hechos por **quien tiene el trabajo asignado** | Es el trabajo, no una manipulación |
+| **Repetición diaria de un evento de hace 30 días** | Un evento se reporta el día que ocurre |
+| `ap_sin_confirmacion` como está hoy | Dispara en 8 de 8: no discrimina. Ver §3.4 |
+| **El correo entero, cuando no hay ninguna de E1–E8** | Ver §6.4 |
+
+---
+
+## 2. Cómo distinguir anomalía de condición
+
+### 2.1 La regla de oro: reportar el **delta**, no el **estado**
+
+El semáforo ya tiene la infraestructura y la usa **solo para los log notes** — en
+`Code - buildLogNotes` hay una firma por proyecto (`color_a|color_b|banderas`) guardada en
+`staticData.estadoPrev`, y la nota se escribe **solo si la firma cambió**. Ese mismo criterio,
+aplicado al correo, es la mitad del rediseño.
+
+Propuesta concreta:
+
+```
+firma(proyecto) = estado_cobranza | dias_de_atraso_por_tramo | banderas_activas | stage
+```
+
+`dias_de_atraso_por_tramo` en lugar de días exactos, para que un renglón no "cambie" cada 24
+horas: tramos `0` / `1-5` / `6-15` / `16-30` / `>30`. Así SO10300 aparece el día que cruza a
+"16-30 días de atraso" y **no** los quince días intermedios.
+
+Cada renglón se clasifica y se pinta distinto:
+
+- 🆕 **NUEVO** — no estaba ayer. Es la anomalía.
+- 📈 **EMPEORÓ** — cambió de tramo hacia arriba, o le cambió el estado de cobranza.
+- ✅ **SE RESOLVIÓ** — estaba y ya no. **Esto hoy no se reporta y debería**: es lo único que
+  le dice al equipo que su trabajo tuvo efecto.
+- ➖ **SIN CAMBIO** — **no se imprime**; se cuenta en una línea al pie.
+
+### 2.2 La condición sigue existiendo, pero deja de mandar correo
+
+Una condición no se ignora: se **acumula y se revisa en junta**. Dos salidas, ninguna diaria:
+
+- **Un renglón al pie del correo:** *"32 proyectos en condición estable (sin cambio ≥ 5
+  corridas) — ver el tablero"*.
+- **Un digest semanal, los lunes**, con las condiciones ordenadas por dinero y antigüedad.
+  Ahí sí caben SO7723 (401 días) y SO11037 (266 días en Hold): **una vez por semana, no 58
+  veces**. Es exactamente el foro que Erick pidió por escrito.
+
+Y el destino natural de ese digest es el frontend `operaciones/semaforo/` que sigue pendiente
+(CLAUDE.md §18 #4 y #5). Hoy los 60 snapshots **no los lee nadie**: darles un lector convierte
+el correo diario en "lo que cambió" y el tablero en "cómo estamos".
+
+### 2.3 Y el semáforo B (falta de seguimiento) se retira como métrica
+
+No es un ajuste de umbral, es un retiro, y lo sostienen tres medidas de la auditoría:
+
+1. **Verde es inalcanzable.** `rojo_dias = 2` → amarillo = 1 → verde exige
+   `dias_sin_seguimiento = 0`, o sea una nota escrita **hoy antes de las 08:00 CST**, que es
+   cuando sale el correo. Los 15 verdes del 25-ago tienen **todos** el valor 0; no hay un solo
+   verde con 1.
+2. **Lleva 11 corridas seguidas en 0 % verde**, dos de ellas con el 100 % de la cartera en
+   rojo (34/34 el 4-sep, 35/35 el 8-sep), contra una meta impresa de ≥ 90 %.
+3. **Mide el día de la semana.** Los 19 renglones de Operaciones del 8-sep traen
+   `nota = 2d` — **los 19, el mismo número** — porque el equipo escribe notas en tanda el
+   viernes. El lunes 7-sep, 20 proyectos traían exactamente `1d`. La métrica no distingue
+   proyectos.
+
+Una métrica que nunca puede estar verde no mide desempeño: **entrena a ignorar el correo**. Y
+el daño es mayor que el ruido, porque los renglones legítimos (E1–E8) llegan en el mismo
+mensaje.
+
+Lo que **sí** se conserva de esa idea, porque sí pasa la vara: **`SEGUIMIENTO SIN AVANCE`**
+(racha de notas casi idénticas ≥ 2 sobre un proyecto que no avanza). Esa señal no cuenta días,
+detecta un patrón — copy-paste sostenido — y su falso positivo es barato. Se queda tal cual.
+
+---
+
+## 3. Qué hacer con lo accionable por terceros
+
+Hoy no hay dónde ponerlo, y el equipo lo dijo dos veces: *"nos responden cuando quieren"*
+(Magnekon), *"no han ido para calar el sensor para que Juventino nos de el VoBo"* (SO7723),
+más el rigging detenido en la aduana del cliente (SO11233). La única salida disponible es
+mover a `Hold`, y Hold **castiga** (rojo a 30 días) y **además** levanta
+`hold_sin_fecha_vigente` si no se captura una fecha que, cuando el bloqueo es una aduana, no
+existe. El proyecto 2361 lo demuestra: hoy trae `hold_sin_fecha_vigente` **y** `nota_vacia`.
+
+### 3.1 Un estado explícito de espera, con caducidad obligatoria
+
+```
+espera: {
+  motivo: 'cliente' | 'aduana' | 'proveedor' | 'permiso' | 'clima',
+  desde: 'AAAA-MM-DD',
+  hasta: 'AAAA-MM-DD',        // OBLIGATORIO
+  quien_declara: '<persona>',
+  nota: '<una línea>'
+}
+```
+
+Efectos:
+
+- Mientras `hoy <= hasta`: el proyecto **sale de las secciones rojas** y aparece en un bloque
+  **`⏳ EN ESPERA DE TERCEROS`**, sin color, informativo, con el motivo y la fecha.
+- El día que `hasta` vence: **vuelve como 🆕 anomalía** con la etiqueta *"la espera venció —
+  ¿se reactivó o se re-declara?"*. Esa es la señal E7, y es una anomalía de verdad: alguien
+  pactó una fecha y llegó.
+- **Sin `hasta` no hay espera.** Una espera sin caducidad es la forma más limpia de apagar el
+  watchdog por la puerta de atrás, y hay que cerrarla de entrada.
+- Tope: `hasta` no puede estar a más de **20 días hábiles**. Una espera más larga que eso se
+  re-declara, que es un acto deliberado y deja rastro.
+
+### 3.2 Dónde vive
+
+Recomiendo **`shared/operaciones/esperas.json` en el repo**, no un campo de Studio, por tres
+razones: se edita con un PR (queda quién y cuándo, gratis), el patrón de config viva ya está
+probado en cinco workflows, y **no requiere que Esteban toque Odoo** — que hoy es un cuello de
+botella porque el MCP de Odoo es read-only (CLAUDE.md §17). Si más adelante se quiere que
+Felipe lo declare desde el kiosk o desde el panel, el archivo se sustituye por un campo sin
+tocar la lógica.
+
+### 3.3 Lo que la espera NO debe hacer
+
+No debe **ocultar la cobranza**. Un proyecto puede estar esperando a la aduana y tener una
+factura vencida al mismo tiempo; son dos relojes distintos con dos dueños distintos. La espera
+silencia el reloj de **operación**, nunca el de **dinero**.
+
+### 3.4 El caso `ap_sin_confirmacion`
+
+509 apariciones, el tipo de bandera más frecuente de la historia, y ayer disparó en **8 de 8**
+proyectos del stage 13. Un control que marca al 100 % de su población no está midiendo
+cumplimiento: está midiendo que el proceso que pide (log note + pantallazo del portal de AP)
+**nunca se adoptó**. Dos caminos honestos, y hay que elegir uno:
+
+- **(a)** Es un requisito real → entonces es un tema de capacitación y de una fecha de
+  arranque, y hasta esa fecha la bandera **no va en el correo**.
+- **(b)** No se va a adoptar → **se apaga** (`ap_confirmacion.aplica_stages: []`).
+
+Lo que no se puede seguir haciendo es mandarla todos los días a cinco personas durante tres
+meses. **Recomiendo (b) por ahora**, y reconsiderar si con `invoice_date_due` (§7) todavía
+hace falta: buena parte de lo que ese control quería aproximar —*"¿esta factura de verdad está
+en el circuito de pago del cliente?"*— lo responde mejor el vencimiento real de la factura.
+
+---
+
+## 4. Qué estados deben ser terminales
+
+Terminal = **el watchdog deja de mirarlo, para siempre o hasta que vuelva a moverse**.
+
+### 4.1 Terminal por cobranza — el que falta y es el más importante
+
+**Un proyecto cuyas facturas están todas en `amount_residual = 0` está terminado para el
+watchdog**, sin importar en qué stage lo hayan dejado.
+
+Evidencia de que esto sobra hoy: **SO11789** (proyecto 2357) sigue en "En plazo de credito" y
+llevaba **14 corridas** en el correo; su factura **INV171 tiene `amount_residual = 0.00`,
+`payment_state: in_payment`** — está cobrada. Y **SO11557** (proyecto 2305) acumuló **32
+corridas rojas** con **INV172 en `residual 0.00`**.
+
+Ese cálculo **ya existe y está en producción**: `project/archive-budget-cierre`
+(`RW7KnoeEzYLvavI0`) computa AR y AP por analítica con `account.move.line` +
+`analytic_distribution 'in' [cuenta]` + `parent_state = posted` + `amount_residual != 0`, y
+usa `amount_residual` en vez de `payment_state` justamente para blindarse contra los 5,649
+`in_payment` (CLAUDE.md §17 Frente B). **Es código que copiar, no que inventar.** Y de paso
+cierra el hueco de que dos automatizaciones miren el mismo proyecto, una con noción de
+cobranza y la otra sin ella.
+
+### 4.2 Terminal por stage
+
+Ya excluidos: 8 (Complete TOTAL), 4 (Canceled), 6 (Templates). Agregar **14 "Incobrables"**,
+que `docs/operaciones/FASE15_CUENTAS_WATCHDOGS.md` §7.2 ya identificó como hueco: un
+incobrable no se acciona persiguiéndolo en un correo diario.
+
+### 4.3 Terminal por decisión declarada
+
+El caso Luminarias (SO11037, 58 de 58 corridas, 266 días en Hold, *"no se puede cancelar por
+estar ya facturado"*). Ningún estado de Odoo describe eso, así que hace falta declararlo:
+**`cerrado_administrativamente`**, con motivo y quién lo declaró, en el mismo archivo de
+config. El proyecto queda en su stage —porque contablemente tiene que quedarse— y el watchdog
+lo saca. Reaparece **solo** si vuelve a cambiar de stage o si le nace una factura vencida.
+
+### 4.4 Lo que NO debe ser terminal
+
+- **"Lleva mucho tiempo así"**. Eso es condición → digest semanal (§2.2), no terminal.
+- **"El equipo ya explicó por qué"**. Una explicación no cierra un pendiente. SO7723 tiene
+  explicación desde el 19-ago y sigue con 269,708.12 sin cobrar.
+
+---
+
+## 5. Qué necesita ver cada destinatario, y qué le sobra
+
+Destinatarios reales de hoy (leídos de `shared/operaciones/sla_stages.json`, §1.2 de la
+auditoría). Regla del PASO 4: **si un renglón no es accionable por nadie de la lista, no va en
+ese correo.**
+
+### 5.1 Semáforo Operaciones → Felipe, Gibrán, Mateo, Esteban, info_comercialFTS
+
+| Necesita | Le sobra |
+|---|---|
+| Fecha compromiso **vencida** en un proyecto suyo (E3) — **11 de los 19 renglones de ayer** | Los 19 renglones de `2d sin nota`. Es el día de la semana, no información |
+| Fecha compromiso **incoherente** (E6): 4 proyectos con `31-dic` de relleno, y SO11860 **creado el 4-sep con fecha compromiso del 28-ago** | Renglones de crédito y cobranza: **ninguno de los cinco los acciona** |
+| Cambios de stage de ayer en su cartera (E4) | La bandera "Stage regresado … por OPERACIONES FTS-YIN": **son ellos mismos**, 133 veces |
+| `SEGUIMIENTO SIN AVANCE` (nota copy-paste) | Esperas de terceros vigentes |
+| Proyectos que se resolvieron (✅) | Repetición de un evento de hace 30 días |
+
+**Cambio de fondo:** el correo de Operaciones debe dejar de preguntar *"¿pusiste tu nota?"* y
+empezar a preguntar *"¿esta fecha que prometiste sigue siendo verdad?"*. Es la misma cadencia
+diaria, sobre un dato que sí es del equipo y que sí tiene consecuencia con el cliente.
+
+⚠️ **`info_comercialFTS@fts.mx` está en los dos correos.** Es un buzón de grupo que recibe
+~114 correos por trimestre de los cuales, con el rediseño, casi nada le corresponde accionar.
+Recomiendo **sacarlo de los dos** y, si Comercial necesita visibilidad, darle el digest
+semanal. Un buzón compartido en copia diaria es donde la alerta muere sin dueño.
+
+### 5.2 Semáforo Admin → Erick, Gerardo, Carolina, Esteban, info_comercialFTS
+
+| Necesita | Le sobra |
+|---|---|
+| **Facturas vencidas y no pagadas, con monto y días de atraso** (E1) — hoy: **$1,284,178 MXN de Magnekon vencidos hace 16 días hábiles**, enterrados entre renglones de 401 días | Los 9 renglones `Done Operations` de 7–16 días marcados CRITICO, 5 de ellos creados el mismo día en una carga de materiales |
+| **Facturas por vencer en ≤ 5 días** (E2) — hoy: **INV1996, $123,424, vence el 10-sep** | Facturas que vencen en octubre, noviembre y diciembre |
+| Proyectos con **AR = 0** que hay que **cerrar** (§4.1) | "N días en stage" como métrica: por el error #1 es la edad del proyecto |
+| Clientes **sin plazo configurado**, como tarea de captura | `ap_sin_confirmacion` en 8 de 8 |
+| Facturas emitidas ayer (E4 del lado de cobranza) | Renglones de fechas compromiso de operación |
+
+**Erick ya escribió qué le sobra**, y es la lista de arriba casi textual. Su frase sobre
+INV1996 —*"no le vemos sentido a estar comente y comente sino hasta que se acerque el
+vencimiento"*— **es la regla E2**, propuesta por el destinatario.
+
+### 5.3 `fin/watchdog-captura` → solo Esteban
+
+Aquí el problema es el inverso: **un solo destinatario, hardcodeado en el Code node**, para
+alertas cuya acción es de otro. `LINK_DESCONECTADO` pide *"Reconnect en Odoo"* —
+Gerardo/Eduardo. `CHASE_DELTA_DERIVO` con el saldo inicial de la 122 pide *"que Gerardo
+registre el asiento de apertura"*, y así lo dice el propio comentario del código.
+
+Propuesta: mover los destinatarios a **`shared/finanzas/watchdog_captura.json`** (mismo patrón
+que los otros cuatro) y **rutear por tipo de alerta**: enlace/sync/delta → Gerardo + Esteban;
+faltantes/rechazos/matcher → Esteban; el latido del propio watchdog → Esteban. Un destinatario
+único que no puede ejecutar la acción es una alerta que se lee y no se atiende.
+
+Sobre el ruido de este watchdog: **17 de 17 correos dijeron ALERTA**, con `LINK_DESCONECTADO`
+cuatro días seguidos, `CHASE_SYNC_RANCIO` otros cuatro, y `CHASE_DELTA_DERIVO` el 3-sep
+(0.00 → −62.53) y otra vez el 4-sep (−62.53 → 0.00) por **el mismo hueco transitorio en las
+dos direcciones**. La edición del **2026-09-09 04:49 UTC** ya atacó las dos últimas
+(`delta_esperado` constante en vez de comparar contra ayer, gracia de captura por journal, y
+frescura medida con `create_date` en vez de `last_sync`). **Lo que queda por aplicarle es
+§2.1: reportar el delta.** Un `LINK_DESCONECTADO` es una anomalía **el día 1**; los días 2, 3
+y 4 es una condición conocida, y con eso basta un recordatorio semanal hasta que se reconecte.
+
+---
+
+## 6. La estructura de correo propuesta
+
+### 6.1 Asunto
+
+Hoy: `[Semaforo Admin] 08/Sep/2026 - 🔴🔴 14 criticos · 🔵 0 estancados · 📝 2 sin nota`.
+Tres números que llevan semanas casi iguales, así que el asunto no informa.
+
+Propuesto: **lo que cambió, y el dinero.**
+
+```
+[Cobranza] 09/Sep — 2 nuevas vencidas ($1,288,647) · 1 vence en 2 días · 1 por cerrar
+[Operacion] 09/Sep — 3 fechas vencidas nuevas · 4 sin fecha creible · 1 espera vencida
+```
+
+Si no hay nada nuevo: `[Cobranza] 09/Sep — sin cambios (4 en seguimiento)`. Y si no hay nada
+en absoluto, **no hay correo** (§6.4).
+
+### 6.2 Orden de las secciones
+
+1. **🆕 NUEVO HOY** — lo que no estaba ayer. Si está vacía, se dice en una línea.
+2. **📈 EMPEORÓ** — cambió de tramo.
+3. **✅ SE RESOLVIÓ** — cerró desde el último correo. *(Sección nueva.)*
+4. **⏰ POR VENCER (≤ 5 días hábiles)** — la única preventiva que sobrevive.
+5. **⏳ EN ESPERA DE TERCEROS** — informativa, con motivo y caducidad.
+6. **🔧 DATOS QUE NO CUADRAN** — fechas incoherentes, plazo asumido, search vacío. *(Antes
+   "posible manipulación", sin la acusación.)*
+7. **Al pie, en una línea:** `N en condición estable sin cambio · digest completo el lunes`.
+
+Se van: `CRITICOS/SOLO ESTANCADOS/SOLO SIN NOTA/AMARILLOS` (las cuatro dependen del contador
+roto o del semáforo B), y `EN OBSERVACION` (su fecha `hasta: 2026-08-24` **ya caducó**).
+
+### 6.3 Cada renglón
+
+```
+🆕 SO10300 · Techo de Magnekon — MAGNEKON S.A. DE C.V.
+   $1,284,178.00 MXN vencidos hace 16 días hábiles · INV2019 + INV2020, vencimiento 17-ago
+   Plazo: Immediate Payment (de la factura) · [abrir proyecto] [abrir INV2019]
+   ↳ Erick / Gerardo: cobrar o pactar fecha
+```
+
+Tres cosas que hoy no están: el **monto**, el **documento con su vencimiento real**, y un
+**dueño nombrado**. El "↳" de hoy dice *"Avanza de stage o documenta por que sigue aqui"* —
+que es lo que el watchdog quiere, no lo que el negocio necesita.
+
+### 6.4 Cuándo NO mandar correo
+
+**Si las secciones 1–5 están todas vacías, no se manda.** Cuatro de los cinco watchdogs ya se
+callan cuando no tienen nada; **el semáforo es el único que manda siempre**, y esa asimetría
+es por sí sola una de las causas de que se lea como ruido. Excepción: **los lunes siempre sale
+el digest semanal**, para que el silencio nunca sea ambiguo.
+
+Contra-medida obligatoria, porque el silencio se puede volver ceguera (Hallazgo #14):
+**el latido**. Cada corrida deja su marcador —el semáforo ya escribe el snapshot diario, y
+captura ya escribe su `CBWATCH`— y **si un watchdog deja de latir 2 días hábiles, eso sí
+manda correo.** Es la señal E8, y es la única que nunca se debe silenciar.
+
+---
+
+## 7. La decisión pendiente de administración: la fuente de verdad para contar días
+
+Cuatro candidatos: **emisión**, **envío**, **aceptación**, **fecha comercial**. La
+recomendación no es ninguno de los cuatro tal cual.
+
+### 7.1 Recomendación
+
+> **La fuente de verdad es `account.move.invoice_date_due` de las facturas posted y no pagadas
+> del proyecto** — el vencimiento que Odoo ya calcula con el término **de la factura** — y el
+> reloj de Admin se cuenta **contra esa fecha**, no contra la antigüedad del proyecto.
+>
+> **La fecha comercial no se descarta: se usa para otra cosa.** No para el reloj de cobranza,
+> sino como fecha de arranque del reloj de **operación** (E3/E5) en los clientes que la
+> imponen, como Magnekon con el 19-ago.
+
+### 7.2 Por qué, con los argumentos
+
+**a) Ya existe, ya está poblada, y ya es correcta.** Crudo:
+
+```
+name    invoice_origin partner_id                    invoice_date invoice_date_due  term                   residual      state
+INV1996 (vacío)        BEBIDAS PURIFICADAS           2026-05-13   2026-09-10        120 Days               123,424.00    not_paid
+INV2006 SO11779        BEBIDAS PURIFICADAS           2026-07-20   2026-11-17        120 Days FTS 2024       14,469.84    not_paid
+INV2013 SO11290        Nalco de Mexico               2026-08-05   2026-10-04        60 Days FTS 2024       184,126.80    not_paid
+INV2022 SO11832        BEBIDAS PURIFICADAS           2026-08-18   2026-12-16        120 Days FTS 2024       86,452.48    not_paid
+INV2019 SO10300        MAGNEKON S.A. DE C.V.         2026-08-17   2026-08-17        (immediate)            733,816.00    not_paid
+INV2020 SO10300        MAGNEKON S.A. DE C.V.         2026-08-17   2026-08-17        (immediate)            550,362.00    not_paid
+INV2021 SO10300        MAGNEKON S.A. DE C.V.         2026-08-24   2026-09-23        30 Days FTS 2024     1,834,540.00    not_paid
+INV172  SO11557        GRUMA CORP DBA MISSION FOODS  2026-07-15   2026-07-15        30 days                      0.00    in_payment
+INV171  SO11789        Corporate USA                 2026-07-10   2026-07-10        30 days                      0.00    in_payment
+```
+
+Los 120 días de INV1996 que Erick citó de memoria **están en el campo**. No hay que construir
+nada, hay que leerlo.
+
+**b) Resuelve tres de los cuatro errores de Admin de una sola vez.**
+- #2 (no cuenta desde emisión ni envío): el vencimiento sale del término **de la factura**.
+- #3 (clientes sin plazo): **desaparece**. 13 de 18 partners no tienen
+  `property_payment_term_id`, pero **las facturas sí traen el suyo** — "120 Days",
+  "60 Days FTS 2024", "30 days", "15 day". El fallback de 37 días se vuelve innecesario.
+- #1 (días en stage): deja de ser el número que sostiene la decisión de cobranza. Sigue
+  habiendo que arreglarlo para el reloj de operación, pero deja de ser crítico para Admin.
+
+**c) Es la fecha que el cliente reconoce.** Emisión y envío son actos nuestros; la aceptación
+en el portal de AP no está en ningún sistema que podamos leer (y el intento de aproximarla
+—`ap_sin_confirmacion`— disparó en 8 de 8). El **vencimiento** es lo único que el cliente y
+nosotros leemos igual, y es lo que se cita en una llamada de cobranza.
+
+**d) Cambia la señal de forma medible.** Con el criterio de hoy, el correo de Admin de ayer
+tuvo **16 renglones, 14 de ellos en rojo**. Con `invoice_date_due`, de esos 16:
+
+| Proyecto | Hoy | Con `invoice_date_due` |
+|---|---|---|
+| SO10300 (160) | 1 renglón de "330 días en stage" | **$1,284,178 vencidos hace 16 días hábiles** ← lo más grave del correo |
+| SO11748 (2360) | "29 días en stage" | **$4,469 vencidos hace 15 días hábiles** |
+| SO11511 (2327) | rojo, 58 corridas seguidas, "100 días" | **vence el 10-sep — preventivo, hoy** |
+| SO11290 (241) | rojo, "203 días" | vence 04-oct → **no entra** |
+| SO11779 (2353) | rojo, "53 días" | vence 17-nov → **no entra** |
+| SO11832 (2364) | rojo, "16 días" | vence 16-dic → **no entra** |
+| SO11789 (2357) | rojo, 14 corridas | **residual 0 → cerrar el proyecto** |
+| SO11737, SO11772, SO11718, SO11838, SO11846, SO11849, SO11850, SO11851 (8) | 8 CRITICOS de 7–16 días | sin factura vencida → **no entran** |
+
+**De 16 renglones a 4**, y el de $1.28 M pasa de estar sepultado entre proyectos de 401 días a
+ser el primero.
+
+**e) Es lo que ya hace la otra automatización de la casa.** `project/archive-budget-cierre`
+decide archivar con AR/AP por `amount_residual`. Que el semáforo decida "en plazo de crédito"
+sin mirar una factura, mientras su vecino calcula la cobranza bien, es la contradicción de
+fondo del sistema hoy.
+
+### 7.3 Lo que hay que resolver antes de construirlo — y no es menor
+
+**El vínculo proyecto → factura no es confiable, y hay que probarlo antes de creerle.**
+Medido:
+
+- `invoice_origin` es texto libre y **falla en los dos casos más marcados**: INV1996 (la de
+  SO11511) lo trae **vacío**, y para **SO7723** (proyecto 101, 401 días, 58/58 corridas) **no
+  hay ninguna factura con ese origen**, aunque Erick afirme que está cobrado al 90 %.
+- `sale.order.invoice_status` **tampoco sirve**: SO10917 dice `to invoice` teniendo INV1989 de
+  $558,014.52 **`paid`**. SO11037 dice `to invoice` y es el caso Luminarias.
+- Solo 6 de los 35 proyectos vigilados traen `sale_order_id` poblado (crudo de la ejecución
+  90897: `soIds: [11231, 11488, 10459, 7822, 9568, 10496]`), así que **pasar por la SO deja
+  fuera a 29**.
+
+Esto **no invalida la recomendación**, pero define el primer paso: **medir la cobertura del
+vínculo antes de construir sobre él**. Candidatos a probar, en orden: `sale.order.invoice_ids`
+/ las líneas de venta; `account.move.line.analytic_distribution` contra la cuenta analítica
+del proyecto (el patrón de Frente B, que ya está en producción); y partner + monto como
+último recurso. Es una sesión de medición read-only, y va **antes** de cualquier código.
+
+Y hay que declarar el modo de falla, aplicando la lección de la `ir.rule` 814 (CLAUDE.md §9:
+*elegir el discriminador cuyo fallo es soportable*): **si un proyecto de stage 13 no logra
+vincularse a ninguna factura, el renglón NO desaparece en silencio** — va a la sección
+"🔧 DATOS QUE NO CUADRAN" como *"en plazo de crédito sin factura identificable"*. Ese es
+exactamente el estado de SO7723 hoy, y es un hallazgo legítimo: si un proyecto lleva 401 días
+en cobranza y nadie puede señalar la factura, **eso** es la anomalía.
+
+### 7.4 Y la fecha comercial (caso Hernán)
+
+Va en la config, no en Odoo, y **solo afecta el reloj de operación**:
+
+```
+fecha_comercial_override: {
+  "895": { "regla": "arranque_pactado", "desde": "2026-08-19",
+           "nota": "Magnekon: la fecha oficial la fija el cliente, no la firma ni el portal" }
+}
+```
+
+Por cliente (`res.partner.id`), con fallback por `parent_id` — que además arregla de paso el
+agravante del error #3, donde 6 de 18 partners son contactos hijos sin término heredado.
+Ponerla en el repo evita depender de un campo Studio nuevo, que hoy es cuello de botella
+porque el MCP de Odoo es read-only.
+
+---
+
+## 8. Ejemplo real: el correo de mañana con los datos de hoy
+
+Construido con lecturas reales del 2026-09-08/09. **No se envió nada**; es una maqueta.
+
+### 8.1 `[Cobranza]` → Erick, Gerardo, Carolina, Esteban
+
+```
+Asunto: [Cobranza] 09/Sep — 2 vencidas ($1,288,647) · 1 vence en 1 día · 1 por cerrar · 1 sin factura
+
+🆕 NUEVO HOY (1)
+  SO11511 · Valvula para lavado de botellas — BEBIDAS PURIFICADAS
+    $123,424.00 MXN · INV1996 VENCE MAÑANA (10-sep) · término 120 Days, emitida 13-may
+    ↳ Erick: es el día de llamar. Lleva 120 días de plazo y se acaba mañana.
+
+⏰ VENCIDAS (2 · $1,288,647.00)
+  SO10300 · Techo de Magnekon — MAGNEKON S.A. DE C.V.
+    $1,284,178.00 MXN vencidos hace 16 días hábiles
+    INV2019 $733,816.00 + INV2020 $550,362.00 · vencimiento 17-ago (pago inmediato)
+    (además INV2021 $1,834,540.00 vence el 23-sep — 10 días hábiles)
+    ↳ Erick / Gerardo. Nota del 19-ago: "así es el juego con Magnekon" → si la vía normal
+      no funciona, esto ya es escalamiento, no seguimiento.
+  SO11748 · Chiller instalation — Calbee America
+    $4,469.00 MXN vencidos hace 15 días hábiles · INV176, vencimiento 18-ago
+    ↳ Carolina: monto chico, un correo lo cierra.
+
+✅ POR CERRAR — cobradas, siguen abiertas en Odoo (1)
+  SO11789 · Suministro de Panelview HMI — Corporate USA
+    INV171 residual $0.00 (in_payment) · el proyecto sigue en "En plazo de credito"
+    ↳ Gerardo: mover a Complete TOTAL. El watchdog lo lleva marcando 14 corridas.
+
+🔧 DATOS QUE NO CUADRAN (2)
+  SO7723 · Integración con sensor de nivel — MAGNEKON (Juventino Hernández)
+    En "En plazo de credito" desde antes de que existiera el watchdog, SIN factura
+    identificable en Odoo. La SO vale $269,708.12 y el equipo reporta 90 % cobrado.
+    ↳ Gerardo: ¿dónde está la factura? Si está cobrada, cerrar el proyecto.
+  13 de 18 clientes vigilados sin plazo de crédito configurado en Odoo
+    BEBIDAS PURIFICADAS, Mission Foods, MAGNEKON, Bridgestone, Calbee, GRUMA, CONMET…
+    ↳ No bloquea (el plazo se lee de la factura), pero cualquier reporte que use el
+      default del cliente está usando 30 días inventados.
+
+— 3 facturas en seguimiento sin cambio (vencen 04-oct, 17-nov, 16-dic) · digest el lunes
+— Latido: watchdog corrió 09-sep 08:00 CST ✓
+```
+
+**4 renglones accionables** contra los 16 de ayer, y el de $1.28 M de primero.
+
+### 8.2 `[Operacion]` → Felipe, Gibrán, Mateo, Esteban
+
+```
+Asunto: [Operacion] 09/Sep — 11 fechas compromiso vencidas · 4 sin fecha creíble · 0 cambios
+
+📈 FECHAS COMPROMISO VENCIDAS (11) — ordenadas por atraso
+   28d  SO11037 · Distribución eléctrica luminarias — JOHNSON CONTROLS   (Hold, venció 30-jul)
+   27d  SO11773 · ELECTRICAL DUMP STATION DALLAS 2 — Mission Foods       (venció 31-jul)
+   27d  SO11673 · Póliza de matto Compresor Houston — Mission Foods      (venció 31-jul)
+   17d  SO11833 · Cooling system Quality offices — Mission Foods         (venció 15-ago)
+   17d  SO11842 · prensas materials — Mission Foods                      (venció 14-ago)
+   12d  SO11791 · Power and control panels — Calbee                      (Hold, venció 21-ago)
+    7d  SO11860 · VIP Service Mission HQ — Mission Foods                 (venció 28-ago)
+    6d  SO11762 · Mejoras sistema TOPOCHICO — Nalco                      (venció 31-ago)
+    6d  SO11547 · Desinstalación e integración — Nalco                   (venció 31-ago)
+    6d  SO10337 · Cortinas de seguridad 120s — Bridgestone               (venció 31-ago)
+    6d  SO9428  · Instalación de suministro — Nalco                      (venció 31-ago)
+   ↳ Felipe: mover la fecha con la nueva o mover el proyecto. Una fecha vencida que nadie
+     toca deja de ser un compromiso.
+
+🔧 FECHAS SIN CREDIBILIDAD (4) — 31-dic de relleno
+   SO11699 · Sensores en ductos — Bridgestone        date = 31-dic-2026
+   SO11771 · Subestación PI Aurora — CONMET          date = 31-dic-2026
+   SO11861 · Cubierta acero inoxidable — MAGNEKON    date = 31-dic-2026
+   SO11862 · Cubierta acero inoxidable — MAGNEKON    date = 31-dic-2026
+   ↳ Con 31-dic el semáforo los da por sanos (SO11699 sale VERDE con 53 días en stage).
+     Su propia nota dice "se reanudan en diciembre 2026" — si es cierto, va en ESPERA
+     con motivo y caducidad, no con una fecha de relleno.
+
+⚠️ SO11860 se creó el 4-sep con fecha compromiso del 28-ago — nació vencido.
+
+— 4 proyectos con fecha vigente y creíble (SO11261, SO11492, SO11233, SO11498)
+— 0 cambios de stage ayer · 0 esperas vencidas
+— Latido: watchdog corrió 09-sep 08:00 CST ✓
+```
+
+**Los 19 renglones de `2d sin nota` desaparecen** y en su lugar quedan 15 renglones sobre
+fechas que el equipo prometió — más un dato que nadie había visto: **un proyecto creado con la
+fecha ya vencida**.
+
+Nota honesta sobre esta maqueta: los 11 atrasos se calcularon con `project.date` leído de Odoo
+hoy y días hábiles calculados aparte; **el día que esto se construya hay que recalcularlos en
+el workflow**, no copiarlos de aquí.
+
+---
+
+## 9. Los tres watchdogs huérfanos: arreglar o apagar
+
+| Workflow | Recomendación | Por qué |
+|---|---|---|
+| **`ops/watchdog-mo`** (`RBxoREDTfehELmyr`, activo) | **ARREGLAR** — pero primero **abrirlo** | Vigila dinero de nómina (distribución de MO, §19), que es escritura real a producción, y sus 5 señales son de las que sí pasan la vara (un checkout sin cuenta ni proyecto es un hueco de atribución, no una condición). **Pero está ciego a la auditoría** (`availableInMCP: false`) y tiene un acoplamiento frágil documentado: si alguien cambia dos textos literales en `corregir-bolsa`, W3/W4 se van a 0 **sin lanzar error**. Paso 1: prender MCP access. Paso 2: convertir ese acoplamiento en una prueba (si W3+W4 = 0 varios días seguidos, avisar). |
+| **`rh/watchdog/sin-checkin`** (`Q19zFeJQytSfBjdb`, activo) | **ARREGLAR, chico** | Lleva **2 meses y medio corriendo sin que nadie lo toque**, y su doc lo cree apagado. Su señal es buena (empleado activo sin checar ≥ 5 días hábiles = o es baja no formalizada o es un hueco de nómina) y tiene guarda de vacío, así que **no genera ruido cuando no hay nada**. Pendientes: (a) corregir el doc, (b) cerrar `VALIDAR_VACACIONES = false` cuando exista `hr.leave` — hoy alerta sin filtrar vacaciones, y eso sí produce falsos positivos, (c) sacar los destinatarios del Code a un JSON. |
+| **`comercial/watchdog-enviadas`** (`hJNTUd8E57W4rfjU`, **inactivo**) | **NO PRENDER como está.** Rehacer sobre chatter, o cerrarlo formalmente | Mide desde **`write_date`**, y su propio código dice que **60 órdenes comparten el mismo `write_date`** de una escritura masiva: cualquier script que toque `sale.order` en masa **resetea todos los semáforos a verde** sin que nadie haya llamado a un cliente. Prenderlo así reproduce en Comercial el error #1 (medir una cosa creyendo medir otra), y con 122 órdenes rojas el día 1. `comercial/ROADMAP.md` ya define el v2 sobre `mail.message`. **Mientras tanto: poner `activo: false` en su config**, para que deje de contradecir a la realidad. |
+
+---
+
+## 10. Plan de sesiones, por impacto contra esfuerzo
+
+Todo lo de abajo es propuesta. La regla de la casa (§8: *un hallazgo se anota, no se
+persigue*) aplica: cada sesión cierra su alcance y lo demás va al backlog.
+
+### Antes de todo: dos cosas de 15 minutos que no son sesiones
+
+- **Prender MCP access** en `ops/watchdog-mo` y `rh/watchdog/sin-checkin`. Sin eso, dos
+  watchdogs activos siguen fuera de cualquier auditoría.
+- **`shared/comercial/watchdog_enviadas.json` → `"activo": false`**, para que la config deje
+  de decir que un workflow apagado está encendido.
+
+### S1 · Bajar el ruido sin cambiar ninguna métrica — 2–3 h · impacto ALTÍSIMO
+
+La sesión de mejor relación de todas: no toca la lógica de medición, solo deja de repetir.
+
+1. **Retirar el semáforo B** de los contadores y de las secciones (§2.3). Es lo que produce
+   los 19 renglones idénticos de Operaciones y el 0 % verde.
+2. **Reportar solo el delta** (§2.1): reusar la firma de `staticData` que ya existe en
+   `Code - buildLogNotes`, y agregar la sección ✅ SE RESOLVIÓ.
+3. **Banderas de integridad: una vez por evento**, no 21 veces. Y meter a la whitelist a
+   Operaciones, Administración y el CEO (error #5).
+4. **Apagar `ap_confirmacion`** (`aplica_stages: []`) hasta que se decida (a) o (b) del §3.4.
+5. **Quitar el bloque EN OBSERVACION**, que caducó el 24-ago.
+6. **Guarda de vacío**: si no hay nada en las secciones 1–5, no mandar (§6.4).
+7. **Sacar `info_comercialFTS@fts.mx`** de los dos correos.
+
+Efecto estimado con los datos de ayer: de 35 renglones diarios a **entre 0 y 8**, sin haber
+arreglado todavía ni un solo cálculo.
+**Riesgo:** bajo, todo es config + un Code node. **Requiere:** read-back del flag `active`
+tras el edit (CLAUDE.md §3, regla dura).
+
+### S2 · Medir el vínculo proyecto → factura — 2 h · read-only · **bloquea S3**
+
+Sin código. Medir la cobertura de los cuatro candidatos del §7.3 (`invoice_ids`, líneas,
+`analytic_distribution`, partner+monto) sobre los ~13 proyectos de Admin, y **decir con
+números** cuál cubre cuántos. Entregable: una tabla y una decisión. Si ninguno cubre bien,
+eso también es el resultado, y S3 se rediseña en vez de construirse a ciegas.
+
+### S3 · El reloj de Admin sobre `invoice_date_due` — 4–5 h · impacto ALTO
+
+Depende de S2. Reescribir el modo `credito`: leer `account.move` (posted, `out_invoice` +
+`out_refund`, `amount_residual != 0`), contar contra `invoice_date_due`, terminal por AR = 0
+(§4.1, copiando el patrón de `RW7KnoeEzYLvavI0`), y los que no logren vincularse **al bloque
+de datos que no cuadran, nunca en silencio** (§7.3). Cierra los errores **#2 y #3**, y hace a
+**#1** no crítico para Admin.
+**Riesgo:** medio — es la primera vez que el semáforo lee contabilidad. Se prueba en
+`modo_prueba: true` (que ya existe y manda todo solo a Esteban) al menos dos días antes de
+soltarlo al equipo.
+
+### S4 · Coherencia de fechas compromiso — 2–3 h · impacto ALTO para Operaciones
+
+No requiere ninguna consulta nueva: `project.date` ya viene en el nodo 1. Dos banderas
+—vencida sin actualizar, y de relleno— más el caso "creado con fecha ya vencida" (SO11860).
+Cierra el error **#8** y le da a Operaciones un correo sobre algo que sí es suyo. Con los
+datos de ayer produce los 11 + 4 renglones de la maqueta §8.2.
+
+### S5 · Estado de espera y cierre administrativo — 3–4 h · impacto MEDIO-ALTO
+
+`shared/operaciones/esperas.json` con caducidad obligatoria (§3) +
+`cerrado_administrativamente` (§4.3) + terminal por stage 14 Incobrables (§4.2). Cierra los
+errores **#6 y #7**. Va después de S1 porque sin la regla del delta, una espera mal declarada
+se vuelve un renglón permanente más.
+
+### S6 · Arreglar de verdad `dias_en_stage` — 3–4 h · impacto MEDIO · **el más incierto**
+
+Cierra el error **#1** para el reloj de operación. Empieza por la pregunta que quedó abierta:
+**¿qué es hoy el subtype 94 y por qué no hay ninguno?** (no la pude contestar: `mail.message`
+está en denylist del MCP de Odoo). Alternativa que no depende de esa respuesta:
+`mail.tracking.value` del campo **24714**, que el workflow **ya consulta** para
+`stage_atras` — el dato está en la mano, solo hay que usarlo también para la fecha de entrada.
+Y **recalibrar los umbrales**, que llevan 12 semanas calibrados contra la edad del proyecto.
+Va al final a propósito: es el bug más grave y el arreglo más incierto, y S1+S3+S4 entregan la
+mayor parte del valor sin él.
+
+### S7 · Higiene de la familia de watchdogs — 2–3 h · impacto MEDIO, se paga solo
+
+Unificar las convenciones que hoy están mezcladas (§1.7 de la auditoría): un solo criterio de
+cron (UTC + `timezone: UTC`, que es el que sobrevive al bug de importación de §18), un solo
+nombre para el modo prueba, destinatarios **siempre** en JSON —incluidos los de
+`fin/watchdog-captura`, hoy hardcodeados— y `retryOnFail` en todos los nodos de Graph (solo
+captura lo tiene). Más el ruteo por tipo de alerta de §5.3 y la regla del delta aplicada a
+captura.
+
+### Fuera de alcance, anotado
+
+- **Frontend `operaciones/semaforo/` + endpoint `ops/semaforo`** (CLAUDE.md §18 #4 y #5): es
+  el destino natural del digest semanal y de los 60 snapshots que hoy no lee nadie. Sesión
+  aparte, y no bloquea nada de lo de arriba.
+- **Auditar el TZ de todos los Schedule de la instancia**, que sigue pendiente desde §18 y ya
+  está marcado como PRIORIDAD ahí.
+- **Los snapshots con nombres de contactos de clientes en un repo público** (anexo #4 de la
+  auditoría).
+- **El salto de 147 → 165 días del proyecto 343** el 22-jul (anexo #3).
+
+### Orden recomendado
+
+```
+[15 min] MCP access + comercial activo:false
+   ↓
+  S1 (ruido)  ──────────────► el equipo deja de ignorar el correo
+   ↓
+  S2 (medir) ──► S3 (invoice_date_due) ──► cierra #2, #3
+   ↓                    ↓
+  S4 (fechas) ──────────┴──► cierra #8
+   ↓
+  S5 (esperas) ─────────────► cierra #6, #7
+   ↓
+  S6 (dias_en_stage) ───────► cierra #1
+   ↓
+  S7 (higiene)
+```
+
+**S1 primero, sin discusión.** Mientras el correo traiga 35 renglones de los cuales 19 son el
+día de la semana, cualquier señal nueva que se agregue llega a un buzón donde ya nadie mira.

--- a/docs/watchdogs/VIVO-AUDITORIA.md
+++ b/docs/watchdogs/VIVO-AUDITORIA.md
@@ -1,0 +1,380 @@
+# Semáforo en vivo — auditoría previa
+
+Sesión de investigación pedida el 2026-09-09. **No se construyó el módulo, no se
+modificó ningún workflow, no se escribió en Odoo.** Continúa la auditoría #220.
+
+Entregables: este documento (pasos 1-4) y el prototipo en
+[`docs/watchdogs/prototipo/semaforo-vivo.html`](prototipo/semaforo-vivo.html).
+
+---
+
+## Veredicto en un párrafo
+
+**Procede, y no hay que construir autenticación: ya existe y está viva.** El bloqueo que
+se temía —repo público, Pages— no es un bloqueo porque el modelo de la suite nunca fue
+«página privada»: es **página pública con datos gateados**, y eso ya corre en producción
+en dos módulos. Lo que sí hay que cambiar es de dónde salen los datos: **la vista en vivo
+no puede leer los snapshots del repo**, porque esos son públicos hoy. Y hay una condición
+de orden: **va después de S3**, porque S3 cambia el reloj de Administración y construir la
+pantalla contra un reloj que está por cambiar es trabajo tirado.
+
+---
+
+## PASO 1 · El gate de acceso
+
+### 1.1 El repo es público y sirve Pages — confirmado
+
+`yinyo1/fts-suite` es público y `https://yinyo1.github.io/fts-suite/` sirve desde él.
+Cualquier archivo commiteado es legible por cualquiera, y **borrarlo no lo borra del
+historial** (CLAUDE.md §20 #7).
+
+### 1.2 ¿Se construyó el login de #131? Sí, y va más allá de comercial
+
+#131 **define** la forma del JWT (punto 4: «se construye en sesión 2, pero el JWT nace ya
+con la forma final: `sub` = persona, `roles` = lista por módulo»). Lo que se construyó es
+más ambicioso que un login de comercial: es un **login de suite**.
+
+**Vivo y activo en n8n**, leído hoy:
+
+```
+auth/suite-login · id kLhyPxVSMbDRwxfC · active: true · triggerCount: 1
+  "Login server-side de la Suite. PBKDF2-SHA256 100k + JWT HS256 (8h) en JS puro.
+   Lee suite_usuarios (Data Table) y SUITE_JWT_SECRET via nodo Set.
+   Lockout 5 -> 15 min en staticData. Fase 0 del issue #136."
+```
+
+El lado que **verifica** también existe y está probado: `docs/n8n-workflows/fase0/jwt-verify.js`,
+el cuerpo de Code que se inserta justo después del Webhook en cada workflow protegido.
+
+```
+verifyJWT(token, secret, scopeRequerido)
+  -> { ok:true,  actor, scopes, exp }
+  -> { ok:false, error: TOKEN_AUSENTE | TOKEN_MALFORMADO | FIRMA_INVALIDA
+                      | PAYLOAD_ILEGIBLE | TOKEN_EXPIRADO | SCOPE_INSUFICIENTE }
+```
+
+Su README documenta 9/9 casos de JWT probados (válido, expirado, scope insuficiente,
+secreto equivocado, **payload manipulado**, malformado, ausente, y dos de compatibilidad),
+y la cripto validada contra dos oráculos independientes: los vectores estándar de
+PBKDF2-HMAC-SHA256 y el `crypto` de Node.
+
+Los scopes ya se usan por módulo (`comercial:read`, `comercial:admin`, `nomina:write`,
+`finanzas:read`…), con la regla anti-trabón aplicada: un token viejo sin `scopes` hereda
+los de finanzas en vez de ser rechazado.
+
+> ⚠️ **No leí la tabla `suite_usuarios`.** Sus columnas incluyen `salt` y `hash`, y
+> `get_data_table_rows` no permite pedir columnas sueltas: leerla habría traído material
+> de credencial al transcript de la sesión (CLAUDE.md §9). El roster y los scopes se
+> confirmaron desde `docs/comercial/ACCESO.md` y `ALMACEN.md`.
+
+### 1.3 Qué protege al kiosko hoy
+
+**Un PIN de 4 dígitos, y nada más.** `operaciones/kiosk/index.html` es HTML público que
+pide PIN en un teclado en pantalla. El reconocimiento facial está en opt-in explícito
+desde el Hallazgo #14. No hay gate de página.
+
+Comercial es el caso más duro que existe hoy: token JWT en el **cuerpo** más una firma
+HMAC en un header, con el secreto HMAC sembrado a mano en `localStorage` por dispositivo.
+Dos factores sobre el webhook, cero sobre la página.
+
+**El patrón de la suite, entonces, es uniforme: la página es pública, los datos no.**
+
+### 1.4 El problema real, y ya es nuestro
+
+El bloqueo no es que no haya auth. Es que **los datos del semáforo YA son públicos**:
+
+```
+shared/operaciones/semaforo_snapshots/  ·  60 archivos  ·  1.3 MB
+  del 2026-06-17 al 2026-09-08, uno por día hábil
+  cada uno: nombre de proyecto, cliente, etapa, días, banderas, racha de notas
+```
+
+S1 (#223) redactó el campo `cliente` **de aquí en adelante**; los 8 nombres de contacto ya
+publicados quedaron como riesgo aceptado. Pero el resto sigue: qué proyectos hay, de qué
+cliente, cuántos días llevan y qué está atorado. **La pregunta no es si se puede publicar
+esta información — ya se publicó. La pregunta es si la vista nueva debe seguir haciéndolo.**
+
+### 1.5 Opciones reales, con su costo
+
+| | Qué es | Costo | Veredicto |
+|---|---|---|---|
+| **A** | Repo privado | **Mata Pages en el plan gratuito.** Toda la suite cambia de hosting | ❌ desproporcionado |
+| **B** | Servir el frontend desde Railway detrás de auth | Servicio nuevo, ruta de deploy nueva, rompe el modelo «un repo, Pages» por un módulo | ❌ caro para el problema |
+| **C** | **Página pública, datos gateados** | ~0 infraestructura nueva. Un webhook con `jwt-verify.js` y scope `ops:read` | ✅ **recomendada** |
+| **D** | Segundo repo privado para módulos sensibles | Parte el código en dos, dos rutas de deploy, dos historiales | ❌ deuda permanente |
+
+**Recomendación: C.** No por elegante: porque **ya está en producción dos veces** (finanzas
+y comercial), la auth está viva y probada, y es la única cuyo costo es un webhook. La
+página se sirve vacía; pide los datos y el workflow decide si los da.
+
+**Tres condiciones para que C no sea teatro:**
+
+1. **La vista en vivo NO lee los snapshots del repo.** Si los lee, el gate es decorativo:
+   los datos siguen siendo descargables sin token.
+2. **Los snapshots dejan de crecer en superficie.** Siguen sirviendo para historia y para
+   el análisis (así se reconstruyó todo #220), pero conviene decidir explícitamente qué
+   campos merecen ser públicos. La redacción de `cliente` fue el primer paso.
+3. **La app tiene que sobrevivir una rotación de secreto sin que nadie abra la consola.**
+   Al rotar `SUITE_JWT_SECRET` el 8-sep, la pantalla dijo «no se pudo confirmar con el
+   servidor» y hubo que borrar la llave a mano (§20 #12b). El módulo nuevo nace con esa
+   clasificación `sesion`/`red`/`servidor` en un solo lugar, no la hereda rota.
+
+### 1.6 Lo que hay que decir aunque no sea de este módulo
+
+`docs/comercial/SECRETOS-EN-EL-NAVEGADOR.md` (8-sep) documenta tres cosas **peores que
+cualquiera que este módulo pudiera introducir**, y siguen abiertas:
+
+- 🔴 `pmo/index.html` L1000 declara un **secreto HMAC de 64 hex en literal** y lo escribe a
+  `localStorage`. Está **publicado**. (CLAUDE.md §15 #3 dice que se rotó — eso fue cierto
+  para la copia en `docs/`; **la de `pmo/index.html` sigue viva**.)
+- 🟠 `shared/config-sync.js` barre **todas** las llaves `fts_*` / `ops_*` / `key_*` con una
+  lista negra de cuatro, las cifra y las commitea a `shared/ops-config.json` **público**.
+  El JWT de la suite y el PAT de GitHub no están excluidos.
+- 🟡 `shared/users-suite.json` (el login viejo, `FTSAuth`) guarda hashes SHA-256 **sin sal**
+  en un archivo público.
+
+**No es de este módulo arreglarlos y no los toqué.** Los menciono porque cambian el cálculo
+de la decisión: agregar una pantalla *gateada* a una suite que publica un HMAC vivo no es
+el riesgo marginal. Van al backlog de #220 con dueño, como pide §8.
+
+### 1.7 Respuesta directa a «¿debe esperar a que exista auth?»
+
+**No. La auth existe, está activa, está probada y ya gatea dos módulos.** El trabajo del
+módulo nuevo no es construir auth: es **usarla**, y dejar de servir los datos por un canal
+que la esquiva.
+
+---
+
+## PASO 2 · El frontend hoy
+
+### 2.1 Estructura
+
+Ocho carpetas de módulo en la raíz más el launcher:
+
+```
+comercial/  finanzas/  hatch/  ingenieria/  modulos/  operaciones/  pmo/  seguridad/
++ shared/  docs/  db/  scripts/  tests/  website/
+```
+
+`index.html` (471 líneas) es el launcher. Declara **ocho cards con el `href` escrito a
+mano**: comercial, finanzas, hatch, ingenieria, operaciones, pmo, seguridad y
+`shared/mi-perfil/`.
+
+`operaciones/` tiene ocho subcarpetas: `carga-mo`, `config`, `confirmar-horas`,
+`dashboard`, `incidencias`, `kiosk`, `planeacion`, `shared`.
+
+### 2.2 `operaciones/semaforo/` NO existe
+
+```
+$ ls operaciones/semaforo/
+ls: cannot access 'operaciones/semaforo/': No such file or directory
+```
+
+CLAUDE.md §18 lo lista como pendiente #5 desde el go-live del watchdog (19-jun). **Nunca
+se empezó.** Es tierra virgen: no hay nada que migrar ni que romper.
+
+### 2.3 Navegación y permisos por módulo
+
+**No hay manifiesto de módulos.** El launcher no lee ninguna lista: los ocho `href` están
+en el HTML. Consecuencia directa: **no hay forma de ocultarle una card a quien no debe
+verla**, porque el launcher no sabe quién está mirando.
+
+### 2.4 Cómo consumen datos los módulos — tres patrones conviviendo
+
+| Patrón | Ejemplo | Gate |
+|---|---|---|
+| JSON del repo por API de GitHub o raw | panel-incidencias, kiosk, watchdog | ninguno |
+| Webhook n8n con token en el cuerpo | finanzas, comercial, RH | JWT + scope |
+| `localStorage` | config del kiosko, secreto HMAC de comercial | por dispositivo |
+
+Y **tres llaves de sesión** conviviendo, herencia de tres logins nacidos por separado:
+`fts_session` (viejo, sin sal), `fts_fin_session` (finanzas), `fts_suite_session` (el
+bueno). La propuesta de unificarlas está escrita y no aplicada.
+
+### 2.5 ¿Sirven los 60 snapshots como fuente?
+
+**Para historia sí; para «en vivo» no.** Son la foto de las 08:00, una por día hábil, y hoy
+sirvieron para reconstruir todo #220 cuando n8n solo retiene 14 días de ejecuciones. Pero:
+
+- son el estado de las 08:00, no el de ahora;
+- son **públicos** (§1.4);
+- y **el PUT que los escribe solo puede CREAR, nunca actualizar** — hallazgo medido hoy en
+  S1: manda el body sin `sha`, GitHub responde 422 y `onError:continueRegularOutput` lo
+  convierte en dato, así que el nodo reporta `success` con el snapshot viejo intacto.
+  Una re-corrida del mismo día no refresca nada.
+
+---
+
+## PASO 3 · Todo en una sola estructura, sin URLs por módulo
+
+### 3.1 Qué se rompe primero
+
+**El launcher**, y por dos motivos distintos:
+
+1. **Crecimiento.** Ocho cards escritas a mano. La novena se agrega editando HTML. No es
+   grave por sí solo — es una línea — pero es el síntoma.
+2. **Permisos.** Este sí es grave. El launcher no sabe quién mira, así que **enseña las
+   ocho puertas a todo el mundo**. Hoy no importa mucho porque los datos están gateados
+   detrás de cada puerta. Importará el día que un módulo dependa de que su card no se vea.
+
+Lo segundo que se rompe son **las llaves de sesión**: tres logins, y un `config-sync` que
+barre `fts_*` a un archivo público (§1.6). Cada módulo nuevo que estrene una llave se
+suma al barrido, porque la regla es lista negra, no lista blanca.
+
+### 3.2 Opciones
+
+| | Qué | Costo | Reversible |
+|---|---|---|---|
+| **1** | Dejarlo así | 0 | — |
+| **2** | **Manifiesto `shared/modulos.json` + launcher que lo renderiza y filtra por scopes del JWT** | ~media sesión | **Sí: se borra el JSON y vuelven las cards** |
+| **3** | URL o subdominio por módulo | Alto: DNS, deploy por módulo, se pierde el «un repo» | No de facto |
+
+### 3.3 Recomendación: opción 2, y con el lado tolerante primero
+
+`shared/modulos.json` con `{ruta, titulo, icono, scope}` por módulo. El launcher lo lee y
+renderiza. **Si hay sesión, filtra por `scopes`; si no hay sesión, muestra todo** — que es
+exactamente lo que hace hoy, así que desplegarlo no deja a nadie afuera (§8 anti-trabón).
+Endurecer viene después, módulo por módulo, cuando cada uno tenga su scope repartido.
+
+**Implicación de deploy: ninguna.** Mismo repo, mismo Pages, mismo push.
+
+**Reversibilidad:** total y en un commit. Si el manifiesto molesta, se borran el JSON y el
+render, y vuelven las ocho cards escritas a mano.
+
+---
+
+## PASO 4 · De dónde salen los datos vivos
+
+El criterio que decide no es la frescura ni el costo. Es, en palabras de Esteban: *«si el
+correo dice una cosa y la pantalla otra, se pierde la credibilidad que apenas estamos
+recuperando»*.
+
+| | **A · snapshot 08:00** | **B · recálculo bajo demanda** | **C · caché en Railway Postgres** |
+|---|---|---|---|
+| Frescura | hasta 24 h de atraso | segundos | minutos |
+| Costo por carga | 0 | ~9 s y ~10 consultas a Odoo | ~0 tras el escritor |
+| Costo de construir | bajo | bajo | **alto**: servicio, esquema, escritor, respaldo |
+| Historia | sí, 60 días | **no** | sí |
+| **Riesgo de discrepancia con el correo** | **cero por construcción** | **alto** | medio |
+
+### 4.1 Por qué B es la trampa
+
+B es la que suena mejor y es la que rompe el criterio. El correo se calcula a las 08:00 con
+`bizDays` en hora de pared de Monterrey y una línea base de delta guardada en
+`staticData`. Recalcular a las 15:00 da **números distintos por razones correctas**: pudo
+pasar un día hábil, pudo escribirse una nota, pudo moverse una etapa. La pantalla tendría
+razón, el correo tendría razón, **y dirían cosas distintas**.
+
+Y hay un límite duro, no de criterio sino de mecánica: **las secciones de delta no se
+pueden recalcular.** «Nuevo hoy», «empeoró», «se resolvió» se computan contra
+`staticData`, que solo persiste en corridas de producción. Un recálculo bajo demanda no
+tiene contra qué comparar.
+
+### 4.2 Por qué C es caro para lo que resuelve
+
+C compra frescura de minutos a cambio de un servicio nuevo con esquema, escritor, respaldo
+y un segundo lugar donde la verdad puede desincronizarse. Es la respuesta correcta el día
+que haya varios consumidores de la medición. Hoy hay uno.
+
+### 4.3 Recomendación: A, con una forma precisa
+
+**La vista lee el MISMO artefacto con el que se construyó el correo. Un solo escritor, una
+sola medición, cero posibilidad de que discrepen.**
+
+En concreto:
+
+1. Al final de su corrida, el watchdog **guarda la medición** (las 35 filas de
+   `Code - MAIN` más el `_diag` y la marca de tiempo) en una Data Table de n8n. Es el
+   mismo array que ya alimenta al correo y al snapshot: **no se calcula nada nuevo**.
+2. Un webhook **`ops/semaforo`** la devuelve, con `jwt-verify.js` exigiendo `ops:read`.
+3. La pantalla la pinta y **dice arriba cuándo se midió**: «Medición del 9-sep 08:00 CST».
+
+Ese tercer punto no es cosmética. **Una pantalla que dice cuándo se midió no está
+desactualizada; una que finge estar en vivo y no lo está, miente.** Es la misma regla que
+«la UI no es fuente de verdad de estado» (§8), aplicada al eje del tiempo.
+
+### 4.4 Cómo ganar frescura después sin romper el invariante
+
+Un botón **«recalcular»** que dispara **el mismo workflow** en un modo que recalcula **y
+reescribe la medición guardada**. Así la pantalla y el correo siguen compartiendo una sola
+fuente: el siguiente correo saldrá del mismo número que vio quien apretó el botón.
+
+**Lo que nunca debe existir es un segundo camino de cálculo.** Dos implementaciones de
+`bizDays` divergen; es el anti-patrón que CLAUDE.md §11 #12 ya documentó cuando dos
+workflows usaron ventanas distintas sobre el mismo dataset.
+
+---
+
+## PASO 5 · El prototipo
+
+**[`docs/watchdogs/prototipo/semaforo-vivo.html`](prototipo/semaforo-vivo.html)** — un solo
+archivo, ~30 KB, **cero dependencias externas y cero backend**. Se abre con doble clic.
+
+- **Datos DEMO anonimizados.** Estructura y forma de los números del snapshot real del
+  8-sep-2026; nombres de proyecto, cliente, SO e ids **sustituidos** (10 clientes →
+  `Cliente A`…`Cliente J`). Verificado con grep: cero nombres reales en el archivo. Una
+  barra morada permanente arriba lo declara, para que nadie confunda la demo con el estado
+  de la operación.
+- **Las dos vistas** por pestaña: **Operaciones** (19) y **Administración** (16). El
+  submódulo *Watchdog* de Operaciones abriría en la primera y el módulo *Watchdog* de
+  Finanzas en la segunda; es la misma pantalla, gateada por scope.
+- **Filtros:** búsqueda libre, etapa, solo con banderas, solo nota repetida, y los
+  **KPI son clicables** como filtro de color. Ordenamiento por cualquier columna.
+- **Detalle por proyecto** con etapa, semáforo, días y tramo, fecha compromiso, racha de
+  notas, banderas, la acción sugerida y una sección **«cómo se midió»** que dice en la cara
+  que el contador sale de `create_date` y que hoy es la edad del proyecto (error #1 de
+  #220).
+- La vista de Administración lleva impreso que **S3 le cambia el reloj** al vencimiento de
+  la factura, con el dato de #225: hoy el número y el vencimiento coinciden en 1 de 9.
+
+**Revisado mirándolo** (§20 #12), no leyendo el diff: abierto en Chromium a 1440 y a 430 px,
+ejercitando pestañas, detalle, filtros y el caso de lista vacía. **Cero `pageerror` y cero
+`console.error`.**
+
+Una decisión de honestidad: el snapshot del 8-sep todavía traía 8 banderas
+`ap_sin_confirmacion`, la regla que S1 apagó. **Se quitaron del demo.** Un prototipo que
+sirve para decidir no debe enseñar una regla retirada como si estuviera viva.
+
+---
+
+## Recomendación final y condición
+
+**Procede.** Bajo tres condiciones, en este orden:
+
+1. **Va después de S3.** S3 cambia el reloj de Administración de «días en etapa» a
+   «vencimiento de la factura», y la vista de Administración es la mitad del módulo.
+   Construirla contra el reloj que está por cambiar es trabajo tirado.
+2. **La vista NO lee los snapshots del repo.** Lee `ops/semaforo`, gateado por `ops:read`
+   con `jwt-verify.js`. Si lee los snapshots, el gate es decorativo.
+3. **Un solo cálculo.** El endpoint devuelve la medición que el correo usó, guardada por
+   el propio watchdog. Nunca un recálculo paralelo.
+
+**Si alguna de las tres no se puede cumplir, la recomendación es esperar**, no construir a
+medias: una pantalla que contradiga al correo cuesta más credibilidad de la que gana en
+comodidad.
+
+---
+
+## Plan de sesiones, si procede
+
+| | Qué | Depende de | Tamaño |
+|---|---|---|---|
+| **V1** | Guardar la medición al final de la corrida + webhook `ops/semaforo` con `jwt-verify.js` y scope `ops:read` | S3 | ~1 sesión |
+| **V2** | `shared/modulos.json` + launcher que lo renderiza y filtra por scopes (lado tolerante primero) | — | ~½ sesión |
+| **V3** | `operaciones/watchdog/` con el prototipo conectado al endpoint, más la clasificación `sesion`/`red`/`servidor` en un solo lugar | V1 | ~1 sesión |
+| **V4** | `finanzas/watchdog/` (misma pantalla, vista de Administración) + botón «recalcular» | V3, S3 | ~½ sesión |
+
+V2 no depende de nada y se puede adelantar.
+
+---
+
+## Anotado en esta sesión, no perseguido (backlog #220)
+
+| Hallazgo | Dueño |
+|---|---|
+| El PUT del snapshot solo puede CREAR: sin `sha`, 422 silencioso tras `onError` | watchdog |
+| Secreto HMAC en literal y publicado en `pmo/index.html` L1000 | Esteban + PMO |
+| `config-sync` barre `fts_*` a un archivo público con lista negra de 4 | operaciones |
+| PAT de GitHub en claro y por duplicado en `localStorage` | Esteban |
+| Tres llaves de sesión conviviendo; `users-suite.json` con SHA-256 sin sal, público | transversal |
+| `operaciones/semaforo/` lleva pendiente desde el go-live del 19-jun (§18 #5) | este plan lo cierra |

--- a/docs/watchdogs/prototipo/semaforo-vivo.html
+++ b/docs/watchdogs/prototipo/semaforo-vivo.html
@@ -1,0 +1,346 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Prototipo · Semáforo en vivo (datos DEMO)</title>
+<style>
+:root{
+  --azul:#0078D4; --azul-osc:#005a9e;
+  --rojo:#c62828; --amarillo:#b35900; --verde:#2e7d32; --morado:#8e24aa; --teal:#00695c;
+  --tinta:#1f2328; --tinta2:#57606a; --linea:#d8dee4; --fondo:#f6f8fa; --papel:#fff;
+}
+*{box-sizing:border-box}
+body{margin:0;font:14px/1.45 -apple-system,BlinkMacSystemFont,"Segoe UI",Arial,sans-serif;
+     color:var(--tinta);background:var(--fondo)}
+a{color:var(--azul)}
+
+/* ── aviso de demo: tiene que ser imposible de confundir con producción ── */
+#demoBar{background:#4a148c;color:#fff;padding:7px 14px;font-size:12.5px;
+         display:flex;gap:10px;align-items:center;flex-wrap:wrap}
+#demoBar b{background:#fff;color:#4a148c;padding:1px 7px;border-radius:3px;font-size:11px;letter-spacing:.4px}
+
+header{background:var(--papel);border-bottom:1px solid var(--linea);padding:12px 14px}
+.hrow{display:flex;gap:14px;align-items:baseline;flex-wrap:wrap}
+h1{font-size:17px;margin:0;font-weight:650}
+.sub{font-size:12px;color:var(--tinta2)}
+
+/* ── vistas ── */
+nav.vistas{display:flex;gap:2px;margin-top:11px;border-bottom:2px solid var(--linea)}
+nav.vistas button{background:none;border:0;border-bottom:2px solid transparent;margin-bottom:-2px;
+  padding:8px 15px;font:inherit;font-weight:600;color:var(--tinta2);cursor:pointer;border-radius:4px 4px 0 0}
+nav.vistas button:hover{background:var(--fondo)}
+nav.vistas button[aria-selected="true"]{color:var(--azul);border-bottom-color:var(--azul)}
+nav.vistas .cnt{font-weight:400;color:var(--tinta2);font-size:12px}
+
+/* ── KPI ── */
+.kpis{display:flex;gap:9px;flex-wrap:wrap;margin:13px 14px 0}
+.k{background:var(--papel);border:1px solid var(--linea);border-radius:7px;padding:9px 13px;min-width:96px}
+.k .n{font-size:21px;font-weight:680;line-height:1.1}
+.k .l{font-size:11px;color:var(--tinta2);text-transform:uppercase;letter-spacing:.4px;margin-top:2px}
+.k.r .n{color:var(--rojo)} .k.a .n{color:var(--amarillo)} .k.v .n{color:var(--verde)}
+.k.clic{cursor:pointer} .k.clic:hover{border-color:var(--azul)}
+.k[aria-pressed="true"]{border-color:var(--azul);box-shadow:inset 0 0 0 1px var(--azul)}
+
+/* ── filtros ── */
+.filtros{display:flex;gap:8px;flex-wrap:wrap;align-items:center;margin:13px 14px}
+.filtros input[type=search],.filtros select{font:inherit;padding:6px 9px;border:1px solid var(--linea);
+  border-radius:6px;background:var(--papel);color:var(--tinta)}
+.filtros input[type=search]{min-width:210px}
+.chk{display:inline-flex;gap:6px;align-items:center;font-size:12.5px;color:var(--tinta2);
+     background:var(--papel);border:1px solid var(--linea);border-radius:6px;padding:6px 9px;cursor:pointer}
+.limpiar{background:none;border:0;color:var(--azul);font:inherit;cursor:pointer;padding:6px}
+
+/* ── layout lista + detalle ── */
+.panes{display:grid;grid-template-columns:minmax(0,1fr) 400px;gap:13px;padding:0 14px 26px;align-items:start}
+@media(max-width:1000px){.panes{grid-template-columns:1fr}}
+.caja{background:var(--papel);border:1px solid var(--linea);border-radius:8px;overflow:hidden}
+
+/* ── tabla ── */
+.tw{overflow-x:auto}
+table{border-collapse:collapse;width:100%;font-size:13px}
+th{text-align:left;font-size:11px;text-transform:uppercase;letter-spacing:.4px;color:var(--tinta2);
+   padding:8px 10px;border-bottom:1px solid var(--linea);background:var(--fondo);
+   position:sticky;top:0;white-space:nowrap;cursor:pointer;user-select:none}
+th:hover{color:var(--azul)}
+th .ord{color:var(--azul)}
+td{padding:8px 10px;border-bottom:1px solid #eef1f4;vertical-align:top}
+tbody tr{cursor:pointer}
+tbody tr:hover{background:#f2f7fd}
+tbody tr[aria-selected="true"]{background:#e3f0fc;box-shadow:inset 3px 0 0 var(--azul)}
+.pt{font-weight:600}
+.pc{color:var(--tinta2);font-size:12px}
+.dias{font-variant-numeric:tabular-nums;font-weight:650;text-align:right;white-space:nowrap}
+.punto{display:inline-block;width:9px;height:9px;border-radius:50%;margin-right:5px;vertical-align:baseline}
+.p-rojo{background:var(--rojo)} .p-amarillo{background:var(--amarillo)} .p-verde{background:var(--verde)}
+.tag{display:inline-block;font-size:10.5px;padding:1px 6px;border-radius:9px;border:1px solid;margin-right:4px;white-space:nowrap}
+.t-flag{color:var(--morado);border-color:var(--morado);background:#f9f2fc}
+.t-rep{color:var(--morado);border-color:var(--morado);background:#f9f2fc}
+.t-mat{color:var(--teal);border-color:var(--teal);background:#effaf8}
+.vacio{padding:26px 14px;text-align:center;color:var(--tinta2)}
+
+/* ── detalle ── */
+.det{padding:14px}
+.det .cerrar{float:right;background:none;border:0;font-size:19px;color:var(--tinta2);cursor:pointer;line-height:1}
+.det h2{font-size:15px;margin:0 0 3px;padding-right:22px}
+.det .meta{color:var(--tinta2);font-size:12.5px;margin-bottom:12px}
+.det dl{display:grid;grid-template-columns:auto 1fr;gap:5px 12px;margin:0;font-size:13px}
+.det dt{color:var(--tinta2)}
+.det dd{margin:0;font-weight:550}
+.det h3{font-size:11px;text-transform:uppercase;letter-spacing:.5px;color:var(--tinta2);
+        margin:16px 0 6px;padding-top:12px;border-top:1px solid var(--linea)}
+.det ul{margin:0;padding-left:17px;font-size:13px}
+.det li{margin-bottom:5px}
+.acc{background:#fff8e6;border:1px solid #f0d795;border-radius:6px;padding:9px 11px;font-size:12.5px;margin-top:13px}
+.acc.ok{background:#eefaf0;border-color:#a8ddb5}
+.det .nada{color:var(--tinta2);font-style:italic;font-size:12.5px}
+.hint{padding:26px 14px;color:var(--tinta2);text-align:center;font-size:13px}
+
+/* ── avisos ── */
+.nota{margin:0 14px 13px;padding:9px 12px;border-radius:7px;font-size:12.5px;
+      background:#eef6fd;border:1px solid #b9daf5;color:#0b4a7a}
+.nota.warn{background:#fff8e6;border-color:#f0d795;color:#6b4a00}
+footer{padding:16px 14px 30px;color:var(--tinta2);font-size:11.5px;border-top:1px solid var(--linea);
+       margin-top:6px;background:var(--papel)}
+code{background:var(--fondo);padding:1px 4px;border-radius:3px;font-size:12px}
+</style>
+</head>
+<body>
+
+<div id="demoBar">
+  <b>DEMO</b>
+  <span>Prototipo sin backend. Los nombres de proyecto, cliente y SO son <strong>inventados</strong>:
+  la estructura y la forma de los números vienen del snapshot real del 8-sep-2026, todo lo
+  identificable está sustituido. <strong>No es el estado de la operación.</strong></span>
+</div>
+
+<header>
+  <div class="hrow">
+    <h1>Semáforo en vivo</h1>
+    <span class="sub" id="hdrFecha"></span>
+  </div>
+  <nav class="vistas" role="tablist" id="tabs"></nav>
+</header>
+
+<div class="kpis" id="kpis"></div>
+<div class="nota" id="notaVista"></div>
+
+<div class="filtros">
+  <input type="search" id="q" placeholder="Buscar proyecto, SO o cliente…" aria-label="Buscar">
+  <select id="fStage" aria-label="Filtrar por etapa"><option value="">Todas las etapas</option></select>
+  <label class="chk"><input type="checkbox" id="fFlag"> Solo con banderas</label>
+  <label class="chk"><input type="checkbox" id="fRep"> Solo nota repetida</label>
+  <button class="limpiar" id="limpiar">Limpiar filtros</button>
+</div>
+
+<div class="panes">
+  <div class="caja">
+    <div class="tw">
+      <table>
+        <thead><tr id="thr"></tr></thead>
+        <tbody id="tb"></tbody>
+      </table>
+    </div>
+    <div class="vacio" id="vacio" hidden>Ningún proyecto cumple los filtros.</div>
+  </div>
+  <div class="caja" id="detCaja">
+    <div class="hint" id="hint">Elige un proyecto de la lista para ver su detalle.</div>
+    <div class="det" id="det" hidden></div>
+  </div>
+</div>
+
+<footer>
+  Prototipo del submódulo <strong>Watchdog</strong>. El correo diario NO se retira: esta pantalla es
+  adicional y lee <em>la misma medición</em>. Diseño de la fuente de datos y del gate de acceso en
+  <code>docs/watchdogs/VIVO-AUDITORIA.md</code>. Auditoría original: issue #220.
+</footer>
+
+<script>
+/* ══ DATOS DEMO ══════════════════════════════════════════════════════════════
+   Estructura y forma de los números tomadas del snapshot real 2026-09-08.
+   Nombres de proyecto, cliente, SO e ids: SUSTITUIDOS. Ver el generador en la
+   sesión que creó este archivo; nada de cliente real vive aquí.            */
+const DATA = {"_demo":true,"_nota":"DATOS DE DEMOSTRACION. Estructura y forma de los numeros tomadas del snapshot real 2026-09-08; nombres de proyecto, cliente, SO e ids SUSTITUIDOS. Ningun dato de cliente real aparece aqui. Se retiraron las banderas ap_sin_confirmacion: S1 (issue #223) apago esa regla, y un prototipo que sirve para decidir no debe mostrar una regla retirada.","fecha":"2026-09-08","total":35,"por_color":{"verde":11,"rojo":24},"_diag":[{"nodo":"Odoo - getAll msg94","problema":"devolvio 0 filas utilizables (llave \"res_id\" ausente)","items_crudos":1,"critico":true}],"proyectos":[{"id":900,"so":"SO9100","name":"SO9100 - Instalacion electrica","cliente":"Cliente A","stage_id":2,"stage":"In Progress","grupo":"Operaciones","es_materiales":false,"dias_en_stage":5,"color_a":"verde","color_a_rep":"verde","tramo_a":"1-5","racha_nota":1,"sin_avance":false,"sin_nota_valida":false,"project_date":null,"banderas":[]},{"id":901,"so":"SO9107","name":"SO9107 - Suministro de materiales","cliente":"Cliente B","stage_id":13,"stage":"En plazo de credito","grupo":"Admin","es_materiales":false,"dias_en_stage":29,"color_a":"verde","color_a_rep":"verde","tramo_a":"16-30","racha_nota":1,"sin_avance":false,"sin_nota_valida":false,"project_date":null,"banderas":[]},{"id":902,"so":"SO9114","name":"SO9114 - Adecuacion de linea","cliente":"Cliente B","stage_id":3,"stage":"Done Operations","grupo":"Admin","es_materiales":false,"dias_en_stage":7,"color_a":"rojo","color_a_rep":"rojo","tramo_a":"6-15","racha_nota":1,"sin_avance":false,"sin_nota_valida":false,"project_date":null,"banderas":[]},{"id":903,"so":"SO9121","name":"SO9121 - Montaje mecanico","cliente":"Cliente C","stage_id":1,"stage":"To Do","grupo":"Operaciones","es_materiales":false,"dias_en_stage":2,"color_a":"rojo","color_a_rep":"rojo","tramo_a":"1-5","racha_nota":0,"sin_avance":false,"sin_nota_valida":true,"project_date":null,"banderas":[]},{"id":904,"so":"SO9128","name":"SO9128 - Servicio de mantenimiento","cliente":"Cliente A","stage_id":2,"stage":"In Progress","grupo":"Operaciones","es_materiales":false,"dias_en_stage":53,"color_a":"verde","color_a_rep":"verde","tramo_a":">30","racha_nota":1,"sin_avance":false,"sin_nota_valida":false,"project_date":null,"banderas":[{"tipo":"stage_atras","detalle":"Stage regresado Hold -> En proceso por Usuario Interno"},{"tipo":"fecha_fin","detalle":"Fecha fin movida por Usuario Interno"}]},{"id":905,"so":"SO9135","name":"SO9135 - Ingenieria de detalle","cliente":"Cliente D","stage_id":13,"stage":"En plazo de credito","grupo":"Admin","es_materiales":false,"dias_en_stage":16,"color_a":"verde","color_a_rep":"verde","tramo_a":"16-30","racha_nota":1,"sin_avance":false,"sin_nota_valida":false,"project_date":null,"banderas":[]},{"id":906,"so":"SO9142","name":"SO9142 - Cortinas de seguridad","cliente":"Cliente B","stage_id":3,"stage":"Done Operations","grupo":"Admin","es_materiales":false,"dias_en_stage":7,"color_a":"rojo","color_a_rep":"rojo","tramo_a":"6-15","racha_nota":1,"sin_avance":false,"sin_nota_valida":false,"project_date":null,"banderas":[]},{"id":907,"so":"SO9149","name":"SO9149 - Distribucion electrica","cliente":"Cliente C","stage_id":3,"stage":"Done Operations","grupo":"Admin","es_materiales":false,"dias_en_stage":7,"color_a":"rojo","color_a_rep":"rojo","tramo_a":"6-15","racha_nota":1,"sin_avance":false,"sin_nota_valida":false,"project_date":null,"banderas":[]},{"id":908,"so":"SO9156","name":"SO9156 - Suministro de tablero","cliente":"Cliente E","stage_id":2,"stage":"In Progress","grupo":"Operaciones","es_materiales":false,"dias_en_stage":7,"color_a":"verde","color_a_rep":"verde","tramo_a":"6-15","racha_nota":1,"sin_avance":false,"sin_nota_valida":false,"project_date":null,"banderas":[]},{"id":909,"so":"SO9163","name":"SO9163 - Integracion de sistema","cliente":"Cliente F","stage_id":5,"stage":"Hold","grupo":"Operaciones","es_materiales":false,"dias_en_stage":266,"color_a":"rojo","color_a_rep":"rojo","tramo_a":">30","racha_nota":1,"sin_avance":false,"sin_nota_valida":false,"project_date":null,"banderas":[{"tipo":"hold_sin_fecha_vigente","detalle":"En Hold con fecha de reactivacion VENCIDA (2026-07-30)"}]},{"id":910,"so":"SO9170","name":"SO9170 - Fabricacion de soporte","cliente":"Cliente G","stage_id":13,"stage":"En plazo de credito","grupo":"Admin","es_materiales":false,"dias_en_stage":203,"color_a":"rojo","color_a_rep":"rojo","tramo_a":">30","racha_nota":1,"sin_avance":false,"sin_nota_valida":false,"project_date":null,"banderas":[]},{"id":911,"so":"SO9177","name":"SO9177 - Rigging de equipo","cliente":"Cliente C","stage_id":3,"stage":"Done Operations","grupo":"Admin","es_materiales":false,"dias_en_stage":7,"color_a":"rojo","color_a_rep":"rojo","tramo_a":"6-15","racha_nota":1,"sin_avance":false,"sin_nota_valida":false,"project_date":null,"banderas":[]},{"id":912,"so":"SO9184","name":"SO9184 - Instalacion electrica","cliente":"Cliente E","stage_id":2,"stage":"In Progress","grupo":"Operaciones","es_materiales":false,"dias_en_stage":7,"color_a":"verde","color_a_rep":"verde","tramo_a":"6-15","racha_nota":1,"sin_avance":false,"sin_nota_valida":false,"project_date":null,"banderas":[]},{"id":913,"so":"SO9191","name":"SO9191 - Suministro de materiales","cliente":"Cliente E","stage_id":13,"stage":"En plazo de credito","grupo":"Admin","es_materiales":false,"dias_en_stage":330,"color_a":"rojo","color_a_rep":"rojo","tramo_a":">30","racha_nota":1,"sin_avance":false,"sin_nota_valida":false,"project_date":null,"banderas":[{"tipo":"nota_vacia","detalle":"1 log note(s) sin contenido en el chatter - no cuentan como seguimiento"}]},{"id":914,"so":"SO9198","name":"SO9198 - Adecuacion de linea","cliente":"Cliente D","stage_id":13,"stage":"En plazo de credito","grupo":"Admin","es_materiales":false,"dias_en_stage":53,"color_a":"rojo","color_a_rep":"rojo","tramo_a":">30","racha_nota":1,"sin_avance":false,"sin_nota_valida":false,"project_date":null,"banderas":[]},{"id":915,"so":"SO9205","name":"SO9205 - Montaje mecanico","cliente":"Cliente B","stage_id":5,"stage":"Hold","grupo":"Operaciones","es_materiales":false,"dias_en_stage":27,"color_a":"verde","color_a_rep":"verde","tramo_a":"16-30","racha_nota":1,"sin_avance":false,"sin_nota_valida":false,"project_date":null,"banderas":[{"tipo":"nota_vacia","detalle":"1 log note(s) sin contenido en el chatter - no cuentan como seguimiento"},{"tipo":"hold_sin_fecha_vigente","detalle":"En Hold con fecha de reactivacion VENCIDA (2026-08-21)"}]},{"id":916,"so":"SO9212","name":"SO9212 - Servicio de mantenimiento","cliente":"Cliente C","stage_id":2,"stage":"In Progress","grupo":"Operaciones","es_materiales":false,"dias_en_stage":21,"color_a":"rojo","color_a_rep":"rojo","tramo_a":"16-30","racha_nota":1,"sin_avance":false,"sin_nota_valida":false,"project_date":null,"banderas":[]},{"id":917,"so":"SO9219","name":"SO9219 - Ingenieria de detalle","cliente":"Cliente C","stage_id":3,"stage":"Done Operations","grupo":"Admin","es_materiales":false,"dias_en_stage":7,"color_a":"rojo","color_a_rep":"rojo","tramo_a":"6-15","racha_nota":1,"sin_avance":false,"sin_nota_valida":false,"project_date":null,"banderas":[]},{"id":918,"so":"SO9226","name":"SO9226 - Cortinas de seguridad","cliente":"Cliente D","stage_id":13,"stage":"En plazo de credito","grupo":"Admin","es_materiales":false,"dias_en_stage":100,"color_a":"rojo","color_a_rep":"rojo","tramo_a":">30","racha_nota":1,"sin_avance":false,"sin_nota_valida":false,"project_date":null,"banderas":[]},{"id":919,"so":"SO9233","name":"SO9233 - Distribucion electrica","cliente":"Cliente G","stage_id":3,"stage":"Done Operations","grupo":"Admin","es_materiales":false,"dias_en_stage":14,"color_a":"rojo","color_a_rep":"rojo","tramo_a":"6-15","racha_nota":1,"sin_avance":false,"sin_nota_valida":false,"project_date":null,"banderas":[]},{"id":920,"so":"SO9240","name":"SO9240 - Suministro de tablero","cliente":"Cliente H","stage_id":13,"stage":"En plazo de credito","grupo":"Admin","es_materiales":false,"dias_en_stage":44,"color_a":"rojo","color_a_rep":"rojo","tramo_a":">30","racha_nota":1,"sin_avance":false,"sin_nota_valida":false,"project_date":null,"banderas":[]},{"id":921,"so":"SO9247","name":"SO9247 - Integracion de sistema","cliente":"Cliente C","stage_id":2,"stage":"In Progress","grupo":"Operaciones","es_materiales":false,"dias_en_stage":22,"color_a":"rojo","color_a_rep":"rojo","tramo_a":"16-30","racha_nota":2,"sin_avance":true,"sin_nota_valida":false,"project_date":null,"banderas":[]},{"id":922,"so":"SO9254","name":"SO9254 - Fabricacion de soporte","cliente":"Cliente G","stage_id":3,"stage":"Done Operations","grupo":"Admin","es_materiales":false,"dias_en_stage":16,"color_a":"rojo","color_a_rep":"rojo","tramo_a":"16-30","racha_nota":1,"sin_avance":false,"sin_nota_valida":false,"project_date":null,"banderas":[]},{"id":923,"so":"SO9261","name":"SO9261 - Rigging de equipo","cliente":"Cliente I","stage_id":2,"stage":"In Progress","grupo":"Operaciones","es_materiales":false,"dias_en_stage":32,"color_a":"verde","color_a_rep":"verde","tramo_a":">30","racha_nota":1,"sin_avance":false,"sin_nota_valida":false,"project_date":null,"banderas":[]},{"id":924,"so":"SO9268","name":"SO9268 - Instalacion electrica","cliente":"Cliente E","stage_id":13,"stage":"En plazo de credito","grupo":"Admin","es_materiales":false,"dias_en_stage":401,"color_a":"rojo","color_a_rep":"rojo","tramo_a":">30","racha_nota":1,"sin_avance":false,"sin_nota_valida":false,"project_date":null,"banderas":[]},{"id":925,"so":"SO9275","name":"SO9275 - Suministro de materiales","cliente":"Cliente J","stage_id":2,"stage":"In Progress","grupo":"Operaciones","es_materiales":false,"dias_en_stage":41,"color_a":"verde","color_a_rep":"verde","tramo_a":">30","racha_nota":1,"sin_avance":false,"sin_nota_valida":false,"project_date":null,"banderas":[{"tipo":"fecha_fin","detalle":"Fecha fin movida por Usuario Interno"}]},{"id":926,"so":"SO9282","name":"SO9282 - Adecuacion de linea","cliente":"Cliente G","stage_id":3,"stage":"Done Operations","grupo":"Admin","es_materiales":false,"dias_en_stage":14,"color_a":"rojo","color_a_rep":"rojo","tramo_a":"6-15","racha_nota":1,"sin_avance":false,"sin_nota_valida":false,"project_date":null,"banderas":[]},{"id":927,"so":"SO9289","name":"SO9289 - Montaje mecanico","cliente":"Cliente C","stage_id":2,"stage":"In Progress","grupo":"Operaciones","es_materiales":false,"dias_en_stage":187,"color_a":"verde","color_a_rep":"verde","tramo_a":">30","racha_nota":1,"sin_avance":false,"sin_nota_valida":false,"project_date":null,"banderas":[{"tipo":"nota_vacia","detalle":"1 log note(s) sin contenido en el chatter - no cuentan como seguimiento"}]},{"id":928,"so":"SO9296","name":"SO9296 - Servicio de mantenimiento","cliente":"Cliente E","stage_id":2,"stage":"In Progress","grupo":"Operaciones","es_materiales":false,"dias_en_stage":199,"color_a":"verde","color_a_rep":"verde","tramo_a":">30","racha_nota":1,"sin_avance":false,"sin_nota_valida":false,"project_date":null,"banderas":[]},{"id":929,"so":"SO9303","name":"SO9303 - Ingenieria de detalle","cliente":"Cliente G","stage_id":2,"stage":"In Progress","grupo":"Operaciones","es_materiales":false,"dias_en_stage":59,"color_a":"rojo","color_a_rep":"rojo","tramo_a":">30","racha_nota":1,"sin_avance":false,"sin_nota_valida":false,"project_date":null,"banderas":[{"tipo":"nota_vacia","detalle":"1 log note(s) sin contenido en el chatter - no cuentan como seguimiento"}]},{"id":930,"so":"SO9310","name":"SO9310 - Cortinas de seguridad","cliente":"Cliente C","stage_id":2,"stage":"In Progress","grupo":"Operaciones","es_materiales":false,"dias_en_stage":48,"color_a":"rojo","color_a_rep":"rojo","tramo_a":">30","racha_nota":1,"sin_avance":false,"sin_nota_valida":false,"project_date":null,"banderas":[]},{"id":931,"so":"SO9317","name":"SO9317 - Distribucion electrica","cliente":"Cliente G","stage_id":2,"stage":"In Progress","grupo":"Operaciones","es_materiales":false,"dias_en_stage":137,"color_a":"rojo","color_a_rep":"rojo","tramo_a":">30","racha_nota":1,"sin_avance":false,"sin_nota_valida":false,"project_date":null,"banderas":[]},{"id":932,"so":"SO9324","name":"SO9324 - Suministro de tablero","cliente":"Cliente C","stage_id":2,"stage":"In Progress","grupo":"Operaciones","es_materiales":false,"dias_en_stage":48,"color_a":"rojo","color_a_rep":"rojo","tramo_a":">30","racha_nota":1,"sin_avance":false,"sin_nota_valida":false,"project_date":null,"banderas":[]},{"id":933,"so":"SO9331","name":"SO9331 - Integracion de sistema","cliente":"Cliente G","stage_id":2,"stage":"In Progress","grupo":"Operaciones","es_materiales":false,"dias_en_stage":371,"color_a":"rojo","color_a_rep":"rojo","tramo_a":">30","racha_nota":1,"sin_avance":false,"sin_nota_valida":false,"project_date":null,"banderas":[]},{"id":934,"so":"SO9338","name":"SO9338 - Fabricacion de soporte","cliente":"Cliente A","stage_id":2,"stage":"In Progress","grupo":"Operaciones","es_materiales":false,"dias_en_stage":267,"color_a":"rojo","color_a_rep":"rojo","tramo_a":">30","racha_nota":1,"sin_avance":false,"sin_nota_valida":false,"project_date":null,"banderas":[]}]};
+
+/* ══ estado de la vista ══ */
+const VISTAS = [
+  { id:'Operaciones', label:'Operaciones',
+    nota:'Reloj: <strong>tiempo en la etapa</strong>. La pregunta es si el proyecto avanza.' },
+  { id:'Admin', label:'Administración',
+    nota:'Reloj HOY: tiempo en la etapa. <strong>S3 lo cambia al vencimiento real de la factura</strong> ' +
+         '(<code>invoice_date_due</code>) — issue #225 midió que hoy el número y el vencimiento coinciden en 1 de 9 casos. ' +
+         'Esta vista es la que más va a cambiar.' }
+];
+const ORD_COL = { rojo:0, amarillo:1, verde:2 };
+let vista = 'Operaciones', sel = null, colorF = '';
+let orden = { col:'dias', dir:-1 };
+
+const $ = s => document.querySelector(s);
+const esc = s => String(s==null?'':s).replace(/[&<>"']/g, c =>
+  ({'&':'&amp;','<':'&lt;','>':'&gt;','"':'&quot;',"'":'&#39;'}[c]));
+
+/* ⚠️ El nombre de la clase CSS y el orden de declaración de const importan:
+   ver CLAUDE.md §20 #12. Todo const usado en una función se declara antes. */
+
+$('#hdrFecha').textContent = 'Medición del ' + DATA.fecha + ' · ' + DATA.total + ' proyectos vigilados';
+
+/* ── pestañas ── */
+$('#tabs').innerHTML = VISTAS.map(v => {
+  const n = DATA.proyectos.filter(r => r.grupo === v.id).length;
+  return '<button role="tab" data-v="' + v.id + '" aria-selected="' + (v.id===vista) + '">' +
+         esc(v.label) + ' <span class="cnt">' + n + '</span></button>';
+}).join('');
+$('#tabs').addEventListener('click', e => {
+  const b = e.target.closest('button[data-v]'); if(!b) return;
+  vista = b.dataset.v; sel = null; colorF = '';
+  [...$('#tabs').children].forEach(x => x.setAttribute('aria-selected', x.dataset.v===vista));
+  pintar();
+});
+
+/* ── etapas del selector, solo las que existen ── */
+function llenarStages(){
+  const st = [...new Set(DATA.proyectos.filter(r=>r.grupo===vista).map(r=>r.stage))].sort();
+  const sv = $('#fStage').value;
+  $('#fStage').innerHTML = '<option value="">Todas las etapas</option>' +
+    st.map(s => '<option' + (s===sv?' selected':'') + '>' + esc(s) + '</option>').join('');
+}
+
+/* ── filtrado ── */
+function filas(){
+  const q = $('#q').value.trim().toLowerCase();
+  const st = $('#fStage').value, ff = $('#fFlag').checked, fr = $('#fRep').checked;
+  let out = DATA.proyectos.filter(r => r.grupo === vista);
+  if(colorF) out = out.filter(r => r.color_a_rep === colorF);
+  if(st)     out = out.filter(r => r.stage === st);
+  if(ff)     out = out.filter(r => (r.banderas||[]).length > 0);
+  if(fr)     out = out.filter(r => r.sin_avance || (r.racha_nota||0) >= 2);
+  if(q)      out = out.filter(r =>
+    (r.name+' '+r.cliente+' '+r.so+' '+r.stage).toLowerCase().includes(q));
+  const dir = orden.dir;
+  return out.sort((a,b) => {
+    let d;
+    if(orden.col === 'dias')   d = (a.dias_en_stage||0) - (b.dias_en_stage||0);
+    else if(orden.col==='color') d = ORD_COL[a.color_a_rep] - ORD_COL[b.color_a_rep];
+    else if(orden.col==='stage') d = a.stage.localeCompare(b.stage);
+    else if(orden.col==='cli')   d = a.cliente.localeCompare(b.cliente);
+    else                         d = a.name.localeCompare(b.name);
+    return d !== 0 ? d*dir : (a.dias_en_stage||0) - (b.dias_en_stage||0);
+  });
+}
+
+/* ── KPI, clicables como filtro de color ── */
+function pintarKpis(){
+  const g = DATA.proyectos.filter(r => r.grupo === vista);
+  const c = k => g.filter(r => r.color_a_rep === k).length;
+  const pct = g.length ? Math.round(c('verde')/g.length*100) : 0;
+  const box = (cls,val,lab,key) =>
+    '<div class="k ' + cls + (key!==undefined?' clic':'') + '"' +
+    (key!==undefined ? ' role="button" tabindex="0" data-c="' + key + '" aria-pressed="' + (colorF===key) + '"' : '') +
+    '><div class="n">' + val + '</div><div class="l">' + lab + '</div></div>';
+  $('#kpis').innerHTML =
+    box('', g.length, 'vigilados', '') +
+    box('r', c('rojo'), 'rojo', 'rojo') +
+    box('a', c('amarillo'), 'amarillo', 'amarillo') +
+    box('v', c('verde'), 'verde', 'verde') +
+    box('', pct + '%', 'verde · meta 90%');
+}
+$('#kpis').addEventListener('click', e => {
+  const k = e.target.closest('.k.clic'); if(!k) return;
+  colorF = (colorF === k.dataset.c) ? '' : k.dataset.c; sel = null; pintar();
+});
+$('#kpis').addEventListener('keydown', e => {
+  if(e.key === 'Enter' || e.key === ' '){ e.preventDefault(); e.target.closest('.k.clic')?.click(); }
+});
+
+/* ── tabla ── */
+const COLS = [
+  { k:'color', t:'' }, { k:'name', t:'Proyecto' }, { k:'cli', t:'Cliente' },
+  { k:'stage', t:'Etapa' }, { k:'dias', t:'Días' }, { k:'señales', t:'Señales' }
+];
+function pintarTabla(rows){
+  $('#thr').innerHTML = COLS.map(c =>
+    '<th data-k="' + c.k + '">' + esc(c.t) +
+    (orden.col===c.k ? ' <span class="ord">' + (orden.dir<0?'▾':'▴') + '</span>' : '') + '</th>').join('');
+  $('#tb').innerHTML = rows.map(r => {
+    const sig = [];
+    if(r.es_materiales)                     sig.push('<span class="tag t-mat">materiales</span>');
+    if(r.sin_avance || (r.racha_nota||0)>=2) sig.push('<span class="tag t-rep">nota repetida ×' + (r.racha_nota||0) + '</span>');
+    if((r.banderas||[]).length)             sig.push('<span class="tag t-flag">' + r.banderas.length + ' bandera' + (r.banderas.length>1?'s':'') + '</span>');
+    return '<tr data-id="' + r.id + '" aria-selected="' + (sel===r.id) + '">' +
+      '<td><span class="punto p-' + r.color_a_rep + '" title="' + r.color_a_rep + '"></span></td>' +
+      '<td><div class="pt">' + esc(r.name) + '</div></td>' +
+      '<td class="pc">' + esc(r.cliente) + '</td>' +
+      '<td class="pc">' + esc(r.stage) + '</td>' +
+      '<td class="dias">' + (r.dias_en_stage==null?'?':r.dias_en_stage) + 'd</td>' +
+      '<td>' + (sig.join('') || '<span class="pc">—</span>') + '</td></tr>';
+  }).join('');
+  $('#vacio').hidden = rows.length > 0;
+}
+$('#thr').addEventListener('click', e => {
+  const th = e.target.closest('th[data-k]'); if(!th || th.dataset.k==='señales') return;
+  if(orden.col === th.dataset.k) orden.dir *= -1;
+  else orden = { col:th.dataset.k, dir: th.dataset.k==='dias' ? -1 : 1 };
+  pintar();
+});
+$('#tb').addEventListener('click', e => {
+  const tr = e.target.closest('tr[data-id]'); if(!tr) return;
+  const id = +tr.dataset.id;
+  sel = (sel === id) ? null : id;
+  pintar();
+});
+
+/* ── detalle ── */
+const ACC = {
+  rojo:     'Avanza de etapa, o documenta en un log note por qué sigue aquí.',
+  amarillo: 'Se acerca al límite: mueve la etapa o documenta.',
+  verde:    'Dentro de umbral. No requiere acción.'
+};
+function pintarDetalle(){
+  const r = DATA.proyectos.find(x => x.id === sel);
+  if(!r){ $('#det').hidden = true; $('#hint').hidden = false; return; }
+  $('#hint').hidden = true; $('#det').hidden = false;
+  const bs = r.banderas || [];
+  $('#det').innerHTML =
+    '<button class="cerrar" id="cerrarDet" aria-label="Cerrar detalle">×</button>' +
+    '<h2>' + esc(r.name) + '</h2>' +
+    '<div class="meta">' + esc(r.cliente) + ' · ' + esc(r.so) + '</div>' +
+    '<dl>' +
+      '<dt>Etapa</dt><dd>' + esc(r.stage) + '</dd>' +
+      '<dt>Semáforo</dt><dd><span class="punto p-' + r.color_a_rep + '"></span>' + esc(r.color_a_rep) + '</dd>' +
+      '<dt>Días en etapa</dt><dd>' + (r.dias_en_stage==null?'?':r.dias_en_stage) + ' (tramo ' + esc(r.tramo_a) + ')</dd>' +
+      (r.project_date ? '<dt>Fecha compromiso</dt><dd>' + esc(String(r.project_date).slice(0,10)) + '</dd>' : '') +
+      '<dt>Notas seguidas iguales</dt><dd>' + (r.racha_nota||0) + '</dd>' +
+      '<dt>Grupo</dt><dd>' + esc(r.grupo) + '</dd>' +
+    '</dl>' +
+    '<h3>Banderas</h3>' +
+    (bs.length ? '<ul>' + bs.map(f => '<li>' + esc(f.detalle) + '</li>').join('') + '</ul>'
+               : '<div class="nada">Ninguna.</div>') +
+    '<div class="acc' + (r.color_a_rep==='verde'?' ok':'') + '">' + esc(ACC[r.color_a_rep]) + '</div>' +
+    '<h3>Cómo se midió</h3>' +
+    '<ul><li>El contador sale de <code>create_date</code>, no de la entrada a la etapa: ' +
+    '<strong>hoy es la EDAD del proyecto</strong>. Es el error #1 del issue #220 y se corrige en S6.</li>' +
+    (r.grupo === 'Admin'
+      ? '<li>Con S3 el reloj de esta vista pasa a ser el <strong>vencimiento de la factura</strong>, no la edad.</li>'
+      : '') +
+    '</ul>';
+  $('#cerrarDet').addEventListener('click', () => { sel = null; pintar(); });
+}
+
+/* ── render ── */
+function pintar(){
+  llenarStages();
+  pintarKpis();
+  $('#notaVista').innerHTML = VISTAS.find(v => v.id === vista).nota;
+  pintarTabla(filas());
+  pintarDetalle();
+}
+['#q','#fStage','#fFlag','#fRep'].forEach(s =>
+  $(s).addEventListener('input', () => { sel = null; pintar(); }));
+$('#limpiar').addEventListener('click', () => {
+  $('#q').value=''; $('#fStage').value=''; $('#fFlag').checked=false; $('#fRep').checked=false;
+  colorF=''; sel=null; pintar();
+});
+pintar();
+</script>
+</body>
+</html>

--- a/shared/comercial/watchdog_enviadas.json
+++ b/shared/comercial/watchdog_enviadas.json
@@ -2,7 +2,8 @@
   "_meta": "Config de comercial/watchdog-enviadas. Se lee de GitHub raw main EN VIVO: editar + push a main, sin re-importar ni re-activar el workflow. Mismo patron que shared/operaciones/watchdogs_mo.json.",
   "_doc": "comercial/baseline.md §5 + comercial/SUPUESTOS.md §T2",
 
-  "activo": true,
+  "activo": false,
+  "_activo_nota": "Puesto en false el 2026-09-09 (auditoria #220 Bloque 0). El workflow hJNTUd8E57W4rfjU esta INACTIVO en n8n (triggerCount 0) desde su creacion; la config decia true y contradecia a la realidad. NO prender sin rehacer la medicion sobre chatter: hoy mide desde write_date y 60 ordenes comparten el mismo write_date de una escritura masiva, asi que cualquier script que toque sale.order en masa resetea todos los semaforos a verde. Ver comercial/ROADMAP.md (watchdog v2).",
   "canary": true,
   "_canary_nota": "canary=true => el digest va SOLO a recipients.esteban. Poner en false y llenar recipients.equipo[] es la decision manual de rollout al equipo. Ver CHECKLIST-MANUAL.md.",
 

--- a/shared/operaciones/sla_stages.TEST.json
+++ b/shared/operaciones/sla_stages.TEST.json
@@ -3,11 +3,12 @@
     "doc": "docs/operaciones/SEMAFORO_WATCHDOG.md",
     "_ATENCION": "ARCHIVO DE PRUEBA. Identico a sla_stages.json salvo modo_prueba:true, que manda UN correo unico a alert_recipient_default y silencia los log notes. Existe para ejercitar el renderizador contra el camino real de produccion (workflow -> Graph -> sales@fts.mx) sin escribirle al equipo. El workflow NUNCA debe quedar apuntado aqui: se apunta, se dispara a mano, y se regresa a sla_stages.json en main.",
     "descripcion": "Config del semáforo/watchdog operativo. Umbrales por stage (project.project.stage_id) para 2 métricas: A=tiempo en stage (chatter subtype 94), B=tiempo sin seguimiento (chatter comment no-bot). 🟡 = max(🔴 - 1, 1). Días = HÁBILES (excluye sáb/dom) contados en hora de Monterrey. Todo read-only en Odoo salvo el log note al chatter.",
-    "version": "1.3",
+    "version": "1.4-TEST-digest",
     "fecha": "2026-09-09",
     "_cambios_v1_3": "S1 de la auditoria #220 (2026-09-09). NINGUN UMBRAL SE MOVIO. Cambios de config: (1) comercial_whitelist_partner_ids 306 -> [306,12,996,3]; (2) ap_confirmacion.aplica_stages [13] -> []; (3) observacion.stages [13] -> [] (caduco el 24-ago); (4) info_comercialFTS fuera de los dos grupos. En el codigo (Code - MAIN y Code - buildEmail): semaforo B retirado del REPORTE pero sigue calculandose, reporte solo del delta contra la corrida previa, banderas una vez por evento, guarda de vacio en los 9 nodos Odoo, guarda de vacio del correo con latido de lunes. Medido sobre el correo del 8-sep: Operaciones 28 lineas -> 0 (no se manda), Admin 25 -> 2.",
     "_cambios_v1_2": "Recalibración a política de captura DIARIA (Mundo A: el run se queda a las 8:00 CST). Semáforo B uniformado a rojo_dias=2 / amarillo=1 en TODOS los stages activos — a las 8:00, 1d significa 'escribió el día hábil anterior y aún no hoy' (normal para quien cumple) y solo 2d es un día hábil perdido; con rojo_dias=1 el semáforo marcaba rojo a gente que sí cumplía (caso real: proy 241, 09-ago). Stage 13 entra en observación hasta 2026-08-24 (ver bloque 'observacion'). Nuevos: guard de nota vacía, detección de nota repetida, bloque SEGUIMIENTO SIN AVANCE y bandera hold_sin_fecha_vigente.",
-    "_cambios_v1_1": "bizDays reescrito: días hábiles TRANSCURRIDOS desde la nota (hoy=0, ayer hábil=1), con granularidad de día en hora de Monterrey. Antes contaba el día de la nota Y el día en curso, y operaba en la TZ del contenedor (UTC), lo que hacía que una nota de ayer 07:26 CST leyera '2d' y saliera roja al día siguiente. Umbrales SIN recalibrar todavía — cambiaron de significado."
+    "_cambios_v1_1": "bizDays reescrito: días hábiles TRANSCURRIDOS desde la nota (hoy=0, ayer hábil=1), con granularidad de día en hora de Monterrey. Antes contaba el día de la nota Y el día en curso, y operaba en la TZ del contenedor (UTC), lo que hacía que una nota de ayer 07:26 CST leyera '2d' y saliera roja al día siguiente. Umbrales SIN recalibrar todavía — cambiaron de significado.",
+    "_cambios_v1_4": "Copia de prueba con digest_dias [3] (miercoles) para ejercitar el render del digest en vivo antes de publicar, y modo_prueba true. Difiere de sla_stages.json SOLO en modo_prueba, digest_dias y _meta.version. El workflow NUNCA debe quedar apuntado aqui."
   },
   "config": {
     "alert_recipient_default": "estebandelacruz@fts.mx",
@@ -64,8 +65,7 @@
     "digest_dias": [
       3
     ],
-    "_digest_dias_nota": "Dias en que el correo trae ademas el ESTADO COMPLETO de todos los proyectos vigilados (el resto de la semana es solo delta). getDay(): 0=domingo, 1=lunes ... 6=sabado. Produccion = [1] (lunes). Si la llave falta, el codigo asume [1].",
-    "version": "1.4-TEST-digest"
+    "_digest_dias_nota": "Dias en que el correo trae ademas el ESTADO COMPLETO de todos los proyectos vigilados (el resto de la semana es solo delta). getDay(): 0=domingo, 1=lunes ... 6=sabado. Produccion = [1] (lunes). Si la llave falta, el codigo asume [1]."
   },
   "stages": {
     "1": {

--- a/shared/operaciones/sla_stages.TEST.json
+++ b/shared/operaciones/sla_stages.TEST.json
@@ -1,6 +1,7 @@
 {
   "_meta": {
     "doc": "docs/operaciones/SEMAFORO_WATCHDOG.md",
+    "_ATENCION": "ARCHIVO DE PRUEBA. Identico a sla_stages.json salvo modo_prueba:true, que manda UN correo unico a alert_recipient_default y silencia los log notes. Existe para ejercitar el renderizador contra el camino real de produccion (workflow -> Graph -> sales@fts.mx) sin escribirle al equipo. El workflow NUNCA debe quedar apuntado aqui: se apunta, se dispara a mano, y se regresa a sla_stages.json en main.",
     "descripcion": "Config del semáforo/watchdog operativo. Umbrales por stage (project.project.stage_id) para 2 métricas: A=tiempo en stage (chatter subtype 94), B=tiempo sin seguimiento (chatter comment no-bot). 🟡 = max(🔴 - 1, 1). Días = HÁBILES (excluye sáb/dom) contados en hora de Monterrey. Todo read-only en Odoo salvo el log note al chatter.",
     "version": "1.3",
     "fecha": "2026-09-09",
@@ -10,7 +11,7 @@
   },
   "config": {
     "alert_recipient_default": "estebandelacruz@fts.mx",
-    "modo_prueba": false,
+    "modo_prueba": true,
     "log_note_silenciar_en_prueba": true,
     "_recipients_nota": "S1 2026-09-09 (#220): se saco info_comercialFTS@fts.mx de los DOS grupos. Es un buzon compartido que recibia ~114 correos por trimestre y no acciona ninguno de los renglones; un buzon de grupo en copia diaria es donde la alerta muere sin dueno. Si Comercial necesita visibilidad, va por el digest semanal (S3+).",
     "recipients_por_grupo": {

--- a/shared/operaciones/sla_stages.TEST.json
+++ b/shared/operaciones/sla_stages.TEST.json
@@ -19,10 +19,17 @@
       "Admin": "erick@fts.mx, gerardo@fts.mx, carolina@fts.mx, estebandelacruz@fts.mx"
     },
     "watchdog_author_partner_id": 2,
-    "comercial_whitelist_partner_ids": [306, 12, 996, 3],
+    "comercial_whitelist_partner_ids": [
+      306,
+      12,
+      996,
+      3
+    ],
     "_comercial_whitelist_nota": "S1 2026-09-09 (#220 error #5): antes solo [306], asi que los dos usuarios que hacen el trabajo real y el propio CEO se acusaban a si mismos. Agregados con su id leido del crudo de la ejecucion 90897: 12 OPERACIONES FTS-YIN (133 de las 265 banderas stage_atras), 996 Administracion FTS-YIN, 3 Jesus Esteban De La Cruz (18 apariciones de un SOLO cambio de fecha). La seccion del correo se renombro a CAMBIOS FUERA DE COMERCIAL: no es una acusacion de manipulacion.",
     "materiales_field": "x_studio_product_type",
-    "materiales_values": ["MRO"],
+    "materiales_values": [
+      "MRO"
+    ],
     "in_progress_fallback_dias": 30,
     "credit_fallback_days": 30,
     "credit_extra_days": 7,
@@ -41,56 +48,145 @@
       "requiere_imagen": true,
       "aplica_stages": [],
       "_apagado_nota": "S1 2026-09-09 (#220 error 'ap 8 de 8'): apagado poniendo aplica_stages en []. Disparo en 8 de 8 proyectos del stage 13 y acumulo 509 apariciones, el tipo de bandera mas frecuente de la historia. Decision pendiente de Esteban: (a) es un requisito real -> es capacitacion + fecha de arranque, y hasta esa fecha no va en el correo; (b) no se va a adoptar -> se queda apagado. Reconsiderar cuando S3 lea invoice_date_due: buena parte de lo que este control queria aproximar lo responde mejor el vencimiento real de la factura.",
-      "_aplica_stages_previo": [13]
+      "_aplica_stages_previo": [
+        13
+      ]
     },
-    "cadencia": { "watchdog": "dias_habiles_8am_cst", "ops": ["diario", "semanal"], "kpi_cumplimiento": "semanal", "cierre": "mensual" }
+    "cadencia": {
+      "watchdog": "dias_habiles_8am_cst",
+      "ops": [
+        "diario",
+        "semanal"
+      ],
+      "kpi_cumplimiento": "semanal",
+      "cierre": "mensual"
+    },
+    "digest_dias": [
+      3
+    ],
+    "_digest_dias_nota": "Dias en que el correo trae ademas el ESTADO COMPLETO de todos los proyectos vigilados (el resto de la semana es solo delta). getDay(): 0=domingo, 1=lunes ... 6=sabado. Produccion = [1] (lunes). Si la llave falta, el codigo asume [1].",
+    "version": "1.4-TEST-digest"
   },
   "stages": {
     "1": {
-      "label": "To Do", "grupo": "Operaciones",
-      "en_stage": { "modo": "fijo", "rojo_dias": 1 },
-      "sin_seguimiento": { "modo": "fijo", "rojo_dias": 2 }
+      "label": "To Do",
+      "grupo": "Operaciones",
+      "en_stage": {
+        "modo": "fijo",
+        "rojo_dias": 1
+      },
+      "sin_seguimiento": {
+        "modo": "fijo",
+        "rojo_dias": 2
+      }
     },
     "2": {
-      "label": "In Progress", "grupo": "Operaciones",
-      "en_stage": { "modo": "due_date", "campo": "date", "fallback_dias": 30 },
-      "sin_seguimiento": { "modo": "fijo", "rojo_dias": 2 }
-    },
-    "5": {
-      "label": "Hold", "grupo": "Operaciones",
-      "en_stage": { "modo": "fijo", "rojo_dias": 30 },
-      "sin_seguimiento": { "modo": "fijo", "rojo_dias": 2 }
+      "label": "In Progress",
+      "grupo": "Operaciones",
+      "en_stage": {
+        "modo": "due_date",
+        "campo": "date",
+        "fallback_dias": 30
+      },
+      "sin_seguimiento": {
+        "modo": "fijo",
+        "rojo_dias": 2
+      }
     },
     "3": {
-      "label": "Done Operations", "grupo": "Admin",
-      "en_stage": { "modo": "fijo", "rojo_dias": 2 },
-      "sin_seguimiento": { "modo": "fijo", "rojo_dias": 2 }
+      "label": "Done Operations",
+      "grupo": "Admin",
+      "en_stage": {
+        "modo": "fijo",
+        "rojo_dias": 2
+      },
+      "sin_seguimiento": {
+        "modo": "fijo",
+        "rojo_dias": 2
+      }
+    },
+    "5": {
+      "label": "Hold",
+      "grupo": "Operaciones",
+      "en_stage": {
+        "modo": "fijo",
+        "rojo_dias": 30
+      },
+      "sin_seguimiento": {
+        "modo": "fijo",
+        "rojo_dias": 2
+      }
     },
     "7": {
-      "label": "Admin - In progress", "grupo": "Admin",
-      "en_stage": { "modo": "fijo", "rojo_dias": 14 },
-      "sin_seguimiento": { "modo": "fijo", "rojo_dias": 2 }
+      "label": "Admin - In progress",
+      "grupo": "Admin",
+      "en_stage": {
+        "modo": "fijo",
+        "rojo_dias": 14
+      },
+      "sin_seguimiento": {
+        "modo": "fijo",
+        "rojo_dias": 2
+      }
     },
     "13": {
-      "label": "En plazo de credito", "grupo": "Admin",
-      "en_stage": { "modo": "credito" },
-      "sin_seguimiento": { "modo": "fijo", "rojo_dias": 2 }
+      "label": "En plazo de credito",
+      "grupo": "Admin",
+      "en_stage": {
+        "modo": "credito"
+      },
+      "sin_seguimiento": {
+        "modo": "fijo",
+        "rojo_dias": 2
+      }
     }
   },
   "materiales_overrides": {
-    "_descripcion": "Proyectos cuya SO tiene x_studio_product_type='MRO'. Umbrales agresivos + sub-semáforo SEPARADO (impacta Compras + Ops).",
-    "1": { "en_stage": { "modo": "fijo", "rojo_dias": 1 }, "sin_seguimiento": { "modo": "fijo", "rojo_dias": 1 } },
-    "2": { "en_stage": { "modo": "fijo", "rojo_dias": 1 }, "sin_seguimiento": { "modo": "fijo", "rojo_dias": 2 } }
+    "1": {
+      "en_stage": {
+        "modo": "fijo",
+        "rojo_dias": 1
+      },
+      "sin_seguimiento": {
+        "modo": "fijo",
+        "rojo_dias": 1
+      }
+    },
+    "2": {
+      "en_stage": {
+        "modo": "fijo",
+        "rojo_dias": 1
+      },
+      "sin_seguimiento": {
+        "modo": "fijo",
+        "rojo_dias": 2
+      }
+    },
+    "_descripcion": "Proyectos cuya SO tiene x_studio_product_type='MRO'. Umbrales agresivos + sub-semáforo SEPARADO (impacta Compras + Ops)."
   },
-  "excluidos": [8, 4, 6],
-  "_excluidos_labels": { "8": "Complete TOTAL (Gera)", "4": "Canceled", "6": "Templates" },
+  "excluidos": [
+    8,
+    4,
+    6
+  ],
+  "_excluidos_labels": {
+    "4": "Canceled",
+    "6": "Templates",
+    "8": "Complete TOTAL (Gera)"
+  },
   "observacion": {
     "_descripcion": "Stages cuyo criterio de seguimiento acaba de cambiar. Mientras dure, siguen puntuando en bloques, contadores y KPI con su criterio PREVIO (sin_seguimiento_previo); su veredicto con el criterio NUEVO aparece SOLO en la sección '🔬 NUEVO CRITERIO — EN OBSERVACIÓN' del correo. Al pasar la fecha 'hasta', la excepción caduca sola y el stage entra al régimen normal sin tocar nada.",
     "stages": [],
-    "_stages_previo": [13],
+    "_stages_previo": [
+      13
+    ],
     "hasta": "2026-08-24",
     "_caducado_nota": "S1 2026-09-09 (#220): la excepcion caduco el 2026-08-24 y el bloque seguia en el correo. stages vaciado. El mecanismo (caduca solo, sin tocar nada) esta bien disenado y se conserva documentado para la proxima vez que un stage cambie de criterio. Efecto medido de su caducidad: el rojo del semaforo B en el grupo Admin salto de 1 el 21-ago a 18 el 24-ago.",
-    "sin_seguimiento_previo": { "13": { "modo": "credito" } }
+    "sin_seguimiento_previo": {
+      "13": {
+        "modo": "credito"
+      }
+    }
   },
   "nota_repetida": {
     "_descripcion": "Detección de copy-paste en el chatter. Compara cada nota contra la anterior del mismo proyecto: texto normalizado idéntico, o coeficiente de Dice sobre bigramas de caracteres >= umbral_similitud. Usa el campo 'body' que YA viene en 'Odoo - getAll msgComment' → cero consultas extra a Odoo. Las notas vacías se descartan ANTES de comparar. Medición 10-jul→09-ago: 43 de 195 notas (25%) caerían en la regla; racha máxima 10 (proy 2356).",
@@ -102,7 +198,9 @@
     "dias_en_stage_min": 60
   },
   "banderas": {
-    "hold_sin_fecha_stages": [5],
+    "hold_sin_fecha_stages": [
+      5
+    ],
     "_hold_sin_fecha_vigente": "Levanta bandera si un proyecto en estos stages tiene project.date vacío o vencido. 'date' es la fecha comprometida de reactivación; la bandera solo sirve si el proceso la mantiene al mover a Hold. Caso 09-ago: proy 213 con fecha vencida el 30-jul y 244 días en Hold; proy 2352 con fecha 31-ago pero su propia nota decía 'se reanudan en diciembre 2026' — ninguna automatización caza esa contradicción.",
     "_nota_vacia": "Levanta bandera si el proyecto tiene log notes cuyo body normalizado queda vacío. Esas notas NO cuentan como seguimiento válido. Caso 09-ago: proy 2345 salía verde con 22d teniendo sus DOS únicas notas de toda su historia vacías; con el guard pasa a 39d desde create_date."
   },

--- a/shared/operaciones/sla_stages.json
+++ b/shared/operaciones/sla_stages.json
@@ -18,10 +18,17 @@
       "Admin": "erick@fts.mx, gerardo@fts.mx, carolina@fts.mx, estebandelacruz@fts.mx"
     },
     "watchdog_author_partner_id": 2,
-    "comercial_whitelist_partner_ids": [306, 12, 996, 3],
+    "comercial_whitelist_partner_ids": [
+      306,
+      12,
+      996,
+      3
+    ],
     "_comercial_whitelist_nota": "S1 2026-09-09 (#220 error #5): antes solo [306], asi que los dos usuarios que hacen el trabajo real y el propio CEO se acusaban a si mismos. Agregados con su id leido del crudo de la ejecucion 90897: 12 OPERACIONES FTS-YIN (133 de las 265 banderas stage_atras), 996 Administracion FTS-YIN, 3 Jesus Esteban De La Cruz (18 apariciones de un SOLO cambio de fecha). La seccion del correo se renombro a CAMBIOS FUERA DE COMERCIAL: no es una acusacion de manipulacion.",
     "materiales_field": "x_studio_product_type",
-    "materiales_values": ["MRO"],
+    "materiales_values": [
+      "MRO"
+    ],
     "in_progress_fallback_dias": 30,
     "credit_fallback_days": 30,
     "credit_extra_days": 7,
@@ -40,56 +47,145 @@
       "requiere_imagen": true,
       "aplica_stages": [],
       "_apagado_nota": "S1 2026-09-09 (#220 error 'ap 8 de 8'): apagado poniendo aplica_stages en []. Disparo en 8 de 8 proyectos del stage 13 y acumulo 509 apariciones, el tipo de bandera mas frecuente de la historia. Decision pendiente de Esteban: (a) es un requisito real -> es capacitacion + fecha de arranque, y hasta esa fecha no va en el correo; (b) no se va a adoptar -> se queda apagado. Reconsiderar cuando S3 lea invoice_date_due: buena parte de lo que este control queria aproximar lo responde mejor el vencimiento real de la factura.",
-      "_aplica_stages_previo": [13]
+      "_aplica_stages_previo": [
+        13
+      ]
     },
-    "cadencia": { "watchdog": "dias_habiles_8am_cst", "ops": ["diario", "semanal"], "kpi_cumplimiento": "semanal", "cierre": "mensual" }
+    "cadencia": {
+      "watchdog": "dias_habiles_8am_cst",
+      "ops": [
+        "diario",
+        "semanal"
+      ],
+      "kpi_cumplimiento": "semanal",
+      "cierre": "mensual"
+    },
+    "digest_dias": [
+      1
+    ],
+    "_digest_dias_nota": "Dias en que el correo trae ademas el ESTADO COMPLETO de todos los proyectos vigilados (el resto de la semana es solo delta). getDay(): 0=domingo, 1=lunes ... 6=sabado. Produccion = [1] (lunes). Si la llave falta, el codigo asume [1].",
+    "version": "1.4"
   },
   "stages": {
     "1": {
-      "label": "To Do", "grupo": "Operaciones",
-      "en_stage": { "modo": "fijo", "rojo_dias": 1 },
-      "sin_seguimiento": { "modo": "fijo", "rojo_dias": 2 }
+      "label": "To Do",
+      "grupo": "Operaciones",
+      "en_stage": {
+        "modo": "fijo",
+        "rojo_dias": 1
+      },
+      "sin_seguimiento": {
+        "modo": "fijo",
+        "rojo_dias": 2
+      }
     },
     "2": {
-      "label": "In Progress", "grupo": "Operaciones",
-      "en_stage": { "modo": "due_date", "campo": "date", "fallback_dias": 30 },
-      "sin_seguimiento": { "modo": "fijo", "rojo_dias": 2 }
-    },
-    "5": {
-      "label": "Hold", "grupo": "Operaciones",
-      "en_stage": { "modo": "fijo", "rojo_dias": 30 },
-      "sin_seguimiento": { "modo": "fijo", "rojo_dias": 2 }
+      "label": "In Progress",
+      "grupo": "Operaciones",
+      "en_stage": {
+        "modo": "due_date",
+        "campo": "date",
+        "fallback_dias": 30
+      },
+      "sin_seguimiento": {
+        "modo": "fijo",
+        "rojo_dias": 2
+      }
     },
     "3": {
-      "label": "Done Operations", "grupo": "Admin",
-      "en_stage": { "modo": "fijo", "rojo_dias": 2 },
-      "sin_seguimiento": { "modo": "fijo", "rojo_dias": 2 }
+      "label": "Done Operations",
+      "grupo": "Admin",
+      "en_stage": {
+        "modo": "fijo",
+        "rojo_dias": 2
+      },
+      "sin_seguimiento": {
+        "modo": "fijo",
+        "rojo_dias": 2
+      }
+    },
+    "5": {
+      "label": "Hold",
+      "grupo": "Operaciones",
+      "en_stage": {
+        "modo": "fijo",
+        "rojo_dias": 30
+      },
+      "sin_seguimiento": {
+        "modo": "fijo",
+        "rojo_dias": 2
+      }
     },
     "7": {
-      "label": "Admin - In progress", "grupo": "Admin",
-      "en_stage": { "modo": "fijo", "rojo_dias": 14 },
-      "sin_seguimiento": { "modo": "fijo", "rojo_dias": 2 }
+      "label": "Admin - In progress",
+      "grupo": "Admin",
+      "en_stage": {
+        "modo": "fijo",
+        "rojo_dias": 14
+      },
+      "sin_seguimiento": {
+        "modo": "fijo",
+        "rojo_dias": 2
+      }
     },
     "13": {
-      "label": "En plazo de credito", "grupo": "Admin",
-      "en_stage": { "modo": "credito" },
-      "sin_seguimiento": { "modo": "fijo", "rojo_dias": 2 }
+      "label": "En plazo de credito",
+      "grupo": "Admin",
+      "en_stage": {
+        "modo": "credito"
+      },
+      "sin_seguimiento": {
+        "modo": "fijo",
+        "rojo_dias": 2
+      }
     }
   },
   "materiales_overrides": {
-    "_descripcion": "Proyectos cuya SO tiene x_studio_product_type='MRO'. Umbrales agresivos + sub-semáforo SEPARADO (impacta Compras + Ops).",
-    "1": { "en_stage": { "modo": "fijo", "rojo_dias": 1 }, "sin_seguimiento": { "modo": "fijo", "rojo_dias": 1 } },
-    "2": { "en_stage": { "modo": "fijo", "rojo_dias": 1 }, "sin_seguimiento": { "modo": "fijo", "rojo_dias": 2 } }
+    "1": {
+      "en_stage": {
+        "modo": "fijo",
+        "rojo_dias": 1
+      },
+      "sin_seguimiento": {
+        "modo": "fijo",
+        "rojo_dias": 1
+      }
+    },
+    "2": {
+      "en_stage": {
+        "modo": "fijo",
+        "rojo_dias": 1
+      },
+      "sin_seguimiento": {
+        "modo": "fijo",
+        "rojo_dias": 2
+      }
+    },
+    "_descripcion": "Proyectos cuya SO tiene x_studio_product_type='MRO'. Umbrales agresivos + sub-semáforo SEPARADO (impacta Compras + Ops)."
   },
-  "excluidos": [8, 4, 6],
-  "_excluidos_labels": { "8": "Complete TOTAL (Gera)", "4": "Canceled", "6": "Templates" },
+  "excluidos": [
+    8,
+    4,
+    6
+  ],
+  "_excluidos_labels": {
+    "4": "Canceled",
+    "6": "Templates",
+    "8": "Complete TOTAL (Gera)"
+  },
   "observacion": {
     "_descripcion": "Stages cuyo criterio de seguimiento acaba de cambiar. Mientras dure, siguen puntuando en bloques, contadores y KPI con su criterio PREVIO (sin_seguimiento_previo); su veredicto con el criterio NUEVO aparece SOLO en la sección '🔬 NUEVO CRITERIO — EN OBSERVACIÓN' del correo. Al pasar la fecha 'hasta', la excepción caduca sola y el stage entra al régimen normal sin tocar nada.",
     "stages": [],
-    "_stages_previo": [13],
+    "_stages_previo": [
+      13
+    ],
     "hasta": "2026-08-24",
     "_caducado_nota": "S1 2026-09-09 (#220): la excepcion caduco el 2026-08-24 y el bloque seguia en el correo. stages vaciado. El mecanismo (caduca solo, sin tocar nada) esta bien disenado y se conserva documentado para la proxima vez que un stage cambie de criterio. Efecto medido de su caducidad: el rojo del semaforo B en el grupo Admin salto de 1 el 21-ago a 18 el 24-ago.",
-    "sin_seguimiento_previo": { "13": { "modo": "credito" } }
+    "sin_seguimiento_previo": {
+      "13": {
+        "modo": "credito"
+      }
+    }
   },
   "nota_repetida": {
     "_descripcion": "Detección de copy-paste en el chatter. Compara cada nota contra la anterior del mismo proyecto: texto normalizado idéntico, o coeficiente de Dice sobre bigramas de caracteres >= umbral_similitud. Usa el campo 'body' que YA viene en 'Odoo - getAll msgComment' → cero consultas extra a Odoo. Las notas vacías se descartan ANTES de comparar. Medición 10-jul→09-ago: 43 de 195 notas (25%) caerían en la regla; racha máxima 10 (proy 2356).",
@@ -101,7 +197,9 @@
     "dias_en_stage_min": 60
   },
   "banderas": {
-    "hold_sin_fecha_stages": [5],
+    "hold_sin_fecha_stages": [
+      5
+    ],
     "_hold_sin_fecha_vigente": "Levanta bandera si un proyecto en estos stages tiene project.date vacío o vencido. 'date' es la fecha comprometida de reactivación; la bandera solo sirve si el proceso la mantiene al mover a Hold. Caso 09-ago: proy 213 con fecha vencida el 30-jul y 244 días en Hold; proy 2352 con fecha 31-ago pero su propia nota decía 'se reanudan en diciembre 2026' — ninguna automatización caza esa contradicción.",
     "_nota_vacia": "Levanta bandera si el proyecto tiene log notes cuyo body normalizado queda vacío. Esas notas NO cuentan como seguimiento válido. Caso 09-ago: proy 2345 salía verde con 22d teniendo sus DOS únicas notas de toda su historia vacías; con el guard pasa a 39d desde create_date."
   },

--- a/shared/operaciones/sla_stages.json
+++ b/shared/operaciones/sla_stages.json
@@ -2,11 +2,12 @@
   "_meta": {
     "doc": "docs/operaciones/SEMAFORO_WATCHDOG.md",
     "descripcion": "Config del semáforo/watchdog operativo. Umbrales por stage (project.project.stage_id) para 2 métricas: A=tiempo en stage (chatter subtype 94), B=tiempo sin seguimiento (chatter comment no-bot). 🟡 = max(🔴 - 1, 1). Días = HÁBILES (excluye sáb/dom) contados en hora de Monterrey. Todo read-only en Odoo salvo el log note al chatter.",
-    "version": "1.3",
+    "version": "1.4",
     "fecha": "2026-09-09",
     "_cambios_v1_3": "S1 de la auditoria #220 (2026-09-09). NINGUN UMBRAL SE MOVIO. Cambios de config: (1) comercial_whitelist_partner_ids 306 -> [306,12,996,3]; (2) ap_confirmacion.aplica_stages [13] -> []; (3) observacion.stages [13] -> [] (caduco el 24-ago); (4) info_comercialFTS fuera de los dos grupos. En el codigo (Code - MAIN y Code - buildEmail): semaforo B retirado del REPORTE pero sigue calculandose, reporte solo del delta contra la corrida previa, banderas una vez por evento, guarda de vacio en los 9 nodos Odoo, guarda de vacio del correo con latido de lunes. Medido sobre el correo del 8-sep: Operaciones 28 lineas -> 0 (no se manda), Admin 25 -> 2.",
     "_cambios_v1_2": "Recalibración a política de captura DIARIA (Mundo A: el run se queda a las 8:00 CST). Semáforo B uniformado a rojo_dias=2 / amarillo=1 en TODOS los stages activos — a las 8:00, 1d significa 'escribió el día hábil anterior y aún no hoy' (normal para quien cumple) y solo 2d es un día hábil perdido; con rojo_dias=1 el semáforo marcaba rojo a gente que sí cumplía (caso real: proy 241, 09-ago). Stage 13 entra en observación hasta 2026-08-24 (ver bloque 'observacion'). Nuevos: guard de nota vacía, detección de nota repetida, bloque SEGUIMIENTO SIN AVANCE y bandera hold_sin_fecha_vigente.",
-    "_cambios_v1_1": "bizDays reescrito: días hábiles TRANSCURRIDOS desde la nota (hoy=0, ayer hábil=1), con granularidad de día en hora de Monterrey. Antes contaba el día de la nota Y el día en curso, y operaba en la TZ del contenedor (UTC), lo que hacía que una nota de ayer 07:26 CST leyera '2d' y saliera roja al día siguiente. Umbrales SIN recalibrar todavía — cambiaron de significado."
+    "_cambios_v1_1": "bizDays reescrito: días hábiles TRANSCURRIDOS desde la nota (hoy=0, ayer hábil=1), con granularidad de día en hora de Monterrey. Antes contaba el día de la nota Y el día en curso, y operaba en la TZ del contenedor (UTC), lo que hacía que una nota de ayer 07:26 CST leyera '2d' y saliera roja al día siguiente. Umbrales SIN recalibrar todavía — cambiaron de significado.",
+    "_cambios_v1_4": "Digest semanal (adicion a S1, #223). Nueva llave config.digest_dias = [1]: el lunes el correo trae, ademas del delta, el ESTADO COMPLETO de todos los proyectos vigilados. El resto de la semana sigue siendo delta puro. NINGUN UMBRAL SE MOVIO y ningun calculo cambio: misma metrica, solo cambia QUE se imprime segun el dia. Si la llave falta, el codigo asume [1] (lado tolerante primero). Corregido de paso un defecto de la propia sesion: el bump se habia escrito en un config.version nuevo en vez de _meta.version, dejando dos numeros de version que se contradecian."
   },
   "config": {
     "alert_recipient_default": "estebandelacruz@fts.mx",
@@ -63,8 +64,7 @@
     "digest_dias": [
       1
     ],
-    "_digest_dias_nota": "Dias en que el correo trae ademas el ESTADO COMPLETO de todos los proyectos vigilados (el resto de la semana es solo delta). getDay(): 0=domingo, 1=lunes ... 6=sabado. Produccion = [1] (lunes). Si la llave falta, el codigo asume [1].",
-    "version": "1.4"
+    "_digest_dias_nota": "Dias en que el correo trae ademas el ESTADO COMPLETO de todos los proyectos vigilados (el resto de la semana es solo delta). getDay(): 0=domingo, 1=lunes ... 6=sabado. Produccion = [1] (lunes). Si la llave falta, el codigo asume [1]."
   },
   "stages": {
     "1": {


### PR DESCRIPTION
Cierra la brecha de #220 / #223. **El workflow `ops/watchdog-semaforo` ya corre el código nuevo contra la config VIEJA de `main`**; este merge es lo que alinea las dos mitades.

Issues: **#220** (auditoría) · **#223** (S1) · **#225** (S2) · **#226** (semáforo en vivo).

---

## Los commits — 7, no 6

| SHA | Qué |
|---|---|
| `ebc412c` | Auditoría de `ops/watchdog-semaforo` + `fin/watchdog-captura` y propuesta de rediseño |
| `18ea17d` | **Config S1**: retira ruido sin mover ningún umbral |
| `9f7878b` | Cuerpos de los Code nodes de S1, para que el cambio sea revisable en un diff |
| `d5dc91c` | **`digest_dias` configurable**: el estado completo sale los lunes |
| `0b74bcd` | S1 publicado: **redacción de `cliente`** en snapshots + `Code-buildSnapshot.js` |
| `9e76d60` | Auditoría del semáforo en vivo + prototipo sin backend |
| `79be250` | **`fix`**: el bump de versión va en `_meta.version`, no en `config` |

> El séptimo salió de verificar este PR. El bump del digest había escrito `config.version = "1.4"` —un campo **nuevo**— mientras `_meta.version`, que es donde este archivo versiona desde v1.1, se quedaba en `"1.3"`. Dos números de versión contradiciéndose en un archivo que se lee **en vivo** desde `main`. Sin impacto funcional (ningún Code node lee `version`), pero es justo lo que manda a la siguiente sesión a mirar el número equivocado — y la descripción de este PR iba a citar uno de los dos.

**S2 no aporta commits**: fue una medición read-only. Su resultado vive completo en **#225**.

---

## Verificaciones antes de mergear

### 1 · Conflictos con `main`: ninguno

```
merge-base: 1add0a2
main avanzó 5 commits desde la base
git merge-tree <base> origin/main HEAD  ->  0 marcadores de conflicto
```

Y por la vía independiente: de los 14 archivos que `main` tocó en esos 5 commits
(`comercial/machote/*`, `CLAUDE.md`, `shared/config-sync.js`, `db/migrations/…`,
`shared/config/empleados-master.json`, el snapshot del 9-sep), **ninguno** está entre los 11
de esta rama. Conjuntos disjuntos.

### 2 · `sla_stages.json` queda en lo que el código publicado espera

Diff **semántico** (recursivo sobre el objeto, no por líneas) contra `main`. Cambios funcionales, exactamente 6:

| campo | main | rama |
|---|---|---|
| `config.recipients_por_grupo.Operaciones` | …`, info_comercialFTS@fts.mx` | **sin** `info_comercialFTS` |
| `config.recipients_por_grupo.Admin` | …`, info_comercialFTS@fts.mx` | **sin** `info_comercialFTS` |
| `config.comercial_whitelist_partner_ids` | `[306]` | `[306,12,996,3]` |
| `config.ap_confirmacion.aplica_stages` | `[13]` | `[]` |
| `observacion.stages` | `[13]` | `[]` |
| `config.digest_dias` | *(no existía)* | `[1]` |

Más 8 llaves `_*` de pura documentación y `_meta.version` 1.2 → 1.4.

**Ningún umbral se movió — verificado uno por uno, no afirmado:**

```
stage 1  To Do                IDENTICO      config.credit_fallback_days              IDENTICO  30
stage 2  In Progress          IDENTICO      config.credit_extra_days                 IDENTICO  7
stage 3  Done Operations      IDENTICO      config.in_progress_fallback_dias         IDENTICO  30
stage 5  Hold                 IDENTICO      config.in_progress_amarillo_dias_habiles IDENTICO  3
stage 7  Admin - In progress  IDENTICO      config.tz_offset_hours                   IDENTICO  -6
stage 13 En plazo de credito  IDENTICO      config.excluir_findes                    IDENTICO  true
                                            nota_repetida.umbral_similitud           IDENTICO  0.85
                                            nota_repetida.racha_minima               IDENTICO  2
                                            sin_avance.dias_en_stage_min             IDENTICO  60

>>> UMBRALES MOVIDOS: 0
```

Y la config de la rama **pasa las guardas del código publicado**, ejecutadas contra el archivo real:

```
GUARDA DE buildEmail:     PASA
LECTURAS DE Code - MAIN:  TODAS PRESENTES
modo_prueba = false       (correcto para main)
```

### 3 · Sin secretos en el diff

9 reglas sobre las **3,326 líneas agregadas**: hex de 32+, JWT `eyJ…`, PAT de GitHub, PEM de clave privada, URL de webhook n8n, dominio `primary-production-*`, asignaciones `secret|token|api_key|password|salt|hash`, base64 largo suelto, y nombres de variables de entorno conocidas (`ODOO_RPC_KEY`, `N8N_API_KEY`, `SUITE_JWT_SECRET`, `FINANZAS_JWT_SECRET`, `FTS_COMERCIAL_HMAC`).

**Total de coincidencias: 0.**

---

## Qué cambia en producción al mergear

El código publicado (`versionId == activeVersionId == 2aac86ca-732e-4aab-9208-68f1e9458777`) lee esta config **en vivo** desde `main`. Con el merge, en el correo del próximo día hábil:

- **`ap_confirmacion` se apaga.** Disparaba en 8 de 8 proyectos del stage 13 y acumuló 509 apariciones — el tipo de bandera más frecuente de la historia. Mide algo que no está registrado en ningún sistema legible.
- **La whitelist pasa de 1 a 4 partners.** Antes, con solo `[306]`, los dos usuarios que hacen el trabajo real y el propio CEO se acusaban a sí mismos en «cambios fuera de Comercial».
- **`info_comercialFTS@fts.mx` sale de los dos grupos.** Buzón compartido que recibía ~114 correos por trimestre sin accionar ninguno.
- **`observacion.stages` se vacía.** La excepción caducó el 24-ago y el bloque seguía imprimiéndose.
- **`digest_dias: [1]`** hace explícito el lunes. El código ya asume `[1]` si la llave falta, así que esto no cambia comportamiento — lo documenta donde se configura.

**Nada de esto mueve un umbral.** Un renglón que desaparezca es por deduplicación, por destinatario, o porque la regla se apagó a propósito. Nunca por un cálculo.

## Qué NO cambia

`shared/comercial/watchdog_enviadas.json` pasa a `"activo": false` con nota: ese watchdog lleva inactivo desde su creación y mide desde `write_date`, pero 60 órdenes comparten un `write_date` de una escritura masiva. No se enciende sin rehacer la medición sobre el chatter.

## Plan de verificación posterior al merge

Confirmar **con una corrida real, no con el archivo**, que el workflow lee la config nueva: `ap_confirmacion` apagado, whitelist con 4 partners, e `info_comercialFTS` fuera de ambos grupos. Se reporta en #223.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BpNa3pA8Y3jDHR1FqQrPWv