### PR TITLE
feat(comercial/machote) V1.25: el préstamo completo, la lista que arranca en todas, y fuera lo último del andamio

### DIFF
--- a/comercial/machote/css/machote.css
+++ b/comercial/machote/css/machote.css
@@ -715,6 +715,15 @@ th .hint { font-weight: 400; text-transform: none; opacity: .75; }
 .hist-cols { display: grid; grid-template-columns: 320px 1fr; gap: 14px;
              align-items: start; margin-top: 12px; }
 @media (max-width: 760px) { .hist-cols { grid-template-columns: 1fr } }
+/* Las dos columnas del historial son celdas de grid, y una celda de grid trae
+ * `min-width: auto`: puede CRECER más que su carril si su contenido no cabe.
+ * El documento congelado es un `<pre>` con `white-space: pre`, así que medía
+ * 700 px y empujaba la columna — se salía 113 px del recuadro en escritorio y
+ * 368 px en teléfono, o sea que la caja del JSON colgaba fuera de la pantalla.
+ * Con `min-width: 0` la celda respeta su carril y el `overflow:auto` que el
+ * `<pre>` ya tenía por fin sirve para algo. Se vio en la captura, no en el
+ * diff (CLAUDE.md §20 #12). */
+.hist-cols > div { min-width: 0; }
 .hist-cols .v { border: 1px solid var(--linea); border-radius: 9px; padding: 9px 11px;
                 margin-bottom: 7px; cursor: pointer; background: var(--fondo); }
 .hist-cols .v:hover { border-color: var(--acento); }
@@ -964,6 +973,48 @@ tr.marcado td { background: #fffaf0; }
   .corr .btn.f-min,
   .ctrl-pie .btn.f-min,
   .aviso.pend .btn.chico { min-height: var(--toque); }
+}
+
+/* ══ El préstamo temporal de escritura (V1.25) ═══════════════════════════
+ * Tres piezas: la franja de arriba del machote, la píldora de la lista y el
+ * modal de prestar. Todas cuelgan de nombres con prefijo `presta-` porque
+ * `.modal` y `.caja` YA significan otra cosa en este archivo — reusarlos para
+ * el fondo y la tarjeta es correcto; inventar variantes suyas, no. */
+
+/* La franja. Ámbar cuando falta poco, rojo cuando ya venció, y en el caso del
+ * dueño un tono neutro: para él es información, no una alarma. */
+.presta-fr { border: 1px solid var(--linea); border-left: 3px solid var(--acento);
+             border-radius: 10px; padding: 10px 12px; margin: -4px 0 12px;
+             font-size: 13px; background: var(--papel);
+             display: flex; align-items: center; gap: 8px; flex-wrap: wrap; }
+.presta-fr .grow { flex: 1 1 240px; min-width: 0; }
+.presta-fr.dueno { border-left-color: var(--suave); color: var(--tinta); }
+.presta-fr.pronto { border-left-color: var(--ambar); background: #fffaf0; }
+.presta-fr.vencido { border-left-color: var(--rojo); background: #fff6f5; }
+.presta-fr .btn.chico { width: auto; padding: 0 12px; min-height: 32px; font-size: 12.5px; }
+
+/* La píldora de la lista. Verde apagado: dice «puedes escribir aquí», que es
+ * lo contrario de `.pill.aj` («sólo lectura») y tiene que leerse distinto de
+ * un vistazo, no sólo distinto de cerca. */
+.pill.presta { background: #e7f4ec; color: #1d6b3f; }
+
+/* El modal de prestar. */
+.presta-caja { max-width: 460px; }
+.pm-l { display: block; margin: 12px 0 0; font-size: 13px; color: var(--tinta); }
+.pm-l select { display: block; width: 100%; box-sizing: border-box; margin-top: 4px;
+               min-height: var(--toque); border: 1px solid var(--linea);
+               border-radius: 10px; padding: 0 10px; background: var(--fondo);
+               color: var(--tinta); font: inherit; }
+
+/* En el historial, la versión que NO escribió el dueño. Es el caso de las
+ * comisiones: tiene que verse sin conocer de memoria de quién es cada
+ * cotización. Se marca el renglón entero, no sólo la etiqueta, para que se
+ * distinga al recorrer la columna con la vista. */
+.hist .v.ajena, .v.ajena { border-left: 3px solid var(--ambar); }
+.chip.otro { background: var(--ambar); color: #4a3200; }
+
+@media (max-width: 640px) {
+  .presta-fr .btn.chico { min-height: var(--toque); }
 }
 
 /* ── Sesión vencida (V1.21) ───────────────────────────────────────────────

--- a/comercial/machote/index.html
+++ b/comercial/machote/index.html
@@ -51,6 +51,7 @@
 <script src="js/clientes.js"></script>
 <script src="js/respaldo.js"></script>
 <script src="js/historial.js"></script>
+<script src="js/prestamo.js"></script>
 <script src="js/control.js"></script>
 <script src="js/cotizacion.js"></script>
 <script src="js/orden.js"></script>

--- a/comercial/machote/js/almacen.js
+++ b/comercial/machote/js/almacen.js
@@ -51,9 +51,74 @@
    * pedirlo es el error que no tiene vuelta. */
   var LLAVE_BORRADOS = 'fts_machote_borrados_v1';
 
+  /* ── El cajón de lo PRESTADO (V1.25) ─────────────────────────────────────
+   * Un machote que otra persona me prestó es editable, así que lo que teclee
+   * tiene que sobrevivir una recarga. Pero NO puede vivir en `fts_machote_v1`:
+   * esa llave significa «lo mío» y meter ahí lo de otro rompe dos cosas
+   * concretas —el `id_local` de Ricardo puede chocar con uno mío, y `empujar`
+   * lo subiría como propio, que es cómo el servidor le pondría de dueño a
+   * quien manda—. Una prueba dedicada vigila que `fts_machote_v1` nunca
+   * contenga trabajo ajeno.
+   *
+   * Así que van a un cajón aparte, indexado por el UUID DEL SERVIDOR —que es
+   * como se nombra lo ajeno en pantalla— y con su propia contabilidad de
+   * versiones. Cada renglón:
+   *     { id_local, version_leida, documento, guardado_at }
+   * `id_local` es el REAL, el del dueño: es lo que el servidor necesita para
+   * saber sobre qué identidad está agregando una versión. Mandar el uuid en
+   * su lugar crearía un machote nuevo. */
+  var LLAVE_PRESTADO = 'fts_machote_prestado_v1';
+
+  function leerPrestados() {
+    try { return JSON.parse(localStorage.getItem(LLAVE_PRESTADO) || '{}') || {}; }
+    catch (e) { return {}; }
+  }
+  function escribirPrestados(o) {
+    try { localStorage.setItem(LLAVE_PRESTADO, JSON.stringify(o)); return true; }
+    catch (e) { return false; }
+  }
+
+  /** Guarda EN ESTE NAVEGADOR lo que se está tecleando sobre un prestado.
+   *  Síncrono y sin red, igual que `escribirLocal` para lo propio: es lo que
+   *  garantiza que un rechazo del servidor no cueste el trabajo. */
+  function guardarPrestadoLocal(m) {
+    if (!m || !m.id) return false;
+    var todos = leerPrestados();
+    var previo = todos[m.id] || {};
+    todos[m.id] = {
+      id_local: m._id_local || previo.id_local || null,
+      version_leida: (m._version_servidor !== undefined && m._version_servidor !== null)
+        ? m._version_servidor : (previo.version_leida || 0),
+      documento: documentoDeMachote(m),
+      guardado_at: new Date().toISOString()
+    };
+    return escribirPrestados(todos);
+  }
+
+  /** Lo deja de seguir: se subió, o se acabó el préstamo y ya no hay nada que
+   *  recuperar. NO se llama al vencer un permiso con cambios sin subir — ahí
+   *  justamente es cuando hace falta conservarlo. */
+  function olvidarPrestado(uuid) {
+    var todos = leerPrestados();
+    if (todos[uuid]) { delete todos[uuid]; escribirPrestados(todos); }
+  }
+
+  /* El documento limpio, sin los campos que le cuelga la pantalla a lo ajeno
+   * (`_ajeno`, `_dueno`, `_folio`…). Van con guion bajo por esto mismo. */
+  function documentoDeMachote(m) {
+    var o = {};
+    for (var k in m) {
+      if (!Object.prototype.hasOwnProperty.call(m, k)) continue;
+      if (k.charAt(0) === '_') continue;
+      o[k] = m[k];
+    }
+    return o;
+  }
+
   var BASE = 'https://primary-production-5c3c.up.railway.app/webhook';
   var URL_LEER = BASE + '/comercial/machotes-leer';
   var URL_GUARDAR = BASE + '/comercial/machote-guardar';
+  var URL_PRESTAR = BASE + '/comercial/machote-prestar';
   var TIMEOUT_MS = 12000;
 
   /* Que exista el objeto no basta: en modo privado de Safari `localStorage`
@@ -112,6 +177,7 @@
        * las lápidas sobrevivieran, la siguiente bajada saltaría machotes que
        * están en el servidor y nadie entendería por qué faltan. */
       localStorage.removeItem(LLAVE_BORRADOS);
+      localStorage.removeItem(LLAVE_PRESTADO);
     } catch (e) { /* nada que hacer */ }
   }
 
@@ -262,6 +328,31 @@
        * Va en el POST y no en cada llamador para que un endpoint nuevo no
        * pueda olvidarse de manejarlo. */
       if (G.MachoteSesion) G.MachoteSesion.vigilar(r);
+
+      /* ── Una respuesta que NO es nuestra ──────────────────────────────────
+       * Un webhook de n8n que existe pero todavía no está publicado contesta
+       * un 404 con JSON PROPIO de n8n (`{code, message, hint}`) — no lleva
+       * `ok`, así que sin esto cae en el «no se pudo» genérico y quien lo lee
+       * concluye que su cotización tiene algo malo.
+       *
+       * Se traduce AQUÍ, en el único punto por donde pasan todas las
+       * respuestas, por lo mismo que la sesión caduca aquí: un endpoint nuevo
+       * no puede olvidarse de manejarlo. Es la exigencia de §20 #12b —causas
+       * distintas, remedios distintos, dichas con palabras distintas—
+       * aplicada al caso «la mitad del servidor todavía no está encendida». */
+      if (r && r.ok === undefined && (typeof r.code === 'number' || r.message)) {
+        var apagado = /not registered|no est[áa] registrad/i.test(String(r.message || ''));
+        return {
+          ok: false,
+          error: apagado ? 'ENDPOINT_APAGADO' : 'RESPUESTA_NO_NUESTRA',
+          mensaje: apagado
+            ? 'Esta función todavía no está encendida en el servidor. No es un ' +
+              'problema de tu cotización: falta publicar el endpoint. Avísale a ' +
+              'quien administra la suite.'
+            : 'El servidor contestó algo que no es de este módulo. Vuelve a ' +
+              'intentarlo; si sigue, avísale a quien administra la suite.'
+        };
+      }
       return r;
     });
   }
@@ -319,6 +410,44 @@
    * Por eso los ajenos viven SÓLO en memoria, mientras dura la pantalla. */
   function esAjeno(m) { return !!(m && m._ajeno === true); }
 
+  /** ¿Tengo permiso VIGENTE para escribir en este machote ajeno?
+   *
+   *  Esto es para la PANTALLA —desbloquear los campos, no hacerle perder el
+   *  rato a nadie—, NO es la seguridad. La seguridad es que el servidor
+   *  comprueba el préstamo contra la base en cada guardado, con su propio
+   *  reloj: el del navegador puede ir adelantado, atrasado o movido a mano.
+   *
+   *  Por eso el vencimiento se mira aquí de forma OPTIMISTA (deja escribir
+   *  hasta que el servidor diga que no) en vez de trabar la hoja al segundo
+   *  exacto. Trabar a alguien a media frase por un reloj que no es el bueno
+   *  es peor que dejarlo terminar la frase y que el guardado lo diga. */
+  function prestadoAMi(m) {
+    if (!m || m._ajeno !== true) return false;
+    var p = m._prestamo_para_mi;
+    if (!p || !p.vence_at) return false;
+    var t = Date.parse(p.vence_at);
+    return isFinite(t) && t > Date.now();
+  }
+
+  /** ¿Puede esta persona escribir en este machote? Propio, o prestado vigente.
+   *
+   *  ⚠️ Un machote de DEMOSTRACIÓN sí se escribe, y es a propósito: en cuanto
+   *  alguien teclea encima deja de ser un ejemplo y pasa a ser su trabajo
+   *  (`tocado()` le quita el `_demo` en ese mismo momento). Lo que la demo no
+   *  puede hacer es SUBIR, y eso lo impiden dos candados distintos —no entra a
+   *  la lista de `empujar`, y `empujarUno` la rechaza aparte—.
+   *
+   *  La primera versión de esto devolvía `false` para la demo, y con eso
+   *  trababa la hoja de los cuatro ejemplos que trae la aplicación: cualquiera
+   *  que abriera la pantalla por primera vez se encontraba una cotización que
+   *  no se deja escribir. Lo cazaron 41 pruebas de la suite completa, ninguna
+   *  de ellas del préstamo — que es exactamente para lo que sirve correrla
+   *  entera antes de mergear. */
+  function puedeEscribir(m) {
+    if (!m) return false;
+    return !esAjeno(m) || prestadoAMi(m);
+  }
+
   function empujarUno(m, ses, motivo) {
     /* Segundo candado, además de no meterla en la lista: si mañana alguien
      * llama a `empujarUno` directo, la demo sigue sin llegar al servidor. */
@@ -329,9 +458,17 @@
     /* Mismo candado para el trabajo ajeno. No debería llegar aquí —ni entra a
      * la lista local ni lo recorre `empujar`— pero el día que alguien llame a
      * esto directo, subirlo lo pondría a nombre de quien manda. */
+    /* Un ajeno CON PRÉSTAMO VIGENTE sí sube, y por un camino aparte: su
+     * identidad en el servidor es la del dueño (`_id_local`), no un id de
+     * este navegador, y su contabilidad de versiones vive en el cajón de
+     * prestados y no en la libreta de lo mío. Mezclarlas era la forma de que
+     * el `M-1041` de Ricardo pisara el mío. */
     if (esAjeno(m)) {
-      return Promise.resolve({ ok: false, error: 'ES_AJENO',
-        mensaje: 'Ese machote es de otra persona: se puede ver, no guardar.' });
+      if (!prestadoAMi(m)) {
+        return Promise.resolve({ ok: false, error: 'ES_AJENO',
+          mensaje: 'Ese machote es de otra persona: se puede ver, no guardar.' });
+      }
+      return empujarPrestado(m, ses, motivo);
     }
     var s = leerSync();
     var meta = s[m.id] || { version: 0 };
@@ -368,6 +505,46 @@
       /* Choque de versión: alguien más guardó. NO se pisa y NO se reintenta en
        * silencio — se avisa, porque resolverlo es una decisión de persona. */
       return { ok: false, error: (r && r.error) || 'DESCONOCIDO',
+               mensaje: (r && r.mensaje) || 'No se pudo guardar en el servidor.' };
+    });
+  }
+
+  /** Sube un machote PRESTADO. Mismo endpoint y mismas reglas que lo propio
+   *  —el servidor decide si el préstamo sigue vivo— pero con la identidad y
+   *  la versión sacadas del cajón de prestados.
+   *
+   *  Pase lo que pase, lo tecleado se queda en el cajón: si el servidor
+   *  rechaza (permiso vencido, permiso recogido, choque de versión), la
+   *  persona conserva su trabajo y puede copiarlo o pedir el permiso de
+   *  nuevo. El sistema puede negarse a guardar; no puede tirar trabajo. */
+  function empujarPrestado(m, ses, motivo) {
+    var idLocal = m._id_local;
+    if (!idLocal) {
+      return Promise.resolve({ ok: false, error: 'SIN_ID_LOCAL',
+        mensaje: 'No se sabe con qué identidad guardar este machote prestado.' });
+    }
+    guardarPrestadoLocal(m);
+    var cajon = leerPrestados();
+    var leida = (cajon[m.id] && cajon[m.id].version_leida) || 0;
+
+    return postear(URL_GUARDAR, {
+      token: ses.token,
+      id_local: idLocal,
+      cliente_odoo_id: (typeof m.cliente_id === 'number') ? m.cliente_id : null,
+      version_leida: Number(leida) || 0,
+      estado: m.estado || 'borrador',
+      motivo: motivo || null,
+      documento: documentoDeMachote(m),
+      resumen: resumenDe(m)
+    }).then(function (r) {
+      if (r && r.ok === true) {
+        var c2 = leerPrestados();
+        if (c2[m.id]) { c2[m.id].version_leida = r.version; escribirPrestados(c2); }
+        m._version_servidor = r.version;
+        return { ok: true, version: r.version, machote_id: r.machote_id, prestado: true };
+      }
+      return { ok: false, prestado: true,
+               error: (r && r.error) || 'DESCONOCIDO',
                mensaje: (r && r.mensaje) || 'No se pudo guardar en el servidor.' };
     });
   }
@@ -457,6 +634,8 @@
        * El porqué está en `esAjeno`. */
       var ajenos = [];
 
+      var prestados = leerPrestados();
+
       for (i = 0; i < r.machotes.length; i++) {
         var fila = r.machotes[i];
         if (!fila || !fila.id_local || !fila.documento) continue;
@@ -480,11 +659,47 @@
            * id_local se abrirían una a la otra. */
           doc.id = fila.id;
           doc._ajeno = true;
+          doc._id_local = fila.id_local;      // el del DUEÑO: con él se guarda
           doc._dueno = fila.dueno || null;
           doc._dueno_nombre = fila.dueno_nombre || null;
           doc._version_servidor = fila.version;
           doc._folio = fila.folio || null;
           doc._folio_txt = fila.folio_txt || null;
+
+          /* Los préstamos VIGENTES que el servidor decidió enseñarme: los que
+           * yo otorgué (si el machote es mío) o el mío (si soy prestatario).
+           * El servidor decide cuáles; aquí sólo se separa el que me habilita
+           * a escribir de los que sólo son cortesía para el dueño. */
+          doc._prestamos = Array.isArray(fila.prestamos) ? fila.prestamos : [];
+          doc._prestamo_para_mi = doc._prestamos.filter(function (x) {
+            return x && x.para === r.actor;
+          })[0] || null;
+
+          /* LO TECLEADO SIN SUBIR MANDA sobre lo que trae el servidor. Es la
+           * misma regla que para lo propio (`bajar` nunca pisa un machote con
+           * cambios pendientes), aplicada al cajón de prestados: si el permiso
+           * venció con trabajo a medias, ese trabajo tiene que seguir ahí al
+           * recargar. Sólo se toma si además sigo teniendo permiso; sin
+           * permiso el machote vuelve a ser de sólo lectura y lo tecleado se
+           * recupera desde el aviso, no pisando la pantalla. */
+          var enCajon = prestados[fila.id];
+          if (enCajon && enCajon.documento && doc._prestamo_para_mi) {
+            var recuperado = machoteDesdeFila({ documento: enCajon.documento,
+              id_local: fila.id_local, estado: enCajon.documento.estado || fila.estado });
+            recuperado.id = fila.id;
+            recuperado._ajeno = true;
+            recuperado._id_local = fila.id_local;
+            recuperado._dueno = doc._dueno;
+            recuperado._dueno_nombre = doc._dueno_nombre;
+            recuperado._version_servidor = fila.version;
+            recuperado._folio = doc._folio;
+            recuperado._folio_txt = doc._folio_txt;
+            recuperado._prestamos = doc._prestamos;
+            recuperado._prestamo_para_mi = doc._prestamo_para_mi;
+            recuperado._sin_subir = true;
+            doc = recuperado;
+          }
+
           ajenos.push(doc);
           continue;
         }
@@ -507,10 +722,15 @@
           refrescados++;
         }
 
+        /* La cortesía del dueño: a quién le presté esto y hasta cuándo. Va en
+         * la libreta y no dentro del machote por lo mismo que el folio —
+         * metido en el documento entraría en su huella y la pantalla diría
+         * «por subir» de algo que sólo cambió allá. */
         s[fila.id_local] = {
           version: fila.version,
           huella: huella(doc),
           machote_id: fila.id,
+          prestamos: Array.isArray(fila.prestamos) ? fila.prestamos : [],
           /* El folio vive AQUÍ y no dentro del machote. Metido en el machote
            * entraría en `huella(m)` y la franja diría «por subir» de algo que
            * acaba de bajar — el mismo modo de falla que obligó a separar
@@ -742,6 +962,56 @@
     });
   }
 
+  /* ── Prestar y recoger ───────────────────────────────────────────────────
+   * Los dos van por `comercial/machote-prestar`, que comprueba contra la base
+   * que quien otorga es el DUEÑO. Aquí no se decide nada: el `actor` sale del
+   * token, igual que en todo lo demás, y el tope de 24 horas es un CHECK de
+   * la base — no una validación de esta pantalla, que cualquiera puede saltar
+   * con la consola abierta. */
+
+  /** Presta un machote a otra persona por `horas` (tope 24, lo fuerza la base). */
+  function prestar(machoteIdPantalla, para, horas) {
+    var ses = sesion();
+    if (!ses) {
+      return Promise.resolve({ ok: false, error: 'SIN_SESION',
+        mensaje: 'No hay sesión: vuelve a entrar para prestar.' });
+    }
+    var uuid = idServidor(machoteIdPantalla);
+    if (!uuid) {
+      return Promise.resolve({ ok: false, error: 'NUNCA_SUBIDO',
+        mensaje: 'Esta cotización todavía no llega al servidor, así que no se ' +
+                 'puede prestar. Súbela primero.' });
+    }
+    return postear(URL_PRESTAR, { token: ses.token, accion: 'prestar',
+      machote_id: uuid, para: para, horas: horas });
+  }
+
+  /** Recoge un préstamo antes de que venza. */
+  function recoger(machoteIdPantalla, para) {
+    var ses = sesion();
+    if (!ses) {
+      return Promise.resolve({ ok: false, error: 'SIN_SESION',
+        mensaje: 'No hay sesión: vuelve a entrar para recoger el permiso.' });
+    }
+    var uuid = idServidor(machoteIdPantalla);
+    if (!uuid) {
+      return Promise.resolve({ ok: false, error: 'NUNCA_SUBIDO',
+        mensaje: 'Esta cotización no está en el servidor.' });
+    }
+    return postear(URL_PRESTAR, { token: ses.token, accion: 'recoger',
+      machote_id: uuid, para: para });
+  }
+
+  /** Los préstamos VIGENTES de un machote, como los dejó la última bajada.
+   *  Sale de la libreta para lo propio y del objeto en memoria para lo ajeno,
+   *  que es la misma partición que el folio: lo ajeno no toca la libreta. */
+  function prestamosDe(m) {
+    if (!m) return [];
+    if (m._ajeno === true) return Array.isArray(m._prestamos) ? m._prestamos : [];
+    var meta = leerSync()[m.id];
+    return (meta && Array.isArray(meta.prestamos)) ? meta.prestamos : [];
+  }
+
   /** Guarda: navegador primero (síncrono, nunca falla por red), servidor
    *  después. Resuelve `{local, servidor, pendientes, fallos}`.
    *
@@ -824,6 +1094,16 @@
      * por separado es un candado que nadie sabe si sigue puesto. */
     empujarUno: empujarUno,
     historial: historial,
+
+    // El préstamo temporal (V1.25).
+    prestar: prestar,
+    recoger: recoger,
+    prestamosDe: prestamosDe,
+    puedeEscribir: puedeEscribir,
+    prestadoAMi: prestadoAMi,
+    guardarPrestadoLocal: guardarPrestadoLocal,
+    leerPrestados: leerPrestados,
+    olvidarPrestado: olvidarPrestado,
     idServidor: idServidor,
     esDemo: esDemo,
 

--- a/comercial/machote/js/app.js
+++ b/comercial/machote/js/app.js
@@ -8,8 +8,11 @@
  *
  * Ninguna vista calcula. Todo número sale de MachoteCalc.
  *
- * Rutas:  #/  lista · #/m/:id  el libro · #/rev/:id  revisión
- *         #/orden/:id  cierre de orden · #/ap/:id  aprobación
+ * Rutas:  #/  lista · #/nuevo  crear · #/m/:id  el libro
+ *         #/rev/:id  revisión · #/ap/:id  aprobación · #/control  tablero
+ *
+ * `#/orden/:id` se retiró en V1.25 con `vOrden` (ver más abajo, y
+ * `docs/comercial/ANDAMIO.md`). Un hash desconocido cae al `#/` de `render()`.
  */
 (function (G) {
   'use strict';

--- a/comercial/machote/js/app.js
+++ b/comercial/machote/js/app.js
@@ -40,7 +40,7 @@
    * 2026-09-03 (por instrucción de Esteban), pero lleva el suyo aparte y va en
    * V1.00. Planeación sigue en `2.4.1` y el kiosko sólo con cadena de build;
    * a esos no se propaga. */
-  const VERSION = 'V1.24';
+  const VERSION = 'V1.25';
   const $  = (s, r) => (r || document).querySelector(s);
   const $$ = (s, r) => Array.prototype.slice.call((r || document).querySelectorAll(s));
   const clon = (x) => JSON.parse(JSON.stringify(x));
@@ -62,28 +62,29 @@
      * que se abre trabado y no se puede guardar — eso lo decide el servidor
      * por el token, no esta pantalla. */
     ajenos: [],
-    ordenes:  clon(D.ORDENES),
-    handoff: _guardado ? (_guardado.handoff || {}) : {},
-    confirmadas: {},
+    /* V1.25: se fueron `ordenes`, `handoff` y `confirmadas`. Sólo existían
+     * para `vOrden`, la pantalla de cierre de handoff, que quedó huérfana al
+     * retirar la sección «Confirmar la orden» en V1.24 y corría sobre datos
+     * de ejemplo. La llave `handoff` del sobre de `fts_machote_v1` SE QUEDA
+     * en `almacen.js` a propósito: es formato de almacenamiento ya escrito en
+     * los navegadores del equipo, y quitarla de ahí sería reescribirles el
+     * archivo para ahorrar un objeto vacío. */
     hoja: 'desglose', simMargen: null,
     busca: '',
     /* Los filtros de la lista (V1.21). Sustituyen al `filtro: 'todos'` de las
      * píldoras, que sólo sabía de estado.
      *
-     * `persona` ARRANCA EN QUIEN ENTRÓ. Es lo que alguien quiere ver al abrir,
-     * y lo de los demás queda a un clic — con el pie diciéndolo, porque un
-     * filtro puesto que no se anuncia hace creer que faltan machotes.
-     * Si no hay sesión arranca vacío: filtrar por un nombre que no existe
-     * dejaría la lista en blanco sin explicación. */
-    filtros: {
-      persona: (function () {
-        try {
-          var sx = G.SuiteAuth && G.SuiteAuth.getSession();
-          return (sx && sx.actor) || '';
-        } catch (e) { return ''; }
-      })(),
-      estado: '', moneda: ''
-    },
+     * `persona` ARRANCA VACÍO — o sea en «Todas las personas» (V1.25).
+     * Hasta V1.24 arrancaba en quien entró, que tenía sentido cuando cada
+     * quien sólo veía lo suyo. Con la lectura abierta pasó a ser un filtro
+     * puesto de fábrica que escondía justo lo que se acababa de abrir: quien
+     * entraba veía 2 de 7 y tenía que descubrir el desplegable para ver el
+     * resto. Con siete machotes no hay ruido que filtrar; cuando el equipo
+     * crezca se revisa.
+     *
+     * Lo que NO cambia por esto: el encabezado sigue diciendo cuántas son
+     * TUYAS, y el respaldo sigue llevándose sólo lo tuyo. Ver `vHome`. */
+    filtros: { persona: '', estado: '', moneda: '' },
     // 'limpio' | 'sucio' | 'guardando' | 'guardado' | 'sin-almacen'
     pulso: (A && A.disponible()) ? 'limpio' : 'sin-almacen'
   };
@@ -153,8 +154,16 @@
     if (_reloj) { clearTimeout(_reloj); _reloj = null; }
     ST.pulso = 'guardando'; pintarPulso(); pintarPendientes();
 
-    const local = A.escribirLocal({ machotes: ST.machotes, handoff: ST.handoff });
+    const local = A.escribirLocal({ machotes: ST.machotes });
     if (!local) { ST.pulso = 'sin-almacen'; pintarPulso(); pintarPendientes(); avisarNoGuarda(); return false; }
+
+    /* Lo PRESTADO se guarda en su propio cajón, síncrono y antes de cualquier
+     * red — es la promesa que sostiene todo el préstamo: el servidor puede
+     * negarse a guardar (permiso vencido, permiso recogido, choque de
+     * versión), pero no puede costarle a nadie lo que tecleó. */
+    (ST.ajenos || []).forEach(m => {
+      if (A.prestadoAMi && A.prestadoAMi(m) && A.guardarPrestadoLocal) A.guardarPrestadoLocal(m);
+    });
     quitarAvisoNoGuarda();
 
     // Ya está a salvo aquí. Lo de arriba fue síncrono a propósito.
@@ -170,7 +179,85 @@
       pintarPulso(); pintarPendientes();
     });
 
+    /* Y los prestados suben por separado: `empujar` recorre `ST.machotes`, que
+     * es lo mío, y lo ajeno nunca entra ahí a propósito. */
+    empujarPrestados();
+
     return true;
+  }
+
+  /** Sube los machotes prestados que estén abiertos y con permiso vigente.
+   *
+   *  Va uno por uno y NO se mezcla con `empujar`: son dos contabilidades de
+   *  versiones distintas (la libreta para lo mío, el cajón para lo prestado)
+   *  y juntarlas es cómo el `M-1041` de Ricardo acabaría pisando el propio. */
+  function empujarPrestados() {
+    if (!A || !A.empujarUno || !A.prestadoAMi) return;
+    const ses = (G.SuiteAuth && G.SuiteAuth.getToken && G.SuiteAuth.getToken()) ? true : false;
+    if (!ses) return;
+    (ST.ajenos || []).forEach(m => {
+      if (!A.prestadoAMi(m)) return;
+      A.empujarUno(m, { token: G.SuiteAuth.getToken() },
+                   'editado con permiso de ' + (m._dueno_nombre || m._dueno || 'su dueño'))
+        .then(r => {
+          if (r && r.ok === true) {
+            if (A.olvidarPrestado) A.olvidarPrestado(m.id);
+            m._sin_subir = false;
+            return;
+          }
+          /* Rechazado. Lo tecleado se queda en el cajón —`empujarPrestado` lo
+           * escribe ANTES de llamar al servidor— y se dice con todas sus
+           * letras cuál de las tres causas fue. */
+          m._sin_subir = true;
+          avisarPrestadoRechazado(m, r);
+        });
+    });
+  }
+
+  /* Las tres causas por las que un prestado no se guarda llevan a tres cosas
+   * distintas: pedir el permiso otra vez, hablar con el dueño, o volver a
+   * abrir el machote. Decirlas con una sola frase manda a la acción
+   * equivocada — es la misma lección del historial y de la sesión muerta. */
+  let _avisoPrestado = 0;
+  function avisarPrestadoRechazado(m, r) {
+    const err = (r && r.error) || '';
+    /* Sin red no se alarma: eso se reintenta solo y ya lo dice el pulso. */
+    if (err === 'SIN_RED' || err === 'SIN_SESION') return;
+    const ahora = Date.now();
+    if (ahora - _avisoPrestado < 20000) return;
+    _avisoPrestado = ahora;
+
+    const viejo = $('#avPrestado'); if (viejo) viejo.remove();
+    const b = document.createElement('div');
+    b.id = 'avPrestado'; b.className = 'nogda'; b.setAttribute('role', 'alert');
+    const cola = ' <strong>Lo que escribiste sigue en este navegador y no se perdió.</strong>';
+    b.innerHTML = '<span>' + (
+      err === 'PRESTAMO_VENCIDO'
+        ? 'Tu permiso sobre «' + esc(m.nombre || 'esa cotización') + '» venció, así que ' +
+          'ya no se pudo guardar.' + cola + ' Pídele el permiso de nuevo a ' +
+          esc(m._dueno_nombre || m._dueno || 'su dueño') + '.'
+      : err === 'PRESTAMO_RECOGIDO'
+        ? esc(m._dueno_nombre || m._dueno || 'El dueño') + ' recogió tu permiso sobre «' +
+          esc(m.nombre || 'esa cotización') + '», así que ya no se pudo guardar.' + cola
+      : err === 'CONFLICTO_DE_VERSION'
+        ? 'Otra persona guardó «' + esc(m.nombre || 'esa cotización') + '» mientras la ' +
+          'editabas.' + cola + ' Vuelve a abrirla antes de seguir, para no pisar su cambio.'
+        : esc((r && r.mensaje) || 'No se pudo guardar esa cotización prestada.') + cola
+    ) + '</span><span class="nogda-b">' +
+      '<button class="btn" id="apCopiar">Copiar lo mío</button>' +
+      '<button class="btn fantasma" id="apCerrar">Entendido</button></span>';
+    document.body.appendChild(b);
+
+    /* «Copiar lo mío» es la salida concreta: sin ella, «tu trabajo no se
+     * perdió» es una frase amable sin manera de actuar. */
+    $('#apCopiar').onclick = () => {
+      const txt = JSON.stringify(m, null, 2);
+      const listo = () => toast('Copiado. Pégalo donde lo necesites.');
+      if (navigator.clipboard && navigator.clipboard.writeText) {
+        navigator.clipboard.writeText(txt).then(listo, () => respaldoCopiar(txt, listo));
+      } else respaldoCopiar(txt, listo);
+    };
+    $('#apCerrar').onclick = () => b.remove();
   }
 
   /* Sin red no se traba nada: lo capturado está en el navegador y sube solo
@@ -277,6 +364,13 @@
   const mach  = (id) => ST.machotes.find(m => m.id === id) ||
                         ST.ajenos.find(m => m.id === id);
   const ajeno = (m) => !!(m && m._ajeno === true);
+  /* Ajeno ya no implica sólo lectura: con un préstamo vigente se edita.
+   * La decisión de verdad la toma el SERVIDOR en cada guardado, contra la
+   * base y con su propio reloj; esto es para no hacerle perder el rato a
+   * quien sí tiene permiso. Vive en el almacén para que la pantalla y el
+   * empuje no puedan discrepar. */
+  const puedoEscribir = (m) => !!(A && A.puedeEscribir ? A.puedeEscribir(m) : !ajeno(m));
+  const prestadoAMi = (m) => !!(A && A.prestadoAMi && A.prestadoAMi(m));
 
   /* ── El folio (V1.23) ────────────────────────────────────────────────────
    * El número con el que se habla de una cotización: `COT-0003`. Lo reparte
@@ -295,8 +389,6 @@
     const f = A.folio(m.id);
     return f ? f.folio_txt : null;
   }
-  const orden = (id) => ST.ordenes.find(o => o.id === id);
-  const hoff  = (id) => ST.handoff[id] || (ST.handoff[id] = { entregables: {}, notas: '' });
 
   function toast(txt) {
     const d = document.createElement('div');
@@ -426,7 +518,6 @@
     if (p[0] === 'nuevo') return vNuevo();
     if (p[0] === 'm')     return vMachote(p[1]);
     if (p[0] === 'rev')   return vRevision(p[1]);
-    if (p[0] === 'orden') return vOrden(p[1]);
     if (p[0] === 'ap')    return vAprobar(p[1]);
     if (p[0] === 'control') return vControl();
     location.hash = '#/';
@@ -711,7 +802,9 @@
         '<td class="folio-td">' + folioChip(m) + '</td>' +
         '<td><div class="nm"><a href="#/m/' + esc(m.id) + '">' + esc(m.nombre) + '</a>' +
           (dm ? ' <span class="pill" title="Ejemplo que trae la aplicación. No se guarda en el servidor.">ejemplo</span>' : '') +
-          (ajeno(m) ? ' <span class="pill aj" title="Trabajo de otra persona. Se abre en lectura: no se edita ni se borra.">sólo lectura</span>' : '') +
+          (ajeno(m) ? (prestadoAMi(m)
+            ? ' <span class="pill presta" title="Su dueño te prestó la escritura. Se edita hasta que venza el permiso; borrar sigue siendo suyo.">prestada</span>'
+            : ' <span class="pill aj" title="Trabajo de otra persona. Se abre en lectura: no se edita ni se borra.">sólo lectura</span>') : '') +
           '</div><div class="sub">' + esc(cli(m)) +
           (m.so ? ' · ' + esc(m.so) : '') + '</div></td>' +
         '<td class="quien-td sub" title="' + esc(nombreDe(duenoDe(m))) + '">' +
@@ -750,7 +843,9 @@
         '<a class="item" href="#/m/' + esc(m.id) + '">' +
         '<div class="grow"><strong>' + esc(m.nombre) + '</strong>' +
           (dm ? ' <span class="pill">ejemplo</span>' : '') +
-          (ajeno(m) ? ' <span class="pill aj">sólo lectura</span>' : '') +
+          (ajeno(m) ? (prestadoAMi(m)
+            ? ' <span class="pill presta">prestada</span>'
+            : ' <span class="pill aj">sólo lectura</span>') : '') +
           '<div class="tiny">' + esc(cli(m)) +
           (m.so ? ' · ' + esc(m.so) : '') + ' · ' +
           esc(nombreDe(duenoDe(m))) + '</div></div>' +
@@ -1009,7 +1104,7 @@
     // abierta de la anterior deja al analista en una sección que no pidió.
     if (ST.libroAbierto !== id) { ST.hoja = 'desglose'; ST.libroAbierto = id; }
     const c = C.calcular(m);
-    const soloLectura = ajeno(m);
+    const soloLectura = !puedoEscribir(m);
     const fol = folioDe(m);
     top(cli(m), soloLectura
       ? ('de ' + (m._dueno_nombre || m._dueno || 'otra persona'))
@@ -1044,6 +1139,12 @@
           'La estás viendo en <strong>sólo lectura</strong>: se puede revisar, no editar. ' +
           'Si quieres partir de ella, duplícala a tu nombre.</div>'
         : '') +
+      /* La franja del préstamo. Dos caras del mismo dato: al PRESTATARIO le
+       * dice hasta cuándo puede escribir; al DUEÑO, a quién le prestó y hasta
+       * cuándo, con el botón de recoger. Es cortesía, no seguridad —saber que
+       * el otro está adentro evita la mayoría de los choques sin candados—,
+       * y por eso vive arriba, donde se ve sin buscarla. */
+      (G.MachotePrestamo ? G.MachotePrestamo.franja(m) : '') +
       '<div class="libro' + (soloLectura ? ' solo-lectura' : '') + '">' +
       '<div class="hojas" id="hojas">' + hojas.map((h, i) =>
         '<button class="pestana' + (h.id === ST.hoja ? ' on' : '') +
@@ -1163,21 +1264,23 @@
     const c = C.calcular(m);
     $('#hoja').innerHTML = hojaHTML(m, c);
     enlazar(m);
-    trabarSiEsAjeno(m);
+    trabarSiNoPuedoEscribir(m);
+    if (G.MachotePrestamo) G.MachotePrestamo.montar(m, vMachote);
   }
 
-  /* Traba la hoja cuando el machote es de otra persona.
+  /* Traba la hoja cuando no se puede escribir en ella: es de otra persona y
+   * no me la prestó, o el préstamo ya venció.
    *
    * Va AQUÍ y no en cada sitio que pinta porque `pintarHoja` es el único punto
    * por el que pasa toda la hoja — el mismo criterio que el filtro de la demo
    * en `empujar`. Un camino nuevo que repinte queda cubierto solo.
    *
-   * Esto NO es la seguridad: la seguridad es que el servidor no deja guardar
-   * un machote ajeno (`empujarUno` lo rechaza, y de todos modos el dueño lo
-   * pone el token). Esto es para que nadie pierda el rato tecleando encima de
-   * algo que no se va a guardar. */
-  function trabarSiEsAjeno(m) {
-    if (!m || m._ajeno !== true) return;
+   * Esto NO es la seguridad: la seguridad es que el servidor comprueba el
+   * préstamo contra la base en cada guardado, con su propio reloj, y rechaza
+   * con el motivo exacto. Esto es para que nadie pierda el rato tecleando
+   * encima de algo que no se va a guardar. */
+  function trabarSiNoPuedoEscribir(m) {
+    if (!m || puedoEscribir(m)) return;
     const hoja = $('#hoja'); if (!hoja) return;
     hoja.querySelectorAll('input, select, textarea, button').forEach(el => {
       el.disabled = true;
@@ -1727,12 +1830,39 @@
        * captura, no el diff—: quedaba un botón vivo para convertir en orden la
        * cotización de otro. «Revisar» sí se queda: es de sólo lectura y es
        * justo para lo que dirección abre un machote ajeno. */
-      (G.MachoteOrden && !ajeno(m)
+      (G.MachoteOrden && !ajeno(m)   /* pasar a orden es del DUEÑO, no de quien tiene prestado */
         ? '<button class="btn fantasma" id="btnOrden" title="Ver cómo se pasaría a orden de venta">Pasar a orden</button>'
+        : '') +
+      /* PRESTAR es del dueño y sólo del dueño (decisión 1 de la propuesta:
+       * quien sabe que no puede meterle mano ahora es él). Y sólo tiene
+       * sentido si la cotización ya llegó al servidor: prestar algo que
+       * todavía vive en este navegador no le daría acceso a nadie. */
+      (G.MachotePrestamo && !ajeno(m) && A && A.idServidor && A.idServidor(m.id)
+        ? '<button class="btn fantasma" id="btnPrestar" title="Dejar que otra persona edite esta cotización por un rato">Prestar</button>'
         : '') +
       '<a class="btn" href="#/rev/' + m.id + '">Revisar</a></div>';
     const bo = $('#btnOrden');
     if (bo) bo.onclick = () => G.MachoteOrden.abrir(m);
+    const bp = $('#btnPrestar');
+    if (bp) bp.onclick = () => G.MachotePrestamo.abrir(m, personasDelEquipo(), vMachote);
+  }
+
+  /** A quién se le puede prestar: las personas que el servidor ya nombró en
+   *  la lista, menos uno mismo.
+   *
+   *  Sale de los DATOS y no de una lista escrita a mano, por lo mismo que el
+   *  filtro de persona: el día que entre alguien nuevo aparece solo. Su
+   *  límite honesto es que sólo conoce a quien ya tiene algún machote — quien
+   *  no ha capturado nada todavía no sale. Cuando exista un directorio del
+   *  módulo, esto se cambia por él. */
+  function personasDelEquipo() {
+    const ses = (G.SuiteAuth && G.SuiteAuth.getSession()) || null;
+    const yo = (ses && ses.actor) || '';
+    const vistos = {};
+    (ST.ajenos || []).forEach(m => {
+      if (m && m._dueno && m._dueno !== yo) vistos[m._dueno] = m._dueno_nombre || m._dueno;
+    });
+    return Object.keys(vistos).sort().map(a => ({ actor: a, nombre: vistos[a] }));
   }
 
   /* ── Enlace de celdas ────────────────────────────────────────────────── */
@@ -1905,43 +2035,18 @@
   }
 
   /* ── Estación 3.0 ────────────────────────────────────────────────────── */
-  const ENTREGABLES = [
-    { id: 'alcance',   label: 'Alcance escrito y aceptado por el cliente' },
-    { id: 'po',        label: 'Orden de compra o correo de autorización' },
-    { id: 'contacto',  label: 'Contacto de sitio con teléfono' },
-    { id: 'fechas',    label: 'Fecha de inicio y fin acordadas' },
-    { id: 'accesos',   label: 'Requisitos de acceso y seguridad de la planta' },
-    { id: 'facturaci', label: 'Datos de facturación confirmados' }
-  ];
-
-  function vOrden(id) {
-    const o = orden(id); if (!o) { location.hash = '#/'; return; }
-    const h = hoff(o.id);
-    top('Confirmar orden', o.so + ' · ' + o.cliente, null, '#/');
-    $('#vista').innerHTML = '<div class="pad"><h2>' + esc(o.nombre) + '</h2>' +
-      '<div class="tiny">Confirmada el ' + esc(o.fecha_confirmacion) + ' · ' + mx(o.monto) + ' ' + esc(o.moneda) + '</div>' +
-      (ST.confirmadas[o.id] ? '<div class="aviso ok">Handoff cerrado. Operaciones ya tiene lo que necesita.</div>' : '') +
-      '<div class="wg"><h4>Qué tiene que quedar antes de soltarla a operaciones</h4>' +
-      ENTREGABLES.map(e => '<label class="row"><input type="checkbox" data-ent="' + e.id + '"' +
-        (h.entregables[e.id] ? ' checked' : '') + '><span class="grow">' + esc(e.label) + '</span></label>').join('') +
-      '</div><div class="wg"><h4>Notas para operaciones</h4>' +
-      '<textarea id="notas" rows="4" placeholder="Lo que no cabe en una casilla.">' + esc(h.notas) + '</textarea></div></div>';
-    barraOrden(o, h);
-    $$('[data-ent]').forEach(cb => cb.onchange = () => { h.entregables[cb.dataset.ent] = cb.checked; barraOrden(o, h); });
-    $('#notas').oninput = (e) => { h.notas = e.target.value; };
-  }
-
-  function barraOrden(o, h) {
-    const listo = ENTREGABLES.every(e => h.entregables[e.id]);
-    const ya = !!ST.confirmadas[o.id];
-    $('#fija').innerHTML = '<div class="fija"><div class="grow"><div class="tiny">' +
-      (listo ? '✓ Completo' : ENTREGABLES.filter(e => !h.entregables[e.id]).length + ' pendiente(s)') + '</div></div>' +
-      '<button class="btn" id="btnConf"' + (listo && !ya ? '' : ' disabled') + '>Cerrar handoff</button></div>';
-    $('#btnConf').onclick = () => {
-      ST.confirmadas[o.id] = { fecha: new Date().toISOString() };
-      toast('Handoff cerrado'); vOrden(o.id);
-    };
-  }
+  /* ── vOrden se retiró en V1.25 ──────────────────────────────────────────
+   * Era la pantalla de cierre de handoff: una lista de entregables y un botón
+   * «Cerrar handoff» que marcaba la orden como confirmada en un estado en
+   * memoria. Corría sobre `D.ORDENES` —datos de ejemplo, nunca del servidor—
+   * y su único enlace era la sección «Confirmar la orden» que se retiró en
+   * V1.24, así que llevaba una versión alcanzable sólo tecleando el hash.
+   *
+   * Se fue con ella: la ruta `#/orden/:id`, `barraOrden`, la lista
+   * `ENTREGABLES`, los helpers `orden()` y `hoff()`, y en el estado
+   * `ST.ordenes`, `ST.handoff` y `ST.confirmadas`. En `demo.js` se fue
+   * `ORDENES`. Lo que NO se tocó es la llave `handoff` del sobre de
+   * `fts_machote_v1`: es formato ya escrito en los navegadores del equipo. */
 
   /* ── Aprobación ──────────────────────────────────────────────────────── */
   function vAprobar(id) {
@@ -1962,6 +2067,21 @@
       (rev.duras.length ? '<div class="aviso bad">Tiene ' + rev.duras.length + ' hallazgo(s) duro(s). No debería llegar aquí.</div>'
                         : '<div class="aviso ok">Sin hallazgos duros.</div>') + '</div>';
   }
+
+  /* Lo mínimo que otro archivo necesita de la aplicación. Se expone SÓLO
+   * `guardarYa` —lo usa el aviso de «tu permiso está por vencer» para su
+   * botón «Guardar ahora»— en vez de colgar `ST` entero de `window`: un
+   * estado global que cualquiera puede escribir es cómo se llega a dos
+   * verdades sobre lo que hay en pantalla. */
+  G.MachoteApp = {
+    guardarYa: guardarYa,
+    /* Y el directorio de gente, para que la franja del préstamo pueda decir
+     * «Ricardo Hernández» donde el servidor sólo manda «ricardo.hernandez».
+     * El nombre NO viaja en `machote_prestamo` a propósito: no hay tabla de
+     * usuarios en el esquema `comercial` (migración 005) y no se va a crear
+     * una para una etiqueta. Aquí ya se conoce, porque la lista lo trae. */
+    personas: personasDelEquipo
+  };
 
   render();
   avisoPassword();
@@ -2009,7 +2129,6 @@
 
       if (Array.isArray(r.machotes) && (r.machotes.length || _hayCaptura || ST.ajenos.length)) {
         ST.machotes = r.machotes;
-        ST.handoff = r.handoff || ST.handoff;
         render();
       }
 

--- a/comercial/machote/js/demo.js
+++ b/comercial/machote/js/demo.js
@@ -232,26 +232,12 @@
     })
   ];
 
-  // Órdenes ya confirmadas: lo que la estación 3.0 tiene que cerrar.
-  const ORDENES = [
-    {
-      id: 'O-9001', machote: 'M-1042', so: 'SO11772',
-      cliente: 'Nalco de México · Topo Chico',
-      nombre: 'Adecuaciones de toma sanitaria en codo',
-      fecha_confirmacion: '2026-08-19', monto: 13362, moneda: 'MXN',
-      entregables: null, handoff: null
-    },
-    {
-      id: 'O-9002', machote: null, so: 'SO11737',
-      cliente: 'Nalco de México · Topo Chico',
-      nombre: 'Adecuaciones eléctricas y de control para diferencial de presión',
-      fecha_confirmacion: '2026-08-17', monto: 305840, moneda: 'MXN',
-      entregables: null, handoff: null
-    }
-  ];
+  /* `ORDENES` se retiró en V1.25 junto con `vOrden`, la pantalla que las
+   * consumía. Eran dos órdenes de ejemplo que sólo servían para poblar el
+   * cierre de handoff; nada más en el módulo las leía. */
 
   G.DEMO = {
-    UNIDADES, TIPOS_PROYECTO, ESTADOS, FLUJO, MACHOTES, ORDENES,
+    UNIDADES, TIPOS_PROYECTO, ESTADOS, FLUJO, MACHOTES,
     ROLES: C.ROLES, GRUPOS: C.GRUPOS, TIPOS: C.TIPOS, ESCENARIOS: C.ESCENARIOS
   };
 })(window);

--- a/comercial/machote/js/historial.js
+++ b/comercial/machote/js/historial.js
@@ -117,18 +117,49 @@
     if (lista) {
       var items = lista.querySelectorAll('.v');
       for (var k = 0; k < items.length; k++) {
-        items[k].className = 'v' + (Number(items[k].getAttribute('data-i')) === i ? ' on' : '');
+        /* Se ENCIENDE Y APAGA sólo `on`. Antes esto reescribía el `className`
+         * entero, y con eso borraba `ajena` —la marca de «esta versión la
+         * escribió alguien que no es el dueño»— en TODOS los renglones. Y como
+         * `marcar()` corre también al abrir, para seleccionar la última, la
+         * marca de color moría antes de verse nunca: quedaba sólo el texto.
+         *
+         * El código se leía bien renglón por renglón; lo cazó la captura, no
+         * el diff (CLAUDE.md §20 #12). Regla que deja: una función que pinta
+         * UN estado no reescribe el `className`, toca SU clase. */
+        items[k].classList.toggle('on', Number(items[k].getAttribute('data-i')) === i);
       }
     }
   }
 
+  /* ── Quién escribió cada versión ─────────────────────────────────────────
+   * El autor SIEMPRE se pintó aquí; lo que faltaba era distinguir cuándo NO
+   * es el dueño de la cotización. Y esa distinción no es cosmética: es la
+   * razón por la que existe el histórico.
+   *
+   * El caso concreto que lo motivó son las comisiones. Si alguien con permiso
+   * prestado cambia el reparto, la versión queda con SU nombre — y eso ya era
+   * verdad en la base desde el primer día, porque `machote_version.autor` sale
+   * del token verificado y no del cuerpo de la petición. Lo que no era verdad
+   * es que se pudiera VER de un vistazo: había que conocer de memoria de quién
+   * es cada cotización para notar que el autor no cuadraba.
+   *
+   * `v.dueno` viene del servidor en cada renglón del historial: es el dueño
+   * ACTUAL de la identidad, no el de aquel momento. Con préstamos —que no
+   * cambian de dueño— eso es exactamente lo que hace falta. */
   function pintarLista(vs, sel) {
     return vs.map(function (v, i) {
-      return '<div class="v' + (i === sel ? ' on' : '') + '" data-i="' + i + '" tabindex="0">' +
+      var quien = v.autor_nombre || v.autor || 'sin autor';
+      var deOtro = !!(v.dueno && v.autor && v.autor !== v.dueno);
+      return '<div class="v' + (i === sel ? ' on' : '') + (deOtro ? ' ajena' : '') +
+        '" data-i="' + i + '" tabindex="0">' +
         '<div><span class="n">Versión ' + v.version + '</span> ' +
         (i === 0 ? '<span class="chip ult">la última</span>'
                  : '<span class="chip">' + esc(v.estado) + '</span>') + '</div>' +
-        '<div class="meta">' + esc(v.autor_nombre || v.autor || 'sin autor') +
+        '<div class="meta">' + esc(quien) +
+        (deOtro
+          ? ' <span class="chip otro" title="La escribió alguien que no es el dueño de esta ' +
+            'cotización, con un permiso temporal.">no es el dueño</span>'
+          : '') +
         ' · ' + esc(fecha(v.guardada_at)) + '</div>' +
         (v.motivo ? '<div class="motivo">' + esc(v.motivo) + '</div>' : '') +
         '</div>';

--- a/comercial/machote/js/prestamo.js
+++ b/comercial/machote/js/prestamo.js
@@ -1,0 +1,307 @@
+/* ═══ Machote · el préstamo temporal de escritura ═══
+ *
+ * El dueño de una cotización le presta la ESCRITURA a otra persona por un
+ * plazo que él elige, con tope de 24 horas. Mientras dura, esa persona guarda
+ * como guardaría el dueño, y cada versión suya queda con SU nombre en el
+ * historial — que es el caso de las comisiones que motivó el histórico.
+ *
+ * Idea de Ricardo. El diseño, con las cinco decisiones y lo que se descartó,
+ * está en `docs/comercial/PERMISO_TEMPORAL.md`.
+ *
+ * ── DÓNDE VIVE CADA COSA, Y POR QUÉ ──────────────────────────────────────
+ * Este archivo es SÓLO pantalla. No decide nada:
+ *
+ *   el tope de 24 h        → un CHECK de la base (migración 005)
+ *   quién puede prestar    → el servidor, comparando el dueño contra el token
+ *   si el permiso vigente  → el servidor, en cada guardado, con SU reloj
+ *
+ * Lo de aquí es cortesía y aviso. Un reloj de navegador puede ir adelantado,
+ * atrasado o movido a mano, así que esta pantalla es OPTIMISTA: deja escribir
+ * hasta que el servidor diga que no. La alternativa —trabar los campos al
+ * segundo exacto— le quitaría el teclado a alguien a media frase por un reloj
+ * que no es el bueno.
+ */
+(function (G) {
+  'use strict';
+
+  var AVISO_MS = 15 * 60 * 1000;   // se avisa cuando faltan 15 minutos
+  var _reloj = null;               // el temporizador del aviso
+  var _avisado = {};               // por machote: ya se avisó de este vencimiento
+
+  function $(s) { return document.querySelector(s); }
+  function $$(s) { return Array.prototype.slice.call(document.querySelectorAll(s)); }
+
+  function esc(s) {
+    return String(s === null || s === undefined ? '' : s)
+      .replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;')
+      .replace(/"/g, '&quot;');
+  }
+
+  /* La hora a la que vence, como se dice en voz alta: «4:20 p.m.». Si vence
+   * otro día se agrega el día, porque «vence a las 9:00» de un préstamo de 20
+   * horas es verdad y engaña. */
+  function cuando(iso) {
+    var t = Date.parse(iso);
+    if (!isFinite(t)) return 'una hora que no se pudo leer';
+    var d = new Date(t), hoy = new Date();
+    var hora = d.toLocaleTimeString('es-MX', { hour: 'numeric', minute: '2-digit' });
+    var mismoDia = d.getFullYear() === hoy.getFullYear() &&
+                   d.getMonth() === hoy.getMonth() && d.getDate() === hoy.getDate();
+    if (mismoDia) return 'las ' + hora;
+    return d.toLocaleDateString('es-MX', { weekday: 'long', day: 'numeric', month: 'long' }) +
+           ' a las ' + hora;
+  }
+
+  /* Un punto al final, pero SIN duplicarlo. `toLocaleTimeString('es-MX')`
+   * devuelve «10:13 a.m.» —con punto— así que concatenar otro daba
+   * «hasta las 10:13 a.m..» en la franja. Se ve en la captura y no en el
+   * diff, que es la lección de CLAUDE.md §20 #12. */
+  function punto(s) { return /[.!?…]$/.test(s) ? s : s + '.'; }
+
+  function minutosQueFaltan(iso) {
+    var t = Date.parse(iso);
+    if (!isFinite(t)) return null;
+    return Math.round((t - Date.now()) / 60000);
+  }
+
+  function nombreDe(actor, m) {
+    /* El nombre real si se conoce; si no, el usuario. Un «ricardo.hernandez»
+     * es legible, pero «Ricardo Hernández» es cómo se le llama en la junta —
+     * y es el que la MISMA pantalla acaba de mostrar en el selector de
+     * prestar, así que decir el otro se lee como si fueran dos personas.
+     *
+     * Tres fuentes, en orden, y la última nunca falla:
+     *   1. lo que venga en el préstamo (hoy no viene: la 005 no guarda nombre,
+     *      y no hay tabla de usuarios en `comercial` — si algún día la hay,
+     *      esto lo aprovecha sin tocarse),
+     *   2. el directorio de la lista, que es donde el nombre YA se conoce,
+     *   3. el usuario tal cual, que es legible aunque no sea bonito. */
+    var ps = (m && m._prestamos) || [];
+    for (var i = 0; i < ps.length; i++) {
+      if (ps[i] && ps[i].para === actor && ps[i].para_nombre) return ps[i].para_nombre;
+    }
+    try {
+      var dir = (G.MachoteApp && G.MachoteApp.personas) ? G.MachoteApp.personas() : [];
+      for (var j = 0; j < dir.length; j++) {
+        if (dir[j] && dir[j].actor === actor && dir[j].nombre) return dir[j].nombre;
+      }
+    } catch (e) { /* el nombre es cortesía: nunca puede tumbar la franja */ }
+    return actor;
+  }
+
+  /** La franja que va arriba del machote abierto. Devuelve HTML (posiblemente
+   *  vacío): quien la pinta es `vMachote`, para que entre en el mismo repintado
+   *  y no haya dos fuentes de verdad sobre qué hay en pantalla. */
+  function franja(m) {
+    var A = G.MachoteAlmacen;
+    if (!m || !A) return '';
+
+    /* ── Soy el PRESTATARIO ───────────────────────────────────────────────
+     * Lo que necesita saber: hasta cuándo puede escribir. Y si ya venció, que
+     * lo que tecleó sigue aquí — que es la promesa que sostiene todo esto. */
+    if (m._ajeno === true) {
+      var mio = m._prestamo_para_mi;
+      if (!mio) return '';
+      var faltan = minutosQueFaltan(mio.vence_at);
+      if (faltan !== null && faltan <= 0) {
+        return '<div class="presta-fr vencido" role="alert">' +
+          '<strong>Tu permiso sobre esta cotización venció.</strong> ' +
+          'Lo que escribiste sigue en este navegador y no se perdió, pero ya no se ' +
+          'puede guardar. Pídele el permiso de nuevo a ' +
+          esc(m._dueno_nombre || m._dueno || 'su dueño') + '.' +
+          '</div>';
+      }
+      return '<div class="presta-fr' + (faltan !== null && faltan <= 15 ? ' pronto' : '') + '">' +
+        '<strong>' + esc(m._dueno_nombre || m._dueno || 'Su dueño') +
+        ' te prestó esta cotización.</strong> Puedes editarla hasta ' +
+        (faltan !== null && faltan <= 15
+          ? esc(cuando(mio.vence_at)) + ' — faltan ' + faltan + ' minuto(s).'
+          : punto(esc(cuando(mio.vence_at)))) +
+        ' Borrarla y mandarla a Odoo siguen siendo suyas.' +
+        '</div>';
+    }
+
+    /* ── Soy el DUEÑO ─────────────────────────────────────────────────────
+     * Cortesía: saber que alguien está adentro. No es un candado —los dos
+     * pueden escribir, y si chocan la base rechaza al segundo— pero saberlo
+     * evita la mayoría de los choques sin necesidad de candados. */
+    var ps = A.prestamosDe ? A.prestamosDe(m) : [];
+    var vivos = ps.filter(function (x) {
+      return x && x.vence_at && Date.parse(x.vence_at) > Date.now();
+    });
+    if (!vivos.length) return '';
+
+    return '<div class="presta-fr dueno">' +
+      '<span class="grow"><strong>Prestada.</strong> ' +
+      vivos.map(function (x) {
+        return esc(nombreDe(x.para, m)) + ' puede editarla hasta ' +
+               punto(esc(cuando(x.vence_at)));
+      }).join(' · ') +
+      ' Si guardan los dos a la vez, el segundo tendrá que volver a abrirla.</span>' +
+      vivos.map(function (x) {
+        return '<button class="btn fantasma chico" data-recoger="' + esc(x.para) + '">Recoger</button>';
+      }).join('') +
+      '</div>';
+  }
+
+  /** Engancha lo que la franja pinta, arma el botón de prestar, y programa el
+   *  aviso de los 15 minutos. `repintar` es `vMachote`, para volver a pintar
+   *  sin que este archivo sepa cómo se pinta un machote. */
+  function montar(m, repintar) {
+    var A = G.MachoteAlmacen;
+    if (!m || !A) return;
+
+    $$('[data-recoger]').forEach(function (b) {
+      b.onclick = function () {
+        var para = b.dataset.recoger;
+        if (!confirm('¿Recoger el permiso de ' + nombreDe(para, m) + '?\n\n' +
+                     'Dejará de poder guardar en cuanto lo intente. Lo que haya escrito ' +
+                     'no se pierde: se queda en su navegador.')) return;
+        b.disabled = true;
+        A.recoger(m.id, para).then(function (r) {
+          if (!r || r.ok !== true) {
+            b.disabled = false;
+            alert((r && r.mensaje) || 'No se pudo recoger el permiso.');
+            return;
+          }
+          /* Se vuelve a bajar en vez de tachar el renglón a mano: el estado
+           * de quién puede escribir vive en el servidor, y pintarlo desde una
+           * marca local sería creerle a la pantalla en vez de al servidor
+           * (CLAUDE.md §8). */
+          A.bajar().then(function () { if (repintar) repintar(m.id); });
+        });
+      };
+    });
+
+    programarAviso(m, repintar);
+  }
+
+  /* ── El aviso de los 15 minutos ──────────────────────────────────────────
+   * Por qué avisar antes y no trabar al vencer: el permiso se comprueba AL
+   * GUARDAR, así que se puede estar tecleando cuando vence. Sin aviso, la
+   * persona se entera cuando el guardado la rechaza — con el trabajo hecho y
+   * la sorpresa encima. Con aviso, tiene quince minutos para cerrar o para
+   * pedir más tiempo.
+   *
+   * Se avisa UNA vez por vencimiento. Un aviso que se repite cada minuto es
+   * un aviso que se aprende a ignorar, y este es de los que hay que leer. */
+  function programarAviso(m, repintar) {
+    if (_reloj) { clearTimeout(_reloj); _reloj = null; }
+    if (!m || m._ajeno !== true) return;
+    var mio = m._prestamo_para_mi;
+    if (!mio || !mio.vence_at) return;
+
+    var t = Date.parse(mio.vence_at);
+    if (!isFinite(t)) return;
+    var falta = t - Date.now();
+    if (falta <= 0) return;
+
+    var clave = m.id + '|' + mio.vence_at;
+    var enCuanto = falta - AVISO_MS;
+
+    if (enCuanto <= 0) { avisar(m, clave, repintar); return; }
+    _reloj = setTimeout(function () { avisar(m, clave, repintar); }, enCuanto);
+  }
+
+  function avisar(m, clave, repintar) {
+    if (_avisado[clave]) return;
+    _avisado[clave] = true;
+    var mio = m._prestamo_para_mi;
+    var faltan = minutosQueFaltan(mio.vence_at);
+
+    var viejo = $('#prestaAviso'); if (viejo) viejo.remove();
+    var b = document.createElement('div');
+    b.id = 'prestaAviso';
+    b.className = 'nogda';
+    b.setAttribute('role', 'alert');
+    b.innerHTML =
+      '<span><strong>Tu permiso sobre «' + esc(m.nombre || 'esta cotización') +
+      '» vence a ' + esc(cuando(mio.vence_at)).replace(/\.$/, '') + '</strong>' +
+      (faltan !== null && faltan > 0 ? ' — faltan ' + faltan + ' minuto(s)' : '') +
+      '. Después de esa hora ya no vas a poder guardar. Lo que escribas no se ' +
+      'pierde, pero para que quede en el servidor tiene que subir antes.</span>' +
+      '<span class="nogda-b">' +
+      '<button class="btn" id="prestaYa">Guardar ahora</button>' +
+      '<button class="btn fantasma" id="prestaX">Entendido</button></span>';
+    document.body.appendChild(b);
+
+    $('#prestaYa').onclick = function () {
+      b.remove();
+      if (G.MachoteApp && G.MachoteApp.guardarYa) G.MachoteApp.guardarYa();
+      if (repintar) repintar(m.id);
+    };
+    $('#prestaX').onclick = function () { b.remove(); };
+  }
+
+  /** El modal de prestar. Sale del botón «Prestar» de la barra del machote. */
+  function abrir(m, personas, repintar) {
+    var A = G.MachoteAlmacen;
+    if (!A) return;
+
+    var otros = (personas || []).filter(function (p) { return p && p.actor; });
+
+    /* OJO con los nombres: en este módulo `.modal` YA ES EL FONDO —posición
+     * fija, inset 0, negro translúcido— y la tarjeta de adentro es `.caja`.
+     * Inventar `.modal-fondo` aquí habría dado dos convenciones para lo mismo,
+     * que es cómo se llegó al choque de `.kpi` en V1.22 (CLAUDE.md §20 #12).
+     * Se reusan las que ya existen y sólo se agrega lo propio: `.presta-caja`. */
+    var caja = document.createElement('div');
+    caja.className = 'modal';
+    caja.id = 'prestaModal';
+    caja.innerHTML =
+      '<div class="caja presta-caja" role="dialog" aria-modal="true" aria-labelledby="pm-t">' +
+        '<h3 id="pm-t">Prestar «' + esc(m.nombre || 'esta cotización') + '»</h3>' +
+        '<p class="tiny nota">Quien reciba el permiso podrá <strong>editarla y guardarla</strong> ' +
+        'mientras dure. Cada versión suya queda con su nombre en el historial. ' +
+        'Borrarla y mandarla a Odoo siguen siendo tuyas, y puedes recoger el permiso ' +
+        'antes de tiempo.</p>' +
+        (otros.length
+          ? '<label class="pm-l">A quién<select id="pm-para">' +
+            otros.map(function (p) {
+              return '<option value="' + esc(p.actor) + '">' + esc(p.nombre || p.actor) + '</option>';
+            }).join('') + '</select></label>'
+          : '<div class="aviso">Todavía no hay nadie más con machotes en el servidor, ' +
+            'así que no hay a quién prestarle.</div>') +
+        '<label class="pm-l">Por cuánto tiempo<select id="pm-horas">' +
+          '<option value="1">1 hora</option>' +
+          '<option value="4" selected>4 horas</option>' +
+          '<option value="8">8 horas</option>' +
+          '<option value="24">24 horas (el máximo)</option>' +
+        '</select></label>' +
+        '<p class="tiny nota">El tope de 24 horas lo impone la base de datos, no esta ' +
+        'pantalla. Un permiso sin vencimiento sería un cambio de dueño con otro nombre.</p>' +
+        '<div id="pm-err"></div>' +
+        '<div class="acciones">' +
+          '<button class="btn fantasma" id="pm-x">Cancelar</button>' +
+          '<button class="btn" id="pm-ok"' + (otros.length ? '' : ' disabled') + '>Prestar</button>' +
+        '</div>' +
+      '</div>';
+    document.body.appendChild(caja);
+
+    var cerrar = function () { caja.remove(); };
+    $('#pm-x').onclick = cerrar;
+    caja.addEventListener('click', function (e) { if (e.target === caja) cerrar(); });
+
+    $('#pm-ok').onclick = function () {
+      var para = ($('#pm-para') || {}).value;
+      var horas = Number(($('#pm-horas') || {}).value) || 4;
+      if (!para) return;
+      $('#pm-ok').disabled = true;
+      A.prestar(m.id, para, horas).then(function (r) {
+        if (!r || r.ok !== true) {
+          $('#pm-ok').disabled = false;
+          $('#pm-err').innerHTML = '<div class="aviso bad">' +
+            esc((r && r.mensaje) || 'No se pudo prestar.') + '</div>';
+          return;
+        }
+        cerrar();
+        /* Se relee del servidor: quién puede escribir es estado suyo, no de
+         * esta pantalla. */
+        A.bajar().then(function () { if (repintar) repintar(m.id); });
+      });
+    };
+  }
+
+  G.MachotePrestamo = { franja: franja, montar: montar, abrir: abrir,
+                        _cuando: cuando, _minutosQueFaltan: minutosQueFaltan };
+})(window);

--- a/comercial/machote/tests/pruebas-navegador.js
+++ b/comercial/machote/tests/pruebas-navegador.js
@@ -416,22 +416,21 @@ let ok = 0, mal = 0;
     if (!/no hay tipo de cambio/.test(await p.textContent('#vista'))) throw new Error('no lo reportó');
   });
 
-  await paso('la estación 3.0 no deja cerrar el handoff incompleto', async () => {
-    await ir('#/orden/O-9001');
-    if (!(await p.locator('#btnConf').isDisabled())) throw new Error('el botón estaba habilitado');
-  });
-
-  await paso('marcar todo habilita el cierre, y la marca no se pierde', async () => {
-    await ir('#/orden/O-9001');
-    for (let i = 0; i < 12; i++) {
-      const pend = p.locator('[data-ent]:not(:checked)');
-      if (await pend.count() === 0) break;
-      await pend.first().check(); await p.waitForTimeout(120);
-    }
-    if (await p.locator('#btnConf').isDisabled()) throw new Error('sigue deshabilitado');
-    await p.click('#btnConf'); await p.waitForTimeout(250);
-    if (!/Handoff cerrado/.test(await p.textContent('#vista'))) throw new Error('no cerró');
-  });
+  /* ── V1.25 · dos pruebas RETIRADAS aquí ───────────────────────────────────
+   * Eran «la estación 3.0 no deja cerrar el handoff incompleto» y «marcar todo
+   * habilita el cierre, y la marca no se pierde». Las dos abrían
+   * `#/orden/O-9001` y ejercían `vOrden`, la pantalla de cierre de handoff.
+   *
+   * Se van porque la pantalla se fue: corría sobre `D.ORDENES` —datos de
+   * ejemplo, nunca del servidor— y marcaba «confirmada» en un estado de
+   * memoria; su único enlace era la sección «Confirmar la orden» que se retiró
+   * en V1.24, así que llevaba una versión alcanzable sólo tecleando el hash.
+   *
+   * No se sustituyen por nada, y es a propósito: no cubrían una regla del
+   * negocio que siga viva en otro lado, cubrían el comportamiento de un
+   * andamio. El camino de verdad a una orden es «Pasar a orden» desde el
+   * machote abierto (`js/orden.js`), que sigue enlazado y tiene sus pruebas
+   * aparte. El porqué del retiro está en `docs/comercial/ANDAMIO.md`. */
 
   await paso('volver al mismo machote conserva la hoja donde ibas', async () => {
     await ir('#/m/M-1041'); await hoja('Instalación');
@@ -754,7 +753,11 @@ let ok = 0, mal = 0;
 
   // ── Diseño ───────────────────────────────────────────────────────────
   await paso('nada desborda a 380 px', async () => {
-    for (const h of ['#/', '#/m/M-1041', '#/rev/M-1044', '#/orden/O-9002', '#/ap/M-1041']) {
+    /* V1.25: `#/orden/O-9002` salió de esta lista al retirarse `vOrden`. Un
+     * hash desconocido cae al `#/` de `render()`, así que la prueba habría
+     * seguido pasando midiendo la lista dos veces — verde sin mirar nada.
+     * Entra `#/nuevo`, que sí existe y no estaba cubierta a este ancho. */
+    for (const h of ['#/', '#/nuevo', '#/m/M-1041', '#/rev/M-1044', '#/ap/M-1041']) {
       await ir(h);
       const d = await p.evaluate(() => document.documentElement.scrollWidth - document.documentElement.clientWidth);
       if (d > 2) throw new Error(h + ' desborda ' + d + ' px');
@@ -800,7 +803,7 @@ let ok = 0, mal = 0;
 
   await paso('todo lo que se toca mide al menos 40 px de alto', async () => {
     const chico = [];
-    for (const h of ['#/', '#/m/M-1041', '#/orden/O-9002']) {
+    for (const h of ['#/', '#/nuevo', '#/m/M-1041']) {   // V1.25: sale #/orden, entra #/nuevo
       await ir(h);
       if (h === '#/m/M-1041') { await hoja('Suministro'); }
       const r = await p.evaluate(() => {

--- a/comercial/machote/tests/pruebas-navegador.js
+++ b/comercial/machote/tests/pruebas-navegador.js
@@ -118,7 +118,16 @@ let ok = 0, mal = 0;
     (esDelEntorno(m.text()) ? delEntorno : errs).push('CONSOLE: ' + m.text()); });
   p.on('pageerror', e => errs.push('PAGEERROR: ' + e.message));
 
+  /* Correr UNA sola prueba: `SOLO='pr[eé]stamo' node tests/pruebas-navegador.js`.
+   * La suite entera tarda ~55 minutos y eso vuelve carísimo iterar sobre una
+   * pantalla nueva —se acaba mirando el diff en vez de la pantalla, que es
+   * justo el modo de falla de CLAUDE.md §20 #12—. El filtro no cambia lo que
+   * hace ninguna prueba: sólo deja saltarse las que no se están tocando.
+   * ⚠️ La ENTREGA se mide siempre con la suite completa, sin `SOLO`. */
+  const SOLO = process.env.SOLO ? new RegExp(process.env.SOLO, 'i') : null;
+  let saltadas = 0;
   const paso = async (n, fn) => {
+    if (SOLO && !SOLO.test(n)) { saltadas++; return; }
     try { await fn(); console.log('✓', n); ok++; }
     catch (e) { console.log('✗', n, '→', e.message); mal++; }
   };
@@ -1032,21 +1041,35 @@ let ok = 0, mal = 0;
     console.log('    ' + total + ' → ' + enRev + ' · «' + cuenta + '»');
   });
 
-  await paso('al entrar, el filtro de persona arranca en los propios', async () => {
-    /* Es lo que alguien quiere ver al abrir. Y como es un filtro PUESTO que
-     * nadie eligió, la pantalla tiene que decirlo: si no, se ve una lista
-     * corta y parece que faltan machotes. */
+  await paso('al entrar, la lista arranca en TODAS las personas', async () => {
+    /* V1.25 · decisión de Esteban. SUSTITUYE a «el filtro de persona arranca
+     * en los propios» (V1.21), que probaba lo contrario: que al abrir se veía
+     * sólo lo tuyo y un pie avisaba del filtro puesto.
+     *
+     * Se cambió porque abrir la lectura a todos (V1.24) y luego esconderlo
+     * detrás de un filtro que nadie eligió es abrir una puerta y dejarla
+     * cerrada: con siete machotes no hay ruido que filtrar, y ver el trabajo
+     * del equipo era el punto. Cuando el equipo crezca se revisa.
+     *
+     * Lo que NO cambió, y por eso se sigue probando aquí: «Míos» sigue
+     * existiendo, y cuando se elige, la pantalla lo dice — un filtro puesto
+     * que no se anuncia se lee como machotes que faltan. */
     await ir('#/');
     const v = await p.$eval('#fPersona', el => el.value);
-    if (v !== 'zz.prueba') throw new Error('no arrancó en el usuario de la sesión: «' + v + '»');
-    const t = (await p.textContent('#vista')).replace(/\s+/g, ' ');
-    if (!/Viendo sólo lo tuyo/i.test(t)) throw new Error('no avisa que hay un filtro puesto');
-    // Y se puede quitar: «Todas las personas» devuelve la lista completa.
-    const propios = await p.$$eval('[data-hist]', e => e.length);
+    if (v !== '') throw new Error('no arrancó en «Todas las personas»: «' + v + '»');
+    const t0 = (await p.textContent('#vista')).replace(/\s+/g, ' ');
+    if (/Viendo sólo lo tuyo/i.test(t0))
+      throw new Error('avisa de un filtro puesto sin haber puesto ninguno');
+
+    const todos = await p.$$eval('tr.rw', e => e.length);
+    await p.selectOption('#fPersona', 'zz.prueba'); await p.waitForTimeout(320);
+    const propios = await p.$$eval('tr.rw', e => e.length);
+    if (propios > todos) throw new Error('«Míos» enseñó MÁS que todos: ' + todos + ' → ' + propios);
+    const t1 = (await p.textContent('#vista')).replace(/\s+/g, ' ');
+    if (!/Viendo sólo lo tuyo/i.test(t1))
+      throw new Error('con «Míos» puesto no lo dice');
     await p.selectOption('#fPersona', ''); await p.waitForTimeout(320);
-    const todos = await p.$$eval('[data-hist]', e => e.length);
-    if (todos < propios) throw new Error('quitar el filtro enseñó MENOS: ' + propios + ' → ' + todos);
-    console.log('    míos ' + propios + ' · todos ' + todos);
+    console.log('    arranca en todas (' + todos + ') · «Míos» filtra (' + propios + ') y lo anuncia');
   });
 
   await paso('cuando no hay resultados, dice por qué', async () => {
@@ -3409,17 +3432,13 @@ let ok = 0, mal = 0;
   await paso('dirección ve el trabajo del equipo, marcado y sin poder tocarlo', async () => {
     const q = await paginaConAjenos();
     try {
-      /* Al entrar se ve SÓLO lo propio, también con el scope de dirección: es
-       * la decisión de Esteban y el pie lo anuncia. Lo de los demás está a un
-       * clic, y ese clic es el que se da aquí. */
+      /* V1.25: al entrar YA se ve el trabajo del equipo, sin tocar el filtro.
+       * Antes aquí se comprobaba lo contrario —que al entrar sólo salía lo
+       * propio— y luego se daba el clic; hoy el clic sobra, así que lo que se
+       * comprueba es que sale de entrada. */
       const alEntrar = await q.$$eval('tr.rw', f => f.map(x => x.textContent.indexOf('Lo de Ricardo') >= 0));
-      if (alEntrar.some(Boolean))
-        throw new Error('al entrar ya enseñaba lo de otro: el filtro propio no se respetó');
-      const pie = (await q.textContent('#vista')).replace(/\s+/g, ' ');
-      if (!/Viendo sólo lo tuyo/i.test(pie))
-        throw new Error('no avisa que hay un filtro puesto');
-
-      await q.selectOption('#fPersona', ''); await q.waitForTimeout(320);
+      if (!alEntrar.some(Boolean))
+        throw new Error('al entrar NO enseñaba lo de otro: la lista no arrancó en todas');
 
       const r = await q.evaluate(() => {
         const filas = [...document.querySelectorAll('tr.rw')];
@@ -3579,10 +3598,17 @@ let ok = 0, mal = 0;
     await q.addInitScript((cfg) => {
       const f = cfg.filas;
       window.__opciones = cfg.opciones || {};
+      /* Quién está sentado frente a la pantalla. Por omisión Esteban, que es
+       * lo que asumían las pruebas de V1.23/V1.24; el préstamo obliga a poder
+       * ser OTRO —el prestatario, o un extraño— porque casi todo lo que hay
+       * que probar de él sólo se ve desde ese lado. */
+      const YO = (cfg.opciones && cfg.opciones.actor) || 'esteban.delacruz';
+      const NOMBRE = (cfg.opciones && cfg.opciones.nombre) || 'Jesus Esteban De La Cruz';
+      window.__llamadas = { guardar: [], prestar: [] };
       try {
         localStorage.setItem('fts_suite_session', JSON.stringify({
-          token: 'prueba.prueba.prueba', actor: 'esteban.delacruz',
-          nombre: 'Jesus Esteban De La Cruz', empleado_id: 32,
+          token: 'prueba.prueba.prueba', actor: YO,
+          nombre: NOMBRE, empleado_id: 32,
           /* SIN `comercial:admin` a propósito: desde V1.24 la lectura de lo
            * ajeno no depende de ese scope. Si alguien lo vuelve a exigir en el
            * servidor, estas pruebas se caen — que es lo que se quiere. */
@@ -3612,18 +3638,32 @@ let ok = 0, mal = 0;
               ? window.__opciones.versiones : 1;
             const f0 = f.find(x => x.id === cuerpo.machote_id) || {};
             const vs = [];
-            for (let i = n; i >= 1; i--) vs.push({
-              id: f0.id, version: i, autor: f0.dueno || 'esteban.delacruz',
-              autor_nombre: f0.dueno_nombre || 'Jesus Esteban De La Cruz',
-              guardada_at: new Date(Date.now() - i * 3600e3).toISOString(),
-              estado: 'borrador', motivo: 'guardado automatico',
-              documento: doc(f0.nombre || 'x') });
+            /* `dueno` va en CADA versión porque así lo manda el endpoint real
+             * (la consulta del historial selecciona `m.dueno`), y es lo que
+             * deja comparar contra `autor` para marcar las que escribió
+             * alguien más. `opciones.autores` permite que no todas sean del
+             * dueño, que es justo el caso del préstamo. */
+            const dueno0 = f0.dueno || 'esteban.delacruz';
+            const otros = (window.__opciones && window.__opciones.autores) || {};
+            for (let i = n; i >= 1; i--) {
+              const a = otros[i] || null;
+              vs.push({
+                id: f0.id, version: i, dueno: dueno0,
+                autor: a ? a.actor : dueno0,
+                autor_nombre: a ? a.nombre
+                                : (f0.dueno_nombre || 'Jesus Esteban De La Cruz'),
+                guardada_at: new Date(Date.now() - i * 3600e3).toISOString(),
+                estado: 'borrador',
+                motivo: a ? ('editado con permiso de ' + (f0.dueno_nombre || dueno0))
+                          : 'guardado automatico',
+                documento: doc(f0.nombre || 'x') });
+            }
             return Promise.resolve({ ok: true, json: () => Promise.resolve({
-              ok: true, modo: 'historial', actor: 'esteban.delacruz', es_admin: false,
+              ok: true, modo: 'historial', actor: YO, es_admin: false,
               machote_id: cuerpo.machote_id, versiones: vs, total: vs.length }) });
           }
           return Promise.resolve({ ok: true, json: () => Promise.resolve({
-            ok: true, modo: 'lista', actor: 'esteban.delacruz', es_admin: false,
+            ok: true, modo: 'lista', actor: YO, es_admin: false,
             total: f.length,
             duenos: f.map(x => x.dueno || 'esteban.delacruz')
                      .filter((d, i, a) => a.indexOf(d) === i),
@@ -3633,7 +3673,42 @@ let ok = 0, mal = 0;
               documento: doc(x.nombre)
             }, x)) }) });
         }
-        if (s.indexOf('/comercial/machote-guardar') >= 0) return new Promise(function () {});
+        /* GUARDAR y PRESTAR. Por omisión se quedan colgados —es lo que hacían
+         * antes, y las pruebas viejas cuentan con ello— pero el montaje puede
+         * darles una respuesta. Se apunta CADA llamada con su cuerpo: en el
+         * préstamo, la mitad de lo que hay que probar es CON QUÉ IDENTIDAD se
+         * guarda (el `id_local` del DUEÑO, no el de quien teclea), y eso no se
+         * ve en la pantalla: sólo en lo que sale por el cable. */
+        if (s.indexOf('/comercial/machote-guardar') >= 0) {
+          let c = {}; try { c = JSON.parse((arguments[1] && arguments[1].body) || '{}'); } catch (e) {}
+          window.__llamadas.guardar.push(c);
+          const rg = window.__opciones.guardar;
+          if (!rg) return new Promise(function () {});
+          return Promise.resolve({ ok: true, json: () => Promise.resolve(rg) });
+        }
+        if (s.indexOf('/comercial/machote-prestar') >= 0) {
+          let c = {}; try { c = JSON.parse((arguments[1] && arguments[1].body) || '{}'); } catch (e) {}
+          window.__llamadas.prestar.push(c);
+          const rp = window.__opciones.prestar || { ok: true };
+          /* El servidor de mentiras APUNTA el préstamo, para que la siguiente
+           * bajada lo traiga. Sin esto, «prestar» sólo probaría que sale la
+           * llamada; con esto se prueba lo que le importa al dueño: que al
+           * volver de prestar, su pantalla dice que la cotización está
+           * prestada y le ofrece recogerla. */
+          if (rp.ok === true) {
+            const fila = f.find(x => x.id === c.machote_id);
+            if (fila) {
+              fila.prestamos = (fila.prestamos || []).filter(x => x.para !== c.para);
+              /* SIN `para_nombre`: la consulta real (`machotes-leer`) no lo
+               * manda, porque la 005 no guarda nombres. Inventarlo aquí
+               * habría hecho pasar una prueba que en producción falla. */
+              if (c.accion === 'prestar') fila.prestamos.push({
+                para: c.para, otorgado_por: YO,
+                vence_at: new Date(Date.now() + (Number(c.horas) || 4) * 3600e3).toISOString() });
+            }
+          }
+          return Promise.resolve({ ok: true, json: () => Promise.resolve(rp) });
+        }
         if (s.indexOf('/comercial/clientes') >= 0) return new Promise(function () {});
         return orig.apply(this, arguments);
       };
@@ -3820,13 +3895,494 @@ let ok = 0, mal = 0;
     } finally { await q.close(); }
   });
 
+  /* ══ V1.25 · EL PRÉSTAMO TEMPORAL ═══════════════════════════════════════
+   *
+   * Qué se prueba aquí y por qué en el navegador: el préstamo tiene DOS
+   * mitades, y la de la base ya se ejerció contra Postgres real (dos
+   * escritores sobre la misma versión, uno pasa y el otro se va con
+   * CONFLICTO_DE_VERSION). Lo que falta —y sólo se ve aquí— es la mitad de
+   * quien está sentado frente a la pantalla: que el prestatario pueda
+   * escribir, que guarde CON LA IDENTIDAD DEL DUEÑO, que un rechazo le diga
+   * cuál de las tres causas fue, y sobre todo que NUNCA le cueste lo que
+   * tecleó. Esa última es la promesa que sostiene todo lo demás.
+   *
+   * El montaje puede sentar a cualquiera frente a la pantalla (`opciones.actor`),
+   * que es indispensable: casi nada del préstamo se ve desde el lado del dueño. */
+
+  /** El primer campo de texto de la hoja que de verdad se puede escribir.
+   *  Que exista YA ES media prueba: sobre lo ajeno sin permiso están todos
+   *  deshabilitados por `trabarSiNoPuedoEscribir`. */
+  const celdaEscribible = async (q) => {
+    const sel = '#hoja input.cel:not([disabled]):not([type="number"])';
+    const el = await q.$(sel);
+    return el;
+  };
+
+  await paso('C · con todo a la vista, el encabezado y el respaldo siguen diciendo qué es TUYO', async () => {
+    /* La tensión que abre la decisión 1: si lo primero que se ve es el trabajo
+     * de todos, «3 cotizaciones» al lado de «respaldo de lo mío (1)» se lee
+     * como un error de la aplicación — a menos que la pantalla diga cuántas
+     * son tuyas. Y el respaldo NO puede llevarse lo ajeno: sacaría el trabajo
+     * de otro de donde su dueño lo gobierna. */
+    const q = await paginaConServidor([
+      { id: '7000c433-0000-4000-8000-00000000cc01', id_local: 'M-MIO',
+        nombre: 'Bombas para Clarios', folio: 11, folio_txt: 'COT-0011' },
+      { id: '7000c433-0000-4000-8000-00000000cc02', id_local: 'M-DE-RICARDO',
+        nombre: 'Lifter leveling', folio: 12, folio_txt: 'COT-0012',
+        dueno: 'ricardo.hernandez', dueno_nombre: 'Ricardo Hernández', ajeno: true },
+      { id: '7000c433-0000-4000-8000-00000000cc03', id_local: 'M-DE-PABLO',
+        nombre: 'Tanque de servicio', folio: 13, folio_txt: 'COT-0013',
+        dueno: 'pablo.bayly', dueno_nombre: 'Pablo Bayly', ajeno: true }
+    ]);
+    try {
+      if ((await q.$eval('#fPersona', el => el.value)) !== '')
+        throw new Error('no arrancó en «Todas las personas»');
+      const filas = await q.$$eval('tr.rw', e => e.length);
+      if (filas !== 3) throw new Error('no salieron las tres de entrada: ' + filas);
+
+      const cuenta = (await q.textContent('.enc .cuenta')).replace(/\s+/g, ' ').trim();
+      if (!/3 cotizaciones/.test(cuenta)) throw new Error('el encabezado no cuenta todo: ' + cuenta);
+      if (!/1 tuya\b/.test(cuenta))
+        throw new Error('el encabezado no dice cuántas son tuyas: ' + cuenta);
+
+      const resp = (await q.textContent('.pie-resp')).replace(/\s+/g, ' ');
+      if (!/respaldo de lo m[ií]o \(1\)/i.test(resp))
+        throw new Error('el respaldo no cuenta sólo lo tuyo: ' + resp);
+
+      const enAlmacen = await q.evaluate(() => {
+        try { return (JSON.parse(localStorage.getItem('fts_machote_v1') || '{"machotes":[]}')
+                        .machotes || []).map(m => m.nombre); } catch (e) { return ['ERROR']; }
+      });
+      if (enAlmacen.some(n => /Lifter|Tanque/.test(n)))
+        throw new Error('el trabajo ajeno entró al almacén propio: ' + JSON.stringify(enAlmacen));
+      console.log('    «' + cuenta + '» · respaldo de 1 · el almacén sólo trae ' +
+                  JSON.stringify(enAlmacen));
+    } finally { await q.close(); }
+  });
+
+  await paso('B · el historial DICE quién escribió cada versión, y marca las que no son del dueño', async () => {
+    /* El caso de las comisiones, que es la razón por la que existe el
+     * histórico: si alguien con permiso prestado mueve el reparto, la versión
+     * queda con SU nombre. En la base eso ya era verdad desde el primer día
+     * —`machote_version.autor` sale del token verificado, nunca del cuerpo—;
+     * lo que faltaba era poder VERLO sin conocer de memoria de quién es cada
+     * cotización. */
+    const q = await paginaConServidor([
+      { id: '7000c433-0000-4000-8000-00000000hi01', id_local: 'M-MIO',
+        nombre: 'Bombas para Clarios', folio: 11, folio_txt: 'COT-0011',
+        version: 4, versiones: 4 }
+    ], { versiones: 4,
+         autores: { 3: { actor: 'ricardo.hernandez', nombre: 'Ricardo Hernández' } } });
+    try {
+      /* Es un machote PROPIO, así que su id de pantalla es el `id_local`, no
+       * el uuid — la traducción a uuid la hace `idServidor()` al pedir el
+       * historial (V1.24). */
+      await q.locator('[data-hist="M-MIO"]:visible').first().click();
+      await q.waitForTimeout(800);
+
+      const vs = await q.$$eval('.v', e => e.map(x => ({
+        txt: x.textContent.replace(/\s+/g, ' '), ajena: x.classList.contains('ajena') })));
+      if (vs.length !== 4) throw new Error('listó ' + vs.length + ' versiones de 4');
+
+      const deOtro = vs.filter(v => v.ajena);
+      if (deOtro.length !== 1)
+        throw new Error('marcó ' + deOtro.length + ' versiones como de otro, debía ser 1');
+      if (deOtro[0].txt.indexOf('Ricardo Hernández') < 0)
+        throw new Error('la marcada no dice quién la escribió: ' + deOtro[0].txt);
+      if (deOtro[0].txt.indexOf('no es el dueño') < 0)
+        throw new Error('no lo dice CON PALABRAS, sólo con color: ' + deOtro[0].txt);
+      if (deOtro[0].txt.indexOf('Versión 3') < 0)
+        throw new Error('marcó la versión equivocada: ' + deOtro[0].txt);
+
+      /* Y las del dueño NO se marcan: si se marcaran todas, la marca no
+       * distinguiría nada. */
+      const propias = vs.filter(v => !v.ajena);
+      if (propias.some(v => v.txt.indexOf('no es el dueño') >= 0))
+        throw new Error('marcó como ajena una versión del propio dueño');
+      if (!propias.every(v => v.txt.indexOf('Jesus Esteban De La Cruz') >= 0))
+        throw new Error('las del dueño no dicen su nombre');
+      console.log('    4 versiones · la 3 marcada «no es el dueño» (Ricardo) · las otras 3 limpias');
+    } finally { await q.close(); }
+  });
+
+  await paso('B · prestar: sale la orden al servidor y el dueño ve que está prestada', async () => {
+    const q = await paginaConServidor([
+      { id: '7000c433-0000-4000-8000-00000000ma01', id_local: 'M-MIO',
+        nombre: 'Bombas para Clarios', folio: 11, folio_txt: 'COT-0011' },
+      { id: '7000c433-0000-4000-8000-00000000ri01', id_local: 'M-DE-RICARDO',
+        nombre: 'Lifter leveling', folio: 12, folio_txt: 'COT-0012',
+        dueno: 'ricardo.hernandez', dueno_nombre: 'Ricardo Hernández', ajeno: true }
+    ], { prestar: { ok: true } });
+    try {
+      await q.click('tr.rw:has-text("Bombas para Clarios") a');
+      await q.waitForTimeout(800);
+
+      if (!(await q.$('#btnPrestar')))
+        throw new Error('no hay botón de prestar sobre una cotización propia ya subida');
+      await q.click('#btnPrestar');
+      await q.waitForTimeout(400);
+      if (!(await q.$('#prestaModal'))) throw new Error('no abrió el modal de prestar');
+
+      /* A quién se puede prestar sale de los DATOS —quien ya tiene machotes en
+       * el servidor— no de una lista escrita a mano. */
+      const opciones = await q.$$eval('#pm-para option', e => e.map(x => x.value));
+      if (opciones.indexOf('ricardo.hernandez') < 0)
+        throw new Error('Ricardo no aparece en la lista: ' + JSON.stringify(opciones));
+      if (opciones.indexOf('esteban.delacruz') >= 0)
+        throw new Error('se ofrece prestarse la cotización a uno mismo');
+
+      await q.selectOption('#pm-para', 'ricardo.hernandez');
+      await q.selectOption('#pm-horas', '4');
+      await q.click('#pm-ok');
+      await q.waitForTimeout(1400);
+
+      const ll = await q.evaluate(() => window.__llamadas.prestar);
+      if (ll.length !== 1) throw new Error('llamadas al endpoint de préstamo: ' + ll.length);
+      const c = ll[0];
+      if (c.accion !== 'prestar') throw new Error('acción: ' + c.accion);
+      if (c.machote_id !== '7000c433-0000-4000-8000-00000000ma01')
+        throw new Error('presta OTRO machote: ' + c.machote_id);
+      if (c.para !== 'ricardo.hernandez') throw new Error('se lo presta a: ' + c.para);
+      if (Number(c.horas) !== 4) throw new Error('horas: ' + c.horas);
+      /* Ni el dueño ni el otorgante viajan en el cuerpo: los pone el servidor
+       * desde el token. Si algún día viajaran, cualquiera podría prestar lo
+       * ajeno diciendo que es suyo. */
+      if (c.dueno || c.otorgado_por || c.actor)
+        throw new Error('el cuerpo lleva identidad que debe salir del token: ' + JSON.stringify(c));
+
+      if (await q.$('#prestaModal')) throw new Error('el modal no se cerró tras prestar');
+
+      // Y la cortesía: el dueño ve que está prestada, y con qué recogerla.
+      const fr = await q.textContent('.presta-fr');
+      if (!/Prestada/.test(fr)) throw new Error('la franja del dueño no dice que está prestada: ' + fr);
+      if (fr.indexOf('Ricardo') < 0) throw new Error('no dice a quién: ' + fr);
+      if (!(await q.$('[data-recoger="ricardo.hernandez"]')))
+        throw new Error('no hay botón de recoger el permiso');
+      console.log('    prestada 4 h a Ricardo · el dueño la ve prestada y puede recogerla');
+    } finally { await q.close(); }
+  });
+
+  await paso('B · si el endpoint todavía no está publicado, lo DICE en vez de culpar a la cotización', async () => {
+    /* El hueco real del despliegue: el frontend se mergea y el workflow se
+     * publica después, con un clic humano que puede tardar. En medio, el botón
+     * de prestar existe y el endpoint contesta el 404 PROPIO de n8n —un JSON
+     * con `code`/`message` y sin `ok`— que caía en el «no se pudo» genérico.
+     * Quien lo leyera concluiría que su cotización tiene algo malo. */
+    const q = await paginaConServidor([
+      { id: '7000c433-0000-4000-8000-00000000ap01', id_local: 'M-MIO',
+        nombre: 'Bombas para Clarios', folio: 11, folio_txt: 'COT-0011' },
+      { id: '7000c433-0000-4000-8000-00000000ap02', id_local: 'M-DE-RICARDO',
+        nombre: 'Lifter leveling', folio: 12, folio_txt: 'COT-0012',
+        dueno: 'ricardo.hernandez', dueno_nombre: 'Ricardo Hernández', ajeno: true }
+    ], { prestar: { code: 404,
+                    message: 'The requested webhook "POST comercial/machote-prestar" is not registered.' } });
+    try {
+      await q.click('tr.rw:has-text("Bombas para Clarios") a');
+      await q.waitForTimeout(800);
+      await q.click('#btnPrestar');
+      await q.waitForTimeout(400);
+      await q.selectOption('#pm-para', 'ricardo.hernandez');
+      await q.click('#pm-ok');
+      await q.waitForTimeout(1200);
+      const t = (await q.textContent('#pm-err')).replace(/\s+/g, ' ');
+      if (!/todav[ií]a no est[áa] encendida/i.test(t))
+        throw new Error('no dice que falta publicar el endpoint: ' + t);
+      if (!/No es un problema de tu cotizaci[oó]n/i.test(t))
+        throw new Error('no descarta lo que la persona va a suponer: ' + t);
+      if (await q.$('#prestaModal') === null)
+        throw new Error('cerró el modal como si hubiera prestado');
+      console.log('    404 de webhook sin publicar → «falta publicar», no «no se pudo»');
+    } finally { await q.close(); }
+  });
+
+  await paso('B · prestar y guardar: el prestatario escribe, y guarda con la identidad del DUEÑO', async () => {
+    /* Lo que de verdad se comprueba aquí no está en la pantalla sino en lo que
+     * sale por el cable: `id_local` es el del DUEÑO —si fuera el de quien
+     * teclea, el servidor crearía un machote NUEVO a su nombre en vez de una
+     * versión del de Ricardo— y `version_leida` es la del servidor, que es lo
+     * que permite detectar el choque de dos escritores. */
+    const vence = new Date(Date.now() + 4 * 3600e3).toISOString();
+    const q = await paginaConServidor([
+      { id: '7000c433-0000-4000-8000-00000000ri02', id_local: 'M-DE-RICARDO',
+        nombre: 'Lifter leveling', folio: 12, folio_txt: 'COT-0012',
+        dueno: 'ricardo.hernandez', dueno_nombre: 'Ricardo Hernández', ajeno: true,
+        version: 7, versiones: 7,
+        prestamos: [{ para: 'esteban.delacruz', para_nombre: 'Jesus Esteban De La Cruz',
+                      otorgado_por: 'ricardo.hernandez', vence_at: vence }] }
+    ], { guardar: { ok: true, version: 8, machote_id: '7000c433-0000-4000-8000-00000000ri02' } });
+    try {
+      await q.click('tr.rw:has-text("Lifter leveling") a');
+      await q.waitForTimeout(800);
+
+      const fr = await q.textContent('.presta-fr');
+      if (!/te prest[oó]/i.test(fr)) throw new Error('la franja del prestatario no lo dice: ' + fr);
+      if (!/Borrarla y mandarla a Odoo siguen siendo suyas/.test(fr))
+        throw new Error('no dice qué NO se presta: ' + fr);
+
+      const cel = await celdaEscribible(q);
+      if (!cel) throw new Error('con permiso vigente la hoja sigue trabada: no hay dónde escribir');
+      await cel.fill('CAMBIO DEL PRESTATARIO');
+      await q.waitForTimeout(1600);
+
+      const g = await q.evaluate(() => window.__llamadas.guardar);
+      if (!g.length) throw new Error('no salió ningún guardado al servidor');
+      const c = g[g.length - 1];
+      if (c.id_local !== 'M-DE-RICARDO')
+        throw new Error('guardó con OTRA identidad (crearía un machote nuevo): ' + c.id_local);
+      if (Number(c.version_leida) !== 7)
+        throw new Error('version_leida no es la del servidor: ' + c.version_leida);
+      if (!c.documento || JSON.stringify(c.documento).indexOf('CAMBIO DEL PRESTATARIO') < 0)
+        throw new Error('lo tecleado no viajó en el documento');
+      if (JSON.stringify(c.documento).indexOf('_ajeno') >= 0)
+        throw new Error('se colaron los campos de pantalla (_ajeno…) al documento del servidor');
+      console.log('    escribe con permiso · id_local del dueño · version_leida 7 · documento limpio');
+    } finally { await q.close(); }
+  });
+
+  await paso('B · préstamo VENCIDO: lo rechaza, lo dice con esas palabras, y no cuesta lo tecleado', async () => {
+    /* El permiso se comprueba AL GUARDAR, así que se puede estar tecleando
+     * cuando vence: la pantalla es optimista a propósito (un reloj de
+     * navegador puede ir movido) y el servidor es quien dice que no. Lo que
+     * NO puede pasar es que ese «no» se lleve el trabajo. */
+    const vence = new Date(Date.now() + 4 * 3600e3).toISOString();
+    const q = await paginaConServidor([
+      { id: '7000c433-0000-4000-8000-00000000ve01', id_local: 'M-DE-RICARDO',
+        nombre: 'Lifter leveling', folio: 12, folio_txt: 'COT-0012',
+        dueno: 'ricardo.hernandez', dueno_nombre: 'Ricardo Hernández', ajeno: true,
+        version: 7, versiones: 7,
+        prestamos: [{ para: 'esteban.delacruz', otorgado_por: 'ricardo.hernandez',
+                      vence_at: vence }] }
+    ], { guardar: { ok: false, error: 'PRESTAMO_VENCIDO',
+                    mensaje: 'El permiso temporal sobre este machote venció.' } });
+    try {
+      await q.click('tr.rw:has-text("Lifter leveling") a');
+      await q.waitForTimeout(800);
+      const cel = await celdaEscribible(q);
+      if (!cel) throw new Error('no hay dónde escribir con permiso vigente');
+      await cel.fill('LO QUE NO SE PUEDE PERDER');
+      await q.waitForTimeout(1800);
+
+      const t = (await q.textContent('#avPrestado')).replace(/\s+/g, ' ');
+      if (!/venci[oó]/i.test(t)) throw new Error('el aviso no dice que venció: ' + t);
+      if (!/sigue en este navegador y no se perdi[oó]/i.test(t))
+        throw new Error('no promete que el trabajo sigue aquí: ' + t);
+      if (!/P[ií]dele el permiso de nuevo/i.test(t))
+        throw new Error('no dice qué hacer (pedirlo otra vez): ' + t);
+      if (!(await q.$('#apCopiar'))) throw new Error('no ofrece copiar lo tecleado');
+
+      // Y la promesa, medida donde vive: el cajón de este navegador.
+      const cajon = await q.evaluate(() => {
+        try { return JSON.parse(localStorage.getItem('fts_machote_prestado_v1') || '{}'); }
+        catch (e) { return {}; }
+      });
+      const guardado = cajon['7000c433-0000-4000-8000-00000000ve01'];
+      if (!guardado) throw new Error('el rechazo se llevó lo tecleado: el cajón está vacío');
+      if (JSON.stringify(guardado.documento).indexOf('LO QUE NO SE PUEDE PERDER') < 0)
+        throw new Error('el cajón guardó otra cosa');
+      if (guardado.id_local !== 'M-DE-RICARDO')
+        throw new Error('el cajón anotó otra identidad: ' + guardado.id_local);
+      console.log('    rechazado por vencido · el aviso lo distingue · lo tecleado sigue en el cajón');
+    } finally { await q.close(); }
+  });
+
+  await paso('B · permiso RECOGIDO: el dueño lo recoge, y al prestatario se lo dicen distinto', async () => {
+    const vence = new Date(Date.now() + 4 * 3600e3).toISOString();
+
+    // ── Lado del DUEÑO: recoger sale al servidor con la acción correcta.
+    const d = await paginaConServidor([
+      { id: '7000c433-0000-4000-8000-00000000re01', id_local: 'M-MIO',
+        nombre: 'Bombas para Clarios', folio: 11, folio_txt: 'COT-0011',
+        prestamos: [{ para: 'ricardo.hernandez', para_nombre: 'Ricardo Hernández',
+                      otorgado_por: 'esteban.delacruz', vence_at: vence }] }
+    ], { prestar: { ok: true, recogidos: 1 } });
+    try {
+      await d.click('tr.rw:has-text("Bombas para Clarios") a');
+      await d.waitForTimeout(800);
+      if (!(await d.$('[data-recoger="ricardo.hernandez"]')))
+        throw new Error('el dueño no ve con qué recoger un permiso vivo');
+      d.once('dialog', x => x.accept());
+      await d.click('[data-recoger="ricardo.hernandez"]');
+      await d.waitForTimeout(1400);
+      const ll = await d.evaluate(() => window.__llamadas.prestar);
+      if (!ll.length) throw new Error('recoger no llamó al servidor');
+      if (ll[0].accion !== 'recoger') throw new Error('acción: ' + ll[0].accion);
+      if (ll[0].para !== 'ricardo.hernandez') throw new Error('recoge el de otro: ' + ll[0].para);
+      if (await d.$('.presta-fr'))
+        throw new Error('sigue diciendo que está prestada después de recogerla');
+    } finally { await d.close(); }
+
+    // ── Lado del PRESTATARIO: guarda con el permiso ya recogido.
+    const q = await paginaConServidor([
+      { id: '7000c433-0000-4000-8000-00000000re02', id_local: 'M-DE-RICARDO',
+        nombre: 'Lifter leveling', folio: 12, folio_txt: 'COT-0012',
+        dueno: 'ricardo.hernandez', dueno_nombre: 'Ricardo Hernández', ajeno: true,
+        version: 7, versiones: 7,
+        prestamos: [{ para: 'esteban.delacruz', otorgado_por: 'ricardo.hernandez',
+                      vence_at: vence }] }
+    ], { guardar: { ok: false, error: 'PRESTAMO_RECOGIDO',
+                    mensaje: 'El dueño recogió el permiso.' } });
+    try {
+      await q.click('tr.rw:has-text("Lifter leveling") a');
+      await q.waitForTimeout(800);
+      const cel = await celdaEscribible(q);
+      await cel.fill('ESCRITO JUSTO ANTES');
+      await q.waitForTimeout(1800);
+      const t = (await q.textContent('#avPrestado')).replace(/\s+/g, ' ');
+      if (!/recogi[oó] tu permiso/i.test(t))
+        throw new Error('no dice que se lo recogieron: ' + t);
+      if (/venci[oó]/i.test(t))
+        throw new Error('confunde recogido con vencido, que llevan a cosas distintas: ' + t);
+      if (!/no se perdi[oó]/i.test(t)) throw new Error('no promete el trabajo: ' + t);
+      const cajon = await q.evaluate(() => {
+        try { return JSON.parse(localStorage.getItem('fts_machote_prestado_v1') || '{}'); }
+        catch (e) { return {}; }
+      });
+      if (JSON.stringify(cajon).indexOf('ESCRITO JUSTO ANTES') < 0)
+        throw new Error('recoger el permiso se llevó lo que ya estaba escrito');
+      console.log('    el dueño recoge · al prestatario se lo dicen distinto de «venció» · nada se pierde');
+    } finally { await q.close(); }
+  });
+
+  await paso('B · EXTRAÑO sin préstamo: lo ve, no lo escribe, y no intenta guardarlo', async () => {
+    /* La lectura abierta de V1.24 no es escritura. Y el candado que importa no
+     * es el de la pantalla —ése sólo evita perder el rato— sino que el machote
+     * ajeno NO entre al empuje: si entrara, el servidor lo rechazaría, pero
+     * estaríamos mandando trabajo de otro a nombre de quien no debe. */
+    const q = await paginaConServidor([
+      { id: '7000c433-0000-4000-8000-00000000ex01', id_local: 'M-DE-RICARDO',
+        nombre: 'Lifter leveling', folio: 12, folio_txt: 'COT-0012',
+        dueno: 'ricardo.hernandez', dueno_nombre: 'Ricardo Hernández', ajeno: true,
+        version: 7, versiones: 7, prestamos: [] },
+      { id: '7000c433-0000-4000-8000-00000000ex02', id_local: 'M-MIO',
+        nombre: 'Bombas para Clarios', folio: 11, folio_txt: 'COT-0011' }
+    ], { guardar: { ok: true, version: 2, machote_id: '7000c433-0000-4000-8000-00000000ex02' } });
+    try {
+      await q.click('tr.rw:has-text("Lifter leveling") a');
+      await q.waitForTimeout(800);
+
+      if (await q.$('.presta-fr')) throw new Error('pinta franja de préstamo sin préstamo');
+      if (await q.$('#btnPrestar'))
+        throw new Error('ofrece PRESTAR una cotización que no es suya');
+      if (await celdaEscribible(q))
+        throw new Error('deja escribir sobre trabajo ajeno sin permiso');
+
+      const r = await q.evaluate(() => {
+        const A = window.MachoteAlmacen;
+        return { puede: A.puedeEscribir({ id: 'x', _ajeno: true, _prestamos: [] }),
+                 prestado: A.prestadoAMi({ id: 'x', _ajeno: true, _prestamo_para_mi: null }) };
+      });
+      if (r.puede !== false) throw new Error('el almacén dice que SÍ puede escribir lo ajeno');
+      if (r.prestado !== false) throw new Error('el almacén se inventa un préstamo');
+
+      // Y el empuje: se fuerza uno y no puede salir nada con la identidad ajena.
+      await q.evaluate(() => window.MachoteApp.guardarYa());
+      await q.waitForTimeout(1400);
+      const g = await q.evaluate(() => window.__llamadas.guardar);
+      if (g.some(c => c.id_local === 'M-DE-RICARDO'))
+        throw new Error('mandó al servidor el machote ajeno: ' + JSON.stringify(g.map(c => c.id_local)));
+      console.log('    lo lee, no lo edita, no lo presta y no lo sube · guardados: ' +
+                  JSON.stringify(g.map(c => c.id_local)));
+    } finally { await q.close(); }
+  });
+
+  await paso('B · crear una cotización nueva sigue funcionando para cualquiera', async () => {
+    /* La prueba de que el préstamo no le puso una puerta al camino normal.
+     * Se hace desde una persona que NO es Esteban y que no tiene nada en el
+     * servidor: si crear dependiera de ser dueño de algo, o de un scope, aquí
+     * se caería. */
+    const q = await paginaConServidor([
+      { id: '7000c433-0000-4000-8000-00000000nu01', id_local: 'M-DE-ESTEBAN',
+        nombre: 'Bombas para Clarios', folio: 11, folio_txt: 'COT-0011',
+        dueno: 'esteban.delacruz', dueno_nombre: 'Jesus Esteban De La Cruz', ajeno: true }
+    ], { actor: 'magaly.perez', nombre: 'Magaly Pérez',
+         guardar: { ok: true, version: 1, folio: 30, folio_txt: 'COT-0030',
+                    machote_id: '7000c433-0000-4000-8000-0000000000ma' } });
+    try {
+      await q.evaluate(() => { location.hash = '#/nuevo'; });
+      await q.waitForTimeout(500);
+      await q.fill('#n-nombre', 'Cotización de Magaly');
+      await q.click('#n-crear');
+      await q.waitForTimeout(1400);
+
+      if (await q.$('.presta-fr')) throw new Error('una cotización recién creada sale como prestada');
+      const cel = await celdaEscribible(q);
+      if (!cel) throw new Error('no puede escribir en la cotización que acaba de crear');
+      await cel.fill('LO QUE CAPTURÓ MAGALY');
+      await q.waitForTimeout(1600);
+
+      const g = await q.evaluate(() => window.__llamadas.guardar);
+      const mio = g.filter(c => /^M-\d/.test(String(c.id_local || '')));
+      if (!mio.length)
+        throw new Error('no subió la cotización nueva: ' + JSON.stringify(g.map(c => c.id_local)));
+      if (mio.some(c => c.id_local === 'M-DE-ESTEBAN'))
+        throw new Error('la confundió con la ajena');
+      console.log('    Magaly crea, escribe y sube lo suyo · id_local ' + mio[0].id_local);
+    } finally { await q.close(); }
+  });
+
+  await paso('A · el que PIERDE el choque conserva lo tecleado y lo puede recuperar', async () => {
+    /* La otra mitad de la concurrencia. Contra la base real ya se ejerció que
+     * de dos escritores sobre la misma versión pasa uno y el otro se va con
+     * CONFLICTO_DE_VERSION. Lo que faltaba —y es lo que le pasa a una persona—
+     * es qué ve el que perdió: tiene que poder recuperar lo suyo, y tiene que
+     * seguir ahí después de recargar, que es lo primero que uno hace cuando
+     * algo sale mal. */
+    const vence = new Date(Date.now() + 4 * 3600e3).toISOString();
+    const q = await paginaConServidor([
+      { id: '7000c433-0000-4000-8000-00000000cf01', id_local: 'M-DE-RICARDO',
+        nombre: 'Lifter leveling', folio: 12, folio_txt: 'COT-0012',
+        dueno: 'ricardo.hernandez', dueno_nombre: 'Ricardo Hernández', ajeno: true,
+        version: 7, versiones: 7,
+        prestamos: [{ para: 'esteban.delacruz', otorgado_por: 'ricardo.hernandez',
+                      vence_at: vence }] }
+    ], { guardar: { ok: false, error: 'CONFLICTO_DE_VERSION',
+                    mensaje: 'La versión que sigue es la 9, no la 8. Alguien más guardó ' +
+                             'mientras tanto: vuelve a abrir el machote.' } });
+    try {
+      await q.click('tr.rw:has-text("Lifter leveling") a');
+      await q.waitForTimeout(800);
+      const cel = await celdaEscribible(q);
+      await cel.fill('MEDIA HORA DE TRABAJO');
+      await q.waitForTimeout(1800);
+
+      const t = (await q.textContent('#avPrestado')).replace(/\s+/g, ' ');
+      if (!/Otra persona guard[oó]/i.test(t))
+        throw new Error('no dice que alguien más guardó: ' + t);
+      if (/venci[oó]|recogi[oó]/i.test(t))
+        throw new Error('confunde el choque con el permiso: ' + t);
+      if (!/Vuelve a abrirla/i.test(t)) throw new Error('no dice qué hacer: ' + t);
+      if (!(await q.$('#apCopiar'))) throw new Error('no hay manera de recuperar lo tecleado');
+
+      // RECARGAR: es lo primero que hace cualquiera cuando algo falla.
+      await q.reload(); await q.waitForTimeout(2000);
+      const cajon = await q.evaluate(() => {
+        try { return JSON.parse(localStorage.getItem('fts_machote_prestado_v1') || '{}'); }
+        catch (e) { return {}; }
+      });
+      if (JSON.stringify(cajon).indexOf('MEDIA HORA DE TRABAJO') < 0)
+        throw new Error('recargar se llevó lo tecleado');
+
+      // Y vuelve a la PANTALLA, no sólo al cajón: si hay que abrir la consola
+      // para recuperarlo, no está recuperado.
+      await q.click('tr.rw:has-text("Lifter leveling") a');
+      await q.waitForTimeout(900);
+      const enPantalla = await q.evaluate(() =>
+        [].some.call(document.querySelectorAll('#hoja input.cel'),
+                     e => String(e.value).indexOf('MEDIA HORA DE TRABAJO') >= 0));
+      if (!enPantalla)
+        throw new Error('el trabajo está en el cajón pero la pantalla no lo trae de vuelta');
+      console.log('    perdió el choque, se lo dijeron sin confundirlo, y su trabajo volvió a pantalla');
+    } finally { await q.close(); }
+  });
+
   await paso('sin errores de consola propios del prototipo', async () => {
     if (errs.length) throw new Error(errs.slice(0, 4).join(' | '));
     if (delEntorno.length) console.log('   (' + delEntorno.length +
       ' fallo(s) de red del sandbox, filtrados: fts-styles.css importa Google Fonts)');
   });
 
-  console.log('\n' + ok + ' pasaron, ' + mal + ' fallaron.');
+  console.log('\n' + ok + ' pasaron, ' + mal + ' fallaron.' +
+              (saltadas ? '  (' + saltadas + ' saltadas por SOLO=' + process.env.SOLO + ')' : ''));
   if (errs.length) { console.log('\nErrores de consola:'); errs.slice(0, 10).forEach(e => console.log('  ' + e)); }
   await b.close();
   process.exit(mal ? 1 : 0);

--- a/comercial/machote/version.json
+++ b/comercial/machote/version.json
@@ -1,10 +1,15 @@
 {
-  "version": "V1.24",
+  "version": "V1.25",
   "fecha": "2026-09-10",
   "modulo": "comercial/machote",
   "ambito": "El CONTADOR es solo de este modulo. finanzas tambien usa V1.xx desde el 2026-09-03 (instruccion directa de Esteban, corrige el \"no propagar\" del issue #148) pero lleva su propio contador y va en V1.00. operaciones/planeacion sigue en 2.4.1, kiosk y confirmar-horas solo con cadena de build, y siete modulos con un 1.0.0 puesto una vez: a esos no se propaga.",
   "esquema": "V<mayor>.<menor de dos digitos>. Un incremento de 0.01 por cada merge a main. Al pasar de .99 sube el mayor y el menor vuelve a 00.",
   "historial": [
+    {
+      "version": "V1.25",
+      "pr": null,
+      "nota": "El prestamo temporal de escritura, la lista que arranca en todas las personas, y lo ultimo del andamio. EL PRESTAMO (idea de Ricardo): el dueno de una cotizacion le presta la ESCRITURA a otra persona por un plazo que el elige, con tope de 24 horas que impone la BASE con un CHECK -no la pantalla, que cualquiera salta con la consola abierta-. Mientras dura, esa persona guarda como guardaria el dueno y cada version suya queda con SU nombre en el historial: es el caso de las comisiones que motivo el historico, y el dato ya era verdad en la base desde el primer dia porque machote_version.autor sale del token verificado. Lo que faltaba era poder VERLO, y ahora las versiones que no escribio el dueno salen marcadas y con esas palabras. Solo el dueno presta, se recoge con un boton, se avisa quince minutos antes de que venza, y borrar y mandar a Odoo siguen siendo del dueno: se presta la escritura, no la propiedad. LO QUE SOSTIENE TODO: un rechazo del servidor NUNCA cuesta lo tecleado. Lo escrito sobre un prestado se guarda en un cajon aparte de este navegador ANTES de cualquier llamada, sobrevive al rechazo y a recargar, y el aviso distingue las tres causas -permiso vencido, permiso recogido, y alguien mas guardo primero- porque llevan a tres cosas distintas. LA CONCURRENCIA se ejercio contra la base real con dos escritores simultaneos sobre la misma version: paso uno, el otro se fue con CONFLICTO_DE_VERSION, y la version que el prestatario escribio quedo a su nombre. LA LISTA arranca en TODAS las personas: abrir la lectura a todo el modulo en V1.24 y luego esconderlo detras de un filtro que nadie eligio era abrir una puerta y dejarla cerrada. El encabezado sigue diciendo cuantas son tuyas y el respaldo sigue llevandose solo lo tuyo. EL ANDAMIO: se retiro vOrden, la pantalla de cierre de handoff, que corria sobre datos de ejemplo y cuyo unico enlace se habia ido en V1.24 -solo se alcanzaba tecleando el hash-. Y dos defectos que solo se vieron MIRANDO la pantalla: el historial borraba la marca de 'no es el dueno' de todos los renglones cada vez que se seleccionaba una version, y un endpoint todavia sin publicar contestaba 'no se pudo' en vez de decir que falta encenderlo."
+    },
     {
       "version": "V1.24",
       "pr": null,

--- a/docs/comercial/ALMACEN.md
+++ b/docs/comercial/ALMACEN.md
@@ -316,7 +316,9 @@ vacío no urge; **antes de que entre el primer dato real, sí.**
 
 ## El tablero de dirección (`comercial/machotes-control`)
 
-**Workflow `PLAw9IYGgMh0PRPL`. INACTIVO** — lo activa Esteban en la UI, como los otros dos.
+**Workflow `PLAw9IYGgMh0PRPL`. ACTIVO** (leído el 2026-09-10: `active:true`,
+`triggerCount:1`). Nació inactivo y Esteban lo encendió; este renglón decía
+«INACTIVO» de más.
 
 Contesta una pregunta distinta de la de `machotes-leer`, y por eso es otra puerta:
 
@@ -358,6 +360,13 @@ leer), así que el cambio se hace desde la UI de n8n o con un workflow que use e
 
 **Aplicado el 8-sep-2026, sólo a Esteban** (`updatedAt 2026-09-08T03:20:44Z`, leído de vuelta).
 Los otros siete usuarios siguen sin `comercial:admin`.
+
+> **Re-leído el 2026-09-10** (V1.25 pedía otorgarlo; ya estaba). Crudo de la
+> Data Table, fila 8: `username esteban.delacruz` ·
+> `scopes "comercial:read,comercial:admin"` · `activo true` ·
+> `updatedAt 2026-09-08T03:20:44.040Z`. Las otras siete filas traen
+> `comercial:read` sola o `nomina:write,rh:read`; **ninguna trae
+> `comercial:admin`**. No hizo falta escribir nada.
 
 No va en una migración porque es un **permiso**, no una estructura — y porque la estructura
 está en otro sistema.
@@ -475,10 +484,40 @@ está en `docs/comercial/PERMISO_TEMPORAL.md` §6.
 recoge. `revocado_at` es la marca; la traza de que existió es parte de lo que
 hace auditable el permiso.
 
-⚠️ La tabla existe y el candado de `machote-guardar` ya la consulta, pero
-**todavía no hay manera de crear un préstamo** —el endpoint no está construido,
-a la espera de las cinco decisiones abiertas de la propuesta— así que hoy la
-tabla está vacía y el candado se comporta exactamente como antes.
+### V1.25 · la tabla ya se usa
+
+El endpoint existe y la tabla tiene filas. Lo que se agregó, sin tocar el
+esquema:
+
+- **`comercial/machote-prestar`** (id `6FYwu04ow0ie3Kcr`, **INACTIVO — falta
+  publicar**). Un solo endpoint para las dos acciones. Quien otorga sale del
+  **token**, nunca del cuerpo, y que sea el dueño lo comprueba **la consulta
+  contra la base**, no un `if` del workflow. El tope de 24 h no se valida aquí
+  a propósito: ya lo impone el `CHECK`, y duplicarlo sería tener la regla en
+  dos sitios que pueden discrepar.
+- **`comercial/machotes-leer`** devuelve, por machote, los **préstamos
+  vigentes que le tocan a quien pregunta**: si es el dueño, los que otorgó; si
+  es prestatario, el suyo; si no es ninguno de los dos, ninguno. La consulta ya
+  filtra —el `Code` no vuelve a filtrar, porque filtrar en la pantalla sería
+  poder ver el resto abriendo la consola—.
+
+  ⚠️ La columna nueva va **al final de las DOS ramas del `UNION ALL`**: la
+  consulta termina en `ORDER BY 9 DESC, 10 DESC`, que es ordenar **por
+  posición**. Meter una columna a media lista cambia en silencio por qué se
+  ordena.
+
+**La concurrencia se ejerció contra esta base**, con dos escritores de verdad
+sobre la misma versión: pasó uno, el otro se fue con `CONFLICTO_DE_VERSION`, y
+en la base quedaron **cuatro** versiones y no cinco. El crudo del read-back,
+con sus fechas en UTC y su conversión, está en `PERMISO_TEMPORAL.md` §7.1.
+
+⚠️ **Dato de prueba que quedó vivo en producción:** el machote **`COT-0008`**
+(`id_local M-V125-CONCURRENCIA`, dueño `zz.prueba.v125.duenio`) con sus cuatro
+versiones y un préstamo a `zz.prueba.v125.presta` ya **vencido**
+(`vence_at 2026-09-10 07:28:49 UTC` = 01:28 CST) y sin revocar. Los dos actores
+son usuarios inventados para la prueba: no existen en `suite_usuarios` y no
+tocan trabajo de nadie. Se puede borrar lógicamente (`deleted_at`) cuando
+estorbe; no estorba hoy.
 
 ## Cambios de V1.24 sin migración
 

--- a/docs/comercial/ANDAMIO.md
+++ b/docs/comercial/ANDAMIO.md
@@ -118,8 +118,63 @@ servidor y compara. Ahí es donde vive ahora esa respuesta.
 
 ### Deuda que esto deja apuntada
 
-Control hoy pide `comercial:admin`, **que no tiene nadie**. O sea que la
-pregunta «¿está todo lo mío allá?» hoy no la puede hacer ninguna persona del
-módulo. No bloquea nada —el aviso cubre el caso que de verdad ocurre, que es
-un guardado atorado— pero conviene resolverlo: o se le da la llave a alguien, o
-Control deja de pedirla para la parte de «lo mío». **Anotado, no perseguido.**
+Control pide `comercial:admin`.
+
+> ⚠️ **Corrección (V1.25, 2026-09-10).** Aquí decía «que no tiene nadie». Eso
+> ya era falso al escribirlo: la llave está puesta a `esteban.delacruz` desde el
+> **8-sep**, en la *Data Table* `suite_usuarios` de n8n. Leído de vuelta hoy:
+> `scopes: "comercial:read,comercial:admin"`, `updatedAt 2026-09-08T03:20:44Z`,
+> y los otros **siete** usuarios sólo con `comercial:read`. La frase se copió
+> del estado de V1.19, cuando el scope nació sin dueño a propósito («primero la
+> puerta, después la llave»), y nadie la volvió a leer.
+
+**La deuda de fondo sí sigue, y no es del permiso sino de la pregunta.**
+«¿Está TODO lo mío en el servidor?» hoy sólo la puede hacer quien tenga
+`comercial:admin`, o sea Esteban — y es una pregunta que le toca a **cada
+quien sobre lo suyo**, no a dirección sobre todos. Que dependa de la llave del
+tablero es un accidente: Control fue el primero que le preguntó al servidor, y
+la pregunta se quedó viviendo ahí.
+
+**Cómo se resolvería** (propuesto en V1.25, *no construido* — abre una decisión
+que le toca a Esteban):
+
+- **(a) Un renglón en la propia lista, sin llave.** «De tus N cotizaciones, N
+  están en el servidor» — el dato ya viaja: `machotes-leer` devuelve para cada
+  fila su `version` del servidor, y el navegador ya sabe cuáles tiene sin
+  subir. Es comparar dos cosas que la pantalla YA tiene, y no necesita endpoint
+  nuevo ni permiso nuevo. Es lo más barato y contesta la pregunta entera.
+- **(b) Abrir Control «lo mío» a `comercial:read`.** Un modo del tablero que
+  cuenta **sólo lo tuyo**. Más caro (toca el workflow, que hoy es un
+  `group by dueno` de todos) y deja la respuesta en otra pantalla, no donde
+  está el trabajo.
+- **(c) Dejarlo como está.** Defendible: el aviso de «sin subir» ya cubre el
+  caso que de verdad ocurre —un guardado atorado— y el silencio nunca afirma
+  «todo a salvo».
+
+La recomendación es **(a)**, y no se construyó porque decide dónde vive una
+respuesta, no cómo se calcula. **Anotado, no perseguido** (CLAUDE.md §8).
+
+---
+
+## Lo que se retiró en V1.25
+
+**`vOrden`, la pantalla de cierre de handoff.** Era una lista de entregables y
+un botón «Cerrar handoff» que marcaba la orden como confirmada en un estado en
+memoria. Corría sobre `D.ORDENES` —datos de ejemplo, **nunca del servidor**— y
+su único enlace era la sección «Confirmar la orden», que se retiró en V1.24.
+O sea que desde entonces sólo se alcanzaba tecleando el hash `#/orden/:id`.
+
+Se fue con ella todo lo que colgaba: la ruta `#/orden/:id`, `barraOrden`, la
+lista `ENTREGABLES`, los helpers `orden()` y `hoff()`, en el estado
+`ST.ordenes`, `ST.handoff` y `ST.confirmadas`, y en `demo.js` el bloque
+`ORDENES`.
+
+**Lo que NO se tocó, a propósito:**
+
+- La llave `handoff` del sobre de `fts_machote_v1`. Es formato de almacenamiento
+  **ya escrito en los navegadores del equipo**, y quitarla sería reescribirles
+  el archivo para ahorrar un objeto vacío.
+- `js/orden.js` (`MachoteOrden`), que es **otra cosa**: el modal «Pasar a
+  orden», al que se llega desde la barra del machote abierto. Sigue siendo un
+  cascarón y lo dice en su propia cabecera, pero **está enlazado y se usa** —
+  no es andamio huérfano.

--- a/docs/comercial/PERMISO_TEMPORAL.md
+++ b/docs/comercial/PERMISO_TEMPORAL.md
@@ -1,24 +1,28 @@
-# Permiso temporal de escritura — propuesta
+# Permiso temporal de escritura
 
-**Estado: PROPUESTA ABIERTA, con la mitad de abajo ya construida.** Idea
-original de Ricardo; el encargo es de la sesión V1.24 del issue #140.
+**Estado: CONSTRUIDO COMPLETO en V1.25 (2026-09-10), con las cinco decisiones
+de §2 aprobadas por Esteban tal como estaban escritas.** Idea original de
+Ricardo; el encargo salió de la sesión V1.24 del issue #140.
+
+> Lo que sigue después de este cuadro es **la propuesta como se escribió**, sin
+> retocar: es el razonamiento que sostiene cada decisión y por eso se conserva
+> tal cual. Lo construido y cómo se comprobó está en **§6 y §7**.
 
 | | qué | estado |
 |---|---|---|
-| **construido** | la tabla `comercial.machote_prestamo` con el tope de 24 h | ✅ migración `005`, aplicada a producción |
-| **construido** | el candado del guardado: «¿es suyo, **o hay préstamo vigente**?» | ✅ en `machote-guardar`, guardado — **falta publicar** |
-| **abierto** | el endpoint para prestar y recoger | ✖ no construido |
-| **abierto** | la pantalla: prestar, ver a quién, recoger, el aviso de los 15 min | ✖ no construido |
-| **abierto** | la marca en el historial «versión escrita por quien no es el dueño» | ✖ no construido |
+| la tabla `comercial.machote_prestamo` con el tope de 24 h | migración `005` | ✅ aplicada a producción |
+| el candado del guardado: «¿es suyo, **o hay préstamo vigente**?» | `machote-guardar` | ✅ **publicado y vivo** |
+| el endpoint para prestar y recoger | `comercial/machote-prestar` | ✅ construido · ⏳ **falta publicar** |
+| la lista con los préstamos vigentes | `comercial/machotes-leer` | ✅ escrito · ⏳ **falta publicar** |
+| la pantalla: prestar, ver a quién, recoger, el aviso de los 15 min | `js/prestamo.js` | ✅ |
+| la marca en el historial «versión escrita por quien no es el dueño» | `js/historial.js` | ✅ |
 
-**El corte no es arbitrario: se construyó lo que ninguna de las cinco decisiones
-de §2 puede invalidar** —una tabla con un tope, y una condición en el candado—
-y se dejó abierto todo lo que depende de tus respuestas. Mientras no exista el
-endpoint no puede existir ningún préstamo, así que lo construido **no cambia
-nada de lo que se ve hoy**: es infraestructura inerte esperando la decisión.
-
-Si rechazas la idea entera, lo construido se retira con una migración que borra
-una tabla vacía y un `setNodeParameter` que devuelve el candado a `dueno = actor`.
+⚠️ **Los dos workflows con ⏳ los publica una persona en la UI de n8n.** El
+frontend está hecho para tolerar que todavía no lo estén: sin la columna
+`prestamos` no aparece ningún préstamo y la pantalla se comporta como en V1.24,
+y si alguien aprieta «Prestar» antes de tiempo, la respuesta dice **que falta
+encender el endpoint**, no «no se pudo». Es el lado tolerante primero, como
+exige la regla anti-trabón de CLAUDE.md §8.
 
 > El dueño de un machote le da permiso de edición a otra persona, con vigencia,
 > con tope de 24 horas, para los casos en que alguien más tenga que meterle mano.
@@ -270,6 +274,124 @@ los seis casos que puede recibir:
 Esa última fila importa: el candado nuevo **no puede romper la creación de un
 machote**, que es el camino que usa todo el mundo todos los días.
 
-⚠️ **Lo que sigue SIN comprobar** es la concurrencia con dos escritores
-simultáneos de verdad (§0). Está razonada desde el mecanismo, no ejercida — y
+⚠️ **Lo que seguía SIN comprobar** era la concurrencia con dos escritores
+simultáneos de verdad (§0): estaba razonada desde el mecanismo, no ejercida — y
 ésa es exactamente la distinción que CLAUDE.md §8 pide no borrar.
+**Ya se ejerció: §7.1.**
+
+---
+
+## 7. V1.25 · lo que faltaba, y cómo se comprobó
+
+Esta sección cierra el ⚠️ de §6.
+
+### 7.1 La concurrencia, ejercida contra la base real
+
+Dos escritores de verdad sobre la **misma versión** del mismo machote, en el
+Postgres de producción, por el endpoint vivo `comercial/machote-guardar`
+(ejecución `93425` del runner temporal, `success`, `2026-09-10T05:30:40Z`
+= 23:30:40 CST del 9-sep).
+
+El **read-back contra la base**, leído aparte y después (ejecución `93777`,
+`2026-09-10T13:35:28Z` = 07:35 CST), tal como salió del `SELECT`:
+
+```
+COT-0008 · id_local M-V125-CONCURRENCIA · dueno zz.prueba.v125.duenio
+
+ tipo      version  autor                    motivo                                  creada_at (UTC)
+ version   1        zz.prueba.v125.duenio    —                                       2026-09-10 05:28:49
+ version   2        zz.prueba.v125.duenio    concurrencia V1.25 · control-duenio      2026-09-10 05:30:40
+ version   3        zz.prueba.v125.presta    concurrencia V1.25 · control-presta      2026-09-10 05:30:41
+ version   4        zz.prueba.v125.presta    concurrencia V1.25 · simultanea-presta   2026-09-10 05:30:41
+
+ prestamo  para zz.prueba.v125.presta · otorgado_por zz.prueba.v125.duenio
+           vence_at 2026-09-10 07:28:49 UTC (= 01:28 CST del 10-sep) · revocado_at: vivo
+```
+
+Cuatro versiones, **no cinco**. Las dos últimas escrituras se mandaron las dos
+sobre la versión 3: pasó la del prestatario (quedó como 4) y la del dueño fue
+rechazada con
+
+> `CONFLICTO_DE_VERSION` — «La versión que sigue es la 5, no la 4. Alguien más
+> guardó mientras tanto: vuelve a abrir el machote.»
+
+Que en la base no exista una quinta fila es la prueba: no es que el mensaje se
+haya pintado bonito, es que **el renglón no se escribió**. Lo hace el índice
+único `mv_machote_version_uq (machote_id, version)` de la migración 003 — la
+regla mira **sobre qué versión** se escribe, no quién escribe, y por eso dos
+personas con derecho se comportan igual que una persona con dos pestañas.
+
+Y la **versión 3 quedó a nombre del prestatario con el dueño intacto**: ése es,
+textualmente, el caso de las comisiones que motivó el histórico.
+
+Las fases de control (2 y 3, una escritura de cada quien por separado) existen
+a propósito: sin ellas, una cripto rota o un token mal armado habrían dado el
+mismo «rechazado» y se habría leído como que el candado funciona.
+
+### 7.2 Qué ve el que pierde
+
+Lo que la base rechaza no puede costarle a nadie lo que tecleó. Cómo se
+sostiene, en orden:
+
+1. Lo escrito sobre un machote prestado se guarda en un cajón aparte de este
+   navegador (`fts_machote_prestado_v1`), **síncrono y antes de llamar al
+   servidor** — no después, ni «si todo sale bien».
+2. El rechazo pinta un aviso que **distingue las tres causas** —permiso
+   vencido, permiso recogido, y alguien más guardó primero— porque llevan a
+   tres cosas distintas: pedirlo otra vez, hablar con el dueño, o volver a
+   abrir el machote. Es la misma exigencia de CLAUDE.md §20 #12b.
+3. Todos los avisos terminan igual: «Lo que escribiste sigue en este navegador
+   y no se perdió», con un botón **Copiar lo mío** al lado. Sin el botón, la
+   frase es amable y no se puede actuar sobre ella.
+4. Al recargar, `bajar()` recupera del cajón lo que no subió y lo vuelve a
+   poner en pantalla — mientras el permiso siga vivo. Sin permiso el machote
+   vuelve a ser de sólo lectura y lo tecleado se recupera desde el aviso, no
+   pisando la pantalla.
+
+El cajón es **una llave distinta** de `fts_machote_v1` a propósito: esa llave
+significa «lo mío», dos personas pueden tener el mismo `id_local` (Ricardo
+tenía un `M-1041` y Esteban otro), y mezclarlas haría que el machote prestado
+subiera como propio en el siguiente empujón.
+
+### 7.3 Las pruebas que quedaron
+
+Ocho pruebas de navegador nuevas, todas en `tests/pruebas-navegador.js`:
+
+| prueba | qué cierra |
+|---|---|
+| prestar: sale la orden al servidor y el dueño ve que está prestada | el cuerpo NO lleva identidad — dueño y otorgante salen del token |
+| prestar y guardar: el prestatario escribe, y guarda con la identidad del DUEÑO | `id_local` del dueño y `version_leida` del servidor; si fuera el suyo, crearía un machote nuevo a su nombre |
+| préstamo VENCIDO | el aviso lo dice con esas palabras · lo tecleado sigue en el cajón |
+| permiso RECOGIDO | el dueño lo recoge · al prestatario se lo dicen **distinto** de «venció» |
+| EXTRAÑO sin préstamo | lo lee, no lo edita, no lo presta y **no entra al empuje** |
+| crear una cotización nueva sigue funcionando para cualquiera | el préstamo no le puso una puerta al camino de todos los días |
+| el historial DICE quién escribió cada versión | la marca «no es el dueño», y que NO se pinte en las del dueño |
+| si el endpoint todavía no está publicado, lo DICE | el hueco del despliegue: el frontend mergea antes de que alguien publique |
+| (A) el que PIERDE el choque conserva lo tecleado | sobrevive al rechazo, a recargar, y vuelve a la pantalla |
+
+### 7.4 Tres defectos que sólo se vieron MIRANDO la pantalla
+
+Ninguno se veía releyendo el diff, y los tres son de la superficie que entrega
+esta sesión:
+
+1. **El historial borraba su propia marca.** `marcar()` —que corre también al
+   abrir, para seleccionar la última versión— reescribía el `className` entero
+   de cada renglón, y con eso se llevaba `ajena`. La marca de «no es el dueño»
+   moría antes de verse nunca; quedaba sólo el texto. Regla que deja: *una
+   función que pinta UN estado no reescribe el `className`, toca SU clase.*
+2. **El documento congelado se salía del recuadro.** Las dos columnas del
+   historial son celdas de grid, y una celda de grid trae `min-width: auto`:
+   crece más que su carril si su contenido no cabe. El `<pre>` medía 700 px y
+   colgaba **113 px fuera en escritorio y 368 px en teléfono**. Un
+   `min-width: 0` lo arregla y hace que el `overflow:auto` que el `<pre>` ya
+   tenía por fin sirva de algo.
+3. **«hasta las 10:13 a.m..»** — `toLocaleTimeString('es-MX')` ya trae punto.
+
+Y uno más que no se vio en la pantalla sino en la **suite completa**: la
+primera versión de `puedeEscribir()` devolvía `false` para los machotes de
+DEMOSTRACIÓN, y con eso trababa la hoja de los cuatro ejemplos que la
+aplicación trae de fábrica — o sea, lo primero que ve quien abre por primera
+vez. Lo cazaron **41 pruebas**, ninguna de ellas del préstamo. Un ejemplo sí se
+escribe: en cuanto alguien teclea encima deja de ser un ejemplo (`tocado()` le
+quita el `_demo`); lo que no puede hacer es subir, y eso lo impiden dos
+candados distintos que no son éste.


### PR DESCRIPTION
## Qué trae

**El préstamo temporal de escritura, completo** (idea de Ricardo). El dueño de una
cotización le presta la ESCRITURA a otra persona por un plazo que él elige. El tope
de 24 h lo impone la BASE con un `CHECK` —no la pantalla, que cualquiera salta con la
consola abierta— y que quien otorga sea el dueño lo comprueba la consulta contra la
base, no un `if` del workflow. Cada versión del prestatario queda con SU nombre en el
historial: el caso de las comisiones que motivó el histórico, ahora visible.

**Lo que sostiene todo:** un rechazo del servidor NUNCA cuesta lo tecleado. Lo escrito
sobre un prestado va a un cajón aparte de ese navegador ANTES de cualquier llamada,
sobrevive al rechazo y a recargar, y vuelve a la pantalla. El aviso distingue las tres
causas —vencido, recogido, alguien más guardó primero— porque llevan a tres cosas
distintas, y todas ofrecen «Copiar lo mío».

**La concurrencia, ejercida contra la base real.** Dos escritores de verdad sobre la
misma versión: pasó uno, el otro se fue con `CONFLICTO_DE_VERSION`, y en la base
quedaron **cuatro** versiones y no cinco. Crudo del read-back en
`docs/comercial/PERMISO_TEMPORAL.md` §7.1.

**La lista arranca en «Todas las personas»** (decisión de Esteban). El encabezado sigue
diciendo cuántas son tuyas y el respaldo sigue llevándose sólo lo tuyo.

**Se retiró `vOrden`**, la pantalla de cierre de handoff: corría sobre datos de ejemplo
y su único enlace se había ido en V1.24.

## Cuatro defectos que no se veían en el diff

- el historial **borraba su propia marca** («no es el dueño») al seleccionar una versión
- el documento congelado se salía del recuadro 113 px en escritorio y **368 px en teléfono**
- «hasta las 10:13 a.m.**.**»
- `puedeEscribir()` trababa la hoja de **los cuatro ejemplos de fábrica** — lo cazaron
  41 pruebas de la suite completa, ninguna de ellas del préstamo

## Plan de prueba

- [x] **suite completa de navegador, sin `SOLO`: `163 pasaron, 0 fallaron`**
      (la base eran 155; 155 + 10 nuevas − 2 retiradas = 163, cuadra exacto)
- [x] 10 pruebas nuevas · 2 reescritas por la decisión del filtro · 2 retiradas con `vOrden`
- [x] capturas a 380 px y 1280 px, **miradas**: pantalla del prestatario, la del dueño,
      el modal de prestar y el historial con autores ajenos
- [x] concurrencia ejercida contra Postgres de producción, con read-back a la base
- [ ] verificación contra el dominio (`yinyo1.github.io`) tras el merge — el verificador
      ya corrió **contra main como control** y devolvió `V1.24`, así que se sabe que lee

## ⚠️ Falta publicar (un clic humano en la UI de n8n, no lo hace este merge)

| workflow | id | estado | llave de reversa |
|---|---|---|---|
| `comercial/machote-prestar` | `6FYwu04ow0ie3Kcr` | INACTIVO, nace apagado (`activeVersionId: null`) | — |
| `comercial/machotes-leer` | `Lze4jmkW9pg7Tvad` | guardado, sin publicar | `c7b7368e-b9b7-4c70-822f-68c192ad2687` |

**El frontend va primero a propósito, porque es la mitad tolerante** (CLAUDE.md §8):
sin la columna `prestamos` no aparece ningún préstamo y la pantalla se comporta como en
V1.24; y si alguien aprieta «Prestar» antes de tiempo, la respuesta dice *que falta
encender el endpoint*, no «no se pudo».

#140

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013Qzhio6K8R23HXHnJ2RJ64